### PR TITLE
Fix key access in squad evaluation metrics

### DIFF
--- a/lm_eval/tasks/squad.py
+++ b/lm_eval/tasks/squad.py
@@ -40,7 +40,7 @@ def _squad_metric(predictions, references):
 def _squad_agg(key, items):
     predictions, references = zip(*items)
 
-    return _squad_metric(predictions=predictions, references=references)[key]
+    return _squad_metric(predictions=predictions, references=references).get(key, 0)
 
 
 class SQuAD2(Task):


### PR DESCRIPTION
When you run
`python main.py --model gpt2 --tasks squad2 --limit 4`
a key error is encountered because no unanswerable samples are in the first few data points of the Squad dataset:

```
Traceback (most recent call last):
  File "/lm-evaluation-harness/main.py", line 108, in <module>
    main()
  File "/lm-evaluation-harness/main.py", line 79, in main
    results = evaluator.simple_evaluate(
  File "/lm-evaluation-harness/lm_eval/utils.py", line 164, in _wrapper
    return fn(*args, **kwargs)
  File "/lm-evaluation-harness/lm_eval/evaluator.py", line 86, in simple_evaluate
    results = evaluate(
  File "/lm-evaluation-harness/lm_eval/utils.py", line 164, in _wrapper
    return fn(*args, **kwargs)
  File "/lm-evaluation-harness/lm_eval/evaluator.py", line 282, in evaluate
    results[task_name][metric] = task.aggregation()[real_metric] (items)
  File "/lm-evaluation-harness/lm_eval/tasks/squad.py", line 43, in _squad_agg
    return _squad_metric(predictions=predictions, references=references)[key]
KeyError: 'NoAns_exact'
```

Solution: implement safe access to single metrics in the evaluation dictionary, with a default score of 0 if the metric is not supported