### PR TITLE
Bug fix: expression eval order is wrong

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -234,7 +234,7 @@ def positional_deprecated(fn):
 
     @functools.wraps(fn)
     def _wrapper(*args, **kwargs):
-        if len(args) != 1 if inspect.ismethod(fn) else 0:
+        if len(args) != (1 if inspect.ismethod(fn) else 0):
             print(
                 f"WARNING: using {fn.__name__} with positional arguments is "
                 "deprecated and will be disallowed in a future version of "


### PR DESCRIPTION
Without the parenthesis, the `if expression will always be evaluated to be 0, and the warning would be printed out. 