### PR TITLE
Add json files in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/EleutherAI/lm-evaluation-harness",
     packages=setuptools.find_packages(),
+    package_data={
+        "lm_eval": ["**/*.json"]
+    },
+    include_package_data=True,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Users can install this package in non-editable mode. Because of the existence of the bigbench and the usage of relative path, non-editable installation cant run.