### PR TITLE
[Refactor] Use console script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setuptools.setup(
         "lm_eval": ["**/*.yaml"],
         "examples": ["**/*.yaml"],
     },
+    entry_points={
+        "console_scripts": ["lm-eval = main:main", "lm_eval = main:main"],
+    },
     include_package_data=True,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Instead of `python main.py` user can now use either `lm-eval` or `lm_eval` and can be used without needing to be in the lm-eval directory.

Example
```
lm_eval \
    --model hf \
    --model_args "pretrained=EleutherAI/pythia-2.8b" \
    --tasks boolq-seq2seq \
    --limit 10
```

or `accelerate launch --no_python lm_eval ..` to use accelerate for multi-gpu usage.
