### PR TITLE
Add docs on adding a multiple choice metric

### DIFF
--- a/docs/task_guide.md
+++ b/docs/task_guide.md
@@ -219,6 +219,49 @@ Aggregation functions:
 * `weighted_perplexity`
 * `bits_per_byte`
 
+### Adding a Multiple Choice Metric
+
+Adding a multiple choice metric has a few steps. To get it working you need to:
+
+1. register a metric function
+2. register an aggregation function
+3. update the `Task` definition to make sure the correct arguments are passed
+
+The default metric and aggregation functions are in `lm_eval/api/metrics.py`, and you can add a function there if it's for general use. The metrics are towards the bottom of the file and look like this:
+
+
+    @register_metric(
+        metric="mcc",
+        higher_is_better=True,
+        output_type="multiple_choice",
+        aggregation="matthews_corrcoef",
+    )
+    def mcc_fn(items):  # This is a passthrough function
+        return items
+
+Note that many of these are passthrough functions, and for multiple choice (at least) this function is never actually called.
+
+Aggregation functions are defined towards the top of the file, here's an example:
+
+    @register_aggregation("matthews_corrcoef")
+    def matthews_corrcoef(items):
+        unzipped_list = list(zip(*items))
+        golds = unzipped_list[0]
+        preds = unzipped_list[1]
+        return sklearn.metrics.matthews_corrcoef(golds, preds)
+
+This function returns a single numeric value. The input is defined in `Task.process_results` in `lm_eval/api/task.py`. There's a section that looks like this:
+
+
+    result_dict = {
+        **({"acc": acc} if "acc" in use_metric else {}),
+        **({"f1": (gold, pred)} if "f1" in use_metric else {}),
+        **({"mcc": (gold, pred)} if "mcc" in use_metric else {}),
+        **({"acc_norm": acc_norm} if "acc_norm" in use_metric else {}),
+        **({"exact_match": exact_match} if "exact_match" in use_metric else {}),
+    }
+
+The value here determines the input to the aggregation function, though the name used matches the metric function. These metrics all have simple needs and just need the accuracy or gold and predicted values, but immediately below this there are examples of metrics with more complicated needs you can use as reference.
 
 ## Good Reference Tasks
 


### PR DESCRIPTION
I've been working on porting Japanese tasks from https://github.com/Stability-AI/lm-evaluation-harness. This PR is not about the porting in general, but a specific issue I had implementing some metrics we have added, like balanced accuracy. 

This PR outlines the process I went through to add a metric. I know the process outlined here creates a usable metric/aggregation, though I am not sure it is the best way to do things, so I wanted to open this PR against the README to 1. make sure I'm doing the right thing 2. help anyone else who has to do the same thing in the future.

My understanding is that adding a metric requires three steps:

1. Register a metric function
2. Register an aggregation function
3. Modify the `Task.process_results` function so the aggregator gets the right input

Is that reasonable? 

I have to admit I found this a very confusing process, in particular figuring out step three. I wrote this guide as though it was for multiple choice tasks only, since that's what I had in mind when I was working on this, but looking at the code now it looks like maybe this is the same for all custom metrics?