### PR TITLE
Add support for Palm, Claude-2, Cohere, Azure OpenAI Llama2, CodeLlama (100+LLMs)  - using LiteLLM

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -41,17 +41,18 @@ def oa_completion(**kwargs):
     Retry with back-off until they respond
     """
     try:
+        from litellm import completion
         import openai, tiktoken  # noqa: E401
     except ModuleNotFoundError:
         raise Exception(
-            "attempted to use 'openai' LM type, but package `openai` or `tiktoken` are not installed. \
+            "attempted to use 'openai' LM type, but package `openai` or `tiktoken` `litellm` are not installed. \
 please install these via `pip install lm-eval[openai]` or `pip install -e .[openai]`",
         )
 
     backoff_time = 3
     while True:
         try:
-            return openai.Completion.create(**kwargs)
+            return completion(**kwargs)
         except openai.error.OpenAIError:
             import traceback
 
@@ -183,9 +184,8 @@ class OpenaiCompletionsLM(LM):
                 ctxlens.append(ctxlen)
 
             response = oa_completion(
-                engine=self.engine,
-                prompt=inps,
-                echo=True,
+                model=self.engine,
+                messages=[{"role": "user", "content": inps}],
                 max_tokens=0,
                 temperature=0.0,
                 logprobs=10,

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ extras_require = {
     "gptq": ["auto-gptq[triton] @ git+https://github.com/PanQiWei/AutoGPTQ"],
     "anthropic": ["anthropic"],
     "openai": ["openai", "tiktoken"],
+    "litellm": ["litellm"],
 }
 extras_require["all"] = list(itertools.chain.from_iterable(extras_require.values()))
 


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```