### PR TITLE
[Refactor] Port Babi task

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -253,7 +253,7 @@ def evaluate(
                     eval_logger.info(
                         f"Task: {task_name}; document {inst.doc_id}; context prompt (starting on next line):\n{inst.args[0]}\n(end of prompt on previous line)"
                     )
-                    eval_logger.info("Request:", inst)
+                    eval_logger.info(f"Request: {str(inst)}")
 
         # aggregate Instances by LM method requested to get output.
         reqtype = (

--- a/lm_eval/tasks/babi/babi.yaml
+++ b/lm_eval/tasks/babi/babi.yaml
@@ -1,0 +1,20 @@
+group:
+  - greedy_until
+task: babi
+dataset_path: Muennighoff/babi
+dataset_name: null
+output_type: greedy_until
+training_split: train
+validation_split: valid
+test_split: test
+doc_to_text: "Passage: {{passage}}Question: {{question}}\nAnswer:"
+doc_to_target: " {{answer}}"
+target_delimiter: ""
+generation_kwargs:
+  until:
+    - "\n"
+    - "Passage:"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true


### PR DESCRIPTION
This PR ports the babi task. Not directly comparable against master branch because that branch's task is broken, I realized. 

Test result (not 0-shot bc we're exact match with a small model):
```
hf (pretrained=EleutherAI/pythia-410m), limit: None, num_fewshot: 4, batch_size: 8
|Task|Version|Filter|  Metric   |Value |   |Stderr|
|----|-------|------|-----------|-----:|---|-----:|
|babi|Yaml   |none  |exact_match|0.3315|±  |0.0034|
```