### PR TITLE
Add `disable_exllama` model arg for HuggingFaceAutoLM

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -94,6 +94,7 @@ class HuggingFaceAutoLM(BaseLM):
         load_in_4bit: Optional[bool] = False,
         trust_remote_code: Optional[bool] = False,
         gptq_use_triton: Optional[bool] = False,
+        disable_exllama: Optional[bool] = False,
         inject_fused_attention: Optional[bool] = True,
         bnb_4bit_quant_type: Optional[str] = None,
         bnb_4bit_compute_dtype: Optional[Union[str, torch.dtype]] = None,
@@ -161,6 +162,8 @@ class HuggingFaceAutoLM(BaseLM):
                 If True, will trust the remote code when loading the model.
             gptq_use_triton (bool, optional, defaults to False):
                 Use Triton for GPTQ inference.
+            disable_exllama (bool, optional, defaults to False):
+                Disable exllama for GPTQ inference.
             inject_fused_attention (bool, optional, defaults to True):
                 Inject fused attention into GPTQ model.
             bnb_4bit_quant_type (str, optional, defaults to None):
@@ -236,6 +239,7 @@ class HuggingFaceAutoLM(BaseLM):
             subfolder=subfolder,
             torch_dtype=_get_dtype(dtype, self._config),
             gptq_use_triton=gptq_use_triton,
+            disable_exllama=disable_exllama,
             inject_fused_attention=inject_fused_attention,
             load_in_8bit=load_in_8bit,
             load_in_4bit=load_in_4bit,
@@ -286,6 +290,7 @@ class HuggingFaceAutoLM(BaseLM):
         trust_remote_code: Optional[bool] = False,
         torch_dtype: Optional[Union[str, torch.dtype]] = None,
         gptq_use_triton: Optional[bool] = False,
+        disable_exllama: Optional[bool] = False,
         inject_fused_attention: Optional[bool] = True,
         bnb_4bit_quant_type: Optional[str] = None,
         bnb_4bit_compute_dtype: Optional[Union[str, torch.dtype]] = None,
@@ -337,6 +342,7 @@ class HuggingFaceAutoLM(BaseLM):
                 else quantized.endswith(".safetensors"),
                 use_triton=gptq_use_triton,
                 warmup_triton=gptq_use_triton,
+                disable_exllama=disable_exllama,
                 inject_fused_attention=inject_fused_attention,
             )
         return model


### PR DESCRIPTION
Hi again. I'm trying to benchmark some gptq llama2 model derivatives and have the need to disable the exllama backend. I added the model argument `disable_exllama` to the list of supported arguments and decided to create a pull request with the change. Let me know if you need more info. Thanks.