### PR TITLE
Decontam import fix

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -1,15 +1,12 @@
 import collections
 import itertools
-import pathlib
+import numpy as np
 import random
 import lm_eval.metrics
 import lm_eval.models
 import lm_eval.tasks
 import lm_eval.base
-import lm_eval.decontamination
-import numpy as np
 from lm_eval.utils import positional_deprecated, run_task_tests
-from lm_eval.decontamination.decontaminate import get_train_overlap
 
 
 @positional_deprecated
@@ -228,6 +225,7 @@ def evaluate(
 
     # Compare all tasks/sets at once to ensure a single training set scan
     if decontaminate:
+        from lm_eval.decontamination.decontaminate import get_train_overlap
         print("Finding train/test overlap, please wait...")
         overlaps = get_train_overlap(
             docs_for_decontamination, decontamination_ngrams_path, limit

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -226,6 +226,7 @@ def evaluate(
     # Compare all tasks/sets at once to ensure a single training set scan
     if decontaminate:
         from lm_eval.decontamination.decontaminate import get_train_overlap
+
         print("Finding train/test overlap, please wait...")
         overlaps = get_train_overlap(
             docs_for_decontamination, decontamination_ngrams_path, limit

--- a/scripts/clean_training_data/janitor_util.cpp
+++ b/scripts/clean_training_data/janitor_util.cpp
@@ -176,7 +176,7 @@ clean_ngram_with_indices(std::string const &input, std::string const &ignore,
       }
 
       // Skip ignored characters
-    } else if (ignore.find(*iter) != std::string::npos) {
+    } else if (ignore.find(ch) != std::string::npos) {
       continue;
 
       // If it is a non-ignored character, add it to the ngram and update the


### PR DESCRIPTION
Lazily imports `lm_eval.decontamination.decontaminate` to avoid the following `ModuleNotFoundError`:

```python
WARNING: C++ module could not be loaded. Janitor running in python mode
Traceback (most recent call last):
  File "/Users/jon-tow/Git/lm-evaluation-harness/lm_eval/decontamination/janitor.py", line 11, in <module>
    import janitor_util
ModuleNotFoundError: No module named 'janitor_util'
```

This occurs b/c the `janitor_util` module must be compiled from `janitor_util.cpp` (which most users will not have to do).