### PR TITLE
Enabling OpenAI completions via gooseai

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -64,7 +64,7 @@ please install these via `pip install lm-eval[openai]` or `pip install -e .[open
             backoff_time *= 1.5
 
 
-@register_model("gooseai")
+@register_model("openai-completions")
 class OpenaiCompletionsLM(LM):
     REQ_CHUNK_SIZE = 20
 

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -55,8 +55,8 @@ please install these via `pip install lm-eval[openai]` or `pip install -e .[open
     backoff_time = 3
     while True:
         try:
-            return openai.Completions.create(**kwargs)
-        except openai.error.OpenAIError:
+            return openai.completions.create(**kwargs)
+        except openai.OpenAIError:
             import traceback
 
             traceback.print_exc()
@@ -70,7 +70,7 @@ class OpenaiCompletionsLM(LM):
 
     def __init__(
         self,
-        engine: str = "text-davinci-003",
+        model: str = "text-davinci-003",
         truncate: bool = False,
         batch_size: int = 1,
     ) -> None:
@@ -89,8 +89,8 @@ class OpenaiCompletionsLM(LM):
                 "attempted to use 'openai' LM type, but package `openai` or `tiktoken` are not installed. \
     please install these via `pip install lm-eval[openai]` or `pip install -e .[openai]`",
             )
-        self.engine = engine
-        self.tokenizer = tiktoken.encoding_for_model(self.engine)
+        self.model= model
+        self.tokenizer = tiktoken.encoding_for_model(self.model)
         self.vocab_size = self.tokenizer.n_vocab
         self.truncate = truncate
         self.end_of_text_token_id = self.tokenizer.eot_token
@@ -245,7 +245,7 @@ class OpenaiCompletionsLM(LM):
             until = request_args.get("until", ["<|endoftext|>"])
 
             response = oa_completion(
-                engine=self.engine,
+                model=self.model,
                 prompt=inps,
                 max_tokens=self.max_gen_toks,
                 temperature=0.0,
@@ -254,7 +254,7 @@ class OpenaiCompletionsLM(LM):
             )
 
             for resp, (context, args_) in zip(response.choices, chunk):
-                s = resp["text"]
+                s = getattr(resp, 'text')
 
                 until_ = args_.get("until", ["<|endoftext|>"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ promptsource = [
 ]
 gptq = ["auto-gptq[triton] @ git+https://github.com/PanQiWei/AutoGPTQ"]
 anthropic = ["anthropic"]
-openai = ["openai>=1.3.5", "tiktoken"]
+openai = ["openai==1.3.9", "tiktoken"]
 vllm = ["vllm"]
 all = [
     "lm_eval[dev]",


### PR DESCRIPTION
We'd like to enable inference-based model request access for evaluation/inference for models hosted on non-vendor endpoints.

[In working on the PR for this](https://github.com/EleutherAI/lm-evaluation-harness/issues/1072), we need several steps: See [discord conversation here.](https://discordapp.com/channels/729741769192767510/755950983669874798/1185245535494492360) 

1. Test the current OpenAI implementation (in this case the gooseai model). <-- this PR. 
2. Make the modifications to the OpenAI methods and see if that works: https://github.com/EleutherAI/lm-evaluation-harness/issues/1072#issuecomment-1844679585
3. Create a new separate method that abstracts away the API provider if we're loading a local model and points it to a generic API endpoint.


This is step 1, reproducing OpenAI functionality using the Goose model, 

```
The model type you want is the model labeled "gooseai", an OpenAI api clone (actually, this should also be marked with the name "openai-completions")--which is the interface of OpenAI's older Completions API that does still support logits. 
````

In order to run OpenAI completions with the latest version of the API, I had to change some class codepaths and method parameters. For example, `Completions` errors out but `completions` is [correct according to the latest docs. ](https://github.com/openai/openai-python/blob/9e6e1a284eeb2c20c05a03831e5566a4e9eaba50/README.md?plain=1#L37C4-L37C4)

```
AttributeError: module 'openai' has no attribute 'Completions'. Did you mean: 'completions'?
```

FWIW, it looks like this changed sometime between when this code was pushed and the 1.3.9 release that's being used in this version. 

To reproduce, get this branch and run locally:

```
python -m pip install -e .  # install editable package

pip list | grep openai #checking openai version
openai                    1.3.9

lm_eval --model gooseai --tasks gsm8k 

gooseai (), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|  Filter  |n-shot|  Metric   |Value |   |Stderr|
|-----|-------|----------|-----:|-----------|-----:|---|-----:|
|gsm8k|Yaml   |get-answer|     5|exact_match|0.5299|±  |0.0137|
```

These tests passed for this PR - if there's a more specific set of tests I need to run please let me know!
```
tests/test_evaluator.py .                                                                                                                                                         [  0%]
tests/test_janitor.py ............                                                                                                                                                [  0%]
tests/test_misc.py .                                                                                                                                                              [  0%]
tests/test_tasks.py .............                                                                                                                                                 [  1%]
tests/test_utils.py ........                                                                                                                                                      [  2%]
tests/models/test_gguf.py ..                                                                                                                                                      [  2%]
tests/models/test_huggingface.py .......                                                                                                                                          [  2%]
```

