### PR TITLE
Add New Yorker cartoon-caption matching task, typing issue

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -70,7 +70,7 @@ class HuggingFaceAutoLM(BaseLM):
     def __init__(
         self,
         pretrained: str,
-        quantized: Optional[Union[True, str]] = None,
+        quantized: Optional[Union[bool, str]] = None,
         tokenizer: Optional[str] = None,
         subfolder: Optional[str] = None,
         revision: Optional[str] = "main",
@@ -234,7 +234,7 @@ class HuggingFaceAutoLM(BaseLM):
         self,
         *,
         pretrained: str,
-        quantized: Optional[Union[True, str]] = None,
+        quantized: Optional[Union[bool, str]] = None,
         revision: str,
         subfolder: str,
         device_map: Optional[Union[str, _DeviceMapping]] = None,

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -60,6 +60,7 @@ from . import xwinograd
 from . import pawsx
 from . import xnli
 from . import mgsm
+from . import nycartoon
 
 ########################################
 # Translation tasks
@@ -162,6 +163,7 @@ TASK_REGISTRY = {
     "ethics_virtue": hendrycks_ethics.EthicsVirtue,
     "truthfulqa_mc": truthfulqa.TruthfulQAMultipleChoice,
     "truthfulqa_gen": truthfulqa.TruthfulQAGeneration,
+    "nycartoon": nycartoon.NYCartoon,
     # dialogue
     "mutual": mutual.MuTual,
     "mutual_plus": mutual.MuTualPlus,

--- a/lm_eval/tasks/nycartoon.py
+++ b/lm_eval/tasks/nycartoon.py
@@ -23,7 +23,7 @@ _CITATION = """
 
 
 class NYCartoon(MultipleChoiceTask):
-    VERSION = 0
+    VERSION = 1
     DATASET_PATH = "jmhessel/newyorker_caption_contest"
     DATASET_NAME = "matching"
 
@@ -43,6 +43,9 @@ class NYCartoon(MultipleChoiceTask):
 
     def validation_docs(self):
         return map(self._process_doc, self.dataset["validation"])
+
+    def test_docs(self):
+        return map(self._process_doc, self.dataset["test"])
 
     def _process_doc(self, doc):
         out_doc = {

--- a/lm_eval/tasks/nycartoon.py
+++ b/lm_eval/tasks/nycartoon.py
@@ -49,7 +49,11 @@ class NYCartoon(MultipleChoiceTask):
 
     def _process_doc(self, doc):
         out_doc = {
-            "query": "Cartoon description: " + doc["image_description"] + "\nCaption:",
+            "query": f"""In this task, you will see a description of an uncanny situation. Then, you will see five jokes — only one of which was written about the described situation. Pick which of the five choices truly corresponds to the
+described scene.
+###
+This scene takes place in the following location: {doc["image_location"]}. {doc["image_description"]}.
+This caption is most clever, funny, or relevant to the scene:""",
             "choices": doc["caption_choices"],
             "gold": ["A", "B", "C", "D", "E"].index(doc["label"]),
         }

--- a/lm_eval/tasks/nycartoon.py
+++ b/lm_eval/tasks/nycartoon.py
@@ -22,7 +22,7 @@ _CITATION = """
 """
 
 
-class NYCaption(MultipleChoiceTask):
+class NYCartoon(MultipleChoiceTask):
     VERSION = 0
     DATASET_PATH = "jmhessel/newyorker_caption_contest"
     DATASET_NAME = "matching"

--- a/lm_eval/tasks/nycartoon.py
+++ b/lm_eval/tasks/nycartoon.py
@@ -1,0 +1,56 @@
+"""
+The New Yorker Caption Contest
+https://arxiv.org/pdf/2209.06293.pdf
+
+Researchers challenge AI models to "demonstrate understanding" of the humor in
+the New Yorker's regular cartoon captioning contest. In this sub-task for
+text-based models, the model should match a human-written description to the
+associated caption from five options.
+
+Homepage: https://www.capcon.dev/
+"""
+from lm_eval.base import MultipleChoiceTask
+
+
+_CITATION = """
+@article{hessel2022androids,
+  title={Do Androids Laugh at Electric Sheep? Humor "Understanding" Benchmarks from The New Yorker Caption Contest},
+  author={Hessel, Jack and Marasovi{\'c}, Ana and Hwang, Jena D and Lee, Lillian and Da, Jeff and Zellers, Rowan and Mankoff, Robert and Choi, Yejin},
+  journal={arXiv preprint arXiv:2209.06293},
+  year={2022}
+}
+"""
+
+
+class NYCaption(MultipleChoiceTask):
+    VERSION = 0
+    DATASET_PATH = "jmhessel/newyorker_caption_contest"
+    DATASET_NAME = "matching"
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return True
+
+    def training_docs(self):
+        if self._training_docs is None:
+            self._training_docs = list(map(self._process_doc, self.dataset["train"]))
+        return self._training_docs
+
+    def validation_docs(self):
+        return map(self._process_doc, self.dataset["validation"])
+
+    def _process_doc(self, doc):
+        out_doc = {
+            "query": "Cartoon description: " + doc["image_description"] + "\nCaption:",
+            "choices": doc["caption_choices"],
+            "gold": ["A", "B", "C", "D", "E"].index(doc["label"]),
+        }
+        return out_doc
+
+    def doc_to_text(self, doc):
+        return doc["query"]

--- a/lm_eval/tasks/nycartoon.py
+++ b/lm_eval/tasks/nycartoon.py
@@ -10,7 +10,7 @@ associated caption from five options.
 Homepage: https://www.capcon.dev/
 """
 from lm_eval.base import MultipleChoiceTask
-
+from typing import List
 
 _CITATION = """
 @article{hessel2022androids,
@@ -20,6 +20,8 @@ _CITATION = """
   year={2022}
 }
 """
+
+LETTER_ANSWERS = ["A", "B", "C", "D", "E"]
 
 
 class NYCartoon(MultipleChoiceTask):
@@ -48,14 +50,20 @@ class NYCartoon(MultipleChoiceTask):
         return map(self._process_doc, self.dataset["test"])
 
     def _process_doc(self, doc):
+        answer_key: List[str] = []
+        for idx, letter in enumerate(LETTER_ANSWERS):
+            answer_key.append(letter + ") " + doc["caption_choices"][idx] + "\n")
         out_doc = {
             "query": f"""In this task, you will see a description of an uncanny situation. Then, you will see five jokes — only one of which was written about the described situation. Pick which of the five choices truly corresponds to the
 described scene.
 ###
 This scene takes place in the following location: {doc["image_location"]}. {doc["image_description"]}.
-This caption is most clever, funny, or relevant to the scene:""",
-            "choices": doc["caption_choices"],
-            "gold": ["A", "B", "C", "D", "E"].index(doc["label"]),
+This caption is most clever, funny, or relevant to the scene:
+
+{''.join(answer_key)}
+the funny caption that matches the scene is:""",
+            "choices": LETTER_ANSWERS,
+            "gold": LETTER_ANSWERS.index(doc["label"]),
         }
         return out_doc
 


### PR DESCRIPTION
I can separate these into two PRs if it's helpful

1. When I try loading the current repo in CoLab, two lines with`Optional[Union[True, str]]` are rejected. Replaced with `Optional[Union[bool, str]]`.  See https://colab.research.google.com/drive/1498sJRzva7xWipgegr_4lizmEXDT-pq2?usp=sharing

2. Added the New Yorker cartoon dataset's "Matching" task, see https://huggingface.co/datasets/jmhessel/newyorker_caption_contest for dataset

The matching task gives the model a human-written description of the cartoon, and five options for the caption. One caption is associated with this cartoon, the others are not.  I've chosen matching as it's the straightforward multiple choice task in the paper. The other tasks in the paper are: ranking the best of suggested captions, explaining the humor of the cartoon + caption, or doing these tasks with the original image ("from pixels") instead of a text description.

Testing on some models with 24-28% accuracy https://colab.research.google.com/drive/1BVavduo5xckLaWIlWQtrQ1kgw1kcYUyu?usp=sharing

I followed MathQA's setup for adding some context to build the query / prompt. Open to changing this or making this settable by the user. 