### PR TITLE
[Refactor] Package YAMLs alongside pip installations of lm-eval

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,12 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/EleutherAI/lm-evaluation-harness",
     packages=setuptools.find_packages(),
+    # required to include yaml files in pip installation
+    package_data={
+        'lm_eval': ['**/*.yaml'], 
+        'examples': ['**/*.yaml'],
+    },
+    include_package_data=True,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Currently, if not installing the python package via `pip install -e ...`, the YAML files (and any non-python files) will not be copied to the environment's `lm_eval` installation. The solution to this is to tell setuptools.setup to track these files and include them as package data.

Reference:
https://stackoverflow.com/a/1857436

In future, we may also consider switching to `pyproject.toml` with `MANIFEST.in`, potentially. https://stackoverflow.com/questions/69647590/specifying-package-data-in-pyproject-toml