### PR TITLE
[Refactor] tqdm for `build_all_requests` + multi-process tqdm

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -277,7 +277,7 @@ def evaluate(
     ### Run LM on inputs, get all outputs ###
     # execute each type of request
     for reqtype, reqs in requests.items():
-        eval_logger.info("Running {} requests".format(reqtype))
+        eval_logger.info("r{}: Running {} requests".format(lm.rank, reqtype))
         # create `K` copies of each request `req` based off `K = req.repeats`
         cloned_reqs = []
         for req in reqs:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -561,7 +561,11 @@ class HFLM(LM):
             print(f"Determined Largest batch size: {batch_size}")
             adaptive_batch_size = batch_size
 
-        for (string,) in tqdm([req.args for req in requests], disable=(self.rank != 0)):
+        for (string,) in tqdm(
+            [req.args for req in requests],
+            position=self.rank,
+            desc=f"r{self.rank} ll_roll",
+        ):
             rolling_token_windows = list(
                 map(
                     utils.make_disjoint_window,
@@ -647,7 +651,12 @@ class HFLM(LM):
             return self.batch_sizes[sched]
 
         for chunk in utils.chunks(
-            tqdm(re_ord.get_reordered(), disable=(disable_tqdm or (self.rank != 0))),
+            tqdm(
+                re_ord.get_reordered(),
+                disable=disable_tqdm,
+                position=self.rank,
+                desc=f"r{self.rank} ll_tokens",
+            ),
             n=self.batch_size
             if self.batch_size != "auto"
             else override_bs


### PR DESCRIPTION
- implement tqdm progress bar for `build_all_requests`
- display tqdm progress bars on different lines per rank, so that progress of each process can be viewed simultaneously
- give progress bars descriptions, so that each rank can be distinguished

![image](https://github.com/EleutherAI/lm-evaluation-harness/assets/40387940/efd70e75-6588-49ff-836c-f4a97bea8479)

![image](https://github.com/EleutherAI/lm-evaluation-harness/assets/40387940/f9f9963a-9ce6-4c88-ad65-a9175e5e8486)