### PR TITLE
Add argparse "--dtype" for evaluator.simple_evaluate()

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -17,6 +17,7 @@ def simple_evaluate(
     num_fewshot=0,
     batch_size=None,
     device=None,
+    dtype=None,
     no_cache=False,
     limit=None,
     bootstrap_iters=100000,
@@ -40,6 +41,8 @@ def simple_evaluate(
         Batch size for model
     :param device: str, optional
         PyTorch device (e.g. "cpu" or "cuda:0") for running models
+    :param dtype: str, optional
+        PyTorch dtype (e.g. "float32" or "bfloat16" or "float16") for running models
     :param no_cache: bool
         Whether or not to cache
     :param limit: int, optional
@@ -62,7 +65,7 @@ def simple_evaluate(
         if model_args is None:
             model_args = ""
         lm = lm_eval.models.get_model(model).create_from_arg_string(
-            model_args, {"batch_size": batch_size, "device": device}
+            model_args, {"batch_size": batch_size, "device": device, "dtype": dtype}
         )
     else:
         assert isinstance(model, lm_eval.base.LM)

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ def parse_args():
     parser.add_argument("--num_fewshot", type=int, default=0)
     parser.add_argument("--batch_size", type=int, default=None)
     parser.add_argument("--device", type=str, default=None)
+    parser.add_argument("--dtype", type=str, default=None)
     parser.add_argument("--output_path", default=None)
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--no_cache", action="store_true")
@@ -83,6 +84,7 @@ def main():
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,
         device=args.device,
+        dtype=args.dtype,
         no_cache=args.no_cache,
         limit=args.limit,
         description_dict=description_dict,


### PR DESCRIPTION
Hi @StellaAthena 
I added the argparse "--dtype" to the main.py and pass it to evaluator.simple_evaluate() to specify precision. 
the reasons is following.

1. I would like to base this repo to demo the int8 model generated by [neural-compressor](https://github.com/intel/neural-compressor) and [intel-extension-for-transformers](https://github.com/intel/intel-extension-for-transformers) accuracy ,  “--dtype” can be needed to distinguish data type. here is the code I want to use.
```python
from lm_eval import evalator, task
results = evaluator.simple_evaluate(
    model=args.model_dtype,
    model_args="pretrained=decapoda-research/llama-7b-hf",
    tasks=task_names,
    num_fewshot=args.num_fewshot,
    batch_size=args.batch_size,
    device=args.device,
    no_cache=args.no_cache,
    limit=args.limit,
    description_dict=description_dict,
    decontamination_ngrams_path=args.decontamination_ngrams_path,
    check_integrity=args.check_integrity,
    dtype = args.dtype,
        )
```
2. Although the torch_dtype is "float16" in [config.json](https://huggingface.co/decapoda-research/llama-7b-hf/blob/main/config.json), data type can be specified through "--dtype"
example command:
```python
python main.py \
    --model hf-causal \
    --model_args pretrained=decapoda-research/llama-7b-hf \
    --dtype bfloat16
    --tasks piqa \
    --device cpu \
    --output llama-7b/lambada-bfloat16-results.json \
    --no_cache \
```
Could you approve the request?