### PR TITLE
Update template of qqp dataset

### DIFF
--- a/lm_eval/tasks/glue/qqp/default.yaml
+++ b/lm_eval/tasks/glue/qqp/default.yaml
@@ -6,7 +6,7 @@ output_type: multiple_choice
 training_split: train
 validation_split: validation
 test_split: test
-doc_to_text: "\nSentence 1: {{sentence1}}\nSentence 2: {{sentence2}}\nAnswer:"
+doc_to_text: "\nSentence 1: {{question1}}\nSentence 2: {{question2}}\nAnswer:"
 doc_to_target: label
 doc_to_choice: ["no", "yes"]
 metric_list:


### PR DESCRIPTION
Previously, the template for qqp was:
`doc_to_text: "\nSentence 1: {{sentence1}}\nSentence 2: {{sentence2}}\nAnswer:"`
This would lead to errors:
![72ff4f455dd4a83df899d09a1c9119f](https://github.com/EleutherAI/lm-evaluation-harness/assets/34210233/f5a64f60-5b8d-4679-9f20-8014e7176167)
I printed the log information for the apply_template function. I then realized the error was due to a mismatch between the template and doc, so I fixed it and now everything works normally.
```
def apply_template(template: str, doc: dict) -> str:
    rtemplate = env.from_string(template)
    return rtemplate.render(**doc)
```
doc_to_text: "\nSentence 1: {{question1}}\nSentence 2: {{question2}}\nAnswer:"
![6fbddef3242a8637b68ed1c5f7d506e](https://github.com/EleutherAI/lm-evaluation-harness/assets/34210233/c3c42a05-a2ef-4694-bbed-46d204a0d2a6)

The test command:
CUDA_VISIBLE_DEVICES=0 lm_eval --model hf \
--model_args pretrained=gpt2-large \
--tasks qqp \
--batch_size auto \
--output_path ./eval_out/gpt2-large \
--use_cache ./eval_cache/gpt2-large