### PR TITLE
Add `KLUE-NLI` task

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -310,6 +310,7 @@ TASK_REGISTRY = {
   
     "klue_sts": klue.STS,
     "klue_ynat": klue.YNAT,
+    "klue_nli": klue.NLI,
     "nsmc": nsmc.NSMC,    
     "korquad": korquad.Korquad,
     "kobest_boolq": kobest.BoolQ,

--- a/lm_eval/tasks/klue.py
+++ b/lm_eval/tasks/klue.py
@@ -163,7 +163,7 @@ class NLI(Task):
         return self.dataset["validation"]
 
     def doc_to_text(self, doc):
-        return "{}\n질문: {} 참, 거짓, 혹은 무관?\n정답:".format(
+        return "{}\n질문: {} 참, 거짓, 중립 중 무엇인가요?\n정답:".format(
             doc["premise"],
             doc["hypothesis"].strip()
             + ("" if doc["hypothesis"].strip().endswith(".") else "."),
@@ -173,11 +173,11 @@ class NLI(Task):
         # 참 = entailment
         # 거짓 = contradiction
         # 무관 = neutral
-        return " {}".format({0: "참", 1: "무관", 2: "거짓"}[doc["label"]])
+        return " {}".format({0: "참", 1: "중립", 2: "거짓"}[doc["label"]])
 
     def construct_requests(self, doc, ctx):
         ll_true, _ = rf.loglikelihood(ctx, " 참")
-        ll_neither, _ = rf.loglikelihood(ctx, " 무관")
+        ll_neither, _ = rf.loglikelihood(ctx, " 중립")
         ll_false, _ = rf.loglikelihood(ctx, " 거짓")
         return ll_true, ll_neither, ll_false
 

--- a/lm_eval/tasks/klue.py
+++ b/lm_eval/tasks/klue.py
@@ -163,7 +163,7 @@ class NLI(Task):
         return self.dataset["validation"]
 
     def doc_to_text(self, doc):
-        return "{}\질문: {} 참, 거짓, 혹은 무관?\n정답:".format(
+        return "{}\n질문: {} 참, 거짓, 혹은 무관?\n정답:".format(
             doc["premise"],
             doc["hypothesis"].strip()
             + ("" if doc["hypothesis"].strip().endswith(".") else "."),

--- a/lm_eval/tasks/klue.py
+++ b/lm_eval/tasks/klue.py
@@ -52,7 +52,7 @@ class STS(Task):
         return self.dataset["validation"]
 
     def doc_to_text(self, doc):
-        return "질문: 문장 1과 문장 2는 서로 유사한 의미를 가지나요?\n문장 1:{}\n문장 2:{}\n정답:".format(
+        return "질문: 문장 1과 문장 2는 서로 유사한 의미를 가지나요?\n문장 1: {}\n문장 2: {}\n정답:".format(
             general_detokenize(doc["sentence1"]),
             general_detokenize(doc["sentence2"]) 
         )


### PR DESCRIPTION
## Add `KLUE-NLI` task
Sanity check results are as follows.
- Data sample
  ```
  !!@@##@@!! -- Example 0
  참여자들은 어르신들을 위한 전을 만들고, 정성스럽게 포장해 배달하는 등 이웃과 함께 하는 온정의 손길을 함께 모았다.
  질문: 전을 포장하고 배달하는 것은 온전히 복지관 직원들이 해냈다. 참, 거짓, 중립 중 무엇인가요?
  정답: 거짓

  그리고 다시 영화 보면 욕이 저절로 나옵니다.
  질문: 영화를 다시 보면 감탄이 저절로 나옵니다. 참, 거짓, 중립 중 무엇인가요?
  정답: 거짓

  4일 손흥민 선수는 마우리시오 포체티노에게 특별휴가를 받았다.
  질문: 손흥민 선수는 4일동안 특별휴가를 보냈다. 참, 거짓, 중립 중 무엇인가요?
  정답: 중립

  흡연자분들은 발코니가 있는 방이면 발코니에서 흡연이 가능합니다.
  질문: 어떤 방에서도 흡연은 금지됩니다. 참, 거짓, 중립 중 무엇인가요?
  정답:
  ```
- Passed unit test
- Few-shot performance by `polyglot-ko-1.3b`
  - \# shots: 0                                                                                                                                                                                             
    gpt2 (pretrained=EleutherAI/polyglot-ko-1.3b), limit: None, provide_description: False, num_fewshot: 0, batch_size: 4
    |  Task  |Version|Metric|Value |   |Stderr|
    |--------|------:|------|-----:|---|-----:|
    |klue_nli|      0|acc   |0.3133|±  |0.0085|
  - \# shots: 1
    gpt2 (pretrained=EleutherAI/polyglot-ko-1.3b), limit: None, provide_description: False, num_fewshot: 1, batch_size: 4
    |  Task  |Version|Metric|Value |   |Stderr|
    |--------|------:|------|-----:|---|-----:|
    |klue_nli|      0|acc   |0.3333|±  |0.0086|
  - \# shots: 10
    gpt2 (pretrained=EleutherAI/polyglot-ko-1.3b), limit: None, provide_description: False, num_fewshot: 10, batch_size: 4
    |  Task  |Version|Metric|Value |   |Stderr|
    |--------|------:|------|-----:|---|-----:|
    |klue_nli|      0|acc   |0.3393|±  |0.0086|