### PR TITLE
[API] Use private HF token for HF models and hide it when print to json file or console

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -6,7 +6,7 @@ import lm_eval.metrics
 import lm_eval.models
 import lm_eval.tasks
 import lm_eval.base
-from lm_eval.utils import positional_deprecated, run_task_tests
+from lm_eval.utils import positional_deprecated, run_task_tests, hide_private_token
 
 
 @positional_deprecated
@@ -103,6 +103,8 @@ def simple_evaluate(
         output_base_path=output_base_path,
     )
 
+    # hide private token before save it in config
+    model_args = hide_private_token(model_args)
     # add info about the model and few shot config
     results["config"] = {
         "model": (model if isinstance(model, str) else model.model.config._name_or_path),

--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -33,6 +33,8 @@ class HFLM(BaseLM):
         load_in_8bit: Optional[bool] = False,
         trust_remote_code: Optional[bool] = False,
         dtype: Optional[Union[str, torch.dtype]]="auto",
+        use_auth_token: str=None,
+        token: str=None,
     ):
         super().__init__()
 
@@ -65,6 +67,8 @@ class HFLM(BaseLM):
             revision=revision,
             torch_dtype=_get_dtype(dtype),
             trust_remote_code=trust_remote_code,
+            use_auth_token=use_auth_token,
+            token=token,
         ).eval()
         if not load_in_8bit:
             try:

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -46,6 +46,26 @@ def escaped_split(text, sep_char, maxsplit=-1):
     return re.split(r"(?<!\\)" + sep_char, text, maxsplit)
 
 
+def hide_private_token(args_string):
+    """
+    Parses something like
+        args1=val1,arg2=val2
+    Find "token" or "use_auth_token" keys and hide their values
+    Return processed string
+    """
+    args_string = args_string.strip()
+    if not args_string:
+        return {}
+    arg_list = args_string.split(",")
+    new_arg_list = []
+    for key_value in arg_list:
+        key, value = key_value.split("=")
+        if key == "use_auth_token" or key == "token":
+            value = "{PRIVATE_TOKEN}"
+        new_arg_list.append(key + "=" + value)
+    return ",".join(new_arg_list)
+
+
 def simple_parse_args_string(args_string):
     """
     Parses something like

--- a/main.py
+++ b/main.py
@@ -82,6 +82,7 @@ def main():
             f.write(dumped)
 
     batch_sizes = ",".join(map(str, results["config"]["batch_sizes"]))
+    args.model_args = utils.hide_private_token(args.model_args)
     print(
         f"{args.model} ({args.model_args}), limit: {args.limit}, provide_description: {args.provide_description}, "
         f"num_fewshot: {args.num_fewshot}, batch_size: {args.batch_size}{f' ({batch_sizes})' if batch_sizes else ''}"


### PR DESCRIPTION
For models like llama2 the special confirmation and access are needed. Such models are still can be tested in lm-evaluation-harness by put token through model_args. But "use_auth_token" and "token" are not supported on gpt2 side.
When we put private token in model_args it is better to hide the token anywhere. Therefore I replace it by "{PRIVATE_TOKEN}" string before print into console or output json-file.

Example of using:
```bash
export HF_TOKEN=...
python3 main.py --model=hf-causal --model_args="pretrained=meta-llama/Llama-2-7b-chat-hf,use_auth_token=${HF_TOKEN}" --tasks=triviaqa --output_path=./llama2-7b_triviaqa.json --device cuda:0
```

**Notes:**
1. It is also saved in cache and can be extracted from it. Possibly the same trick should be used here for the sake of safety.
2. "use_auth_token" is deprecated by HF, but I've supported it for a moment
3. It looks like better approach to use kwargs on gpt2 side. Thus we support all additional arguments to from_pretrained method and resolve future deprecation issue with "use_auth_token"
4. It was done for HF back-end only. Possibly kwargs trick is needed for other ones.