### PR TITLE
Indexing Bugfix in huggingface.py

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -581,7 +581,7 @@ class AutoCausalLM(HuggingFaceAutoLM):
             do_sample=False,
         )
         return utils.select_continuation_from_batch_left_padding(
-            generations, max_context_size=inputs["input_ids"].size(1)
+            generations, max_context_size=input_ids.size(1)
         )
 
 


### PR DESCRIPTION
Bug: There is a bug when the provided context is longer than the self.max_length that the model can handle. If the provided context is too long, there is a prefix that is discarded from inputs["input_ids"], however in the current index calculation for utils.select_continuation_from_batch_left_padding this is not considered.

Changing the max_content_size argument to input_ids.size(1) resolves this problem.