### PR TITLE
Sort descending as intended for `greedy_until`

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -399,8 +399,15 @@ class BaseLM(LM):
         res = []
 
         def _collate(x):
+            # the negative sign on len(toks) sorts descending - this has a few advantages:
+            # - time estimates will always be over not underestimates, which is more useful for planning
+            # - to know the size of a batch when going through the list, you know the first one is always the batch
+            #   padded context length. this is useful to simplify the batching logic and more importantly to make
+            #   automatic adaptive batches much much easier to implement
+            # - any OOMs will happen right away rather than near the end
+
             toks = self.tok_encode(x[0])
-            return len(toks), x[0]
+            return -len(toks), x[0]
 
         re_ord = utils.Reorderer(requests, _collate)
 


### PR DESCRIPTION
It seems like, though for `_loglikelihood_tokens` we sort in descending order by sequence length, for `BaseLM.greedy_until` we sort in ascending order. This is unintended, so this PR fixes this. 

TODO before merging:
- [ ] Check things run, I made this hotfix from mobile
- [ ] Check that other LMs don't also sort ascending for greedy_until


Potentially closes #602 .