### PR TITLE
Adopt new framework for `glue`

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -1,8 +1,7 @@
 import abc
 import random
-import collections
 import numpy as np
-from sklearn.metrics import precision_recall_fscore_support as score
+import sklearn
 
 class LM(abc.ABC):
     @abc.abstractmethod
@@ -177,15 +176,23 @@ class Dataset(abc.ABC):
         return description + labeled_examples + example
 
 
-
 def mean(arr):
     return sum(arr) / len(arr)
+
+def median(arr):
+    return arr[len(arr) // 2]
+
+def matthews_corrcoef(items):
+    unzipped_list = list(zip(*items))
+    golds = unzipped_list[0]
+    preds = unzipped_list[1]
+    return sklearn.metrics.matthews_corrcoef(golds, preds)
 
 def f1_score(items):
     unzipped_list = list(zip(*items))
     golds = unzipped_list[0]
     preds = unzipped_list[1]
-    precision, recall, fscore, support = score(golds, preds)
+    fscore = sklearn.metrics.f1_score(golds, preds)
     return max(fscore)
 
 def acc_all(items):
@@ -204,9 +211,6 @@ def acc_all(items):
             
     acc = np.mean([int(all(x)) for x in question_scoring_dict.values()])
     return acc
-
-def median(arr):
-    return arr[len(arr) // 2]
 
 req_ret_lens = {
     'loglikelihood': 2


### PR DESCRIPTION
# Changes

- Adopts new framework for all GLUE tasks, **except** for `STSB` which needs a proper replacement of `lm.generate(...)` following the `LM` API.
- Reorders similar tasks together for readability. E.g. All `Inference Tasks` get restructured to sit near each other.
- Introduces a new aggregator: `matthews_corrcoef`. Maybe all aggregators should get pulled out of `base` into a separate file or into `tasks/common.py`?

**Note**: The reordering of tasks messes with the git changelog display and could be hard to follow. I could resubmit a separate PR for this if wanted 👍 .