### PR TITLE
[Refactor] Fix whitespace warning

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -691,7 +691,7 @@ class ConfigurableTask(Task):
                 delimiter_has_whitespace = (
                     True
                     if self.config.target_delimiter.rstrip()
-                    == self.config.target_delimiter
+                    != self.config.target_delimiter
                     else False
                 )
 
@@ -701,7 +701,7 @@ class ConfigurableTask(Task):
                     )
                 elif (not delimiter_has_whitespace) and (not choice_has_whitespace):
                     eval_logger.warning(
-                        f'Both target_delimiter and target choice: "{choice}" does not have whitespace, ignore if the language you are evaluating on does not require/use whitespace'
+                        f'Both target_delimiter "{self.config.target_delimiter}" and target choice: "{choice}" do not have whitespace, ignore if the language you are evaluating on does not require/use whitespace'
                     )
 
     def download(self, dataset_kwargs=None) -> None:


### PR DESCRIPTION
@lintangsutawika small fix to the warning when both target delimiter and the target don't require whitespace.

Also flagging we might want to make some of these checks optional, reviving the `--check_integrity` flag? The code that tests the first doc for these + doc_to_choice return types prevents one from using `streaming=True` in HF datasets.