### PR TITLE
[Refactor] Fixes for when using `num_fewshot`

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -130,6 +130,9 @@ class TaskConfig(dict):
     def __getitem__(self, item):
         return getattr(self, item)
 
+    def __setitem__(self, item, value):
+        return setattr(self, item, value)
+
     def to_dict(self):
         """dumps the current config as a dictionary object, as a printable format.
         null fields will not be printed.

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -122,7 +122,7 @@ def simple_evaluate(
                     f"Overwriting default num_fewshot of {task_name} from {default_num_fewshot} to {num_fewshot}"
                 )
 
-            task_dict[task_name]._config.__setitem__("num_fewshot", num_fewshot)
+            task_dict[task_name]._config["num_fewshot"] = num_fewshot
 
     if check_integrity:
         run_task_tests(task_list=tasks)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -366,7 +366,6 @@ def evaluate(
         for (task_name, key, metric), items in vals.items():
             task = task_dict[task_name]
             results[task_name][metric + "," + key] = task.aggregation()[metric](items)
-            # results[task_name]['num_fewshot'] = configs[task_name]
 
             # hotfix: bleu, chrf, ter seem to be really expensive to bootstrap
             # so we run them less iterations. still looking for a cleaner way to do this

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -267,8 +267,8 @@ def make_table(result_dict):
     latex_writer = LatexTableWriter()
     md_writer.headers = [
         "Task",
-        "Fewshot",
         "Version",
+        "Fewshot",
         "Filter",
         "Metric",
         "Value",
@@ -277,8 +277,8 @@ def make_table(result_dict):
     ]
     latex_writer.headers = [
         "Task",
-        "Fewshot",
         "Version",
+        "Fewshot",
         "Filter",
         "Metric",
         "Value",
@@ -298,7 +298,7 @@ def make_table(result_dict):
 
             if m + "_stderr" + "," + f in dic:
                 se = dic[m + "_stderr" + "," + f]
-                values.append([k, n, version, f, m, "%.4f" % v, "±", "%.4f" % se])
+                values.append([k, version, n, f, m, "%.4f" % v, "±", "%.4f" % se])
             else:
                 values.append([k, n, version, f, m, "%.4f" % v, "", ""])
             k = ""

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -265,9 +265,19 @@ def make_table(result_dict):
 
     md_writer = MarkdownTableWriter()
     latex_writer = LatexTableWriter()
-    md_writer.headers = ["Task", "Version", "Filter", "Metric", "Value", "", "Stderr"]
+    md_writer.headers = [
+        "Task",
+        "Fewshot",
+        "Version",
+        "Filter",
+        "Metric",
+        "Value",
+        "",
+        "Stderr",
+    ]
     latex_writer.headers = [
         "Task",
+        "Fewshot",
         "Version",
         "Filter",
         "Metric",
@@ -280,6 +290,7 @@ def make_table(result_dict):
 
     for k, dic in result_dict["results"].items():
         version = result_dict["versions"][k]
+        n = str(result_dict["configs"][k]["num_fewshot"])
         for (mf), v in dic.items():
             m, _, f = mf.partition(",")
             if m.endswith("_stderr"):
@@ -287,10 +298,11 @@ def make_table(result_dict):
 
             if m + "_stderr" + "," + f in dic:
                 se = dic[m + "_stderr" + "," + f]
-                values.append([k, version, f, m, "%.4f" % v, "±", "%.4f" % se])
+                values.append([k, n, version, f, m, "%.4f" % v, "±", "%.4f" % se])
             else:
-                values.append([k, version, f, m, "%.4f" % v, "", ""])
+                values.append([k, n, version, f, m, "%.4f" % v, "", ""])
             k = ""
+            n = ""
             version = ""
     md_writer.value_matrix = values
     latex_writer.value_matrix = values

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -300,7 +300,7 @@ def make_table(result_dict):
                 se = dic[m + "_stderr" + "," + f]
                 values.append([k, version, n, f, m, "%.4f" % v, "±", "%.4f" % se])
             else:
-                values.append([k, n, version, f, m, "%.4f" % v, "", ""])
+                values.append([k, version, n, f, m, "%.4f" % v, "", ""])
             k = ""
             n = ""
             version = ""

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def parse_args():
     parser.add_argument(
         "--num_fewshot",
         type=int,
-        default=0,
+        default=None,
         help="Number of examples in few-shot context",
     )
     parser.add_argument("--batch_size", type=int, default=1)  # TODO: only integers


### PR DESCRIPTION
PR for #697

1. Allow LM-Eval to use `num_fewshot` set in a yaml if set > 0.
2. Add warning if user inputs a num_fewshot through the arguments in main.py
3. Shows the `num_fewshot` used per task in the final table.