### PR TITLE
Hotfix: patch issues with the `huggingface.py` model classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ python main.py \
     --device cuda:0
 ```
 
-To evaluate models that are called via `AutoSeq2SeqLM`, you instead use `hf-seq2seq`.
+To evaluate models that are loaded via `AutoSeq2SeqLM` in Huggingface, you instead use `hf-seq2seq`. *To evaluate (causal) models across multiple GPUs, use `--model hf-causal-experimental`. Note that this is *
 
 > **Warning**: Choosing the wrong model may result in erroneous outputs despite not erroring.
 
 To use with [PEFT](https://github.com/huggingface/peft), take the call you would run to evaluate the base model and add `,peft=PATH` to the `model_args` argument as shown below:
 ```bash
 python main.py \
-    --model hf-causal \
+    --model hf-causal-experimental \
     --model_args pretrained=EleutherAI/gpt-j-6b,peft=nomic-ai/gpt4all-j-lora \
     --tasks openbookqa,arc_easy,winogrande,hellaswag,arc_challenge,piqa,boolq \ 
     --device cuda:0 

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -6,7 +6,8 @@ from . import dummy
 
 MODEL_REGISTRY = {
     "hf": gpt2.HFLM,
-    "hf-causal": huggingface.AutoCausalLM,
+    "hf-causal": gpt2.HFLM,
+    "hf-causal-experimental": huggingface.AutoCausalLM,
     "hf-seq2seq": huggingface.AutoSeq2SeqLM,
     "gpt2": gpt2.GPT2LM,
     "gpt3": gpt3.GPT3LM,

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -47,27 +47,7 @@ class HFLM(BaseLM):
             revision=revision,
         )
 
-        assert isinstance(
-            self.tokenizer,
-            (
-                transformers.GPT2Tokenizer,
-                transformers.GPT2TokenizerFast,
-                transformers.T5Tokenizer,
-                transformers.T5TokenizerFast,
-            ),
-        ), "this tokenizer has not been checked for compatibility yet!"
-
         self.vocab_size = self.tokenizer.vocab_size
-
-        if isinstance(
-            self.tokenizer, (transformers.GPT2Tokenizer, transformers.GPT2TokenizerFast)
-        ):
-            assert self.tokenizer.encode("hello\n\nhello") == [
-                31373,
-                198,
-                198,
-                31373,
-            ], self.tokenizer.encode("hello\n\nhello")
 
         # multithreading and batching
         self.batch_size_per_gpu = batch_size  # todo: adaptive batch size

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -343,7 +343,7 @@ class HuggingFaceAutoLM(BaseLM):
     def tok_decode(self, tokens: torch.LongTensor) -> List[str]:
         return self.tokenizer.batch_decode(tokens, skip_special_tokens=True)
 
-    def greedy_until(self, requests: List[Tuple[str, dict]]) -> List[str]:
+    def greedy_until(self, requests: List[Tuple[str, Union[List[str], str]]]) -> List[str]:
         def _collate(x):
             tokens = self.tok_encode(x[0])
             return len(tokens), x[0]
@@ -355,18 +355,16 @@ class HuggingFaceAutoLM(BaseLM):
         ):
             context = [c[0] for c in chunk]
             request_args = chunk[0][1]
-            stop_sequences = request_args["stop_sequences"]
-            max_generation_length = request_args["max_generation_length"]
-            num_fewshot = request_args["num_fewshot"]
+            stop_sequences = request_args if isinstance(request_args, list) else [request_args] # request_args["stop_sequences"]
+            max_generation_length = self._max_gen_toks # request_args["max_generation_length"]
 
             assert (
                 isinstance(max_generation_length, int) or max_generation_length is None
             )
             assert isinstance(stop_sequences, list) or stop_sequences is None
-            assert isinstance(num_fewshot, int) or num_fewshot is None
-
+            
             # TODO: Find a better way to handle stop sequences for 0-shot.
-            if stop_sequences is None or num_fewshot == 0:
+            if stop_sequences is None:
                 until = [self.eot_token]
             else:
                 until = stop_sequences + [self.eot_token]


### PR DESCRIPTION
This PR does the following:

- closes #408 #412 #399 

- fixes issues caused by the upstreaming of https://github.com/EleutherAI/lm-evaluation-harness/pull/381 , which was ported from Bigscience. We merged this to rectify confusions surrounding the naming of our causal LM as `gpt2` but this PR hadn't been adequately tested with greedy gen request types before merging
- Drops irritating tokenizer asserts that are not intended from the `gpt2.py` model
- renames the `hf-causal` model to be the old HFLM implementation, and marks the Bigscience fork AutoCausalLM as `hf-causal-experimental` , so that if people are using single-GPU evals then they will use the better-tested-in-this-repo `HFLM` 
- documents this change in the README.


Tested this quickly on `anagrams1`, `--limit 1000` and found equivalent scores between the two model implementations.