### PR TITLE
Update `headqa` deprecation warning to display on init only

### DIFF
--- a/lm_eval/tasks/headqa.py
+++ b/lm_eval/tasks/headqa.py
@@ -37,4 +37,6 @@ class HeadQAEs(HeadQABase):
 class HeadQAEsDeprecated(HeadQABase):
     DATASET_NAME = "es"
 
-    print("WARNING: headqa is deprecated. Please use headqa_es or headqa_en instead. See https://github.com/EleutherAI/lm-evaluation-harness/pull/240 for more info.")
+    def __init__(self):
+        super().__init__()
+        print("WARNING: headqa is deprecated. Please use headqa_es or headqa_en instead. See https://github.com/EleutherAI/lm-evaluation-harness/pull/240 for more info.")


### PR DESCRIPTION
**UX update**
Currently, the `headqa` deprecation warning is displayed for unrelated tasks. This PR changes the behavior to warn only if `headqa` is specified as a task arg across any of the user level interfaces.