### PR TITLE
Fix stderr

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -492,8 +492,10 @@ def evaluate(
                     else bootstrap_iters,
                 )
 
-                if stderr is not None:
+                if stderr is not None and len(items) > 1:
                     results[task_name][metric + "_stderr" + "," + key] = stderr(items)
+                else:
+                    results[task_name][metric + "_stderr" + "," + key] = "N/A"
 
         if bool(results):
             for group, task_list in reversed(task_hierarchy.items()):

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -371,7 +371,9 @@ def make_table(result_dict, column: str = "results"):
 
             if m + "_stderr" + "," + f in dic:
                 se = dic[m + "_stderr" + "," + f]
-                values.append([k, version, f, n, m, "%.4f" % v, "±", "%.4f" % se])
+                if se != "N/A":
+                    se = "%.4f" % se
+                values.append([k, version, f, n, m, "%.4f" % v, "±", se])
             else:
                 values.append([k, version, f, n, m, "%.4f" % v, "", ""])
             k = ""


### PR DESCRIPTION
Sets stderr to `N/A` if `--limit` is 1 or if stderr is not calculated.

```
hf (), gen_kwargs: (), limit: 1.0, num_fewshot: None, batch_size: 1
|Tasks|Version|Filter|n-shot|Metric|Value|   |Stderr|
|-----|-------|------|-----:|------|----:|---|------|
|boolq|Yaml   |none  |     0|acc   |    1|±  |N/A   |
```

closes #1103