### PR TITLE
Fix dummy model not invoking super class constructor 

### DIFF
--- a/lm_eval/models/dummy.py
+++ b/lm_eval/models/dummy.py
@@ -6,7 +6,7 @@ from lm_eval.api.registry import register_model
 @register_model("dummy")
 class DummyLM(LM):
     def __init__(self):
-        pass
+        super().__init__()
 
     @classmethod
     def create_from_arg_string(cls, arg_string, additional_config=None):


### PR DESCRIPTION
This results in `self._rank` and `self._world_size` not being initialized, which causes 
`python main.py --model dummy ...` to error out.