### PR TITLE
Bugfix: SuperGLUE Benchmark tests fail when context + continuation exceed 1024 tokens

### DIFF
--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -40,7 +40,7 @@ class GPT2LM(LM):
         if len(self.tokenizer.encode(context + continuation)) <= self.MAX_LENGTH:
             ctxlen = len(self.tokenizer.encode(context.strip()))
         else:
-            ctxlen = self.MAX_LENGTH - 1
+            ctxlen = self.MAX_LENGTH - len(self.tokenizer.encode(continuation))
 
         cont_toks = inp[:, ctxlen:]  # [batch, seq]
         logits = F.log_softmax(self.gpt2(inp)[0], dim=-1)[:, ctxlen - 1:-1]  # [batch, seq, vocab]


### PR DESCRIPTION
- Caused by context length variable ctxlen incorrectly assigned
- Can be reproduced by running tasks boolq, commitmentbank, wic
- Added fix to correctly set context length when truncation occurs
- Refactored GPT2LM max window length into variable MAX_LENGTH