### PR TITLE
add openbookqa config

### DIFF
--- a/lm_eval/tasks/openbookqa/openbookqa.yaml
+++ b/lm_eval/tasks/openbookqa/openbookqa.yaml
@@ -1,0 +1,21 @@
+group:
+  - multiple_choice
+task: openbookqa
+dataset_path: openbookqa
+dataset_name: main
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+template_aliases: "{% set answer_choices = choices['text'] %}{% set gold = choices.label.index(answerKey.lstrip()) %}" # set the list of possible answer choices, and set what this doc's gold answer is (set what ds column used, and what)
+doc_to_text: "{{question_stem}}"
+doc_to_target: "{{gold}}" # this will be cast to an int.
+should_decontaminate: true
+doc_to_decontamination_query: "{{question_stem}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true


### PR DESCRIPTION
In this PR, `openbookqa.yaml` has been added.
Here is the result of `Master` branch.
![master](https://github.com/EleutherAI/lm-evaluation-harness/assets/30573681/36048664-da1b-4ae1-862e-47ae5948ca42)
Here is also the output of new branch:
![openqa](https://github.com/EleutherAI/lm-evaluation-harness/assets/30573681/002d3386-c110-4765-8958-eefa912c41f9)
