### PR TITLE
Fix non-callable attributes in CachingLM

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -868,6 +868,10 @@ class CachingLM:
         lm.set_cache_hook(self.get_cache_hook())
 
     def __getattr__(self, attr):
+        lm_attr = getattr(self.lm, attr)
+        if not callable(lm_attr):
+            return lm_attr
+
         def fn(requests):
             res = []
             remaining_reqs = []

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -109,7 +109,7 @@ def simple_evaluate(
         "model_args": model_args,
         "num_fewshot": num_fewshot,
         "batch_size": batch_size,
-        "batch_sizes": list(lm.batch_sizes.values()),
+        "batch_sizes": list(lm.batch_sizes.values()) if hasattr(lm, "batch_sizes") else [],
         "device": device,
         "no_cache": no_cache,
         "limit": limit,


### PR DESCRIPTION
Fixes the errors reported in https://github.com/EleutherAI/lm-evaluation-harness/pull/572.

The `hasattr(lm, "batch_sizes")` check is for dummy non-`BaseLM` models.