### PR TITLE
feat: evaluation using peft models with CLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features:
 
 - 200+ tasks implemented. See the [task-table](./docs/task_table.md) for a complete list.
 - Support for GPT-2, GPT-3, GPT-Neo, GPT-NeoX, and GPT-J, with flexible tokenization-agnostic interface.
+- Support for evaluation on adapters (e.g. LoRa) supported in [HuggingFace's PEFT library](https://github.com/huggingface/peft).
 - Task versioning to ensure reproducibility.
 
 ## Install
@@ -57,6 +58,15 @@ python main.py \
 To evaluate models that are called via `AutoSeq2SeqLM`, you instead use `hf-seq2seq`.
 
 > **Warning**: Choosing the wrong model may result in erroneous outputs despite not erroring.
+
+To use with [PEFT](https://github.com/huggingface/peft), you can use the following command:
+```bash
+python main.py \
+    --model hf-causal \
+    --model_args pretrained=EleutherAI/gpt-j-6b,peft=nomic-ai/gpt4all-j-lora \
+    --tasks openbookqa,arc_easy,winogrande,hellaswag,arc_challenge,piqa,boolq \ 
+    --device cuda:0 
+```
 
 Our library also supports the OpenAI API:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To evaluate models that are called via `AutoSeq2SeqLM`, you instead use `hf-seq2
 
 > **Warning**: Choosing the wrong model may result in erroneous outputs despite not erroring.
 
-To use with [PEFT](https://github.com/huggingface/peft), you can use the following command:
+To use with [PEFT](https://github.com/huggingface/peft), take the call you would run to evaluate the base model and add `,peft=PATH` to the `model_args` argument as shown below:
 ```bash
 python main.py \
     --model hf-causal \

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
         "numexpr",
         "openai>=0.6.4",
         "omegaconf>=2.2",
+        "peft>=0.2.0"
         "pybind11>=2.6.2",
         "pycountry",
         "pytablewriter",
@@ -41,5 +42,6 @@ setuptools.setup(
     extras_require={
         "dev": ["black", "flake8", "pre-commit", "pytest", "pytest-cov"],
         "multilingual": ["nagisa>=0.2.7", "jieba>=0.42.1"],
+        "sentencepiece": ["sentencepiece>=0.1.98", "protobuf>=4.22.1"]
     },
 )


### PR DESCRIPTION
Closes #413.

I added an optional install for `sentencepiece` as it was required for me to use the tokenizer for the LLaMa models. Not sure if that's something that you'd like in here but can remove if it's not!