### PR TITLE
[Refactor]fix two bugs when ran with qasper_bool and toxigen

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -15,7 +15,7 @@ from typing import Union
 
 
 def _handle_non_serializable(o):
-    if isinstance(o, np.int64):
+    if isinstance(o, np.int64) or isinstance(o, np.int32):
         return int(o)
     elif isinstance(o, set):
         return list(o)

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -111,9 +111,9 @@ def parse_eval_args() -> argparse.Namespace:
         help="Log error when tasks are not registered.",
     )
     parser.add_argument(
-        "--huggingface_token",
-        type=str,
-        default=None,
+        "--huggingface_login",
+        action="store_true",
+        default=False,
         help="huggingface token for downloading some authorization datasets, like toxigen, https://huggingface.co/settings/tokens",
     )
     return parser.parse_args()
@@ -132,10 +132,14 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
             " --limit SHOULD ONLY BE USED FOR TESTING."
             "REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT."
         )
-    if args.huggingface_token:
+    if args.huggingface_login:
         from huggingface_hub import login
 
-        login(token=args.huggingface_token)
+        assert (
+            "HUGGINGFACE_LOGIN_TOKEN" in os.environ
+        ), "Your environment variable does not contain a HUGGINGFACE_LOGIN_TOKEN. Please set the token first."
+        huggingface_token = os.environ["HUGGINGFACE_LOGIN_TOKEN"]
+        login(token=huggingface_token)
     if args.include_path is not None:
         eval_logger.info(f"Including path: {args.include_path}")
         include_path(args.include_path)

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -19,7 +19,9 @@ def _handle_non_serializable(o):
         return int(o)
     elif isinstance(o, set):
         return list(o)
-    raise TypeError(f"Object of type {o.__class__.__name__} is not JSON serializable")
+    else:
+        print(f"Object of type {o.__class__.__name__} is not JSON serializable,just stringify it")
+        return str(o)
 
 
 def parse_eval_args() -> argparse.Namespace:
@@ -114,7 +116,7 @@ def parse_eval_args() -> argparse.Namespace:
         "--huggingface_login",
         action="store_true",
         default=False,
-        help="huggingface token for downloading some authorization datasets, like toxigen, https://huggingface.co/settings/tokens",
+        help="huggingface token for downloading some authorization datasets, like toxigen, you need add HUGGINGFACE_LOGIN_TOKEN to environment variable firstly. https://huggingface.co/settings/tokens",
     )
     return parser.parse_args()
 

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -20,7 +20,6 @@ def _handle_non_serializable(o):
     elif isinstance(o, set):
         return list(o)
     else:
-        print(f"Object of type {o.__class__.__name__} is not JSON serializable,just stringify it")
         return str(o)
 
 
@@ -112,12 +111,6 @@ def parse_eval_args() -> argparse.Namespace:
         default="INFO",
         help="Log error when tasks are not registered.",
     )
-    parser.add_argument(
-        "--huggingface_login",
-        action="store_true",
-        default=False,
-        help="huggingface token for downloading some authorization datasets, like toxigen, you need add HUGGINGFACE_LOGIN_TOKEN to environment variable firstly. https://huggingface.co/settings/tokens",
-    )
     return parser.parse_args()
 
 
@@ -134,14 +127,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
             " --limit SHOULD ONLY BE USED FOR TESTING."
             "REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT."
         )
-    if args.huggingface_login:
-        from huggingface_hub import login
-
-        assert (
-            "HUGGINGFACE_LOGIN_TOKEN" in os.environ
-        ), "Your environment variable does not contain a HUGGINGFACE_LOGIN_TOKEN. Please set the token first."
-        huggingface_token = os.environ["HUGGINGFACE_LOGIN_TOKEN"]
-        login(token=huggingface_token)
     if args.include_path is not None:
         eval_logger.info(f"Including path: {args.include_path}")
         include_path(args.include_path)

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -15,7 +15,8 @@ from lm_eval.api.registry import (
 
 import logging
 
-eval_logger = logging.getLogger('lm-eval')
+eval_logger = logging.getLogger("lm-eval")
+
 
 def register_configurable_task(config: Dict[str, str]) -> int:
     SubClass = type(


### PR DESCRIPTION
Hi, when I ran qasper_bool with the command:
```accelerate launch -m lm_eval  --model hf  --model_args pretrained=${MODEL_PATH}   --tasks qasper_bool  --batch_size auto:10  --write_out    --log_samples  --output_path ${OUTPUT_PATH}   --show_config ```
I got an error when I tried to write log to output_path: 
<img width="595" alt="image" src="https://github.com/EleutherAI/lm-evaluation-harness/assets/28424280/ded19327-0a56-4a4f-80eb-7c523857db79">
<img width="998" alt="image" src="https://github.com/EleutherAI/lm-evaluation-harness/assets/28424280/f114f793-686e-4920-82b3-cc5d5f39566d">
This is because the 'f1' element type is numpy.int64 and cannot convert to json type with json.dumps.
So I added the _handle_non_serializable to catch the error and convert it to a supported type. If there are other types that are not supported in the future, they can also be directly added to the function.

---
Another error I got when I ran with ToxiGen is:
<img width="986" alt="image" src="https://github.com/EleutherAI/lm-evaluation-harness/assets/28424280/0edbe795-9ce9-40fc-829d-479032b8da7a">
which means if we want to get the datasets that require authorization, we may need to log in first, so I add another argument to support token validation.
