### PR TITLE
`qqp`, `mnli_mismatch`: remove unlabled test sets

### DIFF
--- a/lm_eval/tasks/glue/README.md
+++ b/lm_eval/tasks/glue/README.md
@@ -1,4 +1,5 @@
 # GLUE
+**NOTE**: GLUE benchmark tasks do not provide publicly accessible labels for their test sets, so we default to the validation sets for all sub-tasks.
 
 ### Paper
 

--- a/lm_eval/tasks/glue/mnli/mismatch.yaml
+++ b/lm_eval/tasks/glue/mnli/mismatch.yaml
@@ -1,4 +1,3 @@
 include: default.yaml
 task: mnli_mismatch
 validation_split: validation_mismatched
-test_split: test_mismatched

--- a/lm_eval/tasks/glue/qqp/default.yaml
+++ b/lm_eval/tasks/glue/qqp/default.yaml
@@ -5,7 +5,6 @@ dataset_name: qqp
 output_type: multiple_choice
 training_split: train
 validation_split: validation
-test_split: test
 doc_to_text: "\nSentence 1: {{question1}}\nSentence 2: {{question2}}\nAnswer:"
 doc_to_target: label
 doc_to_choice: ["no", "yes"]


### PR DESCRIPTION
Might close #1107. These GLUE sub-tasks defaulted to the unlabelled test sets while the other sub-tasks do not. HF dataset [here](https://huggingface.co/datasets/glue).