### PR TITLE
Manually concat tokenizer revision with subfolder

### DIFF
--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -42,7 +42,6 @@ class HFLM(BaseLM):
         ).to(self.device)
         self.gpt2.eval()
 
-        # pretrained tokenizer for neo is broken for now so just hard-coding this to gpt2
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(
             pretrained if tokenizer is None else tokenizer,
             revision=revision,

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -33,9 +33,9 @@ class HFLM(BaseLM):
                 else torch.device("cpu")
             )
 
-        # TODO: update this to be less of a hack once subfolder is fixed in HF
         self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
             pretrained,
+            # TODO: update this to be less of a hack once subfolder is fixed in HF
             revision=revision + ("/" + subfolder if subfolder is not None else ""),
         ).to(self.device)
         self.gpt2.eval()
@@ -43,8 +43,8 @@ class HFLM(BaseLM):
         # pretrained tokenizer for neo is broken for now so just hard-coding this to gpt2
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(
             pretrained if tokenizer is None else tokenizer,
-            revision=revision,
-            subfolder=subfolder,
+            # TODO: update this to be less of a hack once subfolder is fixed in HF
+            revision=revision + ("/" + subfolder if subfolder is not None else ""),
         )
 
         assert isinstance(

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -33,18 +33,19 @@ class HFLM(BaseLM):
                 else torch.device("cpu")
             )
 
+        # TODO: update this to be less of a hack once subfolder is fixed in HF
+        revision = revision + ("/" + subfolder if subfolder is not None else "")
+
         self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
             pretrained,
-            # TODO: update this to be less of a hack once subfolder is fixed in HF
-            revision=revision + ("/" + subfolder if subfolder is not None else ""),
+            revision=revision,
         ).to(self.device)
         self.gpt2.eval()
 
         # pretrained tokenizer for neo is broken for now so just hard-coding this to gpt2
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(
             pretrained if tokenizer is None else tokenizer,
-            # TODO: update this to be less of a hack once subfolder is fixed in HF
-            revision=revision + ("/" + subfolder if subfolder is not None else ""),
+            revision=revision,
         )
 
         assert isinstance(


### PR DESCRIPTION
- Updates the `AutoTokenizer.from_pretrained` revision arg to handle repository subfolder locating as similarly done in [model loading ](https://github.com/EleutherAI/lm-evaluation-harness/blob/b0b76d87fc84b2bfdfa88b71ce4592f35f707428/lm_eval/models/gpt2.py#L39).

- Related Issue: #342 