### PR TITLE
Update evaluator.py cache_db argument str if model is not str

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -102,7 +102,7 @@ def simple_evaluate(
 
     # add info about the model and few shot config
     results["config"] = {
-        "model": model,
+        "model": (model if isinstance(model, str) else model.config._name_or_path),
         "model_args": model_args,
         "num_fewshot": num_fewshot,
         "batch_size": batch_size,

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -77,7 +77,7 @@ def simple_evaluate(
         lm = lm_eval.base.CachingLM(
             lm,
             "lm_cache/"
-            + model
+            + (model if isinstance(model, str) else model.config._name_or_path)
             + "_"
             + model_args.replace("=", "-").replace(",", "_").replace("/", "-")
             + ".db",

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -77,7 +77,7 @@ def simple_evaluate(
         lm = lm_eval.base.CachingLM(
             lm,
             "lm_cache/"
-            + (model if isinstance(model, str) else model.config._name_or_path)
+            + (model if isinstance(model, str) else model.model.config._name_or_path)
             + "_"
             + model_args.replace("=", "-").replace(",", "_").replace("/", "-")
             + ".db",
@@ -102,7 +102,7 @@ def simple_evaluate(
 
     # add info about the model and few shot config
     results["config"] = {
-        "model": (model if isinstance(model, str) else model.config._name_or_path),
+        "model": (model if isinstance(model, str) else model.model.config._name_or_path),
         "model_args": model_args,
         "num_fewshot": num_fewshot,
         "batch_size": batch_size,


### PR DESCRIPTION
simple_evaluate can accept model arg both as str and as `lm_eval.base.LM`.
in the latter case case there may be errors:
1) line 80 gives error, because `model` is not `str`. 
2) line 105 inserts `lm_eval.base.LM` into results, this causes crash in json.serialize in main().
both are easily fixable - see the commits.