### PR TITLE
Dataset licenses

### DIFF
--- a/lm_eval/datasets/asdiv/asdiv.py
+++ b/lm_eval/datasets/asdiv/asdiv.py
@@ -43,8 +43,7 @@ level (for indicating the level of difficulty).
 
 _HOMEPAGE = "https://github.com/chaochun/nlu-asdiv-dataset"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "CC BY-NC 4.0"
 
 _URLS = "https://github.com/chaochun/nlu-asdiv-dataset/archive/55790e5270bb91ccfa5053194b25732534696b50.zip"
 

--- a/lm_eval/datasets/asdiv/asdiv.py
+++ b/lm_eval/datasets/asdiv/asdiv.py
@@ -43,6 +43,7 @@ level (for indicating the level of difficulty).
 
 _HOMEPAGE = "https://github.com/chaochun/nlu-asdiv-dataset"
 
+# License available at https://github.com/chaochun/nlu-asdiv-dataset/blob/master/README.md
 _LICENSE = "CC BY-NC 4.0"
 
 _URLS = "https://github.com/chaochun/nlu-asdiv-dataset/archive/55790e5270bb91ccfa5053194b25732534696b50.zip"

--- a/lm_eval/datasets/coqa/coqa.py
+++ b/lm_eval/datasets/coqa/coqa.py
@@ -44,8 +44,7 @@ appear in a conversation.
 
 _HOMEPAGE = "https://stanfordnlp.github.io/coqa/"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "Different licenses depending on the content (see https://stanfordnlp.github.io/coqa/ for details)"
 
 _URLS = {
     "train": "https://nlp.stanford.edu/data/coqa/coqa-train-v1.0.json",

--- a/lm_eval/datasets/drop/drop.py
+++ b/lm_eval/datasets/drop/drop.py
@@ -43,6 +43,7 @@ and perform discrete operations over them (such as addition, counting, or sortin
 
 _HOMEPAGE = "https://allenai.org/data/drop"
 
+# License available at https://allenai.org/data/drop
 _LICENSE = "CC BY"
 
 _URLS = {

--- a/lm_eval/datasets/drop/drop.py
+++ b/lm_eval/datasets/drop/drop.py
@@ -43,8 +43,7 @@ and perform discrete operations over them (such as addition, counting, or sortin
 
 _HOMEPAGE = "https://allenai.org/data/drop"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "CC BY"
 
 _URLS = {
     "drop": "https://s3-us-west-2.amazonaws.com/allennlp/datasets/drop/drop_dataset.zip",

--- a/lm_eval/datasets/headqa/headqa.py
+++ b/lm_eval/datasets/headqa/headqa.py
@@ -51,6 +51,7 @@ The dataset contains questions about the following topics: medicine, nursing, ps
 
 _HOMEPAGE = "https://aghie.github.io/head-qa/"
 
+# License available at https://github.com/aghie/head-qa/blob/master/LICENSE
 _LICENSE = "MIT License"
 
 _URL = "https://drive.google.com/uc?export=download&confirm=t&id=1a_95N5zQQoUCq8IBNVZgziHbeM-QxG2t"

--- a/lm_eval/datasets/hendrycks_ethics/hendrycks_ethics.py
+++ b/lm_eval/datasets/hendrycks_ethics/hendrycks_ethics.py
@@ -41,6 +41,7 @@ learning agents.
 
 _HOMEPAGE = "https://github.com/hendrycks/ethics"
 
+# License available at https://github.com/hendrycks/ethics/blob/master/LICENSE
 _LICENSE = "MIT License"
 
 _URLS = "https://people.eecs.berkeley.edu/~hendrycks/ethics.tar"

--- a/lm_eval/datasets/hendrycks_ethics/hendrycks_ethics.py
+++ b/lm_eval/datasets/hendrycks_ethics/hendrycks_ethics.py
@@ -41,8 +41,7 @@ learning agents.
 
 _HOMEPAGE = "https://github.com/hendrycks/ethics"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "MIT License"
 
 _URLS = "https://people.eecs.berkeley.edu/~hendrycks/ethics.tar"
 

--- a/lm_eval/datasets/hendrycks_math/hendrycks_math.py
+++ b/lm_eval/datasets/hendrycks_math/hendrycks_math.py
@@ -38,6 +38,7 @@ models to generate answer derivations and explanations.
 
 _HOMEPAGE = "https://github.com/hendrycks/math"
 
+# License available at https://github.com/hendrycks/math/blob/main/LICENSE
 _LICENSE = "MIT License"
 
 _URLS = "https://people.eecs.berkeley.edu/~hendrycks/MATH.tar"

--- a/lm_eval/datasets/hendrycks_math/hendrycks_math.py
+++ b/lm_eval/datasets/hendrycks_math/hendrycks_math.py
@@ -38,8 +38,7 @@ models to generate answer derivations and explanations.
 
 _HOMEPAGE = "https://github.com/hendrycks/math"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "MIT License"
 
 _URLS = "https://people.eecs.berkeley.edu/~hendrycks/MATH.tar"
 

--- a/lm_eval/datasets/logiqa/logiqa.py
+++ b/lm_eval/datasets/logiqa/logiqa.py
@@ -38,7 +38,7 @@ NLP setting.
 
 _HOMEPAGE = "https://github.com/lgw863/LogiQA-dataset"
 
-_LICENSE = ""
+_LICENSE = "No license found"
 
 _URLS = {
     "train": "https://raw.githubusercontent.com/lgw863/LogiQA-dataset/master/Train.txt",

--- a/lm_eval/datasets/logiqa/logiqa.py
+++ b/lm_eval/datasets/logiqa/logiqa.py
@@ -38,7 +38,6 @@ NLP setting.
 
 _HOMEPAGE = "https://github.com/lgw863/LogiQA-dataset"
 
-# TODO: Add the licence for the dataset here if you can find it
 _LICENSE = ""
 
 _URLS = {

--- a/lm_eval/datasets/mutual/mutual.py
+++ b/lm_eval/datasets/mutual/mutual.py
@@ -38,7 +38,7 @@ modified from Chinese high school English listening comprehension test data.
 
 _HOMEPAGE = "https://github.com/Nealcly/MuTual"
 
-_LICENSE = ""
+_LICENSE = "No license found"
 
 _URLS = "https://github.com/Nealcly/MuTual/archive/master.zip"
 

--- a/lm_eval/datasets/mutual/mutual.py
+++ b/lm_eval/datasets/mutual/mutual.py
@@ -38,7 +38,6 @@ modified from Chinese high school English listening comprehension test data.
 
 _HOMEPAGE = "https://github.com/Nealcly/MuTual"
 
-# TODO: Add the licence for the dataset here if you can find it
 _LICENSE = ""
 
 _URLS = "https://github.com/Nealcly/MuTual/archive/master.zip"

--- a/lm_eval/datasets/pile/pile.py
+++ b/lm_eval/datasets/pile/pile.py
@@ -38,6 +38,7 @@ math, computer science, and philosophy papers.
 
 _HOMEPAGE = "https://pile.eleuther.ai/"
 
+# License available at https://github.com/EleutherAI/the-pile/blob/master/LICENSE
 _LICENSE = "MIT License"
 
 _URLS = {

--- a/lm_eval/datasets/pile/pile.py
+++ b/lm_eval/datasets/pile/pile.py
@@ -38,8 +38,7 @@ math, computer science, and philosophy papers.
 
 _HOMEPAGE = "https://pile.eleuther.ai/"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "MIT License"
 
 _URLS = {
     "validation": "https://the-eye.eu/public/AI/pile/val.jsonl.zst",

--- a/lm_eval/datasets/quac/quac.py
+++ b/lm_eval/datasets/quac/quac.py
@@ -39,8 +39,7 @@ a teacher who answers the questions by providing short excerpts (spans) from the
 
 _HOMEPAGE = "https://quac.ai/"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "CC BY-SA 4.0"
 
 _URLS = {
     "train": "https://s3.amazonaws.com/my89public/quac/train_v0.2.json",

--- a/lm_eval/datasets/quac/quac.py
+++ b/lm_eval/datasets/quac/quac.py
@@ -39,6 +39,7 @@ a teacher who answers the questions by providing short excerpts (spans) from the
 
 _HOMEPAGE = "https://quac.ai/"
 
+# License available at https://quac.ai/
 _LICENSE = "CC BY-SA 4.0"
 
 _URLS = {

--- a/lm_eval/datasets/sat_analogies/sat_analogies.py
+++ b/lm_eval/datasets/sat_analogies/sat_analogies.py
@@ -39,7 +39,6 @@ multiple-choice analogy questions; 5 choices per question.
 
 _HOMEPAGE = "https://aclweb.org/aclwiki/SAT_Analogy_Questions_(State_of_the_art)"
 
-# TODO: Add the licence for the dataset here if you can find it
 _LICENSE = ""
 
 

--- a/lm_eval/datasets/sat_analogies/sat_analogies.py
+++ b/lm_eval/datasets/sat_analogies/sat_analogies.py
@@ -39,7 +39,7 @@ multiple-choice analogy questions; 5 choices per question.
 
 _HOMEPAGE = "https://aclweb.org/aclwiki/SAT_Analogy_Questions_(State_of_the_art)"
 
-_LICENSE = ""
+_LICENSE = "No license found"
 
 
 class SatAnalogies(datasets.GeneratorBasedBuilder):

--- a/lm_eval/datasets/unscramble/unscramble.py
+++ b/lm_eval/datasets/unscramble/unscramble.py
@@ -42,7 +42,7 @@ addition, or deletion of characters, and asking it to recover the original word.
 
 _HOMEPAGE = "https://github.com/openai/gpt-3/tree/master/data"
 
-_LICENSE = ""
+_LICENSE = "No license found"
 
 _BASE_URL = "https://raw.githubusercontent.com/openai/gpt-3/master/data"
 

--- a/lm_eval/datasets/unscramble/unscramble.py
+++ b/lm_eval/datasets/unscramble/unscramble.py
@@ -42,7 +42,6 @@ addition, or deletion of characters, and asking it to recover the original word.
 
 _HOMEPAGE = "https://github.com/openai/gpt-3/tree/master/data"
 
-# TODO: Add the licence for the dataset here if you can find it
 _LICENSE = ""
 
 _BASE_URL = "https://raw.githubusercontent.com/openai/gpt-3/master/data"


### PR DESCRIPTION
Added the license for 7 datasets. Here are the sources where I found the licenses :

- https://github.com/hendrycks/ethics/blob/master/LICENSE
- https://github.com/hendrycks/math/blob/main/LICENSE
- https://github.com/chaochun/nlu-asdiv-dataset
- https://github.com/EleutherAI/the-pile/blob/master/LICENSE
- https://allenai.org/data/drop
- https://stanfordnlp.github.io/coqa/
- https://quac.ai/

For 4 datasets I can't find the license and removed the TODO.
For the dataset "mutual" I'm not sure. It was published on ACL and the bottom of this page (https://aclanthology.org/2020.acl-main.130/) suggests that it is "CC BY 4.0" if it is "ACL material", but I'm not sure it is considered "ACL material" so I left the field license empty.