### PR TITLE
Dataset licenses - PR 2

### DIFF
--- a/lm_eval/datasets/asdiv/asdiv.py
+++ b/lm_eval/datasets/asdiv/asdiv.py
@@ -43,8 +43,8 @@ level (for indicating the level of difficulty).
 
 _HOMEPAGE = "https://github.com/chaochun/nlu-asdiv-dataset"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+# License declared at https://github.com/chaochun/nlu-asdiv-dataset/blob/master/README.md
+_LICENSE = "CC BY-NC 4.0"
 
 _URLS = "https://github.com/chaochun/nlu-asdiv-dataset/archive/55790e5270bb91ccfa5053194b25732534696b50.zip"
 

--- a/lm_eval/datasets/coqa/coqa.py
+++ b/lm_eval/datasets/coqa/coqa.py
@@ -44,8 +44,7 @@ appear in a conversation.
 
 _HOMEPAGE = "https://stanfordnlp.github.io/coqa/"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "Different licenses depending on the content (see https://stanfordnlp.github.io/coqa/ for details)"
 
 _URLS = {
     "train": "https://nlp.stanford.edu/data/coqa/coqa-train-v1.0.json",

--- a/lm_eval/datasets/drop/drop.py
+++ b/lm_eval/datasets/drop/drop.py
@@ -43,8 +43,8 @@ and perform discrete operations over them (such as addition, counting, or sortin
 
 _HOMEPAGE = "https://allenai.org/data/drop"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+# License declared at https://allenai.org/data/drop
+_LICENSE = "CC BY"
 
 _URLS = {
     "drop": "https://s3-us-west-2.amazonaws.com/allennlp/datasets/drop/drop_dataset.zip",

--- a/lm_eval/datasets/headqa/headqa.py
+++ b/lm_eval/datasets/headqa/headqa.py
@@ -51,7 +51,10 @@ The dataset contains questions about the following topics: medicine, nursing, ps
 
 _HOMEPAGE = "https://aghie.github.io/head-qa/"
 
-_LICENSE = "MIT License"
+# The Spanish data comes from the "Ministerio de Sanidad, Consumo y Bienestar Social", as indicated here : https://github.com/aghie/head-qa
+# This Spanish data seems to follow the intellectual property rights stated here : https://www.sanidad.gob.es/avisoLegal/home.htm
+# The English data was translated by the authors of head-qa (https://arxiv.org/pdf/1906.04701.pdf).
+_LICENSE = "Custom license"
 
 _URL = "https://drive.google.com/uc?export=download&confirm=t&id=1a_95N5zQQoUCq8IBNVZgziHbeM-QxG2t"
 

--- a/lm_eval/datasets/hendrycks_ethics/hendrycks_ethics.py
+++ b/lm_eval/datasets/hendrycks_ethics/hendrycks_ethics.py
@@ -41,8 +41,10 @@ learning agents.
 
 _HOMEPAGE = "https://github.com/hendrycks/ethics"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+# The authors declared that the dataset is not distributed under a copyright or intellectual property (https://arxiv.org/pdf/2008.02275.pdf)
+# On Hugging Face, the dataset is distributed under the MIT license (https://huggingface.co/datasets/hendrycks/ethics)
+# The common sense portion is from Reddit and might incur some licensing complications.
+_LICENSE = "Ambiguous"
 
 _URLS = "https://people.eecs.berkeley.edu/~hendrycks/ethics.tar"
 

--- a/lm_eval/datasets/hendrycks_math/hendrycks_math.py
+++ b/lm_eval/datasets/hendrycks_math/hendrycks_math.py
@@ -38,8 +38,8 @@ models to generate answer derivations and explanations.
 
 _HOMEPAGE = "https://github.com/hendrycks/math"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+# License declared at https://arxiv.org/pdf/2103.03874.pdf
+_LICENSE = "MIT License"
 
 _URLS = "https://people.eecs.berkeley.edu/~hendrycks/MATH.tar"
 

--- a/lm_eval/datasets/logiqa/logiqa.py
+++ b/lm_eval/datasets/logiqa/logiqa.py
@@ -38,8 +38,7 @@ NLP setting.
 
 _HOMEPAGE = "https://github.com/lgw863/LogiQA-dataset"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "No license found"
 
 _URLS = {
     "train": "https://raw.githubusercontent.com/lgw863/LogiQA-dataset/master/Train.txt",

--- a/lm_eval/datasets/mutual/mutual.py
+++ b/lm_eval/datasets/mutual/mutual.py
@@ -38,8 +38,7 @@ modified from Chinese high school English listening comprehension test data.
 
 _HOMEPAGE = "https://github.com/Nealcly/MuTual"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "No license found"
 
 _URLS = "https://github.com/Nealcly/MuTual/archive/master.zip"
 

--- a/lm_eval/datasets/pile/pile.py
+++ b/lm_eval/datasets/pile/pile.py
@@ -38,8 +38,8 @@ math, computer science, and philosophy papers.
 
 _HOMEPAGE = "https://pile.eleuther.ai/"
 
-# License declared at https://arxiv.org/pdf/2201.07311.pdf
-_LICENSE = "MIT license"
+# More details at https://arxiv.org/pdf/2201.07311.pdf
+_LICENSE = "Multiple licenses"
 
 _URLS = {
     "validation": "https://the-eye.eu/public/AI/pile/val.jsonl.zst",

--- a/lm_eval/datasets/pile/pile.py
+++ b/lm_eval/datasets/pile/pile.py
@@ -38,8 +38,8 @@ math, computer science, and philosophy papers.
 
 _HOMEPAGE = "https://pile.eleuther.ai/"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+# License declared at https://arxiv.org/pdf/2201.07311.pdf
+_LICENSE = "MIT license"
 
 _URLS = {
     "validation": "https://the-eye.eu/public/AI/pile/val.jsonl.zst",

--- a/lm_eval/datasets/quac/quac.py
+++ b/lm_eval/datasets/quac/quac.py
@@ -39,8 +39,8 @@ a teacher who answers the questions by providing short excerpts (spans) from the
 
 _HOMEPAGE = "https://quac.ai/"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+# License declared at https://quac.ai/
+_LICENSE = "CC BY-SA 4.0"
 
 _URLS = {
     "train": "https://s3.amazonaws.com/my89public/quac/train_v0.2.json",

--- a/lm_eval/datasets/sat_analogies/sat_analogies.py
+++ b/lm_eval/datasets/sat_analogies/sat_analogies.py
@@ -39,8 +39,7 @@ multiple-choice analogy questions; 5 choices per question.
 
 _HOMEPAGE = "https://aclweb.org/aclwiki/SAT_Analogy_Questions_(State_of_the_art)"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "No license found"
 
 
 class SatAnalogies(datasets.GeneratorBasedBuilder):

--- a/lm_eval/datasets/unscramble/unscramble.py
+++ b/lm_eval/datasets/unscramble/unscramble.py
@@ -42,8 +42,7 @@ addition, or deletion of characters, and asking it to recover the original word.
 
 _HOMEPAGE = "https://github.com/openai/gpt-3/tree/master/data"
 
-# TODO: Add the licence for the dataset here if you can find it
-_LICENSE = ""
+_LICENSE = "No license found"
 
 _BASE_URL = "https://raw.githubusercontent.com/openai/gpt-3/master/data"
 


### PR DESCRIPTION
Sorry for having been so long, I had another occupation. This is a follow-up from the PR #735 that was closed. Here are the licenses :

Hendrycks maths - MIT license (https://arxiv.org/pdf/2103.03874.pdf)
coqa - multiple licenses (https://stanfordnlp.github.io/coqa/ for details)
asdiv - CC BY-NC 4.0 (https://github.com/chaochun/nlu-asdiv-dataset/blob/master/README.md)
drop - CC BY (https://allenai.org/data/drop)

no license found:
logiqa
sat_analogies
mutual
unscramble

Not sure (see the PR #735 for the discussions):
The Pile - MIT license (according to [this paper](https://arxiv.org/pdf/2201.07311.pdf))
headqa - Custom (at least for the Spanish version)
quac - CC BY-SA 4.0 (https://quac.ai/)
hendrycks_ethics - Ambiguous (the authors declared in [the paper](https://arxiv.org/pdf/2008.02275.pdf) that it has no license, on [Hugging Face](https://huggingface.co/datasets/hendrycks/ethics) it is a MIT license ; but the common sense portion is [derived from Reddit](https://www.redditinc.com/policies/data-api-terms) so it may incur complications)

I should have significant time to spare in the month. Do you have any GitHub issue to recommend to me? (an issue can be solved without needing more GPUs that what you can have in Google Colab) 