### PR TITLE
[Refactor] Add Lambada Multilingual

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -73,7 +73,6 @@ class TaskConfig(dict):
     fewshot_delimiter: str = "\n\n"
     # runtime configuration options
     num_fewshot: int = 0
-    batch_size: int = 1
     # scoring options
     metric_list: str = None
     output_type: str = "greedy_until"
@@ -468,7 +467,7 @@ class Task(abc.ABC):
             The fewshot context.
         """
         # TODO: this should only return the overrides applied to a non-YAML task's configuration.
-        # (batch size, num_fewshot)
+        # (num_fewshot)
         return self._config.to_dict()
 
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -181,8 +181,6 @@ def evaluate(
     samples = collections.defaultdict(list)
     requests = collections.defaultdict(list)
 
-    # docs = {}
-
     # get lists of each type of request
     for task_name, task in task_dict.items():
         versions[task_name] = task.VERSION

--- a/lm_eval/tasks/README.md
+++ b/lm_eval/tasks/README.md
@@ -9,7 +9,7 @@ Boxes should be checked iff tasks are implemented in the refactor and tested for
 - [ ] DROP
 - [x] ~~Lambada~~
 - [x] Lambada (Cloze variants)
-- [ ] Lambada (Multilingual)
+- [x] ~~Lambada (Multilingual)~~
 - [x] Wikitext
 - [x] PiQA
 - [ ] PROST (WIP)

--- a/lm_eval/tasks/lambada_multilingual/README.md
+++ b/lm_eval/tasks/lambada_multilingual/README.md
@@ -1,0 +1,43 @@
+# LAMBADA
+
+### Paper
+The LAMBADA dataset: Word prediction requiring a broad discourse context
+https://arxiv.org/pdf/1606.06031.pdf
+
+LAMBADA is a dataset to evaluate the capabilities of computational models for text
+understanding by means of a word prediction task. LAMBADA is a collection of narrative
+passages sharing the characteristic that human subjects are able to guess their last
+word if they are exposed to the whole passage, but not if they only see the last
+sentence preceding the target word. To succeed on LAMBADA, computational models
+cannot simply rely on local context, but must be able to keep track of information
+in the broader discourse.
+
+Homepage: https://zenodo.org/record/2630551#.X4Xzn5NKjUI
+
+### Citation
+
+@misc{
+    author={Paperno, Denis and Kruszewski, Germán and Lazaridou, Angeliki and Pham, Quan Ngoc and Bernardi, Raffaella and Pezzelle, Sandro and Baroni, Marco and Boleda, Gemma and Fernández, Raquel},
+    title={The LAMBADA dataset},
+    DOI={10.5281/zenodo.2630551},
+    publisher={Zenodo},
+    year={2016},
+    month={Aug}
+}
+
+### Subtasks
+
+* `lambada_mt_{en, fr, de, it, es}`: Machine-translated versions of OpenAI's Lambada variant.
+
+### Checklist
+
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+(This task is novel to the Evaluation Harness, and has been checked against v0.3.0 of the harness.)
+
+
+If other tasks on this dataset are already supported:
+* [x] Is the "Main" variant of this task clearly denoted?
+* [x] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [x] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/lambada_multilingual/lambada_mt_de.yaml
+++ b/lm_eval/tasks/lambada_multilingual/lambada_mt_de.yaml
@@ -1,0 +1,7 @@
+include: lambada_mt_en.yaml
+group:
+  - lambada_multilingual
+  - loglikelihood
+  - perplexity
+task: lambada_openai_mt_de
+dataset_name: de

--- a/lm_eval/tasks/lambada_multilingual/lambada_mt_en.yaml
+++ b/lm_eval/tasks/lambada_multilingual/lambada_mt_en.yaml
@@ -1,0 +1,21 @@
+group:
+  - lambada_multilingual
+  - loglikelihood
+  - perplexity
+task: lambada_openai_mt_en
+dataset_path: EleutherAI/lambada_openai
+dataset_name: en
+output_type: loglikelihood
+test_split: test
+template_aliases: ""
+doc_to_text: "{{text.split(' ')[:-1]|join(' ')}}"
+doc_to_target: "{{' '+text.split(' ')[-1]}}"
+should_decontaminate: true
+doc_to_decontamination_query: "{{text}}"
+metric_list:
+  - metric: perplexity
+    aggregation: perplexity
+    higher_is_better: false
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/lambada_multilingual/lambada_mt_es.yaml
+++ b/lm_eval/tasks/lambada_multilingual/lambada_mt_es.yaml
@@ -1,0 +1,7 @@
+include: lambada_mt_en.yaml
+group:
+  - lambada_multilingual
+  - loglikelihood
+  - perplexity
+task: lambada_openai_mt_es
+dataset_name: es

--- a/lm_eval/tasks/lambada_multilingual/lambada_mt_fr.yaml
+++ b/lm_eval/tasks/lambada_multilingual/lambada_mt_fr.yaml
@@ -1,0 +1,7 @@
+include: lambada_mt_en.yaml
+group:
+  - lambada_multilingual
+  - loglikelihood
+  - perplexity
+task: lambada_openai_mt_fr
+dataset_name: fr

--- a/lm_eval/tasks/lambada_multilingual/lambada_mt_it.yaml
+++ b/lm_eval/tasks/lambada_multilingual/lambada_mt_it.yaml
@@ -1,0 +1,7 @@
+include: lambada_mt_en.yaml
+group:
+  - lambada_multilingual
+  - loglikelihood
+  - perplexity
+task: lambada_openai_mt_it
+dataset_name: it

--- a/lm_eval/tasks/super_glue/copa/default.yaml
+++ b/lm_eval/tasks/super_glue/copa/default.yaml
@@ -1,5 +1,5 @@
 group:
-  - super-glue-lm-eval-v1-
+  - super-glue-lm-eval-v1
 task: "copa"
 dataset_path: super_glue
 dataset_name: copa


### PR DESCRIPTION
This PR adds the MT lambada tasks.



On this branch:
```
hf (pretrained=EleutherAI/pythia-70m), limit: None, num_fewshot: 0, batch_size: 1
|        Task        |Version|Filter|  Metric  |  Value   |   | Stderr |
|--------------------|-------|------|----------|---------:|---|-------:|
|lambada_openai      |Yaml   |none  |perplexity|  141.2759|±  |  5.9955|
|                    |       |none  |acc       |    0.1842|±  |  0.0054|
|lambada_openai_mt_de|Yaml   |none  |perplexity| 8342.9730|±  |576.8985|
|                    |       |none  |acc       |    0.0592|±  |  0.0033|
|lambada_openai_mt_en|Yaml   |none  |perplexity|  141.2759|±  |  5.9955|
|                    |       |none  |acc       |    0.1842|±  |  0.0054|
|lambada_openai_mt_es|Yaml   |none  |perplexity|11196.6925|±  |696.3423|
|                    |       |none  |acc       |    0.0491|±  |  0.0030|
|lambada_openai_mt_fr|Yaml   |none  |perplexity| 4620.2840|±  |283.5216|
|                    |       |none  |acc       |    0.0815|±  |  0.0038|
|lambada_openai_mt_it|Yaml   |none  |perplexity|13155.5867|±  |852.3622|
|                    |       |none  |acc       |    0.0638|±  |  0.0034|

```

On master:
```
hf-causal (pretrained=EleutherAI/pythia-70m), limit: None, provide_description: False, num_fewshot: 0, batch_size: None
|        Task        |Version|Metric|  Value   |   | Stderr |
|--------------------|------:|------|---------:|---|-------:|
|lambada_openai_cloze|      0|ppl   |20181.3956|±  |699.7777|
|                    |       |acc   |    0.0002|±  |  0.0002|
|lambada_openai_mt_de|      0|ppl   | 8342.9730|±  |575.5908|
|                    |       |acc   |    0.0592|±  |  0.0033|
|lambada_openai_mt_en|      0|ppl   |  141.2759|±  |  6.0090|
|                    |       |acc   |    0.1842|±  |  0.0054|
|lambada_openai_mt_es|      0|ppl   |11196.6925|±  |697.1550|
|                    |       |acc   |    0.0491|±  |  0.0030|
|lambada_openai_mt_fr|      0|ppl   | 4620.2840|±  |283.7520|
|                    |       |acc   |    0.0815|±  |  0.0038|
|lambada_openai_mt_it|      0|ppl   |13155.5867|±  |852.5457|
|                    |       |acc   |    0.0638|±  |  0.0034|
```