### PR TITLE
[Refactor] HellaSwag YAML fix

### DIFF
--- a/lm_eval/tasks/hellaswag/hellaswag.yaml
+++ b/lm_eval/tasks/hellaswag/hellaswag.yaml
@@ -7,7 +7,7 @@ output_type: multiple_choice
 training_split: train
 validation_split: validation
 test_split: null
-template_aliases: "{% set gold = label %}{% set answer_choices = endings|map('trim')|map('replace', ' [title]', '. ')|map('regex_replace', '\\[.*?\\]', '')|map('replace', '  ', ' ')|list %}"
+template_aliases: "{% set gold = label | int %}{% set answer_choices = endings|map('trim')|map('replace', ' [title]', '. ')|map('regex_replace', '\\[.*?\\]', '')|map('replace', '  ', ' ')|list %}"
 doc_to_text: "{% set text = activity_label ~ ': ' ~ ctx_a ~ ' ' ~ ctx_b.capitalize() %}{{text|trim|replace(' [title]', '. ')|regex_replace('\\[.*?\\]', '')|replace('  ', ' ')}}"
 doc_to_target: "{{answer_choices[gold]}}"
 gold_alias: "{{gold}}"


### PR DESCRIPTION
The HellaSwag task fails with `jinja2.exceptions.UndefinedError: 'list object' has no attribute '3'` because the gold variable (used in `doc_to_target: "{{answer_choices[gold]}}"`) is a string, not an int. This PR fixes the issue.