### PR TITLE
Fix KoBEST few-shot label

### DIFF
--- a/lm_eval/tasks/kobest.py
+++ b/lm_eval/tasks/kobest.py
@@ -53,11 +53,11 @@ class BoolQ(Task):
         return "{} 질문: {} 답변: ".format(doc["paragraph"], doc["question"])
 
     def doc_to_target(self, doc):
-        return " {}".format({0: "아니오.", 1: "예."})
-        
+        return " {}".format({0: "아니오", 1: "예"}[doc["label"]])
+
     def construct_requests(self, doc, ctx):
-        ll_no, _ = rf.loglikelihood(ctx, " 아니오.")
-        ll_yes, _ = rf.loglikelihood(ctx, " 예.")
+        ll_no, _ = rf.loglikelihood(ctx, " 아니오")
+        ll_yes, _ = rf.loglikelihood(ctx, " 예")
 
         return ll_no, ll_yes
 
@@ -180,8 +180,8 @@ class WiC(Task):
         return "문장1: {} 문장2: {} 두 문장에서 {}가 같은 뜻으로 쓰였나?".format(doc["context_1"], doc["context_2"], doc["word"])
 
     def doc_to_target(self, doc):
-        return " {}".format({0: "아니오", 1: "예"})
-        
+        return " {}".format({0: "아니오", 1: "예"}[doc["label"]])
+
     def construct_requests(self, doc, ctx):
         ll_no, _ = rf.loglikelihood(ctx, " 아니오")
         ll_yes, _ = rf.loglikelihood(ctx, " 예")
@@ -295,8 +295,8 @@ class SentiNeg(Task):
         return "문장: {} 긍부정:".format(doc["sentence"])
 
     def doc_to_target(self, doc):
-        return " {}".format({0: "부정", 1: "긍정"})
-        
+        return " {}".format({0: "부정", 1: "긍정"}[doc["label"]])
+
     def construct_requests(self, doc, ctx):
         ll_no, _ = rf.loglikelihood(ctx, " 부정")
         ll_yes, _ = rf.loglikelihood(ctx, " 긍정")


### PR DESCRIPTION
## KoBEST
- Fixed few-shot labels of KoBEST tasks
- Remove period of labels in BoolQ


### Examples before this PR
#### Boolq
```
양말은 보통 목화나 모직으로 만들어지며, 발목까지 오는 종류도 있지만, 무릎 위까지 올라와 다리 전체를 감싸는 것도 있다. 각각의 발가락이 분리되어 있는 형태의 양말은 발가락 양말이라고 한다. 질문: 양말의 종류는 여러가지인가요? 답변:  {0: '아니오.', 1: '예.'}
```
- {0: '아니오.', 1: '예.'} → "아니오" for 0, "예" for 1

#### WiC
```
문장1: 그는 등에 나비 모양의 [자문]이 있다. 문장2: 그들은 전문가의 [자문]을 받아 일을 처리했다. 두 문장에서 자문가 같은 뜻으로 쓰였나? {0: '아니오', 1: '예'}
```
- {0: '아니오', 1: '예'} → "아니오" for 0, "예" for 1


#### SentiNeg
```
문장: 내용이 생각보다 별로 입니다! 긍부정: {0: '부정', 1: '긍정'}
```
- {0: '부정', 1: '긍정'} → "부정" for 0, "긍정" for 1

