### PR TITLE
add correct openai api key to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Our library also supports the evaluation of models served via several commercial
 To call a hosted model, use:
 
 ```bash
-export OPENAI_API_SECRET_KEY=YOUR_KEY_HERE
+export OPENAI_API_KEY=YOUR_KEY_HERE
 lm_eval --model openai-completions \
     --model_args engine=davinci \
     --tasks lambada_openai,hellaswag


### PR DESCRIPTION
The README suggests using `OPENAI_API_SECRET_KEY`, but the code seems to expect `OPENAI_API_KEY`. 

```
raise OpenAIError(
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```