### PR TITLE
Add `accelerate` support for Large Language Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ python main.py \
 ```
 To evaluate mesh-transformer-jax models that are not available on HF, please invoke eval harness through [this script](https://github.com/kingoflolz/mesh-transformer-jax/blob/master/eval_harness.py).
 
+### Large Language Models support
+
+Using HuggingFace `accelerate` library you can now run very large language models on `lm-eval-harness`. We suggest to use the following args:
+```bash
+python main.py \
+  --model gpt2 \
+  --model_args pretrained=bigscience/bloom,device_map=auto,max_memory=50GB \
+  --accelerate \
+  --tasks hellaswag \
+  --batch_size 32 \
+  --skip_tokenier
+```
+
 ## Implementing new tasks
 
 To implement a new task in eval harness, see [this guide](./docs/task_guide.md).

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -23,8 +23,12 @@ def simple_evaluate(
     description_dict=None,
     check_integrity=False,
     decontamination_ngrams_path=None,
-    accelerate=False,
+    use_accelerate=False,
     skip_tokenizer=False,
+    offload_folder=None,
+    max_memory_per_gpu=None,
+    max_cpu_memory=None,
+    dtype=None,
 ):
 
     """Instantiate and evaluate a model on a list of tasks.
@@ -52,8 +56,18 @@ def simple_evaluate(
         Dictionary of custom task descriptions of the form: `task_name: description`
     :param check_integrity: bool
         Whether to run the relevant part of the test suite for the tasks
-    :accelerate: bool
+    :use_accelerate: bool
         Whether to use accelerate as backend for large models inference
+    :skip_tokenizer: bool
+        Whether to skip tokenization test
+    :offload_folder: str
+        Folder to store offloaded data - used only in accelerate
+    :max_memory_per_gpu: str
+        Maximum memory per GPU for accelerate in the format of "NGB"
+    :max_cpu_memory: str
+        Maximum memory for accelerate in the format of "NGB"
+    :dtype: str
+        Model dtype
     :return
         Dictionary of results
     """
@@ -66,7 +80,7 @@ def simple_evaluate(
         if model_args is None:
             model_args = ""
         lm = lm_eval.models.get_model(model).create_from_arg_string(
-            model_args, {"batch_size": batch_size, "device": device, "accelerate": accelerate, "skip_tokenizer": skip_tokenizer}
+            model_args, {"batch_size": batch_size, "device": device, "use_accelerate": use_accelerate, "skip_tokenizer": skip_tokenizer, "offload_folder":offload_folder, "max_memory_per_gpu": max_memory_per_gpu, "max_cpu_memory": max_cpu_memory, "dtype": dtype}
         )
     else:
         assert isinstance(model, lm_eval.base.LM)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -24,6 +24,7 @@ def simple_evaluate(
     check_integrity=False,
     decontamination_ngrams_path=None,
     accelerate=False,
+    skip_tokenizer=False,
 ):
 
     """Instantiate and evaluate a model on a list of tasks.
@@ -65,7 +66,7 @@ def simple_evaluate(
         if model_args is None:
             model_args = ""
         lm = lm_eval.models.get_model(model).create_from_arg_string(
-            model_args, {"batch_size": batch_size, "device": device, "accelerate": accelerate}
+            model_args, {"batch_size": batch_size, "device": device, "accelerate": accelerate, "skip_tokenizer": skip_tokenizer}
         )
     else:
         assert isinstance(model, lm_eval.base.LM)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -23,7 +23,7 @@ def simple_evaluate(
     description_dict=None,
     check_integrity=False,
     decontamination_ngrams_path=None,
-    offloading=False,
+    accelerate=False,
 ):
 
     """Instantiate and evaluate a model on a list of tasks.
@@ -51,8 +51,8 @@ def simple_evaluate(
         Dictionary of custom task descriptions of the form: `task_name: description`
     :param check_integrity: bool
         Whether to run the relevant part of the test suite for the tasks
-    :offloading: bool
-        Whether to use offloading
+    :accelerate: bool
+        Whether to use accelerate as backend for large models inference
     :return
         Dictionary of results
     """
@@ -65,7 +65,7 @@ def simple_evaluate(
         if model_args is None:
             model_args = ""
         lm = lm_eval.models.get_model(model).create_from_arg_string(
-            model_args, {"batch_size": batch_size, "device": device, "offloading": offloading}
+            model_args, {"batch_size": batch_size, "device": device, "accelerate": accelerate}
         )
     else:
         assert isinstance(model, lm_eval.base.LM)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -23,6 +23,7 @@ def simple_evaluate(
     description_dict=None,
     check_integrity=False,
     decontamination_ngrams_path=None,
+    offloading=False,
 ):
 
     """Instantiate and evaluate a model on a list of tasks.
@@ -50,6 +51,8 @@ def simple_evaluate(
         Dictionary of custom task descriptions of the form: `task_name: description`
     :param check_integrity: bool
         Whether to run the relevant part of the test suite for the tasks
+    :offloading: bool
+        Whether to use offloading
     :return
         Dictionary of results
     """
@@ -62,7 +65,7 @@ def simple_evaluate(
         if model_args is None:
             model_args = ""
         lm = lm_eval.models.get_model(model).create_from_arg_string(
-            model_args, {"batch_size": batch_size, "device": device}
+            model_args, {"batch_size": batch_size, "device": device, "offloading": offloading}
         )
     else:
         assert isinstance(model, lm_eval.base.LM)

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -2,28 +2,11 @@ import transformers
 import torch
 from lm_eval.base import BaseLM
 
-def compute_device_map(layers):
-    gpus = torch.cuda.device_count()
-
-    min_block_per_gpu = layers // gpus
-    # TODO @thomasw21 handle rest
-    return {
-	"model.decoder.embed_positions": 0,
-        "model.decoder.embed_tokens": 0,
-        **{
-            f"model.decoder.layers.{i}": i // min_block_per_gpu
-            for i in range(layers)
-        },
-	"model.decoder.final_layer_norm": gpus-1,
-        "lm_head.weight": gpus-1,
-        "lm_head.bias": gpus-1,
-    }
 
 def get_args_for_accelerate(pretrained, max_memory):
     config = transformers.AutoConfig.from_pretrained(pretrained)
     max_memory = {i:max_memory for i in range(torch.cuda.device_count())}
-    
-    layers =config.num_hidden_layers
+
     torch_dtype = config.torch_dtype
 
     return max_memory, torch_dtype

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -44,6 +44,7 @@ class HFLM(BaseLM):
         device_map=None,
         max_memory=None,
         skip_tokenizer=False,
+        offload_folder="./offload"
     ):
         super().__init__()
 
@@ -79,6 +80,7 @@ class HFLM(BaseLM):
                 device_map=device_map,
                 max_memory=max_memory,
                 torch_dtype=torch_dtype,
+                offload_folder=offload_folder,
             )
         self.gpt2.eval()
 

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -23,7 +23,7 @@ class HFLM(BaseLM):
         subfolder=None,
         tokenizer=None,
         batch_size=1,
-        accelerate=False,
+        use_accelerate=False,
         max_memory_per_gpu=None,
         skip_tokenizer=False,
         offload_folder="./offload",
@@ -51,7 +51,7 @@ class HFLM(BaseLM):
             )
 
         # TODO: update this to be less of a hack once subfolder is fixed in HF
-        if not accelerate:
+        if not use_accelerate:
             self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
                 pretrained,
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -41,12 +41,11 @@ class HFLM(BaseLM):
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
             ).to(self.device)
         else:
-            print(pretrained)
             self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
                 pretrained,
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
                 device_map="auto",
-                torch_dtype="auto",
+                torch_dtype=torch.float16,
             )
         self.gpt2.eval()
 

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -128,6 +128,7 @@ class HFLM(BaseLM):
         logits returned from the model
         """
         with torch.no_grad():
+            print(inps.shape)
             return self.gpt2(inps)[0][:, :, :50257]
 
     def _model_generate(self, context, max_length, eos_token_id):

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -21,7 +21,6 @@ class HFLM(BaseLM):
         tokenizer=None,
         batch_size=1,
         accelerate=False,
-        device_map=None,
         max_memory=None,
         skip_tokenizer=False,
         offload_folder="./offload"
@@ -53,7 +52,7 @@ class HFLM(BaseLM):
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
             ).to(self.device)
         else:
-            device_map, max_memory, torch_dtype = get_args_for_accelerate(pretrained, device_map, max_memory)
+            max_memory, torch_dtype = get_args_for_accelerate(pretrained, max_memory)
             self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
                 pretrained,
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -147,7 +147,7 @@ class HFLM(BaseLM):
         logits returned from the model
         """
         with torch.no_grad():
-            return self.gpt2(inps)[0][:, :, :self.tokenizer.vocab_size]
+            return self.gpt2(inps)[0][:, :, :len(self.tokenizer)]
 
     def _model_generate(self, context, max_length, eos_token_id):
         return self.gpt2.generate(

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -68,15 +68,15 @@ class HFLM(BaseLM):
 
         self.vocab_size = self.tokenizer.vocab_size
 
-        if isinstance(
-            self.tokenizer, (transformers.GPT2Tokenizer, transformers.GPT2TokenizerFast)
-        ):
-            assert self.tokenizer.encode("hello\n\nhello") == [
-                31373,
-                198,
-                198,
-                31373,
-            ], self.tokenizer.encode("hello\n\nhello")
+        # if isinstance(
+        #     self.tokenizer, (transformers.GPT2Tokenizer, transformers.GPT2TokenizerFast)
+        # ):
+        #     assert self.tokenizer.encode("hello\n\nhello") == [
+        #         31373,
+        #         198,
+        #         198,
+        #         31373,
+        #     ], self.tokenizer.encode("hello\n\nhello")
 
         # multithreading and batching
         self.batch_size_per_gpu = batch_size  # todo: adaptive batch size

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -62,7 +62,7 @@ class HFLM(BaseLM):
                 pretrained,
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
                 device_map="auto",
-                max_memory_per_gpu=max_memory_per_gpu,
+                max_memory=max_memory_per_gpu,
                 torch_dtype=torch_dtype,
                 offload_folder=offload_folder,
             )

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -3,13 +3,13 @@ import torch
 from lm_eval.base import BaseLM
 
 
-def get_args_for_accelerate(pretrained, max_memory):
+def get_args_for_accelerate(pretrained, max_memory_per_gpu):
     config = transformers.AutoConfig.from_pretrained(pretrained)
-    max_memory = {i:max_memory for i in range(torch.cuda.device_count())}
+    max_memory_per_gpu = {i:max_memory_per_gpu for i in range(torch.cuda.device_count())}
 
     torch_dtype = config.torch_dtype
 
-    return max_memory, torch_dtype
+    return max_memory_per_gpu, torch_dtype
 
 class HFLM(BaseLM):
     def __init__(
@@ -21,7 +21,7 @@ class HFLM(BaseLM):
         tokenizer=None,
         batch_size=1,
         accelerate=False,
-        max_memory=None,
+        max_memory_per_gpu=None,
         skip_tokenizer=False,
         offload_folder="./offload"
     ):
@@ -52,12 +52,12 @@ class HFLM(BaseLM):
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
             ).to(self.device)
         else:
-            max_memory, torch_dtype = get_args_for_accelerate(pretrained, max_memory)
+            max_memory_per_gpu, torch_dtype = get_args_for_accelerate(pretrained, max_memory_per_gpu)
             self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
                 pretrained,
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
                 device_map="auto",
-                max_memory=max_memory,
+                max_memory_per_gpu=max_memory_per_gpu,
                 torch_dtype=torch_dtype,
                 offload_folder=offload_folder,
             )

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -161,7 +161,6 @@ class HFLM(BaseLM):
         logits returned from the model
         """
         with torch.no_grad():
-            print(inps.shape)
             return self.gpt2(inps)[0][:, :, :50257]
 
     def _model_generate(self, context, max_length, eos_token_id):

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -163,7 +163,7 @@ class HFLM(BaseLM):
         logits returned from the model
         """
         with torch.no_grad():
-            return self.gpt2(inps)[0][:, :, :50257]
+            return self.gpt2(inps)[0][:, :, :self.tokenizer.vocab_size]
 
     def _model_generate(self, context, max_length, eos_token_id):
         return self.gpt2.generate(

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -19,17 +19,14 @@ def compute_device_map(layers):
         "lm_head.bias": gpus-1,
     }
 
-def get_args_for_accelerate(pretrained, device_map, max_memory):
+def get_args_for_accelerate(pretrained, max_memory):
     config = transformers.AutoConfig.from_pretrained(pretrained)
     max_memory = {i:max_memory for i in range(torch.cuda.device_count())}
     
     layers =config.num_hidden_layers
     torch_dtype = config.torch_dtype
 
-    if device_map is None:
-        device_map = compute_device_map(layers)
-    else:
-        return device_map, max_memory, torch_dtype
+    return max_memory, torch_dtype
 
 class HFLM(BaseLM):
     def __init__(
@@ -77,7 +74,7 @@ class HFLM(BaseLM):
             self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
                 pretrained,
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
-                device_map=device_map,
+                device_map="auto",
                 max_memory=max_memory,
                 torch_dtype=torch_dtype,
                 offload_folder=offload_folder,

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -41,6 +41,7 @@ class HFLM(BaseLM):
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),
             ).to(self.device)
         else:
+            print(pretrained)
             self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
                 pretrained,
                 revision=revision + ("/" + subfolder if subfolder is not None else ""),

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -23,7 +23,7 @@ def get_args_for_accelerate(pretrained, device_map, maximum_memory):
     config = transformers.AutoConfig.from_pretrained(pretrained)
     maximum_memory = {i:maximum_memory for i in range(torch.cuda.device_count())}
     
-    layers =config.n_layers
+    layers =config.num_hidden_layers
     torch_dtype = config.torch_dtype
 
     if device_map is None:

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -12,6 +12,7 @@ class HFLM(BaseLM):
         subfolder=None,
         tokenizer=None,
         batch_size=1,
+        offloading=False,
     ):
         super().__init__()
 
@@ -34,10 +35,18 @@ class HFLM(BaseLM):
             )
 
         # TODO: update this to be less of a hack once subfolder is fixed in HF
-        self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
-            pretrained,
-            revision=revision + ("/" + subfolder if subfolder is not None else ""),
-        ).to(self.device)
+        if not offloading:
+            self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
+                pretrained,
+                revision=revision + ("/" + subfolder if subfolder is not None else ""),
+            ).to(self.device)
+        else:
+            self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
+                pretrained,
+                revision=revision + ("/" + subfolder if subfolder is not None else ""),
+                device_map="auto",
+                torch_dtype="auto",
+            )
         self.gpt2.eval()
 
         # pretrained tokenizer for neo is broken for now so just hard-coding this to gpt2

--- a/main.py
+++ b/main.py
@@ -40,8 +40,13 @@ def parse_args():
     parser.add_argument("--decontamination_ngrams_path", default=None)
     parser.add_argument("--description_dict_path", default=None)
     parser.add_argument("--check_integrity", action="store_true")
-    parser.add_argument("--accelerate", action="store_true")
+    # Accelerate args
+    parser.add_argument("--use_accelerate", action="store_true")
     parser.add_argument("--skip_tokenizer", action="store_true")
+    parser.add_argument("--offload_folder", type=str, default="./offload")
+    parser.add_argument("--max_memory_per_gpu", type=int, default=None)
+    parser.add_argument("--max_cpu_memory", type=int, default=None)
+    parser.add_argument("--dtype", type=int, default=None)
 
     return parser.parse_args()
 
@@ -90,8 +95,12 @@ def main():
         description_dict=description_dict,
         decontamination_ngrams_path=args.decontamination_ngrams_path,
         check_integrity=args.check_integrity,
-        accelerate=args.accelerate,
+        use_accelerate=args.use_accelerate,
         skip_tokenizer=args.skip_tokenizer,
+        offload_folder=args.offload_folder,
+        max_memory_per_gpu=args.max_memory_per_gpu,
+        max_cpu_memory=args.max_cpu_memory,
+        dtype=args.dtype,
     )
 
     dumped = json.dumps(results, indent=2)

--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ def parse_args():
     parser.add_argument("--decontamination_ngrams_path", default=None)
     parser.add_argument("--description_dict_path", default=None)
     parser.add_argument("--check_integrity", action="store_true")
+    parser.add_argument("--offloading", action="store_true")
 
     return parser.parse_args()
 
@@ -88,6 +89,7 @@ def main():
         description_dict=description_dict,
         decontamination_ngrams_path=args.decontamination_ngrams_path,
         check_integrity=args.check_integrity,
+        offloading=args.offloading,
     )
 
     dumped = json.dumps(results, indent=2)

--- a/main.py
+++ b/main.py
@@ -40,7 +40,8 @@ def parse_args():
     parser.add_argument("--decontamination_ngrams_path", default=None)
     parser.add_argument("--description_dict_path", default=None)
     parser.add_argument("--check_integrity", action="store_true")
-    parser.add_argument("--offloading", action="store_true")
+    parser.add_argument("--accelerate", action="store_true")
+    parser.add_argument("--skip_tokenizer", action="store_true")
 
     return parser.parse_args()
 
@@ -89,7 +90,8 @@ def main():
         description_dict=description_dict,
         decontamination_ngrams_path=args.decontamination_ngrams_path,
         check_integrity=args.check_integrity,
-        offloading=args.offloading,
+        accelerate=args.accelerate,
+        skip_tokenizer=args.skip_tokenizer,
     )
 
     dumped = json.dumps(results, indent=2)

--- a/main.py
+++ b/main.py
@@ -44,9 +44,9 @@ def parse_args():
     parser.add_argument("--use_accelerate", action="store_true")
     parser.add_argument("--skip_tokenizer", action="store_true")
     parser.add_argument("--offload_folder", type=str, default="./offload")
-    parser.add_argument("--max_memory_per_gpu", type=int, default=None)
-    parser.add_argument("--max_cpu_memory", type=int, default=None)
-    parser.add_argument("--dtype", type=int, default=None)
+    parser.add_argument("--max_memory_per_gpu", type=str, default=None)
+    parser.add_argument("--max_cpu_memory", type=str, default=None)
+    parser.add_argument("--dtype", type=str, default=None)
 
     return parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
         "openai==0.6.4",
         "jieba==0.42.1",
         "nagisa==0.2.7",
+        "accelerate>=0.10.0",
         "bleurt@https://github.com/google-research/bleurt/archive/b610120347ef22b494b6d69b4316e303f5932516.zip#egg=bleurt",
     ],
     dependency_links=[


### PR DESCRIPTION
This PR adds accelerate support to run very large language models on `lm-evaluation-harness` 🚀 
Tested on OPT-175 on JZ super computer (8xA100). In order to run properly you need:

- Enough GPU RAM to put the model, OR
- Enough GPU+CPU RAM using CPU offloading (slower) OR
- Enough GPU+CPU RAM+ disk space (even slower)

Added new args:

- `--accelerate`: activates accelerate offloading
- `--skip_tokenizer`: skips the tokenizer check (to run BLOOM or any other model that uses a tokenizer that is different from GPT2)
- In `model_args` (optional args): 
    + `max_memory` that corresponds to the maximum memory you want to allocate on each GPU
    + `device_map` that corresponds to the `device_map` that is supported by `accelerate`. See the [doc](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained)

Others:
- Added support for inferring model that uses different tokenizer that `GPT2Tokenizer` (useful for BLOOM) [here](https://github.com/younesbelkada/lm-evaluation-harness/blob/1fda371847f11d22e030a71f83c6413832d8a65b/lm_eval/models/gpt2.py#L166)  

Updated also the README to add examples and instructions, let me know if I should add anything else

cc @StellaAthena @thomasw21 
cc-ing also @sgugger in cased I missed some important args for `accelerate `