### PR TITLE
[Refactor] Use evaluation mode for accelerate to prevent OOM

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -289,7 +289,9 @@ class HFLM(LM):
                         "Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes`. If the desired GPU is being used, this message is safe to ignore."
                     )
             else:
-                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
+                self._model = accelerator.prepare_model(
+                    self.model, evaluation_mode=True
+                )
                 self._device = torch.device(f"cuda:{accelerator.local_process_index}")
                 self.accelerator = accelerator
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -289,7 +289,7 @@ class HFLM(LM):
                         "Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes`. If the desired GPU is being used, this message is safe to ignore."
                     )
             else:
-                self._model = accelerator.prepare(self.model)
+                self._model = accelerator.prepare_model(self.model, evaluation_mode=True)
                 self._device = torch.device(f"cuda:{accelerator.local_process_index}")
                 self.accelerator = accelerator
 


### PR DESCRIPTION
The following command currently gives an OOM when using 2xA6000 with 48GB each:

```
accelerate launch main.py --model hf --model_args pretrained=huggyllama/llama-13b,dtype=float16 --tasks piqa
```

The full stacktrace can be found [here](https://gist.githubusercontent.com/tju01/9071fd48d3d6d6f1d4e3d5c70ab4f6cd/raw/79f279bc2f61691044ad9acdfdd94f8b850b9b62/lm-evaluation-harness-oom). The reason for the OOM seems to be the `accelerator.prepare()` in the following line:

https://github.com/EleutherAI/lm-evaluation-harness/blob/7634a6ecd3449dcc898129a0bf9363ecae35473f/lm_eval/models/huggingface.py#L292

This `accelerator.prepare()` makes some additional memory allocations. I believe this is because it is intended for training models and so it allocates gradients, but I'm not totally sure. However, replacing the `accelerator.prepare()` with `accelerator.prepare_model(self.model, evaluation_mode=True)` fixes the problem.

I have also tested it and it gives the same scores on PiQA as running the command without accelerate.