### PR TITLE
Add citations and descriptions to all tasks

### DIFF
--- a/docs/task_guide.md
+++ b/docs/task_guide.md
@@ -23,12 +23,35 @@ cd lm_eval/tasks
 touch <task-name>.py
 ```
 
-Then open the file and create a multiline docstring on the first line with the name of the paper associated with your task/s on one line, the paper’s url on the next line, and its BibTeX Code on another. For example, take the QuAC dataset. You’d write:
+Then open the file and create a multiline docstring on the first line with the following contents:
+
+```python
+"""
+<Paper title>
+<Paper PDF URL>
+
+<Short description of task>
+
+Homepage: <URL to task's homepage>
+
+<Citation>
+"""
+```
+
+For example, take the QuAC dataset. We have:
 
 ```python
 """
 QuAC: Question Answering in Context
 https://arxiv.org/abs/1808.07036
+
+Question Answering in Context (QuAC) is a dataset for modeling, understanding, and 
+participating in information seeking dialog. Data instances consist of an interactive
+dialog between two crowd workers: (1) a student who poses a sequence of freeform
+questions to learn as much as possible about a hidden Wikipedia text, and (2)
+a teacher who answers the questions by providing short excerpts (spans) from the text.
+
+Homepage: https://quac.ai/
 
 @article{choi2018quac,
   title={Quac: Question answering in context},

--- a/docs/task_guide.md
+++ b/docs/task_guide.md
@@ -33,8 +33,6 @@ Then open the file and create a multiline docstring on the first line with the f
 <Short description of task>
 
 Homepage: <URL to task's homepage>
-
-<Citation>
 """
 ```
 
@@ -52,15 +50,11 @@ questions to learn as much as possible about a hidden Wikipedia text, and (2)
 a teacher who answers the questions by providing short excerpts (spans) from the text.
 
 Homepage: https://quac.ai/
-
-@article{choi2018quac,
-  title={Quac: Question answering in context},
-  author={Choi, Eunsol and He, He and Iyyer, Mohit and Yatskar, Mark and Yih, Wen-tau and Choi, Yejin and Liang, Percy and Zettlemoyer, Luke},
-  journal={arXiv preprint arXiv:1808.07036},
-  year={2018}
-}
 """
 ```
+
+Next, at the module-level, create a constant variable named
+`_CITATION` that contains the citation information for your task in BibTeX format.
 
 Now let's walk through the actual implementation - from data handling to evaluation.
 

--- a/lm_eval/tasks/anli.py
+++ b/lm_eval/tasks/anli.py
@@ -8,7 +8,14 @@ increase in difficulty and complexity, and each question-answer includes annotat
 provided explanations.
 
 Homepage: "https://github.com/facebookresearch/anli"
+"""
+import numpy as np
+from lm_eval.base import rf
+from ..metrics import mean
+from . common import HFTask
 
+
+_CITATION = """
 @inproceedings{nie-etal-2020-adversarial,
     title = "Adversarial {NLI}: A New Benchmark for Natural Language Understanding",
     author = "Nie, Yixin  and
@@ -22,10 +29,6 @@ Homepage: "https://github.com/facebookresearch/anli"
     publisher = "Association for Computational Linguistics",
 }
 """
-import numpy as np
-from lm_eval.base import rf
-from ..metrics import mean
-from . common import HFTask
 
 
 class ANLIBase(HFTask):

--- a/lm_eval/tasks/anli.py
+++ b/lm_eval/tasks/anli.py
@@ -1,3 +1,27 @@
+"""
+Adversarial NLI: A New Benchmark for Natural Language Understanding
+https://arxiv.org/pdf/1910.14599.pdf
+
+Adversarial NLI (ANLI) is a dataset collected via an iterative, adversarial
+human-and-model-in-the-loop procedure. It consists of three rounds that progressively
+increase in difficulty and complexity, and each question-answer includes annotator-
+provided explanations.
+
+Homepage: "https://github.com/facebookresearch/anli"
+
+@inproceedings{nie-etal-2020-adversarial,
+    title = "Adversarial {NLI}: A New Benchmark for Natural Language Understanding",
+    author = "Nie, Yixin  and
+      Williams, Adina  and
+      Dinan, Emily  and
+      Bansal, Mohit  and
+      Weston, Jason  and
+      Kiela, Douwe",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+    year = "2020",
+    publisher = "Association for Computational Linguistics",
+}
+"""
 import numpy as np
 from lm_eval.base import rf
 from ..metrics import mean

--- a/lm_eval/tasks/arc.py
+++ b/lm_eval/tasks/arc.py
@@ -11,7 +11,12 @@ into a Challenge Set of 2,590 “hard” questions (those that both a retrieval 
 a co-occurrence method fail to answer correctly) and an Easy Set of 5,197 questions.
 
 Homepage: https://allenai.org/data/arc
+"""
+from lm_eval.base import MultipleChoiceTask
+from . common import HFTask
 
+
+_CITATION = """
 @article{Clark2018ThinkYH,
   title={Think you have Solved Question Answering? Try ARC, the AI2 Reasoning Challenge},
   author={Peter Clark and Isaac Cowhey and Oren Etzioni and Tushar Khot and Ashish Sabharwal and Carissa Schoenick and Oyvind Tafjord},
@@ -20,8 +25,6 @@ Homepage: https://allenai.org/data/arc
   volume={abs/1803.05457}
 }
 """
-from lm_eval.base import MultipleChoiceTask
-from . common import HFTask
 
 
 class ARCEasy(HFTask, MultipleChoiceTask):

--- a/lm_eval/tasks/arc.py
+++ b/lm_eval/tasks/arc.py
@@ -1,3 +1,25 @@
+"""
+Think you have Solved Question Answering? Try ARC, the AI2 Reasoning Challenge
+https://arxiv.org/pdf/1803.05457.pdf
+
+The ARC dataset consists of 7,787 science exam questions drawn from a variety
+of sources, including science questions provided under license by a research
+partner affiliated with AI2. These are text-only, English language exam questions
+that span several grade levels as indicated in the files. Each question has a
+multiple choice structure (typically 4 answer options). The questions are sorted
+into a Challenge Set of 2,590 “hard” questions (those that both a retrieval and
+a co-occurrence method fail to answer correctly) and an Easy Set of 5,197 questions.
+
+Homepage: https://allenai.org/data/arc
+
+@article{Clark2018ThinkYH,
+  title={Think you have Solved Question Answering? Try ARC, the AI2 Reasoning Challenge},
+  author={Peter Clark and Isaac Cowhey and Oren Etzioni and Tushar Khot and Ashish Sabharwal and Carissa Schoenick and Oyvind Tafjord},
+  journal={ArXiv},
+  year={2018},
+  volume={abs/1803.05457}
+}
+"""
 from lm_eval.base import MultipleChoiceTask
 from . common import HFTask
 

--- a/lm_eval/tasks/arithmetic.py
+++ b/lm_eval/tasks/arithmetic.py
@@ -6,18 +6,6 @@ A small battery of 10 tests that involve asking language models a simple arithme
 problem in natural language.
 
 Homepage: https://github.com/openai/gpt-3/tree/master/data
-
-@inproceedings{NEURIPS2020_1457c0d6,
- author = {Brown, Tom and Mann, Benjamin and Ryder, Nick and Subbiah, Melanie and Kaplan, Jared D and Dhariwal, Prafulla and Neelakantan, Arvind and Shyam, Pranav and Sastry, Girish and Askell, Amanda and Agarwal, Sandhini and Herbert-Voss, Ariel and Krueger, Gretchen and Henighan, Tom and Child, Rewon and Ramesh, Aditya and Ziegler, Daniel and Wu, Jeffrey and Winter, Clemens and Hesse, Chris and Chen, Mark and Sigler, Eric and Litwin, Mateusz and Gray, Scott and Chess, Benjamin and Clark, Jack and Berner, Christopher and McCandlish, Sam and Radford, Alec and Sutskever, Ilya and Amodei, Dario},
- booktitle = {Advances in Neural Information Processing Systems},
- editor = {H. Larochelle and M. Ranzato and R. Hadsell and M. F. Balcan and H. Lin},
- pages = {1877--1901},
- publisher = {Curran Associates, Inc.},
- title = {Language Models are Few-Shot Learners},
- url = {https://proceedings.neurips.cc/paper/2020/file/1457c0d6bfcb4967418bfb8ac142f64a-Paper.pdf},
- volume = {33},
- year = {2020}
-}
 """
 import abc
 import json
@@ -26,6 +14,22 @@ from collections import namedtuple
 from lm_eval.base import Task, rf
 from lm_eval.metrics import mean
 from best_download import download_file
+
+
+_CITATION = """
+@inproceedings{NEURIPS2020_1457c0d6,
+    author = {Brown, Tom and Mann, Benjamin and Ryder, Nick and Subbiah, Melanie and Kaplan, Jared D and Dhariwal, Prafulla and Neelakantan, Arvind and Shyam, Pranav and Sastry, Girish and Askell, Amanda and Agarwal, Sandhini and Herbert-Voss, Ariel and Krueger, Gretchen and Henighan, Tom and Child, Rewon and Ramesh, Aditya and Ziegler, Daniel and Wu, Jeffrey and Winter, Clemens and Hesse, Chris and Chen, Mark and Sigler, Eric and Litwin, Mateusz and Gray, Scott and Chess, Benjamin and Clark, Jack and Berner, Christopher and McCandlish, Sam and Radford, Alec and Sutskever, Ilya and Amodei, Dario},
+    booktitle = {Advances in Neural Information Processing Systems},
+    editor = {H. Larochelle and M. Ranzato and R. Hadsell and M. F. Balcan and H. Lin},
+    pages = {1877--1901},
+    publisher = {Curran Associates, Inc.},
+    title = {Language Models are Few-Shot Learners},
+    url = {https://proceedings.neurips.cc/paper/2020/file/1457c0d6bfcb4967418bfb8ac142f64a-Paper.pdf},
+    volume = {33},
+    year = {2020}
+}
+"""
+
 
 ArithmeticDoc = namedtuple('ArithmeticDoc', ['context', 'completion'])
 

--- a/lm_eval/tasks/arithmetic.py
+++ b/lm_eval/tasks/arithmetic.py
@@ -1,3 +1,24 @@
+"""
+Language Models are Few-Shot Learners
+https://arxiv.org/pdf/2005.14165.pdf
+
+A small battery of 10 tests that involve asking language models a simple arithmetic
+problem in natural language.
+
+Homepage: https://github.com/openai/gpt-3/tree/master/data
+
+@inproceedings{NEURIPS2020_1457c0d6,
+ author = {Brown, Tom and Mann, Benjamin and Ryder, Nick and Subbiah, Melanie and Kaplan, Jared D and Dhariwal, Prafulla and Neelakantan, Arvind and Shyam, Pranav and Sastry, Girish and Askell, Amanda and Agarwal, Sandhini and Herbert-Voss, Ariel and Krueger, Gretchen and Henighan, Tom and Child, Rewon and Ramesh, Aditya and Ziegler, Daniel and Wu, Jeffrey and Winter, Clemens and Hesse, Chris and Chen, Mark and Sigler, Eric and Litwin, Mateusz and Gray, Scott and Chess, Benjamin and Clark, Jack and Berner, Christopher and McCandlish, Sam and Radford, Alec and Sutskever, Ilya and Amodei, Dario},
+ booktitle = {Advances in Neural Information Processing Systems},
+ editor = {H. Larochelle and M. Ranzato and R. Hadsell and M. F. Balcan and H. Lin},
+ pages = {1877--1901},
+ publisher = {Curran Associates, Inc.},
+ title = {Language Models are Few-Shot Learners},
+ url = {https://proceedings.neurips.cc/paper/2020/file/1457c0d6bfcb4967418bfb8ac142f64a-Paper.pdf},
+ volume = {33},
+ year = {2020}
+}
+"""
 import abc
 import json
 import os

--- a/lm_eval/tasks/asdiv.py
+++ b/lm_eval/tasks/asdiv.py
@@ -13,15 +13,6 @@ level (for indicating the level of difficulty).
 NOTE: We currently ignore formulas for answer generation.
 
 Homepage: https://github.com/chaochun/nlu-asdiv-dataset
-
-@misc{miao2021diverse,
-      title={A Diverse Corpus for Evaluating and Developing English Math Word Problem Solvers},
-      author={Shen-Yun Miao and Chao-Chun Liang and Keh-Yih Su},
-      year={2021},
-      eprint={2106.15772},
-      archivePrefix={arXiv},
-      primaryClass={cs.AI}
-}
 """
 from lm_eval.base import Task
 from pathlib import Path
@@ -32,6 +23,18 @@ from lm_eval.metrics import mean,perplexity
 import numpy as np
 from zipfile import ZipFile
 import os 
+
+
+_CITATION = """
+@misc{miao2021diverse,
+    title={A Diverse Corpus for Evaluating and Developing English Math Word Problem Solvers},
+    author={Shen-Yun Miao and Chao-Chun Liang and Keh-Yih Su},
+    year={2021},
+    eprint={2106.15772},
+    archivePrefix={arXiv},
+    primaryClass={cs.AI}
+}
+"""
 
 
 class Asdiv(Task):

--- a/lm_eval/tasks/asdiv.py
+++ b/lm_eval/tasks/asdiv.py
@@ -2,6 +2,18 @@
 ASDiv: A Diverse Corpus for Evaluating and Developing English Math Word Problem Solvers
 https://arxiv.org/abs/2106.15772
 
+ASDiv (Academia Sinica Diverse MWP Dataset) is a diverse (in terms of both language
+patterns and problem types) English math word problem (MWP) corpus for evaluating
+the capability of various MWP solvers. Existing MWP corpora for studying AI progress
+remain limited either in language usage patterns or in problem types. We thus present
+a new English MWP corpus with 2,305 MWPs that cover more text patterns and most problem
+types taught in elementary school. Each MWP is annotated with its problem type and grade
+level (for indicating the level of difficulty).
+
+NOTE: We currently ignore formulas for answer generation.
+
+Homepage: https://github.com/chaochun/nlu-asdiv-dataset
+
 @misc{miao2021diverse,
       title={A Diverse Corpus for Evaluating and Developing English Math Word Problem Solvers},
       author={Shen-Yun Miao and Chao-Chun Liang and Keh-Yih Su},
@@ -21,9 +33,7 @@ import numpy as np
 from zipfile import ZipFile
 import os 
 
-#currently ignoring formula for answer generation
 
-# given a subset, splits return the docs 
 class Asdiv(Task):
     VERSION = 0
     DATASET_PATH = Path("data/asdiv")

--- a/lm_eval/tasks/blimp.py
+++ b/lm_eval/tasks/blimp.py
@@ -9,7 +9,13 @@ or semantics. The data is automatically generated according to expert-crafted
 grammars.
 
 Homepage: https://github.com/alexwarstadt/blimp
+"""
+from lm_eval.base import rf
+from lm_eval.metrics import mean
+from .common import HFTask
 
+
+_CITATION = """
 @article{warstadt2019blimp,
     author = {Warstadt, Alex and Parrish, Alicia and Liu, Haokun and Mohananey, Anhad and Peng, Wei and Wang, Sheng-Fu and Bowman, Samuel R.},
     title = {BLiMP: The Benchmark of Linguistic Minimal Pairs for English},
@@ -24,10 +30,6 @@ Homepage: https://github.com/alexwarstadt/blimp
     abstract = { We introduce The Benchmark of Linguistic Minimal Pairs (BLiMP),1 a challenge set for evaluating the linguistic knowledge of language models (LMs) on major grammatical phenomena in English. BLiMP consists of 67 individual datasets, each containing 1,000 minimal pairs—that is, pairs of minimally different sentences that contrast in grammatical acceptability and isolate specific phenomenon in syntax, morphology, or semantics. We generate the data according to linguist-crafted grammar templates, and human aggregate agreement with the labels is 96.4\%. We evaluate n-gram, LSTM, and Transformer (GPT-2 and Transformer-XL) LMs by observing whether they assign a higher probability to the acceptable sentence in each minimal pair. We find that state-of-the-art models identify morphological contrasts related to agreement reliably, but they struggle with some subtle semantic and syntactic phenomena, such as negative polarity items and extraction islands. }
 }
 """
-
-from lm_eval.base import rf
-from lm_eval.metrics import mean
-from .common import HFTask
 
 
 class BlimpTask(HFTask):

--- a/lm_eval/tasks/blimp.py
+++ b/lm_eval/tasks/blimp.py
@@ -2,11 +2,26 @@
 BLiMP: A Benchmark of Linguistic Minimal Pairs for English
 https://arxiv.org/abs/1912.00582
 
+BLiMP is a challenge set for evaluating what language models (LMs) know about
+major grammatical phenomena in English. BLiMP consists of 67 sub-datasets, each
+containing 1000 minimal pairs isolating specific contrasts in syntax, morphology,
+or semantics. The data is automatically generated according to expert-crafted
+grammars.
+
+Homepage: https://github.com/alexwarstadt/blimp
+
 @article{warstadt2019blimp,
-  title={BLiMP: A Benchmark of Linguistic Minimal Pairs for English},
-  author={Warstadt, Alex and Parrish, Alicia and Liu, Haokun and Mohananey, Anhad and Peng, Wei, and Wang, Sheng-Fu and Bowman, Samuel R},
-  journal={arXiv preprint arXiv:1912.00582},
-  year={2019}
+    author = {Warstadt, Alex and Parrish, Alicia and Liu, Haokun and Mohananey, Anhad and Peng, Wei and Wang, Sheng-Fu and Bowman, Samuel R.},
+    title = {BLiMP: The Benchmark of Linguistic Minimal Pairs for English},
+    journal = {Transactions of the Association for Computational Linguistics},
+    volume = {8},
+    number = {},
+    pages = {377-392},
+    year = {2020},
+    doi = {10.1162/tacl\_a\_00321},
+    URL = {https://doi.org/10.1162/tacl_a_00321},
+    eprint = {https://doi.org/10.1162/tacl_a_00321},
+    abstract = { We introduce The Benchmark of Linguistic Minimal Pairs (BLiMP),1 a challenge set for evaluating the linguistic knowledge of language models (LMs) on major grammatical phenomena in English. BLiMP consists of 67 individual datasets, each containing 1,000 minimal pairs—that is, pairs of minimally different sentences that contrast in grammatical acceptability and isolate specific phenomenon in syntax, morphology, or semantics. We generate the data according to linguist-crafted grammar templates, and human aggregate agreement with the labels is 96.4\%. We evaluate n-gram, LSTM, and Transformer (GPT-2 and Transformer-XL) LMs by observing whether they assign a higher probability to the acceptable sentence in each minimal pair. We find that state-of-the-art models identify morphological contrasts related to agreement reliably, but they struggle with some subtle semantic and syntactic phenomena, such as negative polarity items and extraction islands. }
 }
 """
 

--- a/lm_eval/tasks/cbt.py
+++ b/lm_eval/tasks/cbt.py
@@ -11,20 +11,23 @@ NOTE: This evaluation is based on the (context + query) question-answering varia
 used by the Recurrent Language Models described in the paper. See section 4.4.
 
 Homepage: https://github.com/facebookresearch/ParlAI/tree/main/parlai/tasks/cbt
-    
-@misc{hill2016goldilocks,
-      title={The Goldilocks Principle: Reading Children's Books with Explicit Memory Representations}, 
-      author={Felix Hill and Antoine Bordes and Sumit Chopra and Jason Weston},
-      year={2016},
-      eprint={1511.02301},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}
 """
 import numpy as np
 from lm_eval.base import rf
 from lm_eval.metrics import mean
 from .common import HFTask
+
+
+_CITATION = """
+@misc{hill2016goldilocks,
+    title={The Goldilocks Principle: Reading Children's Books with Explicit Memory Representations}, 
+    author={Felix Hill and Antoine Bordes and Sumit Chopra and Jason Weston},
+    year={2016},
+    eprint={1511.02301},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
 
 
 class CBTBase(HFTask):

--- a/lm_eval/tasks/cbt.py
+++ b/lm_eval/tasks/cbt.py
@@ -1,3 +1,26 @@
+"""
+The Children’s Book Test (CBT) from the paper:
+https://research.fb.com/wp-content/uploads/2016/11/the_goldilocks_principle_reading_children_s_books_with_explicit_memory_representations.pdf
+
+The Children's Book Test (CBT) is test of how well language models capture 
+meaning in children's books. Unlike standard language modelling benchmarks,
+it distinguishes the task of predicting syntactic function words from that
+of predicting lower-frequency words, which carry greater semantic content.
+
+NOTE: This evaluation is based on the (context + query) question-answering variant
+used by the Recurrent Language Models described in the paper. See section 4.4.
+
+Homepage: https://github.com/facebookresearch/ParlAI/tree/main/parlai/tasks/cbt
+    
+@misc{hill2016goldilocks,
+      title={The Goldilocks Principle: Reading Children's Books with Explicit Memory Representations}, 
+      author={Felix Hill and Antoine Bordes and Sumit Chopra and Jason Weston},
+      year={2016},
+      eprint={1511.02301},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
 import numpy as np
 from lm_eval.base import rf
 from lm_eval.metrics import mean
@@ -5,17 +28,10 @@ from .common import HFTask
 
 
 class CBTBase(HFTask):
-    """The Children’s Book Test (CBT) from the paper:
-    https://research.fb.com/wp-content/uploads/2016/11/the_goldilocks_principle_reading_children_s_books_with_explicit_memory_representations.pdf
-    NOTE: This evaluation is based on the (context + query) question-answering variant
-    used by the Recurrent Language Models described in the aforementioned paper.
-    See section 4.4.
-    """
-
+    VERSION = 0
     DATASET_PATH = "cbt"
     DATASET_NAME = None
 
-    VERSION = 0
 
     def detokenize(self, text):
         text = text.replace(" '", "'")

--- a/lm_eval/tasks/coqa.py
+++ b/lm_eval/tasks/coqa.py
@@ -1,3 +1,23 @@
+"""
+CoQA: A Conversational Question Answering Challenge
+https://arxiv.org/pdf/1808.07042.pdf
+
+CoQA is a large-scale dataset for building Conversational Question Answering 
+systems. The goal of the CoQA challenge is to measure the ability of machines to 
+understand a text passage and answer a series of interconnected questions that 
+appear in a conversation.
+
+Homepage: https://stanfordnlp.github.io/coqa/
+
+@misc{reddy2018coqa,
+    title={CoQA: A Conversational Question Answering Challenge},
+    author={Siva Reddy and Danqi Chen and Christopher D. Manning},
+    year={2018},
+    eprint={1808.07042},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
 import os
 import json
 import transformers.data.metrics.squad_metrics as squad_metrics

--- a/lm_eval/tasks/coqa.py
+++ b/lm_eval/tasks/coqa.py
@@ -8,7 +8,17 @@ understand a text passage and answer a series of interconnected questions that
 appear in a conversation.
 
 Homepage: https://stanfordnlp.github.io/coqa/
+"""
+import os
+import json
+import transformers.data.metrics.squad_metrics as squad_metrics
+from lm_eval.base import Task, rf, mean
+from ..utils import sh
+from itertools import zip_longest
+from best_download import download_file
 
+
+_CITATION = """
 @misc{reddy2018coqa,
     title={CoQA: A Conversational Question Answering Challenge},
     author={Siva Reddy and Danqi Chen and Christopher D. Manning},
@@ -18,13 +28,6 @@ Homepage: https://stanfordnlp.github.io/coqa/
     primaryClass={cs.CL}
 }
 """
-import os
-import json
-import transformers.data.metrics.squad_metrics as squad_metrics
-from lm_eval.base import Task, rf, mean
-from ..utils import sh
-from itertools import zip_longest
-from best_download import download_file
 
 
 class CoQA(Task):

--- a/lm_eval/tasks/drop.py
+++ b/lm_eval/tasks/drop.py
@@ -1,3 +1,26 @@
+"""
+DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs
+https://aclanthology.org/attachments/N19-1246.Supplementary.pdf
+
+DROP is a QA dataset which tests comprehensive understanding of paragraphs. In 
+this crowdsourced, adversarially-created, 96k question-answering benchmark, a 
+system must resolve multiple references in a question, map them onto a paragraph,
+and perform discrete operations over them (such as addition, counting, or sorting).
+
+Homepage: https://allenai.org/data/drop
+
+Acknowledgement: This implementation is based on the official evaluation for `DROP`:
+https://github.com/allenai/allennlp-reading-comprehension/blob/master/allennlp_rc/eval/drop_eval.py
+
+@misc{dua2019drop,
+      title={DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs}, 
+      author={Dheeru Dua and Yizhong Wang and Pradeep Dasigi and Gabriel Stanovsky and Sameer Singh and Matt Gardner},
+      year={2019},
+      eprint={1903.00161},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
 import json
 import numpy as np
 import re
@@ -9,12 +32,8 @@ from lm_eval.metrics import mean
 from pathlib import Path
 from zipfile import ZipFile
 
-"""
-Acknowledgement: This implementation is based on the official evaluation for `DROP`:
-https://github.com/allenai/allennlp-reading-comprehension/blob/master/allennlp_rc/eval/drop_eval.py
-"""
-
 _ARTICLES = re.compile(r"\b(a|an|the)\b", re.UNICODE)
+
 
 class DROP(Task):
     VERSION = 1

--- a/lm_eval/tasks/drop.py
+++ b/lm_eval/tasks/drop.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from zipfile import ZipFile
 
 
-_CITATIONS = """
+_CITATION = """
 @misc{dua2019drop,
     title={DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs}, 
     author={Dheeru Dua and Yizhong Wang and Pradeep Dasigi and Gabriel Stanovsky and Sameer Singh and Matt Gardner},

--- a/lm_eval/tasks/drop.py
+++ b/lm_eval/tasks/drop.py
@@ -11,15 +11,6 @@ Homepage: https://allenai.org/data/drop
 
 Acknowledgement: This implementation is based on the official evaluation for `DROP`:
 https://github.com/allenai/allennlp-reading-comprehension/blob/master/allennlp_rc/eval/drop_eval.py
-
-@misc{dua2019drop,
-      title={DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs}, 
-      author={Dheeru Dua and Yizhong Wang and Pradeep Dasigi and Gabriel Stanovsky and Sameer Singh and Matt Gardner},
-      year={2019},
-      eprint={1903.00161},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}
 """
 import json
 import numpy as np
@@ -31,6 +22,19 @@ from lm_eval.base import Task, rf
 from lm_eval.metrics import mean
 from pathlib import Path
 from zipfile import ZipFile
+
+
+_CITATIONS = """
+@misc{dua2019drop,
+    title={DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs}, 
+    author={Dheeru Dua and Yizhong Wang and Pradeep Dasigi and Gabriel Stanovsky and Sameer Singh and Matt Gardner},
+    year={2019},
+    eprint={1903.00161},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
+
 
 _ARTICLES = re.compile(r"\b(a|an|the)\b", re.UNICODE)
 

--- a/lm_eval/tasks/glue.py
+++ b/lm_eval/tasks/glue.py
@@ -12,7 +12,16 @@ sizes, text genres, and degrees of difficulty, and
 respect to a wide range of linguistic phenomena found in natural language.
 
 Homepage: https://gluebenchmark.com/
+"""
+import numpy as np
+from lm_eval.base import rf
+from ..metrics import mean, matthews_corrcoef, f1_score
+from . common import HFTask, yesno
+from ..utils import general_detokenize
 
+
+# TODO(jon-tow): Add citations for the individual datasets/tasks that make up GLUE.
+_CITATION = """
 @inproceedings{wang-etal-2018-glue,
     title = "{GLUE}: A Multi-Task Benchmark and Analysis Platform for Natural Language Understanding",
     author = "Wang, Alex  and
@@ -32,11 +41,7 @@ Homepage: https://gluebenchmark.com/
     abstract = "Human ability to understand language is \textit{general, flexible, and robust}. In contrast, most NLU models above the word level are designed for a specific task and struggle with out-of-domain data. If we aspire to develop models with understanding beyond the detection of superficial correspondences between inputs and outputs, then it is critical to develop a unified model that can execute a range of linguistic tasks across different domains. To facilitate research in this direction, we present the General Language Understanding Evaluation (GLUE, gluebenchmark.com): a benchmark of nine diverse NLU tasks, an auxiliary dataset for probing models for understanding of specific linguistic phenomena, and an online platform for evaluating and comparing models. For some benchmark tasks, training data is plentiful, but for others it is limited or does not match the genre of the test set. GLUE thus favors models that can represent linguistic knowledge in a way that facilitates sample-efficient learning and effective knowledge-transfer across tasks. While none of the datasets in GLUE were created from scratch for the benchmark, four of them feature privately-held test data, which is used to ensure that the benchmark is used fairly. We evaluate baselines that use ELMo (Peters et al., 2018), a powerful transfer learning technique, as well as state-of-the-art sentence representation models. The best models still achieve fairly low absolute scores. Analysis with our diagnostic dataset yields similarly weak performance over all phenomena tested, with some exceptions.",
 }
 """
-import numpy as np
-from lm_eval.base import rf
-from ..metrics import mean, matthews_corrcoef, f1_score
-from . common import HFTask, yesno
-from ..utils import general_detokenize
+
 
 # Single-Sentence Tasks
 

--- a/lm_eval/tasks/glue.py
+++ b/lm_eval/tasks/glue.py
@@ -1,3 +1,37 @@
+"""
+GLUE: A Multi-Task Benchmark and Analysis Platform for Natural Language Understanding
+https://openreview.net/pdf?id=rJ4km2R5t7
+
+The General Language Understanding Evaluation (GLUE) benchmark is a collection of
+resources for training, evaluating, and analyzing natural language understanding
+systems. GLUE consists of:
+- A benchmark of nine sentence- or sentence-pair language understanding tasks built
+on established existing datasets and selected to cover a diverse range of dataset
+sizes, text genres, and degrees of difficulty, and
+- A diagnostic dataset designed to evaluate and analyze model performance with
+respect to a wide range of linguistic phenomena found in natural language.
+
+Homepage: https://gluebenchmark.com/
+
+@inproceedings{wang-etal-2018-glue,
+    title = "{GLUE}: A Multi-Task Benchmark and Analysis Platform for Natural Language Understanding",
+    author = "Wang, Alex  and
+      Singh, Amanpreet  and
+      Michael, Julian  and
+      Hill, Felix  and
+      Levy, Omer  and
+      Bowman, Samuel",
+    booktitle = "Proceedings of the 2018 {EMNLP} Workshop {B}lackbox{NLP}: Analyzing and Interpreting Neural Networks for {NLP}",
+    month = nov,
+    year = "2018",
+    address = "Brussels, Belgium",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/W18-5446",
+    doi = "10.18653/v1/W18-5446",
+    pages = "353--355",
+    abstract = "Human ability to understand language is \textit{general, flexible, and robust}. In contrast, most NLU models above the word level are designed for a specific task and struggle with out-of-domain data. If we aspire to develop models with understanding beyond the detection of superficial correspondences between inputs and outputs, then it is critical to develop a unified model that can execute a range of linguistic tasks across different domains. To facilitate research in this direction, we present the General Language Understanding Evaluation (GLUE, gluebenchmark.com): a benchmark of nine diverse NLU tasks, an auxiliary dataset for probing models for understanding of specific linguistic phenomena, and an online platform for evaluating and comparing models. For some benchmark tasks, training data is plentiful, but for others it is limited or does not match the genre of the test set. GLUE thus favors models that can represent linguistic knowledge in a way that facilitates sample-efficient learning and effective knowledge-transfer across tasks. While none of the datasets in GLUE were created from scratch for the benchmark, four of them feature privately-held test data, which is used to ensure that the benchmark is used fairly. We evaluate baselines that use ELMo (Peters et al., 2018), a powerful transfer learning technique, as well as state-of-the-art sentence representation models. The best models still achieve fairly low absolute scores. Analysis with our diagnostic dataset yields similarly weak performance over all phenomena tested, with some exceptions.",
+}
+"""
 import numpy as np
 from lm_eval.base import rf
 from ..metrics import mean, matthews_corrcoef, f1_score

--- a/lm_eval/tasks/gsm8k.py
+++ b/lm_eval/tasks/gsm8k.py
@@ -15,7 +15,17 @@ for how to make use of the dataset's calculator annotations in your language
 model's sample/generation function.
 
 Homepage: https://github.com/openai/grade-school-math
+"""
 
+import json
+import re
+from best_download import download_file
+from pathlib import Path
+from lm_eval.base import Task, rf
+from lm_eval.metrics import mean
+
+
+_CITATION = """
 @misc{cobbe2021training,
       title={Training Verifiers to Solve Math Word Problems},
       author={Karl Cobbe and Vineet Kosaraju and Mohammad Bavarian and Jacob Hilton and Reiichiro Nakano and Christopher Hesse and John Schulman},
@@ -26,12 +36,6 @@ Homepage: https://github.com/openai/grade-school-math
 }
 """
 
-import json
-import re
-from best_download import download_file
-from pathlib import Path
-from lm_eval.base import Task, rf
-from lm_eval.metrics import mean
 
 ANS_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
 INVALID_ANS = "[invalid]"

--- a/lm_eval/tasks/gsm8k.py
+++ b/lm_eval/tasks/gsm8k.py
@@ -2,6 +2,20 @@
 "Training Verifiers to Solve Math Word Problems"
 https://arxiv.org/abs/2110.14168
 
+State-of-the-art language models can match human performance on many tasks, but 
+they still struggle to robustly perform multi-step mathematical reasoning. To 
+diagnose the failures of current models and support research, we introduce GSM8K,
+a dataset of 8.5K high quality linguistically diverse grade school math word problems.
+We find that even the largest transformer models fail to achieve high test performance, 
+despite the conceptual simplicity of this problem distribution.
+
+NOTE: See the official implementation of the task: 
+    https://github.com/openai/grade-school-math/blob/master/grade_school_math/calculator.py
+for how to make use of the dataset's calculator annotations in your language
+model's sample/generation function.
+
+Homepage: https://github.com/openai/grade-school-math
+
 @misc{cobbe2021training,
       title={Training Verifiers to Solve Math Word Problems},
       author={Karl Cobbe and Vineet Kosaraju and Mohammad Bavarian and Jacob Hilton and Reiichiro Nakano and Christopher Hesse and John Schulman},
@@ -10,11 +24,6 @@ https://arxiv.org/abs/2110.14168
       archivePrefix={arXiv},
       primaryClass={cs.LG}
 }
-
-NOTE: See the official implementation of the task: 
-    https://github.com/openai/grade-school-math/blob/master/grade_school_math/calculator.py
-for how to make use of the dataset's calculator annotations in your language
-model's sample/generation function.
 """
 
 import json

--- a/lm_eval/tasks/headqa.py
+++ b/lm_eval/tasks/headqa.py
@@ -1,3 +1,22 @@
+"""
+Interpretable Multi-Step Reasoning with Knowledge Extraction on Complex Healthcare Question Answering
+https://aclanthology.org/P19-1092.pdf
+
+HEAD-QA is a multi-choice HEAlthcare Dataset. The questions come from exams to 
+access a specialized position in the Spanish healthcare system, and are challenging
+even for highly specialized humans.
+
+Homepage: https://aghie.github.io/head-qa/
+
+@misc{liu2020interpretable,
+      title={Interpretable Multi-Step Reasoning with Knowledge Extraction on Complex Healthcare Question Answering}, 
+      author={Ye Liu and Shaika Chowdhury and Chenwei Zhang and Cornelia Caragea and Philip S. Yu},
+      year={2020},
+      eprint={2008.02434},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI}
+}
+"""
 from . common import HFTask
 from lm_eval.base import MultipleChoiceTask
 

--- a/lm_eval/tasks/headqa.py
+++ b/lm_eval/tasks/headqa.py
@@ -7,18 +7,21 @@ access a specialized position in the Spanish healthcare system, and are challeng
 even for highly specialized humans.
 
 Homepage: https://aghie.github.io/head-qa/
-
-@misc{liu2020interpretable,
-      title={Interpretable Multi-Step Reasoning with Knowledge Extraction on Complex Healthcare Question Answering}, 
-      author={Ye Liu and Shaika Chowdhury and Chenwei Zhang and Cornelia Caragea and Philip S. Yu},
-      year={2020},
-      eprint={2008.02434},
-      archivePrefix={arXiv},
-      primaryClass={cs.AI}
-}
 """
 from . common import HFTask
 from lm_eval.base import MultipleChoiceTask
+
+
+_CITATION = """
+@misc{liu2020interpretable,
+    title={Interpretable Multi-Step Reasoning with Knowledge Extraction on Complex Healthcare Question Answering}, 
+    author={Ye Liu and Shaika Chowdhury and Chenwei Zhang and Cornelia Caragea and Philip S. Yu},
+    year={2020},
+    eprint={2008.02434},
+    archivePrefix={arXiv},
+    primaryClass={cs.AI}
+}
+"""
 
 
 class HeadQABase(HFTask, MultipleChoiceTask):

--- a/lm_eval/tasks/hellaswag.py
+++ b/lm_eval/tasks/hellaswag.py
@@ -1,3 +1,25 @@
+"""
+HellaSwag: Can a Machine Really Finish Your Sentence?
+https://arxiv.org/pdf/1905.07830.pdf
+
+Hellaswag is a commonsense inference challenge dataset. Though its questions are
+trivial for humans (>95% accuracy), state-of-the-art models struggle (<48%). This is
+achieved via Adversarial Filtering (AF), a data collection paradigm wherein a
+series of discriminators iteratively select an adversarial set of machine-generated
+wrong answers. AF proves to be surprisingly robust. The key insight is to scale up
+the length and complexity of the dataset examples towards a critical 'Goldilocks'
+zone wherein generated text is ridiculous to humans, yet often misclassified by
+state-of-the-art models.
+
+Homepage: https://rowanzellers.com/hellaswag/
+
+@inproceedings{zellers2019hellaswag,
+    title={HellaSwag: Can a Machine Really Finish Your Sentence?},
+    author={Zellers, Rowan and Holtzman, Ari and Bisk, Yonatan and Farhadi, Ali and Choi, Yejin},
+    booktitle ={Proceedings of the 57th Annual Meeting of the Association for Computational Linguistics},
+    year={2019}
+}
+"""
 import re
 from lm_eval.base import MultipleChoiceTask
 from . common import HFTask

--- a/lm_eval/tasks/hellaswag.py
+++ b/lm_eval/tasks/hellaswag.py
@@ -12,7 +12,13 @@ zone wherein generated text is ridiculous to humans, yet often misclassified by
 state-of-the-art models.
 
 Homepage: https://rowanzellers.com/hellaswag/
+"""
+import re
+from lm_eval.base import MultipleChoiceTask
+from . common import HFTask
 
+
+_CITATION = """
 @inproceedings{zellers2019hellaswag,
     title={HellaSwag: Can a Machine Really Finish Your Sentence?},
     author={Zellers, Rowan and Holtzman, Ari and Bisk, Yonatan and Farhadi, Ali and Choi, Yejin},
@@ -20,9 +26,6 @@ Homepage: https://rowanzellers.com/hellaswag/
     year={2019}
 }
 """
-import re
-from lm_eval.base import MultipleChoiceTask
-from . common import HFTask
 
 
 class HellaSwag(HFTask, MultipleChoiceTask):

--- a/lm_eval/tasks/hendrycks_ethics.py
+++ b/lm_eval/tasks/hendrycks_ethics.py
@@ -14,13 +14,6 @@ tasks are refered to in this work as the `em` sub-metric. See Section 3. Metrics
 of the paper.
 
 Homepage: https://github.com/hendrycks/ethics
-
-@article{hendrycks2021ethics,
-  title={Aligning AI With Shared Human Values},
-  author={Dan Hendrycks and Collin Burns and Steven Basart and Andrew Critch and Jerry Li and Dawn Song and Jacob Steinhardt},
-  journal={Proceedings of the International Conference on Learning Representations (ICLR)},
-  year={2021}
-}
 """ 
 import abc
 import csv
@@ -32,6 +25,16 @@ from lm_eval.metrics import mean
 from lm_eval.utils import sh
 from .common import yesno
 from best_download import download_file
+
+
+_CITATION = """
+@article{hendrycks2021ethics,
+    title={Aligning AI With Shared Human Values},
+    author={Dan Hendrycks and Collin Burns and Steven Basart and Andrew Critch and Jerry Li and Dawn Song and Jacob Steinhardt},
+    journal={Proceedings of the International Conference on Learning Representations (ICLR)},
+    year={2021}
+}
+"""
 
 
 class Ethics(Task):

--- a/lm_eval/tasks/hendrycks_ethics.py
+++ b/lm_eval/tasks/hendrycks_ethics.py
@@ -1,3 +1,27 @@
+"""
+Aligning AI With Shared Human Values
+https://arxiv.org/pdf/2008.02275.pdf
+
+The ETHICS dataset is a benchmark that spans concepts in justice, well-being,
+duties, virtues, and commonsense morality. Models predict widespread moral
+judgments about diverse text scenarios. This requires connecting physical and
+social world knowledge to value judgements, a capability that may enable us
+to steer chatbot outputs or eventually regularize open-ended reinforcement
+learning agents.
+
+NOTE: The reported "group" accuracies for the Deontology, Justice, and Virtue
+tasks are refered to in this work as the `em` sub-metric. See Section 3. Metrics.
+of the paper.
+
+Homepage: https://github.com/hendrycks/ethics
+
+@article{hendrycks2021ethics,
+  title={Aligning AI With Shared Human Values},
+  author={Dan Hendrycks and Collin Burns and Steven Basart and Andrew Critch and Jerry Li and Dawn Song and Jacob Steinhardt},
+  journal={Proceedings of the International Conference on Learning Representations (ICLR)},
+  year={2021}
+}
+""" 
 import abc
 import csv
 import os
@@ -8,12 +32,6 @@ from lm_eval.metrics import mean
 from lm_eval.utils import sh
 from .common import yesno
 from best_download import download_file
-
-"""
-NOTE: The reported "group" accuracies for the Deontology, Justice, and Virtue
-tasks are refered to in this work as the `em` sub-metric. See Section 3. Metrics.
-of the paper.
-"""
 
 
 class Ethics(Task):

--- a/lm_eval/tasks/hendrycks_math.py
+++ b/lm_eval/tasks/hendrycks_math.py
@@ -1,3 +1,20 @@
+"""
+Measuring Mathematical Problem Solving With the MATH Dataset
+https://arxiv.org/pdf/2103.03874.pdf
+
+Math is a dataset of 12,500 challenging competition mathematics problems. Each
+problem in Math has a full step-by-step solution which can be used to teach
+models to generate answer derivations and explanations.
+
+Homepage: https://github.com/hendrycks/math
+
+@article{hendrycksmath2021,
+  title={Measuring Mathematical Problem Solving With the Math Dataset},
+  author={Dan Hendrycks and Collin Burns and Saurav Kadavath and Akul Arora and Steven Basart and Eric Tang and Dawn Song and Jacob Steinhardt},
+  journal={NeurIPS},
+  year={2021}
+}
+"""
 import abc
 import json
 from lm_eval.utils import sh
@@ -8,11 +25,6 @@ from best_download import download_file
 
 
 class Math(Task):
-    """
-    This dataset is based on the following paper:
-    https://arxiv.org/abs/2103.03874 
-    """
-
     DATASET_PATH = Path('data/MATH')
 
     def download(self):

--- a/lm_eval/tasks/hendrycks_math.py
+++ b/lm_eval/tasks/hendrycks_math.py
@@ -7,13 +7,6 @@ problem in Math has a full step-by-step solution which can be used to teach
 models to generate answer derivations and explanations.
 
 Homepage: https://github.com/hendrycks/math
-
-@article{hendrycksmath2021,
-  title={Measuring Mathematical Problem Solving With the Math Dataset},
-  author={Dan Hendrycks and Collin Burns and Saurav Kadavath and Akul Arora and Steven Basart and Eric Tang and Dawn Song and Jacob Steinhardt},
-  journal={NeurIPS},
-  year={2021}
-}
 """
 import abc
 import json
@@ -22,6 +15,16 @@ from lm_eval.metrics import mean
 from lm_eval.base import Task, rf
 from pathlib import Path
 from best_download import download_file
+
+
+_CITATION = """
+@article{hendrycksmath2021,
+  title={Measuring Mathematical Problem Solving With the Math Dataset},
+  author={Dan Hendrycks and Collin Burns and Saurav Kadavath and Akul Arora and Steven Basart and Eric Tang and Dawn Song and Jacob Steinhardt},
+  journal={NeurIPS},
+  year={2021}
+}
+"""
 
 
 class Math(Task):

--- a/lm_eval/tasks/hendrycks_test.py
+++ b/lm_eval/tasks/hendrycks_test.py
@@ -1,3 +1,24 @@
+"""
+Measuring Massive Multitask Language Understanding
+https://arxiv.org/pdf/2009.03300.pdf
+
+The Hendryck's Test is a benchmark that measured a text model’s multitask accuracy.
+The test covers 57 tasks including elementary mathematics, US history, computer 
+science, law, and more. To attain high accuracy on this test, models must possess
+extensive world knowledge and problem solving ability. By comprehensively evaluating
+the breadth and depth of a model’s academic and professional understanding, 
+Hendryck's Test can be used to analyze models across many tasks and to identify 
+important shortcomings.
+
+Homepage: https://github.com/hendrycks/test
+
+@article{hendryckstest2021,
+  title={Measuring Massive Multitask Language Understanding},
+  author={Dan Hendrycks and Collin Burns and Steven Basart and Andy Zou and Mantas Mazeika and Dawn Song and Jacob Steinhardt},
+  journal={Proceedings of the International Conference on Learning Representations (ICLR)},
+  year={2021}
+}
+"""
 import csv
 import random
 from lm_eval.base import MultipleChoiceTask

--- a/lm_eval/tasks/hendrycks_test.py
+++ b/lm_eval/tasks/hendrycks_test.py
@@ -11,13 +11,6 @@ Hendryck's Test can be used to analyze models across many tasks and to identify
 important shortcomings.
 
 Homepage: https://github.com/hendrycks/test
-
-@article{hendryckstest2021,
-  title={Measuring Massive Multitask Language Understanding},
-  author={Dan Hendrycks and Collin Burns and Steven Basart and Andy Zou and Mantas Mazeika and Dawn Song and Jacob Steinhardt},
-  journal={Proceedings of the International Conference on Learning Representations (ICLR)},
-  year={2021}
-}
 """
 import csv
 import random
@@ -25,6 +18,17 @@ from lm_eval.base import MultipleChoiceTask
 from ..utils import sh
 from pathlib import Path
 from best_download import download_file
+
+
+_CITATION = """
+@article{hendryckstest2021,
+    title={Measuring Massive Multitask Language Understanding},
+    author={Dan Hendrycks and Collin Burns and Steven Basart and Andy Zou and Mantas Mazeika and Dawn Song and Jacob Steinhardt},
+    journal={Proceedings of the International Conference on Learning Representations (ICLR)},
+    year={2021}
+}
+"""
+
 
 SUBJECTS = ['abstract_algebra', 'anatomy', 'astronomy', 'business_ethics', 'clinical_knowledge', 'college_biology',
             'college_chemistry', 'college_computer_science', 'college_mathematics', 'college_medicine', 'college_physics',

--- a/lm_eval/tasks/lambada.py
+++ b/lm_eval/tasks/lambada.py
@@ -1,3 +1,26 @@
+"""
+The LAMBADA dataset: Word prediction requiring a broad discourse context∗
+https://arxiv.org/pdf/1606.06031.pdf
+
+LAMBADA is a dataset to evaluate the capabilities of computational models for text
+understanding by means of a word prediction task. LAMBADA is a collection of narrative
+passages sharing the characteristic that human subjects are able to guess their last
+word if they are exposed to the whole passage, but not if they only see the last
+sentence preceding the target word. To succeed on LAMBADA, computational models
+cannot simply rely on local context, but must be able to keep track of information
+in the broader discourse.
+
+Homepage: https://zenodo.org/record/2630551#.X4Xzn5NKjUI
+
+@misc{
+  author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel}, 
+  title={The LAMBADA dataset},
+  DOI={10.5281/zenodo.2630551},
+  publisher={Zenodo},
+  year={2016},
+  month={Aug}
+}
+"""
 import json
 from lm_eval.base import Task, rf
 from lm_eval.metrics import mean, perplexity

--- a/lm_eval/tasks/lambada.py
+++ b/lm_eval/tasks/lambada.py
@@ -11,15 +11,6 @@ cannot simply rely on local context, but must be able to keep track of informati
 in the broader discourse.
 
 Homepage: https://zenodo.org/record/2630551#.X4Xzn5NKjUI
-
-@misc{
-  author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel}, 
-  title={The LAMBADA dataset},
-  DOI={10.5281/zenodo.2630551},
-  publisher={Zenodo},
-  year={2016},
-  month={Aug}
-}
 """
 import json
 from lm_eval.base import Task, rf
@@ -27,6 +18,18 @@ from lm_eval.metrics import mean, perplexity
 from lm_eval.utils import sh
 from best_download import download_file
 import os
+
+
+_CITATION = """
+@misc{
+    author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel}, 
+    title={The LAMBADA dataset},
+    DOI={10.5281/zenodo.2630551},
+    publisher={Zenodo},
+    year={2016},
+    month={Aug}
+}
+"""
 
 
 class LAMBADA(Task):

--- a/lm_eval/tasks/lambada_cloze.py
+++ b/lm_eval/tasks/lambada_cloze.py
@@ -1,9 +1,36 @@
+"""
+The LAMBADA dataset: Word prediction requiring a broad discourse context∗
+https://arxiv.org/pdf/1606.06031.pdf
+
+Cloze-style LAMBADA dataset.
+LAMBADA is a dataset to evaluate the capabilities of computational models for text
+understanding by means of a word prediction task. LAMBADA is a collection of narrative
+passages sharing the characteristic that human subjects are able to guess their last
+word if they are exposed to the whole passage, but not if they only see the last
+sentence preceding the target word. To succeed on LAMBADA, computational models
+cannot simply rely on local context, but must be able to keep track of information
+in the broader discourse.
+
+Homepage: https://zenodo.org/record/2630551#.X4Xzn5NKjUI
+"""
 import json
 from lm_eval.base import Task, rf
 from lm_eval.metrics import mean, perplexity
 from lm_eval.utils import sh
 from lm_eval.tasks.lambada import LAMBADA
 from best_download import download_file
+
+
+_CITATION = """
+@misc{
+    author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel}, 
+    title={The LAMBADA dataset},
+    DOI={10.5281/zenodo.2630551},
+    publisher={Zenodo},
+    year={2016},
+    month={Aug}
+}
+"""
 
 
 class LAMBADA_cloze(LAMBADA):

--- a/lm_eval/tasks/lambada_multilingual.py
+++ b/lm_eval/tasks/lambada_multilingual.py
@@ -1,3 +1,27 @@
+"""
+The LAMBADA dataset: Word prediction requiring a broad discourse context∗
+https://arxiv.org/pdf/1606.06031.pdf
+
+The LAMBADA dataset machine-translated to other languages.
+LAMBADA is a dataset to evaluate the capabilities of computational models for text
+understanding by means of a word prediction task. LAMBADA is a collection of narrative
+passages sharing the characteristic that human subjects are able to guess their last
+word if they are exposed to the whole passage, but not if they only see the last
+sentence preceding the target word. To succeed on LAMBADA, computational models
+cannot simply rely on local context, but must be able to keep track of information
+in the broader discourse.
+
+Homepage: https://zenodo.org/record/2630551#.X4Xzn5NKjUI
+
+@misc{
+  author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel}, 
+  title={The LAMBADA dataset},
+  DOI={10.5281/zenodo.2630551},
+  publisher={Zenodo},
+  year={2016},
+  month={Aug}
+}
+"""
 from . import lambada
 from lm_eval.base import Task, rf
 from lm_eval.metrics import mean, perplexity
@@ -7,7 +31,6 @@ import json
 from functools import partial
 import os 
 
-# This task is lambada but machine-translated to the other languages.
 
 LANGS = ["en", "fr", "de", "it", "es"]
 CHECKSUMS = {"en": "4aa8d02cd17c719165fc8a7887fddd641f43fcafa4b1c806ca8abc31fabdb226", 

--- a/lm_eval/tasks/lambada_multilingual.py
+++ b/lm_eval/tasks/lambada_multilingual.py
@@ -12,15 +12,6 @@ cannot simply rely on local context, but must be able to keep track of informati
 in the broader discourse.
 
 Homepage: https://zenodo.org/record/2630551#.X4Xzn5NKjUI
-
-@misc{
-  author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel}, 
-  title={The LAMBADA dataset},
-  DOI={10.5281/zenodo.2630551},
-  publisher={Zenodo},
-  year={2016},
-  month={Aug}
-}
 """
 from . import lambada
 from lm_eval.base import Task, rf
@@ -30,6 +21,18 @@ from best_download import download_file
 import json
 from functools import partial
 import os 
+
+
+_CITATION = """
+@misc{
+    author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel}, 
+    title={The LAMBADA dataset},
+    DOI={10.5281/zenodo.2630551},
+    publisher={Zenodo},
+    year={2016},
+    month={Aug}
+}
+"""
 
 
 LANGS = ["en", "fr", "de", "it", "es"]

--- a/lm_eval/tasks/logiqa.py
+++ b/lm_eval/tasks/logiqa.py
@@ -9,18 +9,22 @@ also serve as a benchmark for reinvestigating logical AI under the deep learning
 NLP setting.
 
 Homepage: https://github.com/lgw863/LogiQA-dataset
-
-@misc{liu2020logiqa,
-      title={LogiQA: A Challenge Dataset for Machine Reading Comprehension with Logical Reasoning}, 
-      author={Jian Liu and Leyang Cui and Hanmeng Liu and Dandan Huang and Yile Wang and Yue Zhang},
-      year={2020},
-      eprint={2007.08124},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}"""
+"""
 from lm_eval.base import MultipleChoiceTask
 from best_download import download_file
 from pathlib import Path
+
+
+_CITATION = """
+@misc{liu2020logiqa,
+    title={LogiQA: A Challenge Dataset for Machine Reading Comprehension with Logical Reasoning}, 
+    author={Jian Liu and Leyang Cui and Hanmeng Liu and Dandan Huang and Yile Wang and Yue Zhang},
+    year={2020},
+    eprint={2007.08124},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
 
 
 class LogiQA(MultipleChoiceTask):

--- a/lm_eval/tasks/logiqa.py
+++ b/lm_eval/tasks/logiqa.py
@@ -1,3 +1,23 @@
+"""
+LogiQA: A Challenge Dataset for Machine Reading Comprehension with Logical Reasoning
+https://arxiv.org/pdf/2007.08124.pdf
+
+LogiQA is a dataset for testing human logical reasoning. It consists of 8,678 QA
+instances, covering multiple types of deductive reasoning. Results show that state-
+of-the-art neural models perform by far worse than human ceiling. The dataset can
+also serve as a benchmark for reinvestigating logical AI under the deep learning
+NLP setting.
+
+Homepage: https://github.com/lgw863/LogiQA-dataset
+
+@misc{liu2020logiqa,
+      title={LogiQA: A Challenge Dataset for Machine Reading Comprehension with Logical Reasoning}, 
+      author={Jian Liu and Leyang Cui and Hanmeng Liu and Dandan Huang and Yile Wang and Yue Zhang},
+      year={2020},
+      eprint={2007.08124},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}"""
 from lm_eval.base import MultipleChoiceTask
 from best_download import download_file
 from pathlib import Path

--- a/lm_eval/tasks/mathqa.py
+++ b/lm_eval/tasks/mathqa.py
@@ -1,3 +1,22 @@
+"""
+MathQA: Towards Interpretable Math Word Problem Solving with Operation-Based Formalisms
+https://arxiv.org/pdf/1905.13319.pdf
+
+MathQA is a large-scale dataset of 37k English multiple-choice math word problems
+covering multiple math domain categories by modeling operation programs corresponding
+to word problems in the AQuA dataset (Ling et al., 2017).
+
+Homepage: https://math-qa.github.io/math-QA/
+
+@misc{amini2019mathqa,
+      title={MathQA: Towards Interpretable Math Word Problem Solving with Operation-Based Formalisms}, 
+      author={Aida Amini and Saadia Gabriel and Peter Lin and Rik Koncel-Kedziorski and Yejin Choi and Hannaneh Hajishirzi},
+      year={2019},
+      eprint={1905.13319},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
 import re
 from lm_eval.base import MultipleChoiceTask
 from . common import HFTask

--- a/lm_eval/tasks/mathqa.py
+++ b/lm_eval/tasks/mathqa.py
@@ -7,19 +7,22 @@ covering multiple math domain categories by modeling operation programs correspo
 to word problems in the AQuA dataset (Ling et al., 2017).
 
 Homepage: https://math-qa.github.io/math-QA/
-
-@misc{amini2019mathqa,
-      title={MathQA: Towards Interpretable Math Word Problem Solving with Operation-Based Formalisms}, 
-      author={Aida Amini and Saadia Gabriel and Peter Lin and Rik Koncel-Kedziorski and Yejin Choi and Hannaneh Hajishirzi},
-      year={2019},
-      eprint={1905.13319},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}
 """
 import re
 from lm_eval.base import MultipleChoiceTask
 from . common import HFTask
+
+
+_CITATION = """
+@misc{amini2019mathqa,
+    title={MathQA: Towards Interpretable Math Word Problem Solving with Operation-Based Formalisms}, 
+    author={Aida Amini and Saadia Gabriel and Peter Lin and Rik Koncel-Kedziorski and Yejin Choi and Hannaneh Hajishirzi},
+    year={2019},
+    eprint={1905.13319},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
 
 
 class MathQA(HFTask, MultipleChoiceTask):

--- a/lm_eval/tasks/mc_taco.py
+++ b/lm_eval/tasks/mc_taco.py
@@ -18,7 +18,14 @@ answers. This is a problem because the task's metrics require an exhaustive eval
 of a question's options. See section 4 of the paper for details.
 
 Homepage: https://leaderboard.allenai.org/mctaco/submissions/public
+"""
+import numpy as np
+from lm_eval.base import rf
+from collections import defaultdict
+from . common import HFTask
 
+
+_CITATION = """
 @inproceedings{ZKNR19,
     author = {Ben Zhou, Daniel Khashabi, Qiang Ning and Dan Roth},
     title = {“Going on a vacation” takes longer than “Going for a walk”: A Study of Temporal Commonsense Understanding },
@@ -26,11 +33,6 @@ Homepage: https://leaderboard.allenai.org/mctaco/submissions/public
     year = {2019},
 }
 """
-
-import numpy as np
-from lm_eval.base import rf
-from collections import defaultdict
-from . common import HFTask
 
 
 class MCTACO(HFTask):

--- a/lm_eval/tasks/mc_taco.py
+++ b/lm_eval/tasks/mc_taco.py
@@ -3,6 +3,12 @@
 A Study of Temporal Commonsense Understanding
 https://arxiv.org/pdf/1909.03065.pdf
 
+MC-TACO is a dataset of 13k question-answer pairs that require temporal commonsense 
+comprehension. The dataset contains five temporal properties, (1) duration (how long
+an event takes), (2) temporal ordering (typical order of events), (3) typical time 
+(when an event occurs), (4) frequency (how often an event occurs), and (5) stationarity
+(whether a state is maintained for a very long time or indefinitely).
+
 WARNING: Running this task with a `--limit` arg will give misleading results! The 
 corresponding dataset is structured such that each multiple-choice-question gathered
 by the authors is split into question-option pairs, where each such pair gets 
@@ -10,6 +16,8 @@ siloed into an individual document for plausibility testing. Because the harness
 shuffles these documents, setting `--limit` will likely "cut off" certain candidate
 answers. This is a problem because the task's metrics require an exhaustive evaluation 
 of a question's options. See section 4 of the paper for details.
+
+Homepage: https://leaderboard.allenai.org/mctaco/submissions/public
 
 @inproceedings{ZKNR19,
     author = {Ben Zhou, Daniel Khashabi, Qiang Ning and Dan Roth},

--- a/lm_eval/tasks/mutual.py
+++ b/lm_eval/tasks/mutual.py
@@ -6,14 +6,6 @@ MuTual is a retrieval-based dataset for multi-turn dialogue reasoning, which is
 modified from Chinese high school English listening comprehension test data.
 
 Homepage: https://github.com/Nealcly/MuTual
-
-@inproceedings{mutual,
-    title = "MuTual: A Dataset for Multi-Turn Dialogue Reasoning",
-    author = "Cui, Leyang  and Wu, Yu and Liu, Shujie and Zhang, Yue and Zhou, Ming" ,
-    booktitle = "Proceedings of the 58th Conference of the Association for Computational Linguistics",
-    year = "2020",
-    publisher = "Association for Computational Linguistics",
-}
 """
 import json
 import zipfile
@@ -23,6 +15,17 @@ from pathlib import Path
 from lm_eval.base import Task, rf
 from lm_eval.metrics import mean
 from best_download import download_file
+
+
+_CITATION = """
+@inproceedings{mutual,
+    title = "MuTual: A Dataset for Multi-Turn Dialogue Reasoning",
+    author = "Cui, Leyang  and Wu, Yu and Liu, Shujie and Zhang, Yue and Zhou, Ming" ,
+    booktitle = "Proceedings of the 58th Conference of the Association for Computational Linguistics",
+    year = "2020",
+    publisher = "Association for Computational Linguistics",
+}
+"""
 
 
 class MuTualBase(Task):

--- a/lm_eval/tasks/mutual.py
+++ b/lm_eval/tasks/mutual.py
@@ -2,6 +2,11 @@
 MuTual: A Dataset for Multi-Turn Dialogue Reasoning
 https://www.aclweb.org/anthology/2020.acl-main.130/
 
+MuTual is a retrieval-based dataset for multi-turn dialogue reasoning, which is
+modified from Chinese high school English listening comprehension test data.
+
+Homepage: https://github.com/Nealcly/MuTual
+
 @inproceedings{mutual,
     title = "MuTual: A Dataset for Multi-Turn Dialogue Reasoning",
     author = "Cui, Leyang  and Wu, Yu and Liu, Shujie and Zhang, Yue and Zhou, Ming" ,

--- a/lm_eval/tasks/naturalqs.py
+++ b/lm_eval/tasks/naturalqs.py
@@ -14,17 +14,20 @@ downloads even if you dont use it. we should try and only download the val set a
 not even bother with the train set. 
 
 Homepage: https://ai.google.com/research/NaturalQuestions
-
-@article{47761,
-title	= {Natural Questions: a Benchmark for Question Answering Research},
-author	= {Tom Kwiatkowski and Jennimaria Palomaki and Olivia Redfield and Michael Collins and Ankur Parikh and Chris Alberti and Danielle Epstein and Illia Polosukhin and Matthew Kelcey and Jacob Devlin and Kenton Lee and Kristina N. Toutanova and Llion Jones and Ming-Wei Chang and Andrew Dai and Jakob Uszkoreit and Quoc Le and Slav Petrov},
-year	= {2019},
-journal	= {Transactions of the Association of Computational Linguistics}
-}
 """
 import random
 from . common import HFTask
 from itertools import islice
+
+
+_CITATION = """
+@article{47761,
+    title={Natural Questions: a Benchmark for Question Answering Research},
+    author={Tom Kwiatkowski and Jennimaria Palomaki and Olivia Redfield and Michael Collins and Ankur Parikh and Chris Alberti and Danielle Epstein and Illia Polosukhin and Matthew Kelcey and Jacob Devlin and Kenton Lee and Kristina N. Toutanova and Llion Jones and Ming-Wei Chang and Andrew Dai and Jakob Uszkoreit and Quoc Le and Slav Petrov},
+    year={2019},
+    journal={Transactions of the Association of Computational Linguistics}
+}
+"""
 
 
 class NaturalQs(HFTask):

--- a/lm_eval/tasks/naturalqs.py
+++ b/lm_eval/tasks/naturalqs.py
@@ -1,3 +1,27 @@
+"""
+Natural Questions: a Benchmark for Question Answering Research
+https://storage.googleapis.com/pub-tools-public-publication-data/pdf/1f7b46b5378d757553d3e92ead36bda2e4254244.pdf
+
+The Natural Questions (NQ) corpus is a question-answering dataset that contains
+questions from real users and requires QA systems to read and comprehend an entire
+Wikipedia article that may or may not contain the answer to the question. The
+inclusion of real user questions, and the requirement that solutions should read
+an entire page to find the answer, cause NQ to be a more realistic and challenging
+task than prior QA datasets.
+
+TODO: NaturalQS has a *really* large train set that huggingface just automatically
+downloads even if you dont use it. we should try and only download the val set and
+not even bother with the train set. 
+
+Homepage: https://ai.google.com/research/NaturalQuestions
+
+@article{47761,
+title	= {Natural Questions: a Benchmark for Question Answering Research},
+author	= {Tom Kwiatkowski and Jennimaria Palomaki and Olivia Redfield and Michael Collins and Ankur Parikh and Chris Alberti and Danielle Epstein and Illia Polosukhin and Matthew Kelcey and Jacob Devlin and Kenton Lee and Kristina N. Toutanova and Llion Jones and Ming-Wei Chang and Andrew Dai and Jakob Uszkoreit and Quoc Le and Slav Petrov},
+year	= {2019},
+journal	= {Transactions of the Association of Computational Linguistics}
+}
+"""
 import random
 from . common import HFTask
 from itertools import islice
@@ -5,10 +29,6 @@ from itertools import islice
 
 class NaturalQs(HFTask):
     VERSION = 0
-    # TODO: naturalqs has a *really* large train set that huggingface just
-    # automatically downloads even if you dont use it. we should try and only 
-    # download the val set and not even bother with the train set. 
-
     DATASET_PATH = "natural_questions"
     DATASET_NAME = None
 

--- a/lm_eval/tasks/openbookqa.py
+++ b/lm_eval/tasks/openbookqa.py
@@ -1,3 +1,26 @@
+"""
+Can a Suit of Armor Conduct Electricity? A New Dataset for Open Book Question Answering
+https://arxiv.org/pdf/1809.02789.pdf
+
+OpenBookQA is a question-answering dataset modeled after open book exams for
+assessing human understanding of a subject. It consists of 5,957 multiple-choice
+elementary-level science questions (4,957 train, 500 dev, 500 test), which probe
+the understanding of a small “book” of 1,326 core science facts and the application
+of these facts to novel situations. For training, the dataset includes a mapping
+from each question to the core science fact it was designed to probe. Answering
+OpenBookQA questions requires additional broad common knowledge, not contained
+in the book. The questions, by design, are answered incorrectly by both a retrieval-
+based algorithm and a word co-occurrence algorithm.
+
+Homepage: https://allenai.org/data/open-book-qa
+
+@inproceedings{OpenBookQA2018,
+ title={Can a Suit of Armor Conduct Electricity? A New Dataset for Open Book Question Answering},
+ author={Todor Mihaylov and Peter Clark and Tushar Khot and Ashish Sabharwal},
+ booktitle={EMNLP},
+ year={2018}
+}
+"""
 from lm_eval.base import MultipleChoiceTask
 from .common import HFTask
 

--- a/lm_eval/tasks/openbookqa.py
+++ b/lm_eval/tasks/openbookqa.py
@@ -13,16 +13,19 @@ in the book. The questions, by design, are answered incorrectly by both a retrie
 based algorithm and a word co-occurrence algorithm.
 
 Homepage: https://allenai.org/data/open-book-qa
-
-@inproceedings{OpenBookQA2018,
- title={Can a Suit of Armor Conduct Electricity? A New Dataset for Open Book Question Answering},
- author={Todor Mihaylov and Peter Clark and Tushar Khot and Ashish Sabharwal},
- booktitle={EMNLP},
- year={2018}
-}
 """
 from lm_eval.base import MultipleChoiceTask
 from .common import HFTask
+
+
+_CITATION = """
+@inproceedings{OpenBookQA2018,
+    title={Can a Suit of Armor Conduct Electricity? A New Dataset for Open Book Question Answering},
+    author={Todor Mihaylov and Peter Clark and Tushar Khot and Ashish Sabharwal},
+    booktitle={EMNLP},
+    year={2018}
+}
+"""
 
 
 class OpenBookQA(HFTask, MultipleChoiceTask):

--- a/lm_eval/tasks/pile.py
+++ b/lm_eval/tasks/pile.py
@@ -9,13 +9,6 @@ including books, github repositories, webpages, chat logs, and medical, physics,
 math, computer science, and philosophy papers.
 
 Homepage: https://pile.eleuther.ai/
-
-@article{pile,
-  title={The {P}ile: An 800GB Dataset of Diverse Text for Language Modeling},
-  author={Gao, Leo and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and Presser, Shawn and Leahy, Connor},
-  journal={arXiv preprint arXiv:2101.00027},
-  year={2020}
-}
 """
 import os
 
@@ -26,6 +19,16 @@ from lm_eval.base import rf, PerplexityTask
 from ..metrics import mean, matthews_corrcoef, f1_score
 from ..utils import general_detokenize
 from best_download import download_file
+
+
+_CITATION = """
+@article{pile,
+  title={The {P}ile: An 800GB Dataset of Diverse Text for Language Modeling},
+  author={Gao, Leo and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and Presser, Shawn and Leahy, Connor},
+  journal={arXiv preprint arXiv:2101.00027},
+  year={2020}
+}
+"""
 
 
 class PilePerplexityTask(PerplexityTask, abc.ABC):

--- a/lm_eval/tasks/pile.py
+++ b/lm_eval/tasks/pile.py
@@ -1,3 +1,22 @@
+"""
+The Pile: An 800GB Dataset of Diverse Text for Language Modeling
+https://arxiv.org/pdf/2101.00027.pdf
+
+The Pile is a 825 GiB diverse, open source language modelling data set that consists
+of 22 smaller, high-quality datasets combined together. To score well on Pile
+BPB (bits per byte), a model must be able to understand many disparate domains
+including books, github repositories, webpages, chat logs, and medical, physics,
+math, computer science, and philosophy papers.
+
+Homepage: https://pile.eleuther.ai/
+
+@article{pile,
+  title={The {P}ile: An 800GB Dataset of Diverse Text for Language Modeling},
+  author={Gao, Leo and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and Presser, Shawn and Leahy, Connor},
+  journal={arXiv preprint arXiv:2101.00027},
+  year={2020}
+}
+"""
 import os
 
 import lm_dataformat

--- a/lm_eval/tasks/piqa.py
+++ b/lm_eval/tasks/piqa.py
@@ -8,22 +8,25 @@ the physical knowledge of existing models. To what extent are current approaches
 actually learning about the world? 
 
 Homepage: https://yonatanbisk.com/piqa/
-
-@inproceedings{Bisk2020,
-  author = {Yonatan Bisk and Rowan Zellers and
-            Ronan Le Bras and Jianfeng Gao
-            and Yejin Choi},
-  title = {PIQA: Reasoning about Physical Commonsense in
-           Natural Language},
-  booktitle = {Thirty-Fourth AAAI Conference on
-               Artificial Intelligence},
-  year = {2020},
-}
 """
 import numpy as np
 from lm_eval.base import MultipleChoiceTask, rf
 from ..metrics import mean
 from . common import HFTask
+
+
+_CITATION = """
+@inproceedings{Bisk2020,
+    author = {Yonatan Bisk and Rowan Zellers and
+            Ronan Le Bras and Jianfeng Gao
+            and Yejin Choi},
+    title = {PIQA: Reasoning about Physical Commonsense in
+           Natural Language},
+    booktitle = {Thirty-Fourth AAAI Conference on
+               Artificial Intelligence},
+    year = {2020},
+}
+"""
 
 
 class PiQA(HFTask, MultipleChoiceTask):

--- a/lm_eval/tasks/piqa.py
+++ b/lm_eval/tasks/piqa.py
@@ -1,3 +1,25 @@
+"""
+PIQA: Reasoning about Physical Commonsense in Natural Language
+https://arxiv.org/pdf/1911.11641.pdf
+
+Physical Interaction: Question Answering (PIQA) is a physical commonsense
+reasoning and a corresponding benchmark dataset. PIQA was designed to investigate
+the physical knowledge of existing models. To what extent are current approaches
+actually learning about the world? 
+
+Homepage: https://yonatanbisk.com/piqa/
+
+@inproceedings{Bisk2020,
+  author = {Yonatan Bisk and Rowan Zellers and
+            Ronan Le Bras and Jianfeng Gao
+            and Yejin Choi},
+  title = {PIQA: Reasoning about Physical Commonsense in
+           Natural Language},
+  booktitle = {Thirty-Fourth AAAI Conference on
+               Artificial Intelligence},
+  year = {2020},
+}
+"""
 import numpy as np
 from lm_eval.base import MultipleChoiceTask, rf
 from ..metrics import mean

--- a/lm_eval/tasks/prost.py
+++ b/lm_eval/tasks/prost.py
@@ -18,7 +18,7 @@ from lm_eval.base import MultipleChoiceTask
 from . common import HFTask
 
 
-_CITATON = """
+_CITATION = """
 @inproceedings{aroca-ouellette-etal-2021-prost,
     title = "{PROST}: {P}hysical Reasoning about Objects through Space and Time",
     author = "Aroca-Ouellette, St{\'e}phane  and

--- a/lm_eval/tasks/prost.py
+++ b/lm_eval/tasks/prost.py
@@ -2,19 +2,31 @@
 PROST: Physical Reasoning about Objects Through Space and Time
 https://arxiv.org/pdf/2106.03634.pdf
 
+PROST, Physical Reasoning about Objects Through Space and Time, is a dataset
+consisting of 18,736 multiple-choice questions made from 14 manually curated
+templates, covering 10 physical reasoning concepts. All questions are designed
+to probe both causal and masked language models in a zero-shot setting.
+
 NOTE: PROST is limited to the zero-shot setting to adhere to authors' intentions
 as discussed in section 7 of the paper: "We hope that the community will use
 this dataset in the intended way: in a zero-shot setting to probe models which
 have been trained on data not specifically collected to succeed on PROST."
 
-# TODO: Update citation when it is made available at https://github.com/nala-cub/prost.
-@misc{arocaouellette2021prost,
-      title={PROST: Physical Reasoning of Objects through Space and Time}, 
-      author={Stéphane Aroca-Ouellette and Cory Paik and Alessandro Roncone and Katharina Kann},
-      year={2021},
-      eprint={2106.03634},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
+Homepage: https://github.com/nala-cub/prost
+
+@inproceedings{aroca-ouellette-etal-2021-prost,
+    title = "{PROST}: {P}hysical Reasoning about Objects through Space and Time",
+    author = "Aroca-Ouellette, St{\'e}phane  and
+      Paik, Cory  and
+      Roncone, Alessandro  and
+      Kann, Katharina",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL-IJCNLP 2021",
+    month = aug,
+    year = "2021",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2021.findings-acl.404",
+    pages = "4597--4608",
 }
 """
 

--- a/lm_eval/tasks/prost.py
+++ b/lm_eval/tasks/prost.py
@@ -13,7 +13,12 @@ this dataset in the intended way: in a zero-shot setting to probe models which
 have been trained on data not specifically collected to succeed on PROST."
 
 Homepage: https://github.com/nala-cub/prost
+"""
+from lm_eval.base import MultipleChoiceTask
+from . common import HFTask
 
+
+_CITATON = """
 @inproceedings{aroca-ouellette-etal-2021-prost,
     title = "{PROST}: {P}hysical Reasoning about Objects through Space and Time",
     author = "Aroca-Ouellette, St{\'e}phane  and
@@ -29,9 +34,6 @@ Homepage: https://github.com/nala-cub/prost
     pages = "4597--4608",
 }
 """
-
-from lm_eval.base import MultipleChoiceTask
-from . common import HFTask
 
 
 class PROST(HFTask, MultipleChoiceTask):

--- a/lm_eval/tasks/pubmedqa.py
+++ b/lm_eval/tasks/pubmedqa.py
@@ -1,3 +1,28 @@
+"""
+PubMedQA: A Dataset for Biomedical Research Question Answering
+https://arxiv.org/pdf/1909.06146.pdf
+
+PubMedQA is a novel biomedical question answering (QA) dataset collected from
+PubMed abstracts. The task of PubMedQA is to answer research questions with 
+yes/no/maybe (e.g.: Do preoperative statins reduce atrial fibrillation after 
+coronary artery bypass grafting?) using the corresponding abstracts. PubMedQA 
+has 1k expert-annotated, 61.2k unlabeled and 211.3k artificially generated QA 
+instances. Each PubMedQA instance is composed of (1) a question which is either
+an existing research article title or derived from one, (2) a context which is
+the corresponding abstract without its conclusion, (3) a long answer, which is
+the conclusion of the abstract and, presumably, answers the research question, 
+and (4) a yes/no/maybe answer which summarizes the conclusion.
+
+Homepage: https://pubmedqa.github.io/
+
+@inproceedings{jin2019pubmedqa,
+  title={PubMedQA: A Dataset for Biomedical Research Question Answering},
+  author={Jin, Qiao and Dhingra, Bhuwan and Liu, Zhengping and Cohen, William and Lu, Xinghua},
+  booktitle={Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)},
+  pages={2567--2577},
+  year={2019}
+}
+"""
 import numpy as np
 from .common import HFTask
 from lm_eval.base import rf

--- a/lm_eval/tasks/pubmedqa.py
+++ b/lm_eval/tasks/pubmedqa.py
@@ -14,19 +14,22 @@ the conclusion of the abstract and, presumably, answers the research question,
 and (4) a yes/no/maybe answer which summarizes the conclusion.
 
 Homepage: https://pubmedqa.github.io/
-
-@inproceedings{jin2019pubmedqa,
-  title={PubMedQA: A Dataset for Biomedical Research Question Answering},
-  author={Jin, Qiao and Dhingra, Bhuwan and Liu, Zhengping and Cohen, William and Lu, Xinghua},
-  booktitle={Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)},
-  pages={2567--2577},
-  year={2019}
-}
 """
 import numpy as np
 from .common import HFTask
 from lm_eval.base import rf
 from ..metrics import mean
+
+
+_CITATION = """
+@inproceedings{jin2019pubmedqa,
+    title={PubMedQA: A Dataset for Biomedical Research Question Answering},
+    author={Jin, Qiao and Dhingra, Bhuwan and Liu, Zhengping and Cohen, William and Lu, Xinghua},
+    booktitle={Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)},
+    pages={2567--2577},
+    year={2019}
+}
+"""
 
 
 class Pubmed_QA(HFTask):

--- a/lm_eval/tasks/qa4mre.py
+++ b/lm_eval/tasks/qa4mre.py
@@ -12,18 +12,21 @@ Machine Reading, Machine Reading of Biomedical Texts about Alzheimer's disease,
 and Entrance Exam.
 
 Homepage: http://nlp.uned.es/clef-qa/repository/qa4mre.php
-
-@inproceedings{Peas2013QA4MRE2O,
-  title={QA4MRE 2011-2013: Overview of Question Answering for Machine Reading Evaluation},
-  author={Anselmo Pe{\~n}as and Eduard H. Hovy and Pamela Forner and {\'A}lvaro Rodrigo and Richard F. E. Sutcliffe and Roser Morante},
-  booktitle={CLEF},
-  year={2013}
-}
 """
 import os
 import xml.etree.ElementTree as ET
 from best_download import download_file
 from lm_eval.base import MultipleChoiceTask
+
+
+_CITATION = """
+@inproceedings{Peas2013QA4MRE2O,
+    title={QA4MRE 2011-2013: Overview of Question Answering for Machine Reading Evaluation},
+    author={Anselmo Pe{\~n}as and Eduard H. Hovy and Pamela Forner and {\'A}lvaro Rodrigo and Richard F. E. Sutcliffe and Roser Morante},
+    booktitle={CLEF},
+    year={2013}
+}
+"""
 
 
 class QA4MRE(MultipleChoiceTask):

--- a/lm_eval/tasks/qa4mre.py
+++ b/lm_eval/tasks/qa4mre.py
@@ -1,3 +1,25 @@
+"""
+QA4MRE 2011-2013: Overview of Question Answering for Machine Reading Evaluation
+https://www.cs.cmu.edu/~./hovy/papers/13CLEF-QA4MRE.pdf
+
+The (English only) QA4MRE challenge which was run as a Lab at CLEF 2011-2013.
+The main objective of this exercise is to develop a methodology for evaluating 
+Machine Reading systems through Question Answering and Reading Comprehension 
+Tests. Systems should be able to extract knowledge from large volumes of text 
+and use this knowledge to answer questions. Four different tasks have been
+organized during these years: Main Task, Processing Modality and Negation for
+Machine Reading, Machine Reading of Biomedical Texts about Alzheimer's disease,
+and Entrance Exam.
+
+Homepage: http://nlp.uned.es/clef-qa/repository/qa4mre.php
+
+@inproceedings{Peas2013QA4MRE2O,
+  title={QA4MRE 2011-2013: Overview of Question Answering for Machine Reading Evaluation},
+  author={Anselmo Pe{\~n}as and Eduard H. Hovy and Pamela Forner and {\'A}lvaro Rodrigo and Richard F. E. Sutcliffe and Roser Morante},
+  booktitle={CLEF},
+  year={2013}
+}
+"""
 import os
 import xml.etree.ElementTree as ET
 from best_download import download_file

--- a/lm_eval/tasks/qasper.py
+++ b/lm_eval/tasks/qasper.py
@@ -2,6 +2,14 @@
 A Dataset of Information-Seeking Questions and Answers Anchored in Research Papers
 https://arxiv.org/abs/2105.03011
 
+QASPER is a dataset of 5,049 questions over 1,585 Natural Language Processing papers.
+Each question is written by an NLP practitioner who read only the title and abstract
+of the corresponding paper, and the question seeks information present in the full
+text. The questions are then answered by a separate set of NLP practitioners who also
+provide supporting evidence to answers.
+
+Homepage: https://allenai.org/data/qasper
+
 @article{DBLP:journals/corr/abs-2105-03011,
   author    = {Pradeep Dasigi and
                Kyle Lo and

--- a/lm_eval/tasks/qasper.py
+++ b/lm_eval/tasks/qasper.py
@@ -9,26 +9,6 @@ text. The questions are then answered by a separate set of NLP practitioners who
 provide supporting evidence to answers.
 
 Homepage: https://allenai.org/data/qasper
-
-@article{DBLP:journals/corr/abs-2105-03011,
-  author    = {Pradeep Dasigi and
-               Kyle Lo and
-               Iz Beltagy and
-               Arman Cohan and
-               Noah A. Smith and
-               Matt Gardner},
-  title     = {A Dataset of Information-Seeking Questions and Answers Anchored in
-               Research Papers},
-  journal   = {CoRR},
-  volume    = {abs/2105.03011},
-  year      = {2021},
-  url       = {https://arxiv.org/abs/2105.03011},
-  eprinttype = {arXiv},
-  eprint    = {2105.03011},
-  timestamp = {Fri, 14 May 2021 12:13:30 +0200},
-  biburl    = {https://dblp.org/rec/journals/corr/abs-2105-03011.bib},
-  bibsource = {dblp computer science bibliography, https://dblp.org}
-}
 """
 from collections import Counter
 from math import exp
@@ -38,6 +18,29 @@ import string
 from lm_eval.base import rf
 from lm_eval.metrics import f1_score, mean
 from .common import HFTask
+
+
+_CITATION = """
+@article{DBLP:journals/corr/abs-2105-03011,
+    author    = {Pradeep Dasigi and
+               Kyle Lo and
+               Iz Beltagy and
+               Arman Cohan and
+               Noah A. Smith and
+               Matt Gardner},
+    title     = {A Dataset of Information-Seeking Questions and Answers Anchored in
+               Research Papers},
+    journal   = {CoRR},
+    volume    = {abs/2105.03011},
+    year      = {2021},
+    url       = {https://arxiv.org/abs/2105.03011},
+    eprinttype = {arXiv},
+    eprint    = {2105.03011},
+    timestamp = {Fri, 14 May 2021 12:13:30 +0200},
+    biburl    = {https://dblp.org/rec/journals/corr/abs-2105-03011.bib},
+    bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
 
 
 def normalize_answer(s):

--- a/lm_eval/tasks/quac.py
+++ b/lm_eval/tasks/quac.py
@@ -9,19 +9,21 @@ questions to learn as much as possible about a hidden Wikipedia text, and (2)
 a teacher who answers the questions by providing short excerpts (spans) from the text.
 
 Homepage: https://quac.ai/
-
-@article{choi2018quac,
-  title={Quac: Question answering in context},
-  author={Choi, Eunsol and He, He and Iyyer, Mohit and Yatskar, Mark and Yih, Wen-tau and Choi, Yejin and Liang, Percy and Zettlemoyer, Luke},
-  journal={arXiv preprint arXiv:1808.07036},
-  year={2018}
-}
 """
-
 import json
 import os
 from lm_eval.base import Task
 from ..utils import sh
+
+
+_CITATION = """
+@article{choi2018quac,
+    title={Quac: Question answering in context},
+    author={Choi, Eunsol and He, He and Iyyer, Mohit and Yatskar, Mark and Yih, Wen-tau and Choi, Yejin and Liang, Percy and Zettlemoyer, Luke},
+    journal={arXiv preprint arXiv:1808.07036},
+    year={2018}
+}
+"""
 
 
 class QuAC(Task):

--- a/lm_eval/tasks/quac.py
+++ b/lm_eval/tasks/quac.py
@@ -2,6 +2,14 @@
 QuAC: Question Answering in Context
 https://arxiv.org/abs/1808.07036 
 
+Question Answering in Context (QuAC) is a dataset for modeling, understanding, and 
+participating in information seeking dialog. Data instances consist of an interactive
+dialog between two crowd workers: (1) a student who poses a sequence of freeform
+questions to learn as much as possible about a hidden Wikipedia text, and (2)
+a teacher who answers the questions by providing short excerpts (spans) from the text.
+
+Homepage: https://quac.ai/
+
 @article{choi2018quac,
   title={Quac: Question answering in context},
   author={Choi, Eunsol and He, He and Iyyer, Mohit and Yatskar, Mark and Yih, Wen-tau and Choi, Yejin and Liang, Percy and Zettlemoyer, Luke},

--- a/lm_eval/tasks/race.py
+++ b/lm_eval/tasks/race.py
@@ -8,13 +8,6 @@ in China, which are designed for middle school and high school students. The dat
 can be served as the training and test sets for machine comprehension.
 
 Homepage: https://www.cs.cmu.edu/~glai1/data/race/
-
-@article{lai2017large,
-    title={RACE: Large-scale ReAding Comprehension Dataset From Examinations},
-    author={Lai, Guokun and Xie, Qizhe and Liu, Hanxiao and Yang, Yiming and Hovy, Eduard},
-    journal={arXiv preprint arXiv:1704.04683},  
-    year={2017}
-}
 """
 import collections
 import datasets
@@ -22,6 +15,16 @@ import numpy as np
 from lm_eval.base import rf
 from ..metrics import mean
 from . common import HFTask
+
+
+_CITATION = """
+@article{lai2017large,
+    title={RACE: Large-scale ReAding Comprehension Dataset From Examinations},
+    author={Lai, Guokun and Xie, Qizhe and Liu, Hanxiao and Yang, Yiming and Hovy, Eduard},
+    journal={arXiv preprint arXiv:1704.04683},  
+    year={2017}
+}
+"""
 
 
 class each:

--- a/lm_eval/tasks/race.py
+++ b/lm_eval/tasks/race.py
@@ -1,3 +1,21 @@
+"""
+RACE: Large-scale ReAding Comprehension Dataset From Examinations
+https://arxiv.org/pdf/1704.04683.pdf
+
+RACE is a large-scale reading comprehension dataset with more than 28,000 passages
+and nearly 100,000 questions. The dataset is collected from English examinations
+in China, which are designed for middle school and high school students. The dataset
+can be served as the training and test sets for machine comprehension.
+
+Homepage: https://www.cs.cmu.edu/~glai1/data/race/
+
+@article{lai2017large,
+    title={RACE: Large-scale ReAding Comprehension Dataset From Examinations},
+    author={Lai, Guokun and Xie, Qizhe and Liu, Hanxiao and Yang, Yiming and Hovy, Eduard},
+    journal={arXiv preprint arXiv:1704.04683},  
+    year={2017}
+}
+"""
 import collections
 import datasets
 import numpy as np

--- a/lm_eval/tasks/sat.py
+++ b/lm_eval/tasks/sat.py
@@ -6,7 +6,12 @@ SAT (Scholastic Aptitude Test) Analogy Questions is a dataset comprising 374
 multiple-choice analogy questions; 5 choices per question.
 
 Homepage: https://aclweb.org/aclwiki/SAT_Analogy_Questions_(State_of_the_art)
+"""
+import os
+from lm_eval.base import MultipleChoiceTask
 
+
+_CITATION = """
 @article{article,
     author = {Turney, Peter},
     year = {2006},
@@ -18,8 +23,6 @@ Homepage: https://aclweb.org/aclwiki/SAT_Analogy_Questions_(State_of_the_art)
     doi = {10.1162/coli.2006.32.3.379}
 }
 """
-import os
-from lm_eval.base import MultipleChoiceTask
 
 
 class SATAnalogies(MultipleChoiceTask):    

--- a/lm_eval/tasks/sat.py
+++ b/lm_eval/tasks/sat.py
@@ -1,3 +1,23 @@
+"""
+Similarity of Semantic Relations
+https://arxiv.org/pdf/cs/0608100.pdf
+
+SAT (Scholastic Aptitude Test) Analogy Questions is a dataset comprising 374
+multiple-choice analogy questions; 5 choices per question.
+
+Homepage: https://aclweb.org/aclwiki/SAT_Analogy_Questions_(State_of_the_art)
+
+@article{article,
+    author = {Turney, Peter},
+    year = {2006},
+    month = {09},
+    pages = {379-416},
+    title = {Similarity of Semantic Relations},
+    volume = {32},
+    journal = {Computational Linguistics},
+    doi = {10.1162/coli.2006.32.3.379}
+}
+"""
 import os
 from lm_eval.base import MultipleChoiceTask
 

--- a/lm_eval/tasks/sciq.py
+++ b/lm_eval/tasks/sciq.py
@@ -1,3 +1,21 @@
+"""
+Crowdsourcing Multiple Choice Science Questions
+https://aclanthology.org/W17-4413.pdf
+
+The SciQ dataset contains 13,679 crowdsourced science exam questions about Physics,
+Chemistry and Biology, among others. The questions are in multiple-choice format
+with 4 answer options each. For the majority of the questions, an additional paragraph
+with supporting evidence for the correct answer is provided.
+
+Homepage: https://allenai.org/data/sciq
+
+@inproceedings{Welbl2017CrowdsourcingMC,
+  title={Crowdsourcing Multiple Choice Science Questions},
+  author={Johannes Welbl and Nelson F. Liu and Matt Gardner},
+  booktitle={NUT@EMNLP},
+  year={2017}
+}
+"""
 import os
 import json
 import zipfile

--- a/lm_eval/tasks/sciq.py
+++ b/lm_eval/tasks/sciq.py
@@ -8,19 +8,22 @@ with 4 answer options each. For the majority of the questions, an additional par
 with supporting evidence for the correct answer is provided.
 
 Homepage: https://allenai.org/data/sciq
-
-@inproceedings{Welbl2017CrowdsourcingMC,
-  title={Crowdsourcing Multiple Choice Science Questions},
-  author={Johannes Welbl and Nelson F. Liu and Matt Gardner},
-  booktitle={NUT@EMNLP},
-  year={2017}
-}
 """
 import os
 import json
 import zipfile
 from lm_eval.base import MultipleChoiceTask
 from best_download import download_file
+
+
+_CITATION = """
+@inproceedings{Welbl2017CrowdsourcingMC,
+    title={Crowdsourcing Multiple Choice Science Questions},
+    author={Johannes Welbl and Nelson F. Liu and Matt Gardner},
+    booktitle={NUT@EMNLP},
+    year={2017}
+}
+"""
 
 
 class SciQ(MultipleChoiceTask):

--- a/lm_eval/tasks/squad.py
+++ b/lm_eval/tasks/squad.py
@@ -1,3 +1,27 @@
+"""
+Know What You Don’t Know: Unanswerable Questions for SQuAD
+https://arxiv.org/pdf/1806.03822.pdf
+
+Stanford Question Answering Dataset (SQuAD) is a reading comprehension dataset,
+consisting of questions posed by crowdworkers on a set of Wikipedia articles,
+where the answer to every question is a segment of text, or span, from the
+corresponding reading passage, or the question might be unanswerable.
+SQuAD2.0 combines the 100,000 questions in SQuAD1.1 with over 50,000 unanswerable
+questions written adversarially by crowdworkers to look similar to answerable ones.
+To do well on SQuAD2.0, systems must not only answer questions when possible, but
+also determine when no answer is supported by the paragraph and abstain from answering.
+
+Homepage: https://rajpurkar.github.io/SQuAD-explorer/
+
+@misc{rajpurkar2018know,
+      title={Know What You Don't Know: Unanswerable Questions for SQuAD}, 
+      author={Pranav Rajpurkar and Robin Jia and Percy Liang},
+      year={2018},
+      eprint={1806.03822},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
 import datasets
 from math import exp
 from lm_eval.base import rf

--- a/lm_eval/tasks/squad.py
+++ b/lm_eval/tasks/squad.py
@@ -12,15 +12,6 @@ To do well on SQuAD2.0, systems must not only answer questions when possible, bu
 also determine when no answer is supported by the paragraph and abstain from answering.
 
 Homepage: https://rajpurkar.github.io/SQuAD-explorer/
-
-@misc{rajpurkar2018know,
-      title={Know What You Don't Know: Unanswerable Questions for SQuAD}, 
-      author={Pranav Rajpurkar and Robin Jia and Percy Liang},
-      year={2018},
-      eprint={1806.03822},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}
 """
 import datasets
 from math import exp
@@ -29,6 +20,18 @@ from lm_eval.metrics import f1_score, mean
 from . common import HFTask
 from functools import partial
 from packaging import version
+
+
+_CITATION = """
+@misc{rajpurkar2018know,
+    title={Know What You Don't Know: Unanswerable Questions for SQuAD}, 
+    author={Pranav Rajpurkar and Robin Jia and Percy Liang},
+    year={2018},
+    eprint={1806.03822},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
 
 
 def _squad_metric(predictions, references):

--- a/lm_eval/tasks/storycloze.py
+++ b/lm_eval/tasks/storycloze.py
@@ -7,7 +7,12 @@ understanding, story generation, and script learning. This test requires a syste
 to choose the correct ending to a four-sentence story.
 
 Homepage: https://cs.rochester.edu/nlp/rocstories/
+"""
+import csv
+from lm_eval.base import Task
 
+
+_CITATION = """
 @inproceedings{sharma-etal-2018-tackling,
     title = "Tackling the Story Ending Biases in The Story Cloze Test",
     author = "Sharma, Rishi  and
@@ -25,8 +30,6 @@ Homepage: https://cs.rochester.edu/nlp/rocstories/
     abstract = "The Story Cloze Test (SCT) is a recent framework for evaluating story comprehension and script learning. There have been a variety of models tackling the SCT so far. Although the original goal behind the SCT was to require systems to perform deep language understanding and commonsense reasoning for successful narrative understanding, some recent models could perform significantly better than the initial baselines by leveraging human-authorship biases discovered in the SCT dataset. In order to shed some light on this issue, we have performed various data analysis and analyzed a variety of top performing models presented for this task. Given the statistics we have aggregated, we have designed a new crowdsourcing scheme that creates a new SCT dataset, which overcomes some of the biases. We benchmark a few models on the new dataset and show that the top-performing model on the original SCT dataset fails to keep up its performance. Our findings further signify the importance of benchmarking NLP systems on various evolving test sets.",
 }
 """
-import csv
-from lm_eval.base import Task
 
 
 class StoryCloze(Task):

--- a/lm_eval/tasks/storycloze.py
+++ b/lm_eval/tasks/storycloze.py
@@ -1,3 +1,30 @@
+"""
+A Corpus and Cloze Evaluation for Deeper Understanding of Commonsense Stories
+https://arxiv.org/pdf/1604.01696.pdf
+
+'Story Cloze Test' (2018) is a commonsense reasoning framework for evaluating story
+understanding, story generation, and script learning. This test requires a system
+to choose the correct ending to a four-sentence story.
+
+Homepage: https://cs.rochester.edu/nlp/rocstories/
+
+@inproceedings{sharma-etal-2018-tackling,
+    title = "Tackling the Story Ending Biases in The Story Cloze Test",
+    author = "Sharma, Rishi  and
+      Allen, James  and
+      Bakhshandeh, Omid  and
+      Mostafazadeh, Nasrin",
+    booktitle = "Proceedings of the 56th Annual Meeting of the Association for Computational Linguistics (Volume 2: Short Papers)",
+    month = jul,
+    year = "2018",
+    address = "Melbourne, Australia",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P18-2119",
+    doi = "10.18653/v1/P18-2119",
+    pages = "752--757",
+    abstract = "The Story Cloze Test (SCT) is a recent framework for evaluating story comprehension and script learning. There have been a variety of models tackling the SCT so far. Although the original goal behind the SCT was to require systems to perform deep language understanding and commonsense reasoning for successful narrative understanding, some recent models could perform significantly better than the initial baselines by leveraging human-authorship biases discovered in the SCT dataset. In order to shed some light on this issue, we have performed various data analysis and analyzed a variety of top performing models presented for this task. Given the statistics we have aggregated, we have designed a new crowdsourcing scheme that creates a new SCT dataset, which overcomes some of the biases. We benchmark a few models on the new dataset and show that the top-performing model on the original SCT dataset fails to keep up its performance. Our findings further signify the importance of benchmarking NLP systems on various evolving test sets.",
+}
+"""
 import csv
 from lm_eval.base import Task
 

--- a/lm_eval/tasks/superglue.py
+++ b/lm_eval/tasks/superglue.py
@@ -8,18 +8,6 @@ understanding tasks.
 Homepage: https://super.gluebenchmark.com/
 
 TODO: WSC requires free-form generation.
-
-@inproceedings{NEURIPS2019_4496bf24,
- author = {Wang, Alex and Pruksachatkun, Yada and Nangia, Nikita and Singh, Amanpreet and Michael, Julian and Hill, Felix and Levy, Omer and Bowman, Samuel},
- booktitle = {Advances in Neural Information Processing Systems},
- editor = {H. Wallach and H. Larochelle and A. Beygelzimer and F. d\textquotesingle Alch\'{e}-Buc and E. Fox and R. Garnett},
- pages = {},
- publisher = {Curran Associates, Inc.},
- title = {SuperGLUE: A Stickier Benchmark for General-Purpose Language Understanding Systems},
- url = {https://proceedings.neurips.cc/paper/2019/file/4496bf24afe7fab6f046bf4923da8de6-Paper.pdf},
- volume = {32},
- year = {2019}
-}
 """
 import numpy as np
 import sklearn
@@ -28,6 +16,21 @@ from . common import HFTask, yesno
 from lm_eval.base import rf
 from ..metrics import mean, acc_all, metric_max_over_ground_truths
 from ..utils import general_detokenize
+
+
+_CITATION = """
+@inproceedings{NEURIPS2019_4496bf24,
+    author = {Wang, Alex and Pruksachatkun, Yada and Nangia, Nikita and Singh, Amanpreet and Michael, Julian and Hill, Felix and Levy, Omer and Bowman, Samuel},
+    booktitle = {Advances in Neural Information Processing Systems},
+    editor = {H. Wallach and H. Larochelle and A. Beygelzimer and F. d\textquotesingle Alch\'{e}-Buc and E. Fox and R. Garnett},
+    pages = {},
+    publisher = {Curran Associates, Inc.},
+    title = {SuperGLUE: A Stickier Benchmark for General-Purpose Language Understanding Systems},
+    url = {https://proceedings.neurips.cc/paper/2019/file/4496bf24afe7fab6f046bf4923da8de6-Paper.pdf},
+    volume = {32},
+    year = {2019}
+}
+"""
 
 
 class BoolQ(HFTask):

--- a/lm_eval/tasks/superglue.py
+++ b/lm_eval/tasks/superglue.py
@@ -1,7 +1,25 @@
 """
-To-do:
-    - WSC requires free-form generation
-    - ReCoRD
+SuperGLUE: A Stickier Benchmark for General-Purpose Language Understanding Systems
+https://w4ngatang.github.io/static/papers/superglue.pdf
+
+SuperGLUE is a benchmark styled after GLUE with a new set of more difficult language
+understanding tasks.
+
+Homepage: https://super.gluebenchmark.com/
+
+TODO: WSC requires free-form generation.
+
+@inproceedings{NEURIPS2019_4496bf24,
+ author = {Wang, Alex and Pruksachatkun, Yada and Nangia, Nikita and Singh, Amanpreet and Michael, Julian and Hill, Felix and Levy, Omer and Bowman, Samuel},
+ booktitle = {Advances in Neural Information Processing Systems},
+ editor = {H. Wallach and H. Larochelle and A. Beygelzimer and F. d\textquotesingle Alch\'{e}-Buc and E. Fox and R. Garnett},
+ pages = {},
+ publisher = {Curran Associates, Inc.},
+ title = {SuperGLUE: A Stickier Benchmark for General-Purpose Language Understanding Systems},
+ url = {https://proceedings.neurips.cc/paper/2019/file/4496bf24afe7fab6f046bf4923da8de6-Paper.pdf},
+ volume = {32},
+ year = {2019}
+}
 """
 import numpy as np
 import sklearn

--- a/lm_eval/tasks/translation.py
+++ b/lm_eval/tasks/translation.py
@@ -1,3 +1,26 @@
+"""
+NOTE: This file implements translation tasks using datasets from WMT conferences,
+provided by sacrebleu. Traditionally they are evaluated with BLEU scores. TER
+and CHRF are other options.
+
+We defer citations and descriptions of the many translations tasks used
+here to the SacreBLEU repo from which we've obtained the datasets:
+https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/dataset.py
+
+Homepage: https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/dataset.py
+
+@inproceedings{post-2018-call,
+  title = "A Call for Clarity in Reporting {BLEU} Scores",
+  author = "Post, Matt",
+  booktitle = "Proceedings of the Third Conference on Machine Translation: Research Papers",
+  month = oct,
+  year = "2018",
+  address = "Belgium, Brussels",
+  publisher = "Association for Computational Linguistics",
+  url = "https://www.aclweb.org/anthology/W18-6319",
+  pages = "186--191",
+}
+"""
 import pycountry
 from pprint import pprint
 from sacrebleu import sacrebleu
@@ -6,13 +29,6 @@ from lm_eval.base import Task, rf
 from typing import List
 
 
-
-"""
-This file implements translation tasks using datasets from WMT conferences, provided by sacrebleu.
-Traditionally they are evaluated with BLEU scores. TER and CHRF are other options.
-
-See sacrebleu.DATASETS for all available datasets. There are a lot!
-"""
 sacrebleu_datasets = sacrebleu.DATASETS
 
 

--- a/lm_eval/tasks/translation.py
+++ b/lm_eval/tasks/translation.py
@@ -8,18 +8,6 @@ here to the SacreBLEU repo from which we've obtained the datasets:
 https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/dataset.py
 
 Homepage: https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/dataset.py
-
-@inproceedings{post-2018-call,
-  title = "A Call for Clarity in Reporting {BLEU} Scores",
-  author = "Post, Matt",
-  booktitle = "Proceedings of the Third Conference on Machine Translation: Research Papers",
-  month = oct,
-  year = "2018",
-  address = "Belgium, Brussels",
-  publisher = "Association for Computational Linguistics",
-  url = "https://www.aclweb.org/anthology/W18-6319",
-  pages = "186--191",
-}
 """
 import pycountry
 from pprint import pprint
@@ -27,6 +15,21 @@ from sacrebleu import sacrebleu
 from lm_eval import metrics
 from lm_eval.base import Task, rf
 from typing import List
+
+
+_CITATION = """
+@inproceedings{post-2018-call,
+    title = "A Call for Clarity in Reporting {BLEU} Scores",
+    author = "Post, Matt",
+    booktitle = "Proceedings of the Third Conference on Machine Translation: Research Papers",
+    month = oct,
+    year = "2018",
+    address = "Belgium, Brussels",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/W18-6319",
+    pages = "186--191",
+}
+"""
 
 
 sacrebleu_datasets = sacrebleu.DATASETS

--- a/lm_eval/tasks/triviaqa.py
+++ b/lm_eval/tasks/triviaqa.py
@@ -1,3 +1,24 @@
+"""
+TriviaQA: A Large Scale Distantly Supervised Challenge Dataset for Reading Comprehension
+https://arxiv.org/pdf/1705.03551.pdf
+
+TriviaQA is a reading comprehension dataset containing over 650K question-answer-evidence
+triples. TriviaQA includes 95K question-answer pairs authored by trivia enthusiasts
+and independently gathered evidence documents, six per question on average, that provide
+high quality distant supervision for answering the questions.
+
+Homepage: https://nlp.cs.washington.edu/triviaqa/
+
+@InProceedings{JoshiTriviaQA2017,
+     author = {Joshi, Mandar and Choi, Eunsol and Weld, Daniel S. and Zettlemoyer, Luke},
+     title = {TriviaQA: A Large Scale Distantly Supervised Challenge Dataset for Reading Comprehension},
+     booktitle = {Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics},
+     month = {July},
+     year = {2017},
+     address = {Vancouver, Canada},
+     publisher = {Association for Computational Linguistics},
+}
+"""
 import os
 import json
 import jsonlines

--- a/lm_eval/tasks/triviaqa.py
+++ b/lm_eval/tasks/triviaqa.py
@@ -8,16 +8,6 @@ and independently gathered evidence documents, six per question on average, that
 high quality distant supervision for answering the questions.
 
 Homepage: https://nlp.cs.washington.edu/triviaqa/
-
-@InProceedings{JoshiTriviaQA2017,
-     author = {Joshi, Mandar and Choi, Eunsol and Weld, Daniel S. and Zettlemoyer, Luke},
-     title = {TriviaQA: A Large Scale Distantly Supervised Challenge Dataset for Reading Comprehension},
-     booktitle = {Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics},
-     month = {July},
-     year = {2017},
-     address = {Vancouver, Canada},
-     publisher = {Association for Computational Linguistics},
-}
 """
 import os
 import json
@@ -26,6 +16,19 @@ from lm_eval.base import Task, rf
 from ..metrics import mean
 from ..utils import sh
 from best_download import download_file
+
+
+_CITATION = """
+@InProceedings{JoshiTriviaQA2017,
+    author = {Joshi, Mandar and Choi, Eunsol and Weld, Daniel S. and Zettlemoyer, Luke},
+    title = {TriviaQA: A Large Scale Distantly Supervised Challenge Dataset for Reading Comprehension},
+    booktitle = {Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics},
+    month = {July},
+    year = {2017},
+    address = {Vancouver, Canada},
+    publisher = {Association for Computational Linguistics},
+}
+"""
 
 
 class TriviaQA(Task):

--- a/lm_eval/tasks/truthfulqa.py
+++ b/lm_eval/tasks/truthfulqa.py
@@ -18,15 +18,6 @@ https://github.com/sylinrl/TruthfulQA#Fine-tuning-GPT-3-for-evaluation. Maybe
 we could try this?
 
 Homepage: https://github.com/sylinrl/TruthfulQA
-
-@misc{lin2021truthfulqa,
-      title={TruthfulQA: Measuring How Models Mimic Human Falsehoods},
-      author={Stephanie Lin and Jacob Hilton and Owain Evans},
-      year={2021},
-      eprint={2109.07958},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}
 """
 import csv
 import json
@@ -38,6 +29,18 @@ from pathlib import Path
 from best_download import download_file
 from ..metrics import mean
 from datasets import load_metric
+
+
+_CITATION = """
+@misc{lin2021truthfulqa,
+    title={TruthfulQA: Measuring How Models Mimic Human Falsehoods},
+    author={Stephanie Lin and Jacob Hilton and Owain Evans},
+    year={2021},
+    eprint={2109.07958},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
 
 
 # The default QA preset prompt for all models.

--- a/lm_eval/tasks/truthfulqa.py
+++ b/lm_eval/tasks/truthfulqa.py
@@ -2,6 +2,13 @@
 TruthfulQA: Measuring How Models Mimic Human Falsehoods
 https://arxiv.org/pdf/2109.07958.pdf
 
+TruthfulQA is a benchmark to measure whether a language model is truthful in
+generating answers to questions. The benchmark comprises 817 questions that
+span 38 categories, including health, law, finance and politics. Questions are
+crafted so that some humans would answer falsely due to a false belief or
+misconception. To perform well, models must avoid generating false answers
+learned from imitating human texts.
+
 TODO: Add support for the automatic metrics, 'GPT-judge' and 'GPT-info', which
 predict human evaluation of truth and informativeness (respectively) through
 a fine-tuned GPT-3 model. NOTE: This requires access keys to the corresponding
@@ -9,6 +16,8 @@ OpenAI Completion engines (which the authors obviously do not expose). They do
 provide the data used to fine-tune GPT-3 into `GPT-judge` and `GPT-info`, see
 https://github.com/sylinrl/TruthfulQA#Fine-tuning-GPT-3-for-evaluation. Maybe
 we could try this?
+
+Homepage: https://github.com/sylinrl/TruthfulQA
 
 @misc{lin2021truthfulqa,
       title={TruthfulQA: Measuring How Models Mimic Human Falsehoods},

--- a/lm_eval/tasks/unscramble.py
+++ b/lm_eval/tasks/unscramble.py
@@ -1,3 +1,25 @@
+"""
+Language Models are Few-Shot Learners
+https://arxiv.org/pdf/2005.14165.pdf
+
+Unscramble is a small battery of 5 “character manipulation” tasks. Each task
+involves giving the model a word distorted by some combination of scrambling,
+addition, or deletion of characters, and asking it to recover the original word.
+
+Homepage: https://github.com/openai/gpt-3/tree/master/data
+
+@inproceedings{NEURIPS2020_1457c0d6,
+    author = {Brown, Tom and Mann, Benjamin and Ryder, Nick and Subbiah, Melanie and Kaplan, Jared D and Dhariwal, Prafulla and Neelakantan, Arvind and Shyam, Pranav and Sastry, Girish and Askell, Amanda and Agarwal, Sandhini and Herbert-Voss, Ariel and Krueger, Gretchen and Henighan, Tom and Child, Rewon and Ramesh, Aditya and Ziegler, Daniel and Wu, Jeffrey and Winter, Clemens and Hesse, Chris and Chen, Mark and Sigler, Eric and Litwin, Mateusz and Gray, Scott and Chess, Benjamin and Clark, Jack and Berner, Christopher and McCandlish, Sam and Radford, Alec and Sutskever, Ilya and Amodei, Dario},
+    booktitle = {Advances in Neural Information Processing Systems},
+    editor = {H. Larochelle and M. Ranzato and R. Hadsell and M. F. Balcan and H. Lin},
+    pages = {1877--1901},
+    publisher = {Curran Associates, Inc.},
+    title = {Language Models are Few-Shot Learners},
+    url = {https://proceedings.neurips.cc/paper/2020/file/1457c0d6bfcb4967418bfb8ac142f64a-Paper.pdf},
+    volume = {33},
+    year = {2020}
+}
+"""
 import gzip
 import json
 import shutil

--- a/lm_eval/tasks/unscramble.py
+++ b/lm_eval/tasks/unscramble.py
@@ -7,7 +7,17 @@ involves giving the model a word distorted by some combination of scrambling,
 addition, or deletion of characters, and asking it to recover the original word.
 
 Homepage: https://github.com/openai/gpt-3/tree/master/data
+"""
+import gzip
+import json
+import shutil
+from pathlib import Path
+from best_download import download_file
+from lm_eval.base import Task, rf
+from lm_eval.metrics import mean
 
+
+_CITATION = """
 @inproceedings{NEURIPS2020_1457c0d6,
     author = {Brown, Tom and Mann, Benjamin and Ryder, Nick and Subbiah, Melanie and Kaplan, Jared D and Dhariwal, Prafulla and Neelakantan, Arvind and Shyam, Pranav and Sastry, Girish and Askell, Amanda and Agarwal, Sandhini and Herbert-Voss, Ariel and Krueger, Gretchen and Henighan, Tom and Child, Rewon and Ramesh, Aditya and Ziegler, Daniel and Wu, Jeffrey and Winter, Clemens and Hesse, Chris and Chen, Mark and Sigler, Eric and Litwin, Mateusz and Gray, Scott and Chess, Benjamin and Clark, Jack and Berner, Christopher and McCandlish, Sam and Radford, Alec and Sutskever, Ilya and Amodei, Dario},
     booktitle = {Advances in Neural Information Processing Systems},
@@ -20,13 +30,6 @@ Homepage: https://github.com/openai/gpt-3/tree/master/data
     year = {2020}
 }
 """
-import gzip
-import json
-import shutil
-from pathlib import Path
-from best_download import download_file
-from lm_eval.base import Task, rf
-from lm_eval.metrics import mean
 
 
 def extract_gzip(gz, to):

--- a/lm_eval/tasks/webqs.py
+++ b/lm_eval/tasks/webqs.py
@@ -1,3 +1,29 @@
+"""
+Semantic Parsing on Freebase from Question-Answer Pairs
+https://cs.stanford.edu/~pliang/papers/freebase-emnlp2013.pdf
+
+WebQuestions is a benchmark for question answering. The dataset consists of 6,642
+question/answer pairs. The questions are supposed to be answerable by Freebase, a
+large knowledge graph. The questions are mostly centered around a single named entity.
+The questions are popular ones asked on the web (at least in 2013).
+
+Homepage: https://worksheets.codalab.org/worksheets/0xba659fe363cb46e7a505c5b6a774dc8a
+
+@inproceedings{berant-etal-2013-semantic,
+    title = "Semantic Parsing on {F}reebase from Question-Answer Pairs",
+    author = "Berant, Jonathan  and
+      Chou, Andrew  and
+      Frostig, Roy  and
+      Liang, Percy",
+    booktitle = "Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing",
+    month = oct,
+    year = "2013",
+    address = "Seattle, Washington, USA",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/D13-1160",
+    pages = "1533--1544",
+}
+"""
 from . common import HFTask
 from lm_eval.base import rf
 from ..metrics import mean

--- a/lm_eval/tasks/webqs.py
+++ b/lm_eval/tasks/webqs.py
@@ -8,7 +8,13 @@ large knowledge graph. The questions are mostly centered around a single named e
 The questions are popular ones asked on the web (at least in 2013).
 
 Homepage: https://worksheets.codalab.org/worksheets/0xba659fe363cb46e7a505c5b6a774dc8a
+"""
+from . common import HFTask
+from lm_eval.base import rf
+from ..metrics import mean
 
+
+_CITATION = """
 @inproceedings{berant-etal-2013-semantic,
     title = "Semantic Parsing on {F}reebase from Question-Answer Pairs",
     author = "Berant, Jonathan  and
@@ -24,9 +30,6 @@ Homepage: https://worksheets.codalab.org/worksheets/0xba659fe363cb46e7a505c5b6a7
     pages = "1533--1544",
 }
 """
-from . common import HFTask
-from lm_eval.base import rf
-from ..metrics import mean
 
 
 class WebQs(HFTask):

--- a/lm_eval/tasks/wikitext.py
+++ b/lm_eval/tasks/wikitext.py
@@ -8,22 +8,24 @@ extracted from the set of verified Good and Featured articles on Wikipedia.
 NOTE: This `Task` is based on WikiText-2.
 
 Homepage: https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/
-
-@misc{merity2016pointer,
-      title={Pointer Sentinel Mixture Models}, 
-      author={Stephen Merity and Caiming Xiong and James Bradbury and Richard Socher},
-      year={2016},
-      eprint={1609.07843},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL}
-}
 """
 import os
 import re
 from lm_eval.base import rf, PerplexityTask
 from lm_eval.utils import sh
-
 from best_download import download_file
+
+
+_CITATION = """
+@misc{merity2016pointer,
+    title={Pointer Sentinel Mixture Models}, 
+    author={Stephen Merity and Caiming Xiong and James Bradbury and Richard Socher},
+    year={2016},
+    eprint={1609.07843},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+"""
 
 
 def wikitext_detokenizer(string):

--- a/lm_eval/tasks/wikitext.py
+++ b/lm_eval/tasks/wikitext.py
@@ -1,3 +1,23 @@
+"""
+Pointer Sentinel Mixture Models
+https://arxiv.org/pdf/1609.07843.pdf
+
+The WikiText language modeling dataset is a collection of over 100 million tokens 
+extracted from the set of verified Good and Featured articles on Wikipedia.
+
+NOTE: This `Task` is based on WikiText-2.
+
+Homepage: https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/
+
+@misc{merity2016pointer,
+      title={Pointer Sentinel Mixture Models}, 
+      author={Stephen Merity and Caiming Xiong and James Bradbury and Richard Socher},
+      year={2016},
+      eprint={1609.07843},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+"""
 import os
 import re
 from lm_eval.base import rf, PerplexityTask

--- a/lm_eval/tasks/winogrande.py
+++ b/lm_eval/tasks/winogrande.py
@@ -13,7 +13,14 @@ Trinh & Le in Simple Method for Commonsense Reasoning (2018).
 See: https://arxiv.org/abs/1806.02847
 
 Homepage: https://leaderboard.allenai.org/winogrande/submissions/public
+"""
+import numpy as np
+from . common import HFTask
+from lm_eval.base import rf
+from ..metrics import mean
 
+
+_CITATION = """
 @article{sakaguchi2019winogrande,
     title={WinoGrande: An Adversarial Winograd Schema Challenge at Scale},
     author={Sakaguchi, Keisuke and Bras, Ronan Le and Bhagavatula, Chandra and Choi, Yejin},
@@ -21,10 +28,6 @@ Homepage: https://leaderboard.allenai.org/winogrande/submissions/public
     year={2019}
 }
 """
-import numpy as np
-from . common import HFTask
-from lm_eval.base import rf
-from ..metrics import mean
 
 
 class Winogrande(HFTask):

--- a/lm_eval/tasks/winogrande.py
+++ b/lm_eval/tasks/winogrande.py
@@ -1,13 +1,30 @@
+"""
+WinoGrande: An Adversarial Winograd Schema Challenge at Scale
+https://arxiv.org/pdf/1907.10641.pdf
+
+WinoGrande is a collection of 44k problems, inspired by Winograd Schema Challenge
+(Levesque, Davis, and Morgenstern 2011), but adjusted to improve the scale and
+robustness against the dataset-specific bias. Formulated as a fill-in-a-blank
+task with binary options, the goal is to choose the right option for a given
+sentence which requires commonsense reasoning.
+
+NOTE: This evaluation of Winogrande uses partial evaluation as described by
+Trinh & Le in Simple Method for Commonsense Reasoning (2018). 
+See: https://arxiv.org/abs/1806.02847
+
+Homepage: https://leaderboard.allenai.org/winogrande/submissions/public
+
+@article{sakaguchi2019winogrande,
+    title={WinoGrande: An Adversarial Winograd Schema Challenge at Scale},
+    author={Sakaguchi, Keisuke and Bras, Ronan Le and Bhagavatula, Chandra and Choi, Yejin},
+    journal={arXiv preprint arXiv:1907.10641},
+    year={2019}
+}
+"""
 import numpy as np
 from . common import HFTask
 from lm_eval.base import rf
 from ..metrics import mean
-
-"""
-This evaluation of Winogrande uses partial evaluation as described by
-Trinh & Le in Simple Method for Commonsense Reasoning (2018).
-Reference: https://arxiv.org/abs/1806.02847
-"""
 
 
 class Winogrande(HFTask):

--- a/lm_eval/tasks/wsc273.py
+++ b/lm_eval/tasks/wsc273.py
@@ -12,7 +12,15 @@ as described by Trinh & Le in Simple Method for Commonsense Reasoning (2018).
 See: https://arxiv.org/abs/1806.0
 
 Homepage: https://cs.nyu.edu/~davise/papers/WinogradSchemas/WS.html
+"""
+import numpy as np
+import random
+from lm_eval.base import rf
+from ..metrics import mean
+from . common import HFTask
 
+
+_CITATION = """
 @inproceedings{ea01b9c0db064caca6986b925d75f2bb,
     title = "The winograd schema challenge",
     abstract = "In this paper, we present an alternative to the Turing Test that has some conceptual and practical advantages. A Wino-grad schema is a pair of sentences that differ only in one or two words and that contain a referential ambiguity that is resolved in opposite directions in the two sentences. We have compiled a collection of Winograd schemas, designed so that the correct answer is obvious to the human reader, but cannot easily be found using selectional restrictions or statistical techniques over text corpora. A contestant in the Winograd Schema Challenge is presented with a collection of one sentence from each pair, and required to achieve human-level accuracy in choosing the correct disambiguation.",
@@ -27,11 +35,6 @@ Homepage: https://cs.nyu.edu/~davise/papers/WinogradSchemas/WS.html
     note = "13th International Conference on the Principles of Knowledge Representation and Reasoning, KR 2012 ; Conference date: 10-06-2012 Through 14-06-2012",
 }
 """
-import numpy as np
-import random
-from lm_eval.base import rf
-from ..metrics import mean
-from . common import HFTask
 
 
 class WinogradSchemaChallenge273(HFTask):

--- a/lm_eval/tasks/wsc273.py
+++ b/lm_eval/tasks/wsc273.py
@@ -1,14 +1,37 @@
+"""
+The Winograd Schema Challenge
+http://commonsensereasoning.org/2011/papers/Levesque.pdf
+
+A Winograd schema is a pair of sentences that differ in only one or two words
+and that contain an ambiguity that is resolved in opposite ways in the two
+sentences and requires the use of world knowledge and reasoning for its resolution.
+The Winograd Schema Challenge 273 is a collection of 273 such Winograd schemas.
+
+NOTE: This evaluation of Winograd Schema Challenge is based on `partial evaluation`
+as described by Trinh & Le in Simple Method for Commonsense Reasoning (2018).
+See: https://arxiv.org/abs/1806.0
+
+Homepage: https://cs.nyu.edu/~davise/papers/WinogradSchemas/WS.html
+
+@inproceedings{ea01b9c0db064caca6986b925d75f2bb,
+    title = "The winograd schema challenge",
+    abstract = "In this paper, we present an alternative to the Turing Test that has some conceptual and practical advantages. A Wino-grad schema is a pair of sentences that differ only in one or two words and that contain a referential ambiguity that is resolved in opposite directions in the two sentences. We have compiled a collection of Winograd schemas, designed so that the correct answer is obvious to the human reader, but cannot easily be found using selectional restrictions or statistical techniques over text corpora. A contestant in the Winograd Schema Challenge is presented with a collection of one sentence from each pair, and required to achieve human-level accuracy in choosing the correct disambiguation.",
+    author = "Levesque, {Hector J.} and Ernest Davis and Leora Morgenstern",
+    year = "2012",
+    language = "English (US)",
+    isbn = "9781577355601",
+    series = "Proceedings of the International Conference on Knowledge Representation and Reasoning",
+    publisher = "Institute of Electrical and Electronics Engineers Inc.",
+    pages = "552--561",
+    booktitle = "13th International Conference on the Principles of Knowledge Representation and Reasoning, KR 2012",
+    note = "13th International Conference on the Principles of Knowledge Representation and Reasoning, KR 2012 ; Conference date: 10-06-2012 Through 14-06-2012",
+}
+"""
 import numpy as np
 import random
 from lm_eval.base import rf
 from ..metrics import mean
 from . common import HFTask
-
-"""
-NOTE: This evaluation of Winograd Schema Challenge is based on `partial evaluation`
-as described by Trinh & Le in Simple Method for Commonsense Reasoning (2018).
-See: https://arxiv.org/abs/1806.02847
-"""
 
 
 class WinogradSchemaChallenge273(HFTask):


### PR DESCRIPTION
Updates:
- Ensures the current suite of tasks contains docstrings with paper names and pdf links.
- Adds short descriptions to each task pulled from their abstract and/or homepages.
- Adds task homepage website links where you can find more information about them.
- Adds citations as module-level constants. This can, in the future, provide a simple way for users to "export-to-Bib-TeX".
