### PR TITLE
Refactor KLUE tasks

### DIFF
--- a/lm_eval/tasks/klue.py
+++ b/lm_eval/tasks/klue.py
@@ -58,11 +58,11 @@ class STS(Task):
         )
 
     def doc_to_target(self, doc):
-        return " {}".format({1: " 예", 0: " 아니"}[doc["labels"]["binary-label"]])
+        return " {}".format({0: "아니오", 1: "예"}[doc["labels"]["binary-label"]])
 
     def construct_requests(self, doc, ctx):
         ll_positive, _ = rf.loglikelihood(ctx, " 예")
-        ll_negative, _ = rf.loglikelihood(ctx, " 아니")
+        ll_negative, _ = rf.loglikelihood(ctx, " 아니오")
         return ll_positive, ll_negative
 
     def process_results(self, doc, results):

--- a/lm_eval/tasks/klue.py
+++ b/lm_eval/tasks/klue.py
@@ -61,13 +61,12 @@ class STS(Task):
         return " {}".format({0: "아니오", 1: "예"}[doc["labels"]["binary-label"]])
 
     def construct_requests(self, doc, ctx):
-        ll_positive, _ = rf.loglikelihood(ctx, " 예")
         ll_negative, _ = rf.loglikelihood(ctx, " 아니오")
-        return ll_positive, ll_negative
+        ll_positive, _ = rf.loglikelihood(ctx, " 예")
+        return ll_negative, ll_positive
 
     def process_results(self, doc, results):
-        ll_positive, ll_negative = results
-        pred = ll_positive > ll_negative
+        pred = np.argmax(results)
         gold = doc["labels"]["binary-label"]
         return {
             "acc": pred == gold,


### PR DESCRIPTION
## Review Korean tasks: KLUE
- [x] Fix typo—remove duplicated spaces
  `return " {}".format({1: " 예", 0: " 아니"}[doc["labels"]["binary-label"]])`
- [x] Align target label format with other Korean tasks
  * Modify target label of KLUE: "아니" to "아니오"
  * Binary classification labels of other korean tasks are also "예"/"아니오".
- [x] Refactor KLUE-STS (use `np.argmax` to calculate `pred`)
- [x] Verify the implementation by evaluating korean autoregressive LMs (to be updated, ex. KoGPT)
  - KLUE-STS One shot evaluation results using `polyglot-ko-1.3b`
  - Scores were slightly decreased due to the modification of target labels—remove duplicated spaces & "아니" to "아니오"
  - Before commit:
    ```json
    {                                                                                                                                                                                                         
      "results": {                                                                                                                                                                                            
        "klue_sts": {                                                                                                                                                                                         
          "acc": 0.5048169556840078,                                                                                                                                                                          
          "acc_stderr": 0.021967719250513364,                                                                                                                                                                 
          "f1": 0.4543524416135881,                                                                                                                                                                           
          "f1_stderr": 0.028531434082189534                                                                                                                                                                   
        }                                                                                                                                                                                                     
      },                                                                                                                                                                                                      
      "versions": {                                                                                                                                                                                           
        "klue_sts": 0                                                                                                                                                                                         
      },                                                                                                                                                                                                      
      "config": {                                                                                                                                                                                             
        "model": "gpt2",                                                                                                                                                                                      
        "model_args": "pretrained=EleutherAI/polyglot-ko-1.3b",                                                                                                                                               
        "num_fewshot": 1,                                                                                                                                                                                     
        "batch_size": 4,                                                                                                                                                                                      
        "device": "cuda:0",                                                                                                                                                                                   
        "no_cache": false,                                                                                                                                                                                    
        "limit": null,                                                                                                                                                                                        
        "bootstrap_iters": 100000,                                                                                                                                                                            
        "description_dict": {}                                                                                                                                                                                
      }                                                                                                                                                                                                       
    }                                                                                                                                                                                                         
    ```
    |  Task  |Version|Metric|Value |   |Stderr|                                                                                                                                                               
    |--------|------:|------|-----:|---|-----:|                                                                                                                                                               
    |klue_sts|      0|acc   |0.5048|±  |0.0220|                                                                                                                                                               
    |        |       |f1    |0.4544|±  |0.0285|
  - After commit:
    ```json
    {                                                                                                                                                                                                         
      "results": {                                                                                                                                                                                            
        "klue_sts": {                                                                                                                                                                                         
          "acc": 0.5028901734104047,
          "acc_stderr": 0.021968371740875285,
          "f1": 0.4487179487179488,
          "f1_stderr": 0.028660094751801764                                                                                                                                                             
        }                                                                                                                                                                                                     
      },                                                                                                                                                                                                      
      "versions": {                                                                                                                                                                                           
        "klue_sts": 0                                                                                                                                                                                         
      },                                                                                                                                                                                                      
      "config": {                                                                                                                                                                                             
        "model": "gpt2",                                                                                                                                                                                      
        "model_args": "pretrained=EleutherAI/polyglot-ko-1.3b",                                                                                                                                               
        "num_fewshot": 1,                                                                                                                                                                                     
        "batch_size": 4,                                                                                                                                                                                      
        "device": "cuda:0",                                                                                                                                                                                   
        "no_cache": false,                                                                                                                                                                                    
        "limit": null,                                                                                                                                                                                        
        "bootstrap_iters": 100000,                                                                                                                                                                            
        "description_dict": {}                                                                                                                                                                                
      }                                                                                                                                                                                                       
    }                                                                                                                                                                                                         
    ```
    |  Task  |Version|Metric|Value |   |Stderr|                                                                                                                                                               
    |--------|------:|------|-----:|---|-----:|                                                                                                                                                               
    |klue_sts|      0|acc   |0.5029|±  |0.0220|
    |        |       |f1    |0.4487|±  |0.0287|