### PR TITLE
doc_to_decontamination_query can use function

### DIFF
--- a/docs/task_guide.md
+++ b/docs/task_guide.md
@@ -46,8 +46,8 @@ Scoring details:
 - **generation_kwargs** (`dict`, *optional*) — Auxiliary arguments for the `generate` function from HF transformers library. Advanced keyword arguments may not be supported for non-HF LM classes.
 - **repeats** (`int`, *optional*, defaults to 1) — Number of repeated runs through model for each sample. can be used for cases such as self-consistency.
 - **filter_list** (`Union[str, list]`, *optional*) — List of filters to postprocess model outputs. See below for further detail on the filter API.
-- **should_decontaminate** (`bool`, *optional*, defaults to False) - Whether to decontaminate
-- **doc_to_decontamination_query** (`str`, *optional*) — Query for decontamination if `should_decontaminate` is True. If `should_decontaminate` is True but `doc_to_decontamination_query` is `None`, `doc_to_decontamination_query` will follow `doc_to_text`
+- **should_decontaminate** (`bool`, *optional*, defaults to False) - Whether to decontaminate or not.
+- **doc_to_decontamination_query** (`str`, *optional*) — Query for decontamination if `should_decontaminate` is True. If `should_decontaminate` is True but `doc_to_decontamination_query` is `None`, `doc_to_decontamination_query` will follow `doc_to_text`.
 
 Other:
 - **metadata** (`Union[str, list]`, *optional*) — An optional field where arbitrary metadata can be passed. A good example would be `version` that is used to denote the version of the yaml config.

--- a/docs/task_guide.md
+++ b/docs/task_guide.md
@@ -46,8 +46,8 @@ Scoring details:
 - **generation_kwargs** (`dict`, *optional*) — Auxiliary arguments for the `generate` function from HF transformers library. Advanced keyword arguments may not be supported for non-HF LM classes.
 - **repeats** (`int`, *optional*, defaults to 1) — Number of repeated runs through model for each sample. can be used for cases such as self-consistency.
 - **filter_list** (`Union[str, list]`, *optional*) — List of filters to postprocess model outputs. See below for further detail on the filter API.
-- **should_decontaminate** (`bool`, *optional*, defaults to False) -
-- **doc_to_decontamination_query** (`str`, *optional*) —
+- **should_decontaminate** (`bool`, *optional*, defaults to False) - Whether to decontaminate
+- **doc_to_decontamination_query** (`str`, *optional*) — Query for decontamination if `should_decontaminate` is True. If `should_decontaminate` is True but `doc_to_decontamination_query` is `None`, `doc_to_decontamination_query` will follow `doc_to_text`
 
 Other:
 - **metadata** (`Union[str, list]`, *optional*) — An optional field where arbitrary metadata can be passed. A good example would be `version` that is used to denote the version of the yaml config.

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -841,7 +841,9 @@ class ConfigurableTask(Task):
                     return doc_to_decontamination_query(doc)
                 else:
                     return ast.literal_eval(
-                        utils.apply_template(self.config.doc_to_decontamination_query, doc)
+                        utils.apply_template(
+                            self.config.doc_to_decontamination_query, doc
+                        )
                     )
 
     def _process_doc(self, doc):

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -831,15 +831,18 @@ class ConfigurableTask(Task):
 
     def doc_to_decontamination_query(self, doc):
         if self.config.should_decontaminate:
-            doc_to_decontamination_query = self.config.doc_to_decontamination_query
-            if doc_to_decontamination_query in self.features:
-                return doc[doc_to_decontamination_query]
-            elif callable(doc_to_decontamination_query):
-                return doc_to_decontamination_query(doc)
+            if self.config.doc_to_decontamination_query is None:
+                return self.doc_to_text(doc)
             else:
-                return ast.literal_eval(
-                    utils.apply_template(self.config.doc_to_decontamination_query, doc)
-                )
+                doc_to_decontamination_query = self.config.doc_to_decontamination_query
+                if doc_to_decontamination_query in self.features:
+                    return doc[doc_to_decontamination_query]
+                elif callable(doc_to_decontamination_query):
+                    return doc_to_decontamination_query(doc)
+                else:
+                    return ast.literal_eval(
+                        utils.apply_template(self.config.doc_to_decontamination_query, doc)
+                    )
 
     def _process_doc(self, doc):
         """

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -831,8 +831,11 @@ class ConfigurableTask(Task):
 
     def doc_to_decontamination_query(self, doc):
         if self.config.should_decontaminate:
-            if self.config.doc_to_decontamination_query in self.features:
-                return doc[self.config.doc_to_decontamination_query]
+            doc_to_decontamination_query = self.config.doc_to_decontamination_query
+            if doc_to_decontamination_query in self.features:
+                return doc[doc_to_decontamination_query]
+            elif callable(doc_to_decontamination_query):
+                return doc_to_decontamination_query(doc)
             else:
                 return ast.literal_eval(
                     utils.apply_template(self.config.doc_to_decontamination_query, doc)


### PR DESCRIPTION
`doc_to_decontamination_query` is sometimes set the same as `doc_to_text`, which means it should also handle `!function` to match it.