### PR TITLE
Clean up `Ethics` few-shot prompts

### DIFF
--- a/lm_eval/tasks/hendrycks_ethics.py
+++ b/lm_eval/tasks/hendrycks_ethics.py
@@ -8,6 +8,12 @@ from lm_eval.metrics import mean
 from lm_eval.utils import sh
 from .common import yesno
 
+"""
+NOTE: The reported "group" accuracies for the Deontology, Justice, and Virtue
+tasks are refered to in this work as the `em` sub-metric. See Section 3. Metrics.
+of the paper.
+"""
+
 
 class Ethics(Task):
     def download(self):


### PR DESCRIPTION
# Changes
- Fix `yes`/`no` prompt target error that was a result of not casting numeric label strings to integers.
- Fix ambiguity in few-shot prompt target for Deontology and Justice tasks:`yes`/`no` -> `reasonable`/`unreasonable`.
- Include `excuse` sentence in Deontology prompt.
- Temporarily remove `hard_test` docs.
- Basic formatting changes.

