### PR TITLE
Exclude the scripts directory from the installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/EleutherAI/lm-evaluation-harness",
-    packages=setuptools.find_packages(exclude=["scripts"]),
+    packages=setuptools.find_packages(exclude=["scripts.*", "scripts"]),
     package_data={"lm_eval": ["**/*.json"]},
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/EleutherAI/lm-evaluation-harness",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["scripts"]),
     package_data={"lm_eval": ["**/*.json"]},
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lit-gpt/issues/558
Fixes https://github.com/EleutherAI/lm-evaluation-harness/issues/901

Can be tested with

```shell
$ virtualenv venv
$ source venv/bin/activate
$ ls venv/lib/python3.10/site-packages | grep scripts
$ pip install pip install https://github.com/carmocca/lm-evaluation-harness/archive/refs/heads/patch-1.zip --no-deps
$ ls venv/lib/python3.10/site-packages | grep scripts
scripts
```