### PR TITLE
[Refactor] Add top-level import

### DIFF
--- a/lm_eval/__init__.py
+++ b/lm_eval/__init__.py
@@ -1,0 +1,1 @@
+from .evaluator import evaluate, simple_evaluate


### PR DESCRIPTION
The lm-eval harness is missing top-level imports in `lm_eval/__init__.py` which prevent any library attributes or sub-modules from being accessible without doing, e.g., `import lm_eval.tasks` directly. `import lm_eval` is not sufficient.

This also adds `evaluate()` and `simple_evaluate()` as attributes of the root package: so now you can either use

```from lm_eval.evaluator import evaluate```
or 
```from lm_eval import evaluate```
or
```
import lm_eval
lm_eval.evaluate(...)
```
instead of only the first option.

Old behavior: 

```
Python 3.9.16 (main, May 15 2023, 23:46:34) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import lm_eval
>>> dir(lm_eval)
['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__']
>>> lm_eval.tasks
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'lm_eval' has no attribute 'tasks'
```

New behavior:

```
Python 3.9.16 (main, May 15 2023, 23:46:34) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import lm_eval
>>> dir(lm_eval)
['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__']
>>> lm_eval.tasks
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'lm_eval' has no attribute 'tasks'
>>> lm_eval.tasks
KeyboardInterrupt
>>> quit()
(eval-dev) mchorse@harness-dev-0:/mnt/ssd-2/hailey/harness-dev/lm-evaluation-harness$ python
Python 3.9.16 (main, May 15 2023, 23:46:34) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import lm_eval
2023-09-04:17:45:53,686 INFO     [utils.py:148] Note: NumExpr detected 32 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2023-09-04:17:45:53,687 INFO     [utils.py:160] NumExpr defaulting to 8 threads.
[2023-09-04 17:45:54,093] [INFO] [real_accelerator.py:110:get_accelerator] Setting ds_accelerator to cuda (auto detect)
.... < removed some prints to console here >
>>> dir(lm_eval)  
['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'api', 'benchmarks', 'evaluate', 'evaluator', 'filters', 'logger', 'models', 'prompts', 'simple_evaluate', 'tasks', 'utils']
>>> lm_eval.tasks 
<module 'lm_eval.tasks' from '/mnt/ssd-2/hailey/harness-dev/lm-evaluation-harness/lm_eval/tasks/__init__.py'>
