### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         "sacrebleu==1.5.0",
         "pycountry==20.7.3",
         "numexpr==2.7.2",
-        "lm_dataformat==0.0.19",
+        "lm_dataformat==0.0.20",
         "pytest==6.2.3",
         "pybind11==2.6.2",
         "tqdm-multiprocess==0.0.11",


### PR DESCRIPTION
It was pointed out in https://github.com/EleutherAI/gpt-neox/issues/455 that we need to use `lm_dataformat>=0.0.20` to permit the user to use custom keys when streaming data. We have verified that `lm_dataformat>=0.0.20` doesn't break GPT-NeoX, but need to update the dependency here as well to prevent a version mismatch.