### PR TITLE
hotfix(gpt2): Remove vocab-size logits slice

### DIFF
--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -119,7 +119,7 @@ class HFLM(BaseLM):
         logits returned from the model
         """
         with torch.no_grad():
-            return self.gpt2(inps)[0][:, :, :50257]
+            return self.gpt2(inps)[0]
 
     def _model_generate(self, context, max_length, eos_token_id):
         return self.gpt2.generate(


### PR DESCRIPTION
* Removes the unnecessary truncation of logits in the vocab dimension for `HFLM` models which can lead to runtime errors for non-GPT-2 models (e.g. https://github.com/EleutherAI/pythia/issues/65).