### PR TITLE
Use asyncio and run LM in batches

### DIFF
--- a/batch_eval/main.py
+++ b/batch_eval/main.py
@@ -1,5 +1,8 @@
+import asyncio
+import collections
 import csv
 import os
+import time
 
 import click
 import torch
@@ -9,46 +12,35 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 @click.command()
 @click.argument("datadir", required=True)
 def main(datadir):
-    model = AutoModelForCausalLM.from_pretrained(
-        # 117M
-        pretrained_model_name_or_path="gpt2",
-        config=AutoConfig.from_pretrained(
-            "gpt2",
-            # <|endoftext|>
-            pad_token_id=50256,
-        ),
-    ).to("cuda")
-    model = model.eval()
+    loop = asyncio.get_event_loop()
+    worker = InferenceWorker(loop)
+    worker.load_model()
+    worker_task = loop.create_task(worker.run())
+    loop.run_until_complete(async_main(worker, datadir))
+    worker_task.cancel()
+    loop._run_once()  # https://stackoverflow.com/a/62443715
+    loop.close()
 
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
-    prompt = "The quick brown fox jumps over"
-    encoded_prompt = tokenizer.encode(
-        prompt, add_special_tokens=False, return_tensors="pt"
-    ).to("cuda")
-
-    # Sanity check the model
-    [output_token_ids] = model.generate(
-        input_ids=encoded_prompt,
-        max_length=100,
-        tempareture=0,
-        do_sample=False,
-        num_return_sequences=1,
-    )
-    decoded_output = tokenizer.decode(output_token_ids.tolist())
-    # Next word should be "the" ("The quick brown fox jumps over *the*...")
-    print(decoded_output[len(prompt + " ") :][:10])
-    assert decoded_output[len(prompt + " ") :].startswith("the")
-
+async def async_main(worker, datadir):
     with open(
         os.path.join(datadir, "cloze_test_test__spring2016 - cloze_test_ALL_test.csv")
     ) as f:
         storycloze_test_examples = list(csv.DictReader(f))
 
-    example_evaluations = [
-        evaluate_example(model, tokenizer, example)
-        for example in storycloze_test_examples
-    ]
+    start_time = time.time()
+    example_evaluations = await asyncio.gather(
+        *(
+            # `ensure_future` is needed to prevent `asyncio.gather` from returning the results out of order
+            # See https://github.com/python/asyncio/pull/433
+            asyncio.ensure_future(evaluate_example(worker, example))
+            for example in storycloze_test_examples
+        )
+    )
+    end_time = time.time()
+    print(
+        f"Total time for {len(storycloze_test_examples)} examples: {end_time - start_time}"
+    )
     fraction_correct = len(
         [
             evaluation
@@ -59,7 +51,7 @@ def main(datadir):
     print(f"Fraction correct: {fraction_correct}")
 
 
-def evaluate_example(model, tokenizer, example):
+async def evaluate_example(worker, example):
     storycloze_prompt = "{} {} {} {}".format(
         example["InputSentence1"],
         example["InputSentence2"],
@@ -68,12 +60,22 @@ def evaluate_example(model, tokenizer, example):
     )
 
     # Calculate *per-token* likelihoods, as the paper did
-    per_token_logit_for_sentence1 = compute_per_token_logit_for_completion(
-        model, tokenizer, storycloze_prompt, example["RandomFifthSentenceQuiz1"]
+    per_token_logits = await asyncio.gather(
+        # `ensure_future` is needed to prevent `asyncio.gather` from returning the results out of order
+        # See https://github.com/python/asyncio/pull/433
+        asyncio.ensure_future(
+            worker.compute_logit_per_token(
+                storycloze_prompt + " " + example["RandomFifthSentenceQuiz1"]
+            )
+        ),
+        asyncio.ensure_future(
+            worker.compute_logit_per_token(
+                storycloze_prompt + " " + example["RandomFifthSentenceQuiz2"]
+            )
+        ),
     )
-    per_token_logit_for_sentence2 = compute_per_token_logit_for_completion(
-        model, tokenizer, storycloze_prompt, example["RandomFifthSentenceQuiz2"]
-    )
+    per_token_logit_for_sentence1 = per_token_logits[0].result()
+    per_token_logit_for_sentence2 = per_token_logits[1].result()
 
     if per_token_logit_for_sentence1 > per_token_logit_for_sentence2:
         model_answer = example["RandomFifthSentenceQuiz1"]
@@ -88,28 +90,106 @@ def evaluate_example(model, tokenizer, example):
     }
 
 
-def compute_per_token_logit_for_completion(model, tokenizer, prompt, completion):
-    encoded_prompt_with_completion = tokenizer.encode(
-        prompt + " " + completion,
-        add_special_tokens=False,
-        return_tensors="pt",
-    ).to("cuda")
-    output_logits = model(encoded_prompt_with_completion).logits
+InferenceRequest = collections.namedtuple("InferenceRequest", ["future", "input_text"])
 
-    # Align the output logits to the input tokens.
-    # The last logit needs to be dropped, because it's predicting the "next token", and it doesn't correspond to any input token
-    logits_for_input_positions = output_logits[0, :-1, :]
-    # The model does not predict the first input token, so it needs to be dropped as well.
-    input_tokens_at_positions_with_logits = encoded_prompt_with_completion[0, 1:]
-    # At each position, the model outputs ~50k logits, one for every possible token.
-    # To get the logits of the tokens that were actually provided, we need to select the right logit at each position.
-    logits_for_provided_tokens = torch.gather(
-        logits_for_input_positions,
-        1,
-        input_tokens_at_positions_with_logits.unsqueeze(1),
-    ).squeeze(1)
 
-    return logits_for_provided_tokens.mean().item()
+class InferenceWorker:
+    def __init__(self, loop):
+        self.loop = loop
+        self.inference_requests = []
+
+        self.model = None
+        self.tokenizer = None
+
+    def load_model(self):
+        self.model = AutoModelForCausalLM.from_pretrained(
+            # 117M
+            pretrained_model_name_or_path="gpt2",
+            config=AutoConfig.from_pretrained(
+                "gpt2",
+                # <|endoftext|>
+                pad_token_id=50256,
+            ),
+        ).to("cuda")
+        self.model = self.model.eval()
+        self.tokenizer = AutoTokenizer.from_pretrained("gpt2")
+
+        prompt = "The quick brown fox jumps over"
+        encoded_prompt = self.tokenizer.encode(
+            prompt, add_special_tokens=False, return_tensors="pt"
+        ).to("cuda")
+
+        # Sanity check the model
+        [output_token_ids] = self.model.generate(
+            input_ids=encoded_prompt,
+            max_length=100,
+            tempareture=0,
+            do_sample=False,
+            num_return_sequences=1,
+        )
+        decoded_output = self.tokenizer.decode(output_token_ids.tolist())
+        # Next word should be "the" ("The quick brown fox jumps over *the*...")
+        assert decoded_output[len(prompt + " ") :].startswith("the")
+
+    async def compute_logit_per_token(self, input_text):
+        future = self.loop.create_future()
+        self.inference_requests.append(
+            InferenceRequest(future=future, input_text=input_text)
+        )
+        return future
+
+    async def run(self):
+        while True:
+            if self.inference_requests:
+                self.process_batch()
+            if not self.inference_requests:
+                # Need to sleep here, or else we'll get into an infinite loop.
+                # The exact timeout duration doesn't matter much, as long as it's short.
+                # It just needs to be not too much longer than the latency of one model inference, or ~10ms.
+                await asyncio.sleep(0.01)
+
+    def process_batch(self):
+        # TODO: optimize batch size
+        requests_to_process = self.inference_requests[:10]
+        self.inference_requests = self.inference_requests[10:]
+
+        for inference_request in requests_to_process:
+            encoded_prompt_with_completion = self.tokenizer.encode(
+                inference_request.input_text,
+                add_special_tokens=False,
+                return_tensors="pt",
+            ).to("cuda")
+            start_time = time.time()
+            # This blocks the event loop, which is normally not recommended. (See https://docs.python.org/3/library/asyncio-dev.html#running-blocking-code)
+            # But when we evaluate a model, we are running a big batch of evaluations and we don't care about responsiveness, only about how long it takes overall.
+            # If we really want this to be non-blocking, we can move model inference to a separate thread.
+            output_logits = self.model(encoded_prompt_with_completion).logits
+            end_time = time.time()
+            print(f"Time to evaluate once: {end_time - start_time}")
+
+            # Align the output logits to the input tokens.
+            logits_for_input_positions = output_logits[
+                0,
+                # The last logit needs to be dropped, because it's predicting the "next token", and it doesn't correspond to any input token
+                :-1,
+                :,
+            ]
+            input_tokens_at_positions_with_logits = encoded_prompt_with_completion[
+                0,
+                # The model does not predict the first input token, so the first token needs to be dropped.
+                1:,
+            ]
+            # At each position, the model outputs ~50k logits, one for every possible token.
+            # To get the logits of the tokens that were actually provided, we need to select the right logit at each position.
+            logits_for_provided_tokens = torch.gather(
+                logits_for_input_positions,
+                1,
+                input_tokens_at_positions_with_logits.unsqueeze(1),
+            ).squeeze(1)
+
+            inference_request.future.set_result(
+                logits_for_provided_tokens.mean().item()
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Background

For each example we evaluate, I expect our code to be organized according to the following steps:

* Preprocessing: generate language model (LM) inputs in whatever way is appropriate for the task
* Model inference: run the LM, possibly multiple times
* Postprocessing: take the LM's output, and score it for accuracy or the like

But if we just naively do that for each example, we run into a serious problem. If we run the examples one by one, we will drastically underutilize our GPUs, or whatever other accelerators we use.

To keep our GPUs busy, we need to process LM inputs in batches. Whatever batching system we go with, we will need to carry out the following tasks:
* Gathering LM requests and queueing them up for inference
* Taking a batch of requests and actually running the LM on them
* Following up on the LM's outputs

## This PR's changes

This PR introduces `asyncio`, and uses it to centralize all LM inference in an `InferenceWorker` class. With `asyncio`, you can write code for each evaluation task without having to worry about batching. Instead, you can call `InferenceWorker` using its one-example-at-a-time interface, and `InferenceWorker` will manage the batching internally.

This PR also makes `InferenceWorker` actually do batching, and so model evaluation is now much faster.

## Performance and accuracy

Since this PR is purely a refactor and performance improvement, the StoryCloze accuracy shouldn't change. I measured the accuracy with and without this PR, and everything looked okay!

Code | Model | Batch size | GPU | Wall-clock time (after model is loaded) | Accuracy on StoryCloze
-- | -- | -- | -- | -- | --
Before | GPT-2-117M | 1 | T4 | ~65 s | 52.4%
With PR | GPT-2-117M | 1 | T4 | ~65 s | 52.4%
With PR | GPT-2-117M | 1 | V100 | ~65 s | 52.4%
With PR | GPT-2-117M | 10 | V100 | 9.2 s | 52.4%
With PR | GPT-2-117M | 20 | V100 | 7.1 s | 52.4%
With PR | GPT-2-774M | 20 | V100 | 38.2 s | 66.1%

## This PR's programming model

* To implement an evaluation task, you can write a single function that operates on a single example. The function will need to be async, and it will look something like this:

```
async def eval_for_my_task(worker, example):
    prompt1 = ...
    prompt2 = ...

    likelihood1 = await worker.run(...)
    likelihood2 = await worker.run(...)

    return evaluate(likelihood1, likehood2, example.actual_answer)
```

* To support a new model, you can extend `InferenceWorker` 

## Alternative, if we don't want to use `asyncio`

I think our second best option is to make each evaluation task implement its own batching logic. For example, for StoryCloze, the code would look something like this:

```
def eval_storycloze_batch(lm, batch_of_examples):
    storycloze_prompts_for_sentence_1 = [generate_storycloze_prompt(example) for example in batch_of_examples]
    storycloze_prompts_for_sentence_2 = [generate_storycloze_prompt(example) for example in batch_of_examples]

    likelihoods_for_sentence_1 = lm.loglikelihood_batched(storycloze_prompts_for_sentence_1)
    likelihoods_for_sentence_2 = lm.loglikelihood_batched(storycloze_prompts_for_sentence_2)

    batch_eval_results = []
    for example, sentence_1_likelihood, sentence_2_likelihood in zip(...):
        batch_eval_results.append(...)

    return batch_eval_results

def main():
    # - find a reasonable batch size (which may be model-dependent and need to be configured)
    # - load the dataset and split the examples into matches
    # - call eval_storycloze_batch on each batch
    # - aggregate the results and compute the overall accuracy
```

