### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This adds a `pyproject.toml` file as specified in [PEP 518](https://peps.python.org/pep-0518/) and [PEP 517](https://peps.python.org/pep-0517/), which lists the build system dependencies. This is mostly just to make building the package more compatible.