### PR TITLE
Allow supplying maximum sequence length

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -16,6 +16,7 @@ def simple_evaluate(
     tasks=[],
     num_fewshot=0,
     batch_size=None,
+    max_length=None,
     device=None,
     no_cache=False,
     limit=None,
@@ -38,6 +39,8 @@ def simple_evaluate(
         Number of examples in few-shot context
     :param batch_size: int, optional
         Batch size for model
+    :param max_length: int, optional
+        Maximum sequence length to supply to the model
     :param device: str, optional
         PyTorch device (e.g. "cpu" or "cuda:0") for running models
     :param no_cache: bool
@@ -62,7 +65,12 @@ def simple_evaluate(
         if model_args is None:
             model_args = ""
         lm = lm_eval.models.get_model(model).create_from_arg_string(
-            model_args, {"batch_size": batch_size, "device": device}
+            model_args,
+            {
+                "batch_size": batch_size,
+                "max_length": max_length,
+                "device": device,
+            },
         )
     else:
         assert isinstance(model, lm_eval.base.LM)
@@ -99,6 +107,7 @@ def simple_evaluate(
         "model_args": model_args,
         "num_fewshot": num_fewshot,
         "batch_size": batch_size,
+        "max_length": lm.max_length if no_cache else lm.lm.max_length,
         "device": device,
         "no_cache": no_cache,
         "limit": limit,

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -84,11 +84,16 @@ class HFLM(BaseLM):
 
     @property
     def max_length(self):
-        try:
-            return self.gpt2.config.n_ctx
-        except AttributeError:
-            # gptneoconfig doesn't have n_ctx apparently
-            return self.gpt2.config.max_position_embeddings
+        for max_len_name in [
+            "n_ctx",
+            "max_position_embeddings",
+            "n_positions",
+        ]:
+            try:
+                return getattr(self.gpt2.config, max_len_name)
+            except AttributeError:
+                pass
+        raise AttributeError("no matching attribute for finding maximum length found")
 
     @property
     def max_gen_toks(self):

--- a/main.py
+++ b/main.py
@@ -33,6 +33,16 @@ def parse_args():
     parser.add_argument("--provide_description", action="store_true")
     parser.add_argument("--num_fewshot", type=int, default=0)
     parser.add_argument("--batch_size", type=int, default=None)
+    parser.add_argument(
+        "--max_length",
+        type=int,
+        default=None,
+        help=(
+            "Maximum sequence length to send to the model. If not given, an attempt is "
+            "made to figure out the maximum sequence length accepted by the model "
+            "automatically. However, this is not always possible."
+        ),
+    )
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--output_path", default=None)
     parser.add_argument("--limit", type=int, default=None)
@@ -82,6 +92,7 @@ def main():
         tasks=task_names,
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,
+        max_length=args.max_length,
         device=args.device,
         no_cache=args.no_cache,
         limit=args.limit,
@@ -99,7 +110,8 @@ def main():
 
     print(
         f"{args.model} ({args.model_args}), limit: {args.limit}, provide_description: {args.provide_description}, "
-        f"num_fewshot: {args.num_fewshot}, batch_size: {args.batch_size}"
+        f"num_fewshot: {args.num_fewshot}, batch_size: {args.batch_size}, "
+        f"max_length: {results['config']['max_length']}"
     )
     print(evaluator.make_table(results))
 


### PR DESCRIPTION
This allows specifying a maximum sequence length for the model. This is especially useful to specify a maximum sequence length for models which do not have one encoded in attributes.
I didn't care for backwards compatibility with this, so if you'd like the argument moved, I can do that. I just thought it really made sense to have it set next to the batch size.