### PR TITLE
Fix `doc_to_text` passage bug

### DIFF
--- a/lm_eval/tasks/superglue.py
+++ b/lm_eval/tasks/superglue.py
@@ -435,11 +435,10 @@ class SGWinogradSchemaChallenge(HFTask):
 
     def doc_to_text(self, doc):
         raw_passage = doc["text"]
-        passage = (
-            raw_passage[:doc["span2_index"]]
-            + "*{}*".format(doc["span2_text"])
-            + raw_passage[doc["span2_index"] + len(doc["span2_text"]):]
-        )
+        # NOTE: HuggingFace span indices are word-based not character-based.
+        pre = " ".join(raw_passage.split()[:doc["span2_index"]])
+        post = raw_passage[len(pre) + len(doc["span2_text"]) + 1:]
+        passage = pre + " *{}*".format(doc['span2_text']) + post
         noun = doc["span1_text"]
         pronoun = doc["span2_text"]
         text = (


### PR DESCRIPTION
# Changes 

- Fixes a `SuperGLUE: WSC` bug where a document's text `passage` is built up from substrings that are mistakenly sliced at character-based indices as opposed to the word-based indices provided by the dataset.