### PR TITLE
Update Linter CI Job

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,6 +32,8 @@ jobs:
       run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Pre-Commit
       uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --exclude="no-commit-to-branch"
     - name: Lint with pylint
       run: python -m pylint --disable=all -e W0311 --jobs=0 --indent-string='    ' **/*.py
     - name: Lint with flake8

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,11 +29,9 @@ jobs:
         cache: pip
         cache-dependency-path: setup.py
     - name: Install dependencies
-      run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+      run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu ; export SKIP=no-commit-to-branch # env var deactivates --no-commit-to-branch
     - name: Pre-Commit
       uses: pre-commit/action@v3.0.0
-      with:
-        extra_args: --exclude="no-commit-to-branch"
     - name: Lint with pylint
       run: python -m pylint --disable=all -e W0311 --jobs=0 --indent-string='    ' **/*.py
     - name: Lint with flake8


### PR DESCRIPTION
This PR deactivates `--no-commit-to-branch` pre-commit hook, which fixes an erroneous failure of the pre-commit when it runs on a squash+merge commit (which we expect to be committing to the main branch so this failure should be ignored).