### PR TITLE
`stdio`-based model wrapper

### DIFF
--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -1,11 +1,13 @@
 from . import gpt2
 from . import gpt3
+from . import byte
 from . import dummy
 
 MODEL_REGISTRY = {
     "hf": gpt2.HFLM,
     "gpt2": gpt2.GPT2LM,
     "gpt3": gpt3.GPT3LM,
+    "cmd": byte.SubprocessLM,
     "dummy": dummy.DummyLM,
 }
 

--- a/lm_eval/models/byte.py
+++ b/lm_eval/models/byte.py
@@ -1,0 +1,75 @@
+from subprocess import Popen, PIPE, STDOUT
+
+import torch
+
+from lm_eval.base import BaseLM
+
+
+class SubprocessLM(BaseLM):
+    def __init__(self, process: Popen, max_length: int, eot_token_id: int):
+        super().__init__()
+        self._eot_token_id = eot_token_id
+        self._max_length = max_length
+        self.process = process
+
+    def _model_call(self, inps):
+        """
+        inps: a torch tensor of shape [batch, sequence]
+        the size of sequence may vary from call to call
+
+        returns: a torch tensor of shape [batch, sequence, 256] with the
+        logits returned from the model
+        """
+        prefix_len = inps.size(-1)
+        batch = inps.size(0)
+        outs = (
+            torch.zeros_like(inps, dtype=torch.float32)
+            .unsqueeze(-1)
+            .expand(batch, prefix_len, 256)
+            .contiguous()
+        )
+        for tok_i in range(prefix_len):
+            batch_of_tokens = bytes(inps[:, tok_i].tolist())
+            self.process.stdin.write(batch_of_tokens)
+            self.process.stdin.flush()
+
+        # float32 logits
+        logits = self.process.stdout.read(batch * prefix_len * 256 * 4)
+        logits = torch.frombuffer(logits, dtype=torch.float32)
+        outs[:, :, :] = logits.view(prefix_len, batch, 256).permute(1, 0, 2)
+
+        return outs
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        raise NotImplementedError()
+
+    @staticmethod
+    def start(cmd):
+        process = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=STDOUT, text=False)
+        return SubprocessLM(process, max_length=256, eot_token_id=0)
+
+    @property
+    def batch_size(self):
+        return 1
+
+    def tok_encode(self, string: str):
+        return list(string.encode("utf-8"))
+
+    def tok_decode(self, tokens):
+        return tokens.decode("utf-8")
+
+    @property
+    def eot_token_id(self):
+        return self._eot_token_id
+
+    @property
+    def max_length(self):
+        return self._max_length
+
+    @property
+    def max_gen_toks(self):
+        return 1024 * 1024 * 1024
+
+    @property
+    def device(self):
+        return torch.device("cpu")

--- a/lm_eval/models/byte.py
+++ b/lm_eval/models/byte.py
@@ -44,9 +44,19 @@ class SubprocessLM(BaseLM):
         raise NotImplementedError()
 
     @staticmethod
-    def start(cmd):
+    def start(cmd, max_length: int, eot_token_id: int = 0):
         process = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=STDOUT, text=False)
-        return SubprocessLM(process, max_length=256, eot_token_id=0)
+        return SubprocessLM(process, max_length=max_length, eot_token_id=eot_token_id)
+
+    @classmethod
+    def create_from_arg_string(cls, arg_string, additional_config=None):
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--max-len", required=True, type=int)
+        parser.add_argument("--eot-token-id", default=0, type=int)
+        parser.add_argument("cmd", nargs=argparse.REMAINDER)
+        args = parser.parse_args(arg_string.split())
+        return cls.start(args.cmd, max_length=args.max_len, eot_token_id=args.eot_token_id)
 
     @property
     def batch_size(self):

--- a/lm_eval/models/echo.py
+++ b/lm_eval/models/echo.py
@@ -1,0 +1,23 @@
+from array import array
+import sys
+
+
+def echo():
+    from .byte import SubprocessLM
+
+    return SubprocessLM.start(["python", __file__])
+
+
+def _echo_loglikelihood():
+    while True:
+        b = sys.stdin.buffer.read(1)
+        if len(b) == 0:
+            break
+        o = array("f", [-float("inf")] * 256)
+        o[b[0]] = 1.0
+        sys.stdout.buffer.write(o)
+        sys.stdout.buffer.flush()
+
+
+if __name__ == "__main__":
+    _echo_loglikelihood()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -1,0 +1,15 @@
+import math
+import pytest
+from lm_eval.models.echo import echo
+
+
+def test_echo():
+    model = echo()
+    eq = model.loglikelihood([("aaaa", "aa")])
+    neq = model.loglikelihood([("aaaa", "bb")])
+    assert 0.0 == pytest.approx(eq[0][0], rel=1e-3)
+    assert math.isinf(neq[0][0]) and neq[0][0] < 0
+
+
+if __name__ == "__main__":
+    test_echo()


### PR DESCRIPTION
Introduces `SubprocessLM` (`cmd` option for `--model` parameter).

`SubprocessLM` is a byte-level model wrapper. Whenever a continuation needs to be generated from a context, `SubprocessLM` simply writes context bytes to stdin of the child process, and reads back continuation logits in binary form (`float32` numbers).

This implements https://github.com/EleutherAI/lm-evaluation-harness/issues/346

P.S. I am not consciously aware about the working details of the current harness, so this implementation may be very wrong. Please check that all abstract method implementations make sense. For example, what is the meaning of `max_gen_toks`?