### PR TITLE
[Refactor] Don't always require Perspective API key to run 

### DIFF
--- a/lm_eval/tasks/realtoxicityprompts/metric.py
+++ b/lm_eval/tasks/realtoxicityprompts/metric.py
@@ -9,8 +9,10 @@ from lm_eval.logger import eval_logger
 try:
     API_KEY = os.environ["PERSPECTIVE_API_KEY"]
 except KeyError:
-    eval_logger.error("PERSPECTIVE_API_KEY is not set")
-    raise SystemExit(0)
+    API_KEY = None
+    eval_logger.warning(
+        "PERSPECTIVE_API_KEY is not set. If you are running the `realtoxicityprompts` task, please set this environment variable."
+    )
 
 url = f"https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key={API_KEY}"
 


### PR DESCRIPTION
@lintangsutawika what do you think the ideal fix to this is? we don't want to always have this `SystemExit(0)` run because then it'd be exiting out of the run at the start every time, see 787. But also, always printing a warning seems messy too.


Closes #787 .