### PR TITLE
place model onto `mps`

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -207,7 +207,7 @@ class HFLM(LM):
         self.model.eval()
         self.model.tie_weights()
 
-        if gpus >= 1 and isinstance(pretrained, str):
+        if (gpus >= 1 or self.device.type == "mps") and isinstance(pretrained, str):
             if not (parallelize or autogptq or ("device_map" in kwargs)):
                 # place model onto device requested manually,
                 # if not using HF Accelerate or device_map


### PR DESCRIPTION
Fixes #1131. In the mps case `gpus = torch.cuda.device_count()` always remained 0, so the model was never placed on the device.