### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.0-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
 
 
 ### Install python 3.10 and set it as default python interpreter


### PR DESCRIPTION
The base image of the `Dockerfile `doesn't exist. Bumping from CUDA 11.2.0 to 11.2.2 fixes this.