### PR TITLE
Fix task packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     # required to include yaml files in pip installation
     package_data={
-        "lm_eval": ["**/*.yaml"],
+        "lm_eval": ["**/*.yaml", "tasks/**/*"],
         "examples": ["**/*.yaml"],
     },
     entry_points={


### PR DESCRIPTION
Non-yaml task files (e.g. [utils.py](https://github.com/EleutherAI/lm-evaluation-harness/blob/big-refactor/lm_eval/tasks/mathqa/utils.py)) are not currently being packaged. Such tasks are not runnable when they are pip installed (although they run fine in the cloned repo). This change treats all files in the tasks directories as package_data.