### PR TITLE
fix: passing max_length to vllm engine args

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -46,6 +46,7 @@ class VLLM(LM):
         batch_size: Union[str, int] = 1,
         max_batch_size=None,
         max_length: int = None,
+        max_model_len: int = None,
         seed: int = 1234,
         gpu_memory_utilization: float = 0.9,
         device: str = "cuda",
@@ -62,6 +63,9 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
             )
 
         assert "cuda" in device or device is None, "vLLM only supports CUDA"
+        assert max_length is None or max_model_len is None, "Either max_length or max_model_len may be provided, but not both"
+
+        self._max_length = max_model_len if max_model_len is not None else max_length
         self.tensor_parallel_size = int(tensor_parallel_size)
         self.data_parallel_size = int(data_parallel_size)
         self.model_args = {
@@ -74,7 +78,7 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
             "tokenizer_revision": tokenizer_revision,
             "trust_remote_code": trust_remote_code,
             "tensor_parallel_size": int(tensor_parallel_size),
-            "max_model_len": int(max_length),
+            "max_model_len": int(self._max_length) if self._max_length else None,
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
@@ -90,7 +94,6 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
             tokenizer_revision=tokenizer_revision,
         )
         self.batch_size = batch_size
-        self._max_length = max_length
         self._max_gen_toks = max_gen_toks
 
     @property

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -74,6 +74,7 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
             "tokenizer_revision": tokenizer_revision,
             "trust_remote_code": trust_remote_code,
             "tensor_parallel_size": int(tensor_parallel_size),
+            "max_model_len": int(max_length),
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -63,7 +63,9 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
             )
 
         assert "cuda" in device or device is None, "vLLM only supports CUDA"
-        assert max_length is None or max_model_len is None, "Either max_length or max_model_len may be provided, but not both"
+        assert (
+            max_length is None or max_model_len is None
+        ), "Either max_length or max_model_len may be provided, but not both"
 
         self._max_length = max_model_len if max_model_len is not None else max_length
         self.tensor_parallel_size = int(tensor_parallel_size)


### PR DESCRIPTION
Current behavior: max_length is not passed to vllm args.

New behavior: It is now passed.

Reason: Trying to run Mistral 7B would just OOM as they have `"max_position_embeddings": 32768,`. `max_length` is not passed to the Engine args, so it would just take this value.

HF accelerate seems to run this fine though. I'm not sure if they have some sane defaults.

Test:
```
Before:
Initializing an LLM engine with config: model='Open-Orca/Mistral-7B-OpenOrca', tokenizer='Open-Orca/Mistral-7B-OpenOrca', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=8, quantization=None, seed=1234)

After:
Initializing an LLM engine with config: model='Open-Orca/Mistral-7B-OpenOrca', tokenizer='Open-Orca/Mistral-7B-OpenOrca', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=8, quantization=None, seed=1234)