### PR TITLE
Fix vllm `batch_size` type

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -260,7 +260,7 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
         for key, re_ord in re_ords.items():
             chunks = utils.chunks(
                 re_ord.get_reordered(),
-                n=self.batch_size if self.batch_size != "auto" else 0,
+                n=int(self.batch_size) if self.batch_size != "auto" else 0,
                 fn=None,
             )
             for chunk in chunks:
@@ -339,7 +339,7 @@ please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
 
         chunks = utils.chunks(
             re_ord.get_reordered(),
-            n=self.batch_size if self.batch_size != "auto" else 0,
+            n=int(self.batch_size) if self.batch_size != "auto" else 0,
             fn=None,
         )
         pbar = tqdm(total=len(requests), disable=disable_tqdm)


### PR DESCRIPTION
The value of `batch_size` can be either "auto" or an integer. In `__main__.py`, the type of `--batch_size` is set to `str`. 
https://github.com/EleutherAI/lm-evaluation-harness/blob/fcb39a5a8ae2c95e0800ced15da4eb81464187e9/lm_eval/__main__.py#L45
So when an integer is passed as an argument from the `lm_eval` command line, this integer type remains as `str`. This will lead to a bug of `utils.chunks()`, generating only **one** chunk.
https://github.com/EleutherAI/lm-evaluation-harness/blob/fcb39a5a8ae2c95e0800ced15da4eb81464187e9/lm_eval/utils.py#L121
`len(arr)` will never equal to `n` because they have different type.