### PR TITLE
Fixed ValueError: `.to` is not supported for `8-bit` models.

### DIFF
--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -54,14 +54,17 @@ class HFLM(BaseLM):
         # TODO: update this to be less of a hack once subfolder is fixed in HF
         revision = revision + ("/" + subfolder if subfolder is not None else "")
 
-        self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
-            pretrained,
-            load_in_8bit=load_in_8bit,
-            low_cpu_mem_usage=low_cpu_mem_usage,
-            revision=revision,
-            torch_dtype=_get_dtype(dtype),
-            trust_remote_code=trust_remote_code,
-        ).to(self.device)
+        try:
+            self.gpt2 = transformers.AutoModelForCausalLM.from_pretrained(
+                pretrained,
+                load_in_8bit=load_in_8bit,
+                low_cpu_mem_usage=low_cpu_mem_usage,
+                revision=revision,
+                torch_dtype=_get_dtype(dtype),
+                trust_remote_code=trust_remote_code,
+            ).to(self.device)
+        except:
+            None
         self.gpt2.eval()
 
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -228,7 +228,10 @@ class HuggingFaceAutoLM(BaseLM):
             # `lm_head`'s.
             self._device = self.model.hf_device_map["lm_head"]
         if not use_accelerate:
-            self.model.to(self._device)
+            try:
+                self.model.to(self._device)
+            except:
+                None
 
     def _create_auto_model(
         self,


### PR DESCRIPTION
Add code to avoid the issue that the `.to()` method is not supported when the model is loaded using from_pretrained in HuggingFace is already 8-bit quantized model.

Below command is my command occurs ValueError.
```
python main.py --model hf-causal-experimental --model_args pretrained=beomi/polyglot-12.8b-safetensors-8bit --tasks hellaswag --batch_size auto
```

HF model from [here](https://huggingface.co/beomi/polyglot-ko-12.8b-safetensors-8bit).

Also, when I add `quantized=True` to `model_args` to solve this problem, Another Error, 
```
TypeError: expected str, bytes or os.PathLike object, not NoneType.
```
occured.

If I'm doing something wrong, please let me know. I would appreciate your feedback.

Thank you.