### PR TITLE
undefined type and output_type when using promptsource fixed

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -61,7 +61,7 @@ def check_prompt_config(config: dict[str, str]) -> List[dict[str, str]]:
                             ]
                         )
                     },
-                    **{"output_type": "greedy_until"}
+                    **{"output_type": "greedy_until"},
                 }
             )
     else:

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -60,7 +60,8 @@ def check_prompt_config(config: dict[str, str]) -> List[dict[str, str]]:
                                 prompt_variation,
                             ]
                         )
-                    }
+                    },
+                    **{"output_type": "greedy_until"}
                 }
             )
     else:

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -60,8 +60,7 @@ def check_prompt_config(config: dict[str, str]) -> List[dict[str, str]]:
                                 prompt_variation,
                             ]
                         )
-                    },
-                    **{"output_type": "greedy_until"},
+                    }
                 }
             )
     else:

--- a/scripts/write_out.py
+++ b/scripts/write_out.py
@@ -48,7 +48,9 @@ def main():
 
         docs = join_iters(iters)
 
-        with open(os.path.join(args.output_base_path, task_name), "w", encoding="utf8") as f:
+        with open(
+            os.path.join(args.output_base_path, task_name), "w", encoding="utf8"
+        ) as f:
             for i, doc in (
                 zip(range(args.num_examples), docs)
                 if args.num_examples > 0

--- a/scripts/write_out.py
+++ b/scripts/write_out.py
@@ -48,7 +48,7 @@ def main():
 
         docs = join_iters(iters)
 
-        with open(os.path.join(args.output_base_path, task_name), "w", encoding='utf8') as f:
+        with open(os.path.join(args.output_base_path, task_name), "w", encoding="utf8") as f:
             for i, doc in (
                 zip(range(args.num_examples), docs)
                 if args.num_examples > 0

--- a/scripts/write_out.py
+++ b/scripts/write_out.py
@@ -48,7 +48,7 @@ def main():
 
         docs = join_iters(iters)
 
-        with open(os.path.join(args.output_base_path, task_name), "w") as f:
+        with open(os.path.join(args.output_base_path, task_name), "w", encoding='utf8') as f:
             for i, doc in (
                 zip(range(args.num_examples), docs)
                 if args.num_examples > 0


### PR DESCRIPTION
1. Set the encoding to "utf8" to handle non-english prompts.
2. When using promptsource, the output_type was overridden by a constant, ignoring the specified type in the yaml file.