### PR TITLE
Implement StoryCloze

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The raw Google doc can be found here: https://docs.google.com/document/d/177dwJp
 
 ## Usage
 
+### Download datasets
+
+The StoryCloze dataset must be downloaded manually. You can get it at https://www.cs.rochester.edu/nlp/rocstories/
+
 ### Evaluate a task
 
 To evaluate a model, (e.g. GPT-2) on NLU tasks (e.g. RTE, Winograd Scheme Challenge), you can run the following command.

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -30,7 +30,6 @@ class LM(abc.ABC):
 
 
 class Dataset(abc.ABC):
-    @abc.abstractmethod
     def __init__(self):
         self.download()
         self._traindocs = None

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -12,6 +12,7 @@ from . import openbookqa
 from . import squad
 from . import naturalqs
 from . import sat
+from . import storycloze
 
 
 TASK_REGISTRY = {
@@ -49,6 +50,7 @@ TASK_REGISTRY = {
     "anli_r1": anli.ANLIRound1,
     "anli_r2": anli.ANLIRound2,
     "anli_r3": anli.ANLIRound3,
+    'storycloze': storycloze.StoryCloze
 }
 
 

--- a/lm_eval/tasks/storycloze.py
+++ b/lm_eval/tasks/storycloze.py
@@ -2,13 +2,12 @@ import json
 import random
 from lm_eval.base import Dataset
 from ..utils import sh
+from .common import simple_accuracy_metric
 import csv
+import os
 
 
 class StoryCloze(Dataset):
-    def __init__(self):
-        self.download()
-
     def download(self):
         # TODO: replace with Eye link
         pass
@@ -22,32 +21,76 @@ class StoryCloze(Dataset):
     def has_test_docs(self):
         return True
 
+    @staticmethod
+    def _assert_has_data():
+        if not os.path.exists("data/storycloze"):
+            raise AssertionError(
+                'StoryCloze must be downloaded manually. Please download the dataset and store it in "data/storycloze/".'
+            )
+
     def training_docs(self):
-        pass
+        self._assert_has_data()
+        # StoryCloze has no training data, so following the GPT-3 paper we will generate few-shot examples using the development set,
+        # and evaluate using the test set
+        return self.load_doc(
+            "data/storycloze/cloze_test_val__spring2016 - cloze_test_ALL_val.csv"
+        )
 
     def load_doc(self, filename):
-        with open(filename, newline="") as file:
-            filereader = csv.reader(file)
-            return list(filereader)
+        with open(filename) as f:
+            return list(csv.DictReader(f))
 
     def validation_docs(self):
+        self._assert_has_data()
+        # StoryCloze has no training data, so following the GPT-3 paper we will generate few-shot examples using the development set,
+        # and evaluate using the test set
         return self.load_doc(
-            "data/storycloze/cloze_test_val__winter2018-cloze_test_ALL_val - 1 - 1.csv"
+            "data/storycloze/cloze_test_test__spring2016 - cloze_test_ALL_test.csv"
         )
 
     def test_docs(self):
+        self._assert_has_data()
         return self.load_doc(
-            "data/storycloze/cloze_test_test__winter2018-cloze_test_ALL_test - 1.csv"
+            "data/storycloze/cloze_test_test__spring2016 - cloze_test_ALL_test.csv"
         )
 
     def fewshot_description(self):
         pass
 
     def doc_to_text(self, doc, include_target=True):
-        if include_target:
-            return " ".join([*doc[1:5], doc[int(doc[-1]) - 4]])
-        else:
-            return " ".join([*doc[1:5]])
+        storycloze_prompt = "{} {} {} {}".format(
+            doc["InputSentence1"],
+            doc["InputSentence2"],
+            doc["InputSentence3"],
+            doc["InputSentence4"],
+        )
 
-    def evaluate(self, docs, lm):
-        pass
+        if include_target:
+            if doc["AnswerRightEnding"] == "1":
+                return storycloze_prompt + " " + doc["RandomFifthSentenceQuiz1"]
+            else:
+                return storycloze_prompt + " " + doc["RandomFifthSentenceQuiz2"]
+        else:
+            return storycloze_prompt
+
+    def evaluate(self, docs, lm, provide_description, num_fewshot):
+        golds = [doc["AnswerRightEnding"] for doc in docs]
+        preds = []
+        for doc in docs:
+            ctx = self.fewshot_context(
+                doc=doc,
+                provide_description=provide_description,
+                num_fewshot=num_fewshot,
+            )
+            loglikelihood_with_sentence_1 = lm.loglikelihood(
+                ctx, " " + doc["RandomFifthSentenceQuiz1"]
+            ).sum()
+            loglikelihood_with_sentence_2 = lm.loglikelihood(
+                ctx, " " + doc["RandomFifthSentenceQuiz2"]
+            ).sum()
+            if loglikelihood_with_sentence_1 > loglikelihood_with_sentence_2:
+                preds.append("1")
+            else:
+                preds.append("2")
+
+        return simple_accuracy_metric(preds=preds, golds=golds)


### PR DESCRIPTION
Support evaluating on StoryCloze

Also show a helpful error message if the dataset is missing. StoryCloze is one of the datasets that we should not distribute, so each person who does evaluation will need to download StoryCloze themselves. 

```
$ pip3 install -r requirements.txt
$ python3 main.py --model gpt2 --model_args device=cuda:0 --tasks storycloze --provide_description --num_fewshot 1
{
  "storycloze": {
    "major": 0.5852485301977552,
    "minor": {
      "acc": 0.5852485301977552
    },
    "higher_is_better": true
  }
}
```