### PR TITLE
Update `download_file` calls to reflect api arg name change

### DIFF
--- a/lm_eval/tasks/qa4mre.py
+++ b/lm_eval/tasks/qa4mre.py
@@ -33,7 +33,7 @@ class QA4MRE(MultipleChoiceTask):
             download_file(
                 url_path,
                 f"data/qa4mre/QA4MRE-{year}-{lang}_GS.xml",
-                checksum=sha256sums[year],
+                sha256sums[year],
                 )
 
     def has_training_docs(self):


### PR DESCRIPTION
The latest `best_download.download_file` (v 0.07) update has changed the `checksum` parameter name to `expected_checksum`.