### PR TITLE
Implement `ARC` evaluation

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -47,8 +47,8 @@ TASK_REGISTRY = {
     "piqa": piqa.PiQA,
 
     #"triviaqa": triviaqa.TriviaQA,
-    # "arc_easy": arc.ARCEasy, # not implemented yet
-    # "arc_challenge": arc.ARCChallenge, # not implemented yet
+    "arc_easy": arc.ARCEasy,
+    "arc_challenge": arc.ARCChallenge,
     # "quac": quac.QuAC, # not implemented yet
     "hellaswag": hellaswag.HellaSwag, # not implemented yet
     # "openbookqa": openbookqa.OpenBookQA, # not implemented yet


### PR DESCRIPTION
# Changes

- Implements evaluation for ARC (Easy) and ARC (Challenge).
- Implements a `__clean_data` function to resolve issues with Hugging Face's unprocessed data.

## Note 
- `ARC` is one of those datasets that gpt3 reportedly performs better with proper normalization. See Section 2.4 Evaluation, Language Models are Few-Shot Learners:
`... on a small number of datasets (ARC, OpenBookQA, and RACE) we gain additional benefit as measured on the development set by normalizing by the unconditional probability of each completion, by computing P(completion|context) / P(completion|answer_context), where P(completion|answer context) answer context is the string "Answer: " or "A: " and is used to prompt that the completion should be an answer but is otherwise generic.` This may need to be addressed at some point in the future.

**Issue Reference**:  #15 