### PR TITLE
Add length normalization to loglikelihood in base.py since the longer…

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -319,7 +319,7 @@ class BaseLM(LM):
                 )  # [1, seq]
 
                 # Answer: (log prob, is-exact-match)
-                answer = (float(logits.sum()//logits.size(1)), bool(max_equal))
+                answer = (float(logits.sum()/logits.size(1)), bool(max_equal))
 
                 # partial caching
                 if cache_key is not None:

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -319,7 +319,7 @@ class BaseLM(LM):
                 )  # [1, seq]
 
                 # Answer: (log prob, is-exact-match)
-                answer = (float(logits.sum()), bool(max_equal))
+                answer = (float(logits.sum()//logits.size(1)), bool(max_equal))
 
                 # partial caching
                 if cache_key is not None:


### PR DESCRIPTION
… target tokens tend to have lower negative log likelihood when we just use sum of negative log likelihood from all tokens.