### PR TITLE
[FIX] Add _encode_pair() to vllm_causallms.py

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -133,6 +133,21 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
             )
         return outputs
 
+    def _encode_pair(
+        self, context: str, continuation: str
+    ) -> Tuple[List[int], List[int]]:
+        n_spaces = len(context) - len(context.rstrip())
+        if n_spaces > 0:
+            continuation = context[-n_spaces:] + continuation
+            context = context[:-n_spaces]
+
+        whole_enc = self.tok_encode(context + continuation, add_special_tokens=False)
+        context_enc = self.tok_encode(context, add_special_tokens=False)
+
+        context_enc_len = len(context_enc)
+        continuation_enc = whole_enc[context_enc_len:]
+        return context_enc, continuation_enc
+
     def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
         new_reqs = []
         for context, continuation in [req.args for req in requests]:
@@ -142,12 +157,7 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
                     continuation
                 )
             else:
-                context_enc, continuation_enc = self.tokenizer(
-                    [context, continuation],
-                    truncation="do_not_truncate",
-                    add_special_tokens=False,
-                    return_attention_mask=False,
-                ).input_ids
+                context_enc, continuation_enc = self._encode_pair(context, continuation)
 
             new_reqs.append(((context, continuation), context_enc, continuation_enc))
 


### PR DESCRIPTION
Most models using the Llama tokenizer currently show drasticly different evaluation results when tested with the new vLLM implementation. The culprit is identical to a, previous solved, llama tokenization issue with the HF implemetation in [this PR](
https://github.com/EleutherAI/lm-evaluation-harness/pull/531). 

The _encode_pair() method is used for the HuggingFace model, where `whole_enc` and `context_enc` are encoded first before setting `continuation_enc` to be `whole_enc[len(context_enc):]`, while basic batch encoding is used for vLLM.

The current vLLM implementation does the encoding of the pair by just running both the inputs to the tokenizer as such:
```
context_enc, continuation_enc = self.tokenizer(
          [context, continuation],
          truncation="do_not_truncate",
          add_special_tokens=False,
          return_attention_mask=False,
      ).input_ids
```
This inconsistency reflects strongly on the results of MMLU due to the continuation encoding having an extra empty string token in the current implementation, while the _encode_pair way returns only the token of the letter.

The following are normalized accuracies for 0 shot evaluations on `meta-llama/Llama-2-7b-hf`:

| Implementation | ARC Easy | ARC Challenge | MMLU
| --- | --- | --- | --- |
HF  | 74.579 | 46.331 | 41.775
VLLM (current)  | 53.577 | 40.529 | 38.769
VLLM (fixed)  | 74.58 | 46.25 | 41.82

This modification also address [this issue](https://github.com/EleutherAI/lm-evaluation-harness/issues/1101), since `GeneZC/MiniMA-3B` uses the `LlamaTokenizer`.

From our testing, it seems that this discrepancy appears in most models that use `LlamaTokenizer`, such as `meta-llama/Llama-2-7b` and `openlm-research/open_llama_7b_v2`. However, some models, like `01-ai/Yi-6B`, do not show this issue. The only notable difference in the tokenizer config is that they set `add_bos_token=False`, which is not the default.
