### PR TITLE
Add `KorUnSmile` task

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -56,6 +56,7 @@ from . import nsmc
 from . import klue
 from . import ko_translation
 from . import korquad
+from . import korunsmile
 
 ########################################
 # Translation tasks
@@ -319,7 +320,8 @@ TASK_REGISTRY = {
     "kobest_hellaswag": kobest.HellaSwag,
     "kobest_sentineg": kobest.SentiNeg,
     "ko_en_translation": ko_translation.KoEnTranslation,
-    "en_ko_translation": ko_translation.EnKoTranslation
+    "en_ko_translation": ko_translation.EnKoTranslation,
+    "korunsmile": korunsmile.KorUnSmile
 }
 
 

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -57,6 +57,7 @@ from . import klue
 from . import ko_translation
 from . import korquad
 from . import korunsmile
+from . import kohatespeech
 
 ########################################
 # Translation tasks
@@ -68,7 +69,6 @@ gpt3_translation_benchmarks = {
     "wmt14": ['en-fr', 'fr-en'],  # French
     "wmt16": ['en-ro', 'ro-en', 'de-en', 'en-de'],  # German, Romanian
 }
-
 
 # 28 total
 selected_translation_benchmarks = {
@@ -88,7 +88,7 @@ all_translation_benchmarks = {
 # All tasks
 ########################################
 
-
+# task 레지스트리에 클래스 추가 
 TASK_REGISTRY = {
     # GLUE
     "cola": glue.CoLA,
@@ -322,8 +322,10 @@ TASK_REGISTRY = {
     "ko_en_translation": ko_translation.KoEnTranslation,
     "en_ko_translation": ko_translation.EnKoTranslation,
     "korunsmile": korunsmile.KorUnSmile
+    "kohatespeech":kohatespeech.HateSpeech,
+    "kohatespeech_gen_bias":kohatespeech.GenderBias,
+    "kohatespeech_apeach":kohatespeech.Apeach
 }
-
 
 ALL_TASKS = sorted(list(TASK_REGISTRY))
 

--- a/lm_eval/tasks/korunsmile.py
+++ b/lm_eval/tasks/korunsmile.py
@@ -20,7 +20,7 @@ _CITATION = """
 def multilable_to_multiclass(label: list):
     """
     0 = 혐오
-    1 = 욕설
+    1 = 악플
     2 = 양호
     """
     assert type(label[0]) == int
@@ -59,7 +59,7 @@ class KorUnSmile(MultipleChoiceTask):
     def _process_doc(self, doc):
         out_doc = {
             "title": doc["문장"],
-            "choices": ["혐오", "욕설", "양호"],
+            "choices": ["혐오", "악플", "양호"],
             "gold": multilable_to_multiclass(doc["labels"])
         }
         return out_doc
@@ -68,7 +68,7 @@ class KorUnSmile(MultipleChoiceTask):
         return "{}".format(doc["title"])
 
     def doc_to_target(self, doc):
-        return " {}".format({0: "혐오", 1: "욕설", 2: "양호"}[doc["gold"]])
+        return " {}".format({0: "혐오", 1: "악플", 2: "양호"}[doc["gold"]])
 
     def process_results(self, doc, results):
         pred = np.argmax(results)

--- a/lm_eval/tasks/korunsmile.py
+++ b/lm_eval/tasks/korunsmile.py
@@ -1,0 +1,71 @@
+"""
+ Korean UnSmile Dataset
+ 
+ Github: https://github.com/smilegate-ai/korean_unsmile_dataset
+"""
+
+import numpy as np
+from lm_eval.base import MultipleChoiceTask
+from lm_eval.metrics import macro_f1_score
+
+_CITATION = """
+@misc{SmilegateAI2022KoreanUnSmileDataset,
+  title         = {Korean UnSmile dataset: Human-annotated Multi-label Korean Hate Speech Dataset},
+  author        = {Seonghyun Kim},
+  year          = {2022},
+  howpublished  = {https://github.com/smilegate-ai/korean_unsmile_dataset},
+}
+"""
+
+class KorUnSmile(MultipleChoiceTask):
+    VERSION = 0
+    DATASET_PATH = "smilegate-ai/kor_unsmile"
+    DATASET_NAME = None
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return False
+
+    def training_docs(self):
+        if self._training_docs is None:
+            self._training_docs = list(map(self._process_doc,self.dataset["train"]))
+        return self._training_docs
+
+    def validation_docs(self):
+        return map(self._process_doc,self.dataset["valid"])
+
+    def _process_doc(self, doc):
+        out_doc = {
+            "title": doc["문장"],
+            "choices": ["여성/가족", "남성", "성소수자", "인종/국적", "연령", "지역", "종교", "기타 혐오", "악플/욕설", "clean"],
+            "gold": np.argmax(doc["labels"])
+        }
+        return out_doc
+
+    def doc_to_text(self, doc):
+        return "{}".format(doc["title"])
+
+    def doc_to_target(self, doc):
+        return " {}".format({0: "여성/가족", 1: "남성", 2: "성소수자", 3: "인종/국적", 4: "연령", 5: "지역", 6: "종교", 7: "기타 혐오", 8: "악플/욕설", 9: "clean"}[doc["gold"]])
+
+    def process_results(self, doc, results):
+        pred = np.argmax(results)
+        gold = doc["gold"]
+        return {
+            "f1": (gold, pred)
+        }
+
+    def higher_is_better(self):
+        return {
+            "f1": True
+        }
+
+    def aggregation(self):
+        return {
+            "f1": macro_f1_score
+        }

--- a/lm_eval/tasks/korunsmile.py
+++ b/lm_eval/tasks/korunsmile.py
@@ -17,6 +17,23 @@ _CITATION = """
 }
 """
 
+def multilable_to_multiclass(label: list):
+    """
+    0 = 혐오
+    1 = 욕설
+    2 = 양호
+    """
+    assert type(label[0]) == int
+    _id = np.argmax(label)
+
+    if _id == 8:
+        return 1
+    elif _id == 9:
+        return 2
+    else:
+        return 0
+
+
 class KorUnSmile(MultipleChoiceTask):
     VERSION = 0
     DATASET_PATH = "smilegate-ai/kor_unsmile"
@@ -42,8 +59,8 @@ class KorUnSmile(MultipleChoiceTask):
     def _process_doc(self, doc):
         out_doc = {
             "title": doc["문장"],
-            "choices": ["여성/가족", "남성", "성소수자", "인종/국적", "연령", "지역", "종교", "기타 혐오", "악플/욕설", "clean"],
-            "gold": np.argmax(doc["labels"])
+            "choices": ["혐오", "욕설", "양호"],
+            "gold": multilable_to_multiclass(doc["labels"])
         }
         return out_doc
 
@@ -51,7 +68,7 @@ class KorUnSmile(MultipleChoiceTask):
         return "{}".format(doc["title"])
 
     def doc_to_target(self, doc):
-        return " {}".format({0: "여성/가족", 1: "남성", 2: "성소수자", 3: "인종/국적", 4: "연령", 5: "지역", 6: "종교", 7: "기타 혐오", 8: "악플/욕설", 9: "clean"}[doc["gold"]])
+        return " {}".format({0: "혐오", 1: "욕설", 2: "양호"}[doc["gold"]])
 
     def process_results(self, doc, results):
         pred = np.argmax(results)


### PR DESCRIPTION
## Add `KorUnSmile` task
Sanity check results are as follows.
- [KorUnSmile Dataset](https://github.com/smilegate-ai/korean_unsmile_dataset)
- Data sample (⚠️ As it is dataset about hate speech, following examples might include offensive expressions or swears.)
  ```
  !!@@##@@!! -- Example 1
  엌 틀무새들 좆됐노 ㅋㅋㅋㅋ 혐오

  틀딱잘못은 맞는데 점주도 싸가지 없이 얘기했겠네 손모양만 봐도 딱 싸가지없게 얘끼했네 혐오

  응안뽑앗어 양호

  우리나라 페미들은 이슬람/인도의 여성대우가 우리보다 좋다고 씨부린다그런소리를 하는거 부터가 그냥 미친거야 혐오

  반대박고 베댓들접어라익이야노 악플

  여자들은 취미가 애낳는건가.. 취미를 좀 가져라
  ```
- Passed unit test
- Few-shot performance by `polyglot-ko-1.3b`
  - \# shots: 0                                                                                                                                                                                             
    gpt2 (pretrained=EleutherAI/polyglot-ko-1.3b), limit: None, provide_description: False, num_fewshot: 0, batch_size: 4
    |   Task   |Version|Metric|Value |   |Stderr|
    |----------|------:|------|-----:|---|-----:|
    |korunsmile|      0|f1    |0.3954|±  | 0.008|
  - \# shots: 1
    gpt2 (pretrained=EleutherAI/polyglot-ko-1.3b), limit: None, provide_description: False, num_fewshot: 1, batch_size: 4
    |   Task   |Version|Metric|Value |   |Stderr|
    |----------|------:|------|-----:|---|-----:|
    |korunsmile|      0|f1    |0.3618|±  | 0.008|
  - \# shots: 10
    gpt2 (pretrained=EleutherAI/polyglot-ko-1.3b), limit: None, provide_description: False, num_fewshot: 10, batch_size: 4
    |   Task   |Version|Metric|Value |   |Stderr|
    |----------|------:|------|-----:|---|-----:|
    |korunsmile|      0|f1    |0.3158|±  |0.0069|