### PR TITLE
Use max_length in AutoSeq2SeqLM

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -351,7 +351,7 @@ class HuggingFaceAutoLM(BaseLM):
         """Return the maximum sequence length of the model.
         NOTE: Different model configurations have different max sequence length
         attribute names.
-            - n_positions: (CTRLConfig)
+            - n_positions: (CTRLConfig, T5Config)
             - max_position_embeddings: (BartConfig, RoFormerConfig)
             - n_ctx: (GPT2Config)
         NOTE: For relative position encoded models you should specify the max
@@ -542,15 +542,6 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
 
     AUTO_MODEL_CLASS = transformers.AutoModelForSeq2SeqLM
     AUTO_PEFT_CLASS = peft.PeftModel
-
-    @property
-    def max_length(self) -> int:
-        """Return the maximum sequence length of the model.
-        TODO: Currently only works for relative position encoded Seq2Seq models.
-        """
-        if self._max_length is not None:
-            return self._max_length
-        return self._DEFAULT_MAX_LENGTH
 
     def loglikelihood(
         self, requests: List[Tuple[str, str]]


### PR DESCRIPTION
Fixes https://github.com/EleutherAI/lm-evaluation-harness/issues/549.

| task                    | flan-t5-small | bart-base    |
| ----------------------- | ------------- | ------------ |
| boolq (master)          | 65.11 ± 0.83  | 0.00         |
| boolq (bart)            | 64.34 ± 0.84  | 49.36 ± 0.87 |
| boolq (diff)            | **-0.76**     | **+49.36**   |
| hellaswag (master)      | 27.91 ± 0.45  | 0.00         |
| hellaswag (bart)        | 27.91 ± 0.45  | 27.35 ± 0.44 |
| hellaswag (diff)        | 0.00          | **+27.35**   |
| lambada_openai (master) | 8.03 ± 0.38   | 0.00         |
| lambada_openai (bart)   | 8.03 ± 0.38   | 0.00         |
| lambada_openai (diff)   | 0.00          | 0.00         |
| openbookqa (master)     | 12.00 ± 1.45  | 0.00         |
| openbookqa (bart)       | 12.00 ± 1.45  | 16.60 ± 1.67 |
| openbookqa (diff)       | 0.00          | **+16.60**   |
| piqa (master)           | 62.13 ± 1.13  | 0.00         |
| piqa (bart)             | 62.13 ± 1.13  | 59.85 ± 1.14 |
| piqa (diff)             | 0.00          | **+59.85**   |
| winogrande (master)     | 50.04 ± 1.41  | 0.00         |
| winogrande (bart)       | 50.04 ± 1.41  | 50.67 ± 1.41 |
| winogrande (diff)       | 0.00          | **+50.67**   |