### PR TITLE
Tweak StoryCloze script to be agnostic to tokenization

### DIFF
--- a/batch_eval/main.py
+++ b/batch_eval/main.py
@@ -89,11 +89,6 @@ def evaluate_example(model, tokenizer, example):
 
 
 def compute_per_token_logit_for_completion(model, tokenizer, prompt, completion):
-    prompt_token_count = (
-        tokenizer.encode(prompt, add_special_tokens=False, return_tensors="pt")
-        .to("cuda")
-        .shape[1]
-    )
     encoded_prompt_with_completion = tokenizer.encode(
         prompt + " " + completion,
         add_special_tokens=False,
@@ -114,15 +109,7 @@ def compute_per_token_logit_for_completion(model, tokenizer, prompt, completion)
         input_tokens_at_positions_with_logits.unsqueeze(1),
     ).squeeze(1)
 
-    return (
-        logits_for_provided_tokens[
-            prompt_token_count
-            # Again, the model does not predict the first input token, so we need
-            - 1 :
-        ]
-        .mean()
-        .item()
-    )
+    return logits_for_provided_tokens.mean().item()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The script currently chooses the model's answer based on the logits of the tokens that correspond to the answer, as opposed to the tokens of the common prompt that the model's input starts with. 

But as @leogao2 pointed out, "tokens that correspond to the answer" is not actually well-defined, because a token spans multiple characters, and a single token might have some characters belonging to the prompt and other characters belonging to the answer.

Also, we just generally want our evaluation to be as tokenization-agnostic as possible, because we might need to add new models that do tokenization differently.

This PR simplifies StoryCloze evaluation to be tokenization-agnostic. Instead of looking at the logits of the answer, we now just look at the logits of the entire input that was passed to the model (prompt+answer).

The accuracy stays about the same, at 52.4% compared to 52.5% before