### PR TITLE
Enable "low_cpu_mem_usage" to reduce the memory usage of HF models

### DIFF
--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -1,5 +1,5 @@
-import transformers
 import torch
+import transformers
 from lm_eval.base import BaseLM
 
 
@@ -9,6 +9,7 @@ class HFLM(BaseLM):
         device="cuda",
         pretrained="gpt2",
         revision="main",
+        low_cpu_mem_usage=None,
         subfolder=None,
         tokenizer=None,
         batch_size=1,
@@ -37,8 +38,7 @@ class HFLM(BaseLM):
         revision = revision + ("/" + subfolder if subfolder is not None else "")
 
         self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
-            pretrained,
-            revision=revision,
+            pretrained, revision=revision, low_cpu_mem_usage=low_cpu_mem_usage
         ).to(self.device)
         self.gpt2.eval()
 

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -7,6 +7,8 @@ import inspect
 import sys
 from typing import List
 
+from omegaconf import OmegaConf
+
 
 class ExitCodeError(Exception):
     pass
@@ -27,10 +29,7 @@ def simple_parse_args_string(args_string):
     if not args_string:
         return {}
     arg_list = args_string.split(",")
-    args_dict = {}
-    for arg in arg_list:
-        k, v = arg.split("=")
-        args_dict[k] = v
+    args_dict = OmegaConf.to_object(OmegaConf.from_dotlist(arg_list))
     return args_dict
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
         "jsonlines",
         "numexpr",
         "openai>=0.6.4",
+        "omegaconf>=2.2",
         "pybind11>=2.6.2",
         "pycountry",
         "pytablewriter",


### PR DESCRIPTION
- [x] Enable the [low_cpu_mem_usage](https://huggingface.co/docs/transformers/model_doc/gptj) so that it will only use 1x the size of the model weight. Example usage:

```shell
python main.py \
    --model gpt2 \
    --model_args pretrained=EleutherAI/gpt-neo-2.7B,low_cpu_mem_usage=1 \
    --tasks lambada_openai,hellaswag \
    --output_path gpt-neo-2.7B
    --device 0
```

- [x] Use OmegaConf to parse the dotlist so that it will correctly convert `low_cpu_mem_usage=1` to `1` rather than `"1"`.

```python
from omegaconf import OmegaConf

args_dict = OmegaConf.to_object(OmegaConf.from_dotlist(["pretrained=EleutherAI/gpt-neo-2.7B", "low_cpu_mem_usage=1"]))
print(args_dict)
```

Output:

```
{'pretrained': 'EleutherAI/gpt-neo-2.7B', 'low_cpu_mem_usage': 1}
```
