### PR TITLE
Fix indent in lm_eval/tasks/bigbench.py

### DIFF
--- a/lm_eval/tasks/bigbench.py
+++ b/lm_eval/tasks/bigbench.py
@@ -229,7 +229,7 @@ def create_task_from_path(json_path):
 
 
 def create_all_tasks():
-     try:
+    try:
         resources_dir = importlib.resources.files("lm_eval.datasets") / "bigbench_resources"
     except:
         import importlib_resources


### PR DESCRIPTION
Hi there 👋 

Thanks for enabling support of Python3.8 in one of the latest commits.
But with this change, the issue with indentation was introduced:
```python
     File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/lm_eval/tasks/bigbench.py", line 234
       except:
              ^
   IndentationError: unindent does not match any outer indentation level
```