### PR TITLE
Generalize Qwen tokenizer fix

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -238,7 +238,7 @@ class HFLM(LM):
         elif self.tokenizer.eos_token:
             self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
         else:
-            if "Qwen" in pretrained:
+            if self.config.model_type == "qwen":
                 # Qwen's trust_remote_code tokenizer does not allow for adding special tokens
                 self.tokenizer.pad_token = "<|endoftext|>"
             else:


### PR DESCRIPTION
This PR improves the handling of Qwen's tokenizer (which is a custom integration of `tiktoken` into HF tokenizers format, and does not support some of HF's functionality/tokenizer methods). It should catch all cases where a Qwen-based model is used now.

closes #1092 .