### PR TITLE
Evaluation with a Portion of Benchmark Data for Fast Experimentation

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -203,8 +203,8 @@ def evaluate(
             if description_dict and task_name in description_dict
             else ""
         )
-        if limit is not None and limit < 1:
-            limit = int(len(task_docs) * limit)
+        if limit is not None:
+            limit = int(len(task_docs) * limit) if limit < 1.0 else int(limit)
 
         for doc_id, doc in enumerate(itertools.islice(task_docs, 0, limit)):
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -42,8 +42,8 @@ def simple_evaluate(
         PyTorch device (e.g. "cpu" or "cuda:0") for running models
     :param no_cache: bool
         Whether or not to cache
-    :param limit: int, optional
-        Limit the number of examples per task (only use this for testing)
+    :param limit: int or float, optional
+        Limit the number of examples per task (only use this for testing), If <1, limit is a percentage of the total number of examples.
     :param bootstrap_iters:
         Number of iterations for bootstrap statistics
     :param description_dict: dict[str, str]
@@ -203,6 +203,8 @@ def evaluate(
             if description_dict and task_name in description_dict
             else ""
         )
+        if limit < 1:
+            limit = int(len(task_docs) * limit)
 
         for doc_id, doc in enumerate(itertools.islice(task_docs, 0, limit)):
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -203,7 +203,7 @@ def evaluate(
             if description_dict and task_name in description_dict
             else ""
         )
-        if limit < 1:
+        if limit is not None and limit < 1:
             limit = int(len(task_docs) * limit)
 
         for doc_id, doc in enumerate(itertools.islice(task_docs, 0, limit)):

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from typing import Union
 import argparse
 import json
 import logging
@@ -35,7 +36,9 @@ def parse_args():
     parser.add_argument("--batch_size", type=str, default=None)
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--output_path", default=None)
-    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--limit", type=Union[int, float], default=None,
+                        description="Limit the number of examples per task. If <1, limit is a percentage of the total number of examples.")
+    parser.add_argument("--data_sampling", type=float, default=None)
     parser.add_argument("--no_cache", action="store_true")
     parser.add_argument("--decontamination_ngrams_path", default=None)
     parser.add_argument("--description_dict_path", default=None)

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def parse_args():
     parser.add_argument("--batch_size", type=str, default=None)
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--output_path", default=None)
-    parser.add_argument("--limit", type=Union[int, float], default=None,
+    parser.add_argument("--limit", type=float, default=None,
                         help="Limit the number of examples per task. "
                              "If <1, limit is a percentage of the total number of examples.")
     parser.add_argument("--data_sampling", type=float, default=None)

--- a/main.py
+++ b/main.py
@@ -37,7 +37,8 @@ def parse_args():
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--output_path", default=None)
     parser.add_argument("--limit", type=Union[int, float], default=None,
-                        description="Limit the number of examples per task. If <1, limit is a percentage of the total number of examples.")
+                        help="Limit the number of examples per task. "
+                             "If <1, limit is a percentage of the total number of examples.")
     parser.add_argument("--data_sampling", type=float, default=None)
     parser.add_argument("--no_cache", action="store_true")
     parser.add_argument("--decontamination_ngrams_path", default=None)


### PR DESCRIPTION
# Proposal
## Motivation
An evaluation of full data is always important to ensure an apple-to-apple comparison.
And during quick experimentation in practice, especially in limited compute scenario, sometimes partitioner would just want to use 10% of benchmark data to do evaluation.  While the current `limit` supports so, it does not proportionately adjust accordingly to the data size.

The proposal is when `limit` is <1, limit represents the percentage of the total number of examples.
If it is >=1,  then it means the number of examples per task (only use this for testing).

## Usage
It evaluates the model with 10% of hellaswag data.
```
python main.py \
    --model hf-causal \
    --model_args pretrained=[MODEL] \
    --tasks hellaswag \
    --limit 0.1 \
    --device cuda:0
```
(original behavior) It evaluates the model with 1000 of hellaswag data.
```
python main.py \
    --model hf-causal \
    --model_args pretrained=[MODEL] \
    --tasks hellaswag \
    --limit 1000 \
    --device cuda:0
```

## Consideration

While this would make the `limit` to be legal in None, int, float at the same time, this also avoid introducing an additional variable.
scikit-learn has similar practice, for example, https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html#sklearn.ensemble.RandomForestClassifier
```
max_samplesint or float, default=None
If bootstrap is True, the number of samples to draw from X to train each base estimator.

If None (default), then draw X.shape[0] samples.

If int, then draw max_samples samples.

If float, then draw max_samples * X.shape[0] samples. Thus, max_samples should be in the interval (0.0, 1.0].
```
