### PR TITLE
Fix positional arguments in HF model generate

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -508,7 +508,7 @@ class HFLM(LM):
             self.tokenizer, stop, 1, context.shape[0]
         )
         return self.model.generate(
-            context,
+            input_ids=context,
             max_length=max_length,
             stopping_criteria=stopping_criteria,
             pad_token_id=self.eot_token_id,


### PR DESCRIPTION
This change fixes calling the generate method in the HF model. The problem appears in transformers v4.33.1 (and probably in some earlier versions too):
```
Traceback (most recent call last):
  File "main.py", line 217, in <module>
    main()
  File "main.py", line 169, in main
    results = evaluator.simple_evaluate(
  File "/lm-evaluation-harness/lm_eval/utils.py", line 334, in _wrapper
    return fn(*args, **kwargs)
  File "/lm-evaluation-harness/lm_eval/evaluator.py", line 139, in simple_evaluate
    results = evaluate(
  File "/lm-evaluation-harness/lm_eval/utils.py", line 334, in _wrapper
    return fn(*args, **kwargs)
  File "/lm-evaluation-harness/lm_eval/evaluator.py", line 299, in evaluate
    resps = getattr(lm, reqtype)(cloned_reqs)
  File "/lm-evaluation-harness/lm_eval/models/huggingface.py", line 892, in greedy_until
    cont = self._model_generate(
  File "/lm-evaluation-harness/lm_eval/models/huggingface.py", line 510, in _model_generate
    return self.model.generate(
TypeError: generate() takes 1 positional argument but 2 were given
```