### PR TITLE
Always mkdir with parents

### DIFF
--- a/lm_eval/tasks/drop.py
+++ b/lm_eval/tasks/drop.py
@@ -23,7 +23,7 @@ class DROP(Task):
     def download(self):
         if self.DATASET_PATH.exists():
             return
-        Path.mkdir(self.DATASET_PATH)
+        Path.mkdir(self.DATASET_PATH, parents=True)
         url = "https://s3-us-west-2.amazonaws.com/allennlp/datasets/drop/drop_dataset.zip"
         checksum = "39d2278a29fd729de301b111a45f434c24834f40df8f4ff116d864589e3249d6"
         zip_path = self.DATASET_PATH / "drop_dataset.zip"

--- a/lm_eval/tasks/logiqa.py
+++ b/lm_eval/tasks/logiqa.py
@@ -10,7 +10,7 @@ class LogiQA(MultipleChoiceTask):
     def download(self):
         if self.DATASET_PATH.exists():
             return
-        Path.mkdir(self.DATASET_PATH)
+        Path.mkdir(self.DATASET_PATH, parents=True)
         base_url = "https://raw.githubusercontent.com/lgw863/LogiQA-dataset/master"
         splits = [
             {"name": "Train", "checksum": "7d5bb1f58278e33b395744cd2ad8d7600faa0b3c4d615c659a44ec1181d759fa"},

--- a/lm_eval/tasks/qa4mre.py
+++ b/lm_eval/tasks/qa4mre.py
@@ -28,7 +28,7 @@ class QA4MRE(MultipleChoiceTask):
         vpath = variable_year_path[year]
         url_path = f"{base_path}{vpath}QA4MRE-{year}-{lang}_GS.xml"
         if not os.path.exists("data/qa4mre"):
-            os.mkdir("data/qa4mre")
+            os.makedirs("data/qa4mre", exist_ok=True)
         if not os.path.isfile(f"data/qa4mre/QA4MRE-{year}-{lang}"):
             download_file(
                 url_path,

--- a/lm_eval/tasks/sciq.py
+++ b/lm_eval/tasks/sciq.py
@@ -10,7 +10,7 @@ class SciQ(MultipleChoiceTask):
     # Multiple languages and multiple years
     def download(self):
         if not os.path.exists('data/sciq'):
-            os.mkdir('data/sciq')
+            os.makedirs('data/sciq', exist_ok=True)
             download_file(
                 'https://ai2-public-datasets.s3.amazonaws.com/sciq/SciQ.zip',
                 'data/sciq/SciQ.zip', 


### PR DESCRIPTION
On a fresh clone of the repo when the `./data` directory has not been created yet, some of the custom datasets may fail because they use `mkdir` without `parents=True`.

For example,
```
python main.py --model gpt2 --device cuda:0 --tasks logiqa
```

Results in 
```
FileNotFoundError: [Errno 2] No such file or directory: 'data/logiqa'
```

This PR simply ensures that all `mkdir` commands (both from `os` and `pathlib`) create the necessary parent dirs.