### PR TITLE
Fix Column Naming and Dataset Naming Conventions in K-MMLU Evaluation

### DIFF
--- a/lm_eval/tasks/kmmlu/_default_kmmlu_yaml
+++ b/lm_eval/tasks/kmmlu/_default_kmmlu_yaml
@@ -18,4 +18,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  - version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/kmmlu/kmmlu_agricultural_sciences.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_agricultural_sciences.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Agricultural Sciences"
+"dataset_name": "Agricultural-Sciences"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_agricultural_sciences"

--- a/lm_eval/tasks/kmmlu/kmmlu_aviation_engineering_and_maintenance.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_aviation_engineering_and_maintenance.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Aviation Engineering and Maintenance"
+"dataset_name": "Aviation-Engineering-and-Maintenance"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_aviation_engineering_and_maintenance"

--- a/lm_eval/tasks/kmmlu/kmmlu_chemical_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_chemical_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Chemical Engineering"
+"dataset_name": "Chemical-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_chemical_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_civil_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_civil_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Civil Engineering"
+"dataset_name": "Civil-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_civil_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_computer_science.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_computer_science.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Computer Science"
+"dataset_name": "Computer-Science"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_computer_science"

--- a/lm_eval/tasks/kmmlu/kmmlu_criminal_law.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_criminal_law.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Criminal Law"
+"dataset_name": "Criminal-Law"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_criminal_law"

--- a/lm_eval/tasks/kmmlu/kmmlu_electrical_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_electrical_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Electrical Engineering"
+"dataset_name": "Electrical-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_electrical_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_electronics_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_electronics_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Electronics Engineering"
+"dataset_name": "Electronics-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_electronics_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_energy_management.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_energy_management.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Energy Management"
+"dataset_name": "Energy-Management"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_energy_management"

--- a/lm_eval/tasks/kmmlu/kmmlu_environmental_science.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_environmental_science.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Environmental Science"
+"dataset_name": "Environmental-Science"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_environmental_science"

--- a/lm_eval/tasks/kmmlu/kmmlu_food_processing.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_food_processing.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Food Processing"
+"dataset_name": "Food-Processing"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_food_processing"

--- a/lm_eval/tasks/kmmlu/kmmlu_gas_technology_and_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_gas_technology_and_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Gas Technology and Engineering"
+"dataset_name": "Gas-Technology-and-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_gas_technology_and_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_general_physics.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_general_physics.yaml
@@ -1,3 +1,0 @@
-"dataset_name": "General-Physics"
-"include": "_default_kmmlu_yaml"
-"task": "kmmlu_general_physics"

--- a/lm_eval/tasks/kmmlu/kmmlu_general_physics.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_general_physics.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "General Physics"
+"dataset_name": "General-Physics"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_general_physics"

--- a/lm_eval/tasks/kmmlu/kmmlu_industrial_engineer.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_industrial_engineer.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Industrial Engineer"
+"dataset_name": "Industrial-Engineer"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_industrial_engineer"

--- a/lm_eval/tasks/kmmlu/kmmlu_information_technology.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_information_technology.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Information Technology"
+"dataset_name": "Information-Technology"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_information_technology"

--- a/lm_eval/tasks/kmmlu/kmmlu_interior_architecture_and_design.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_interior_architecture_and_design.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Interior Architecture and Design"
+"dataset_name": "Interior-Architecture-and-Design"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_interior_architecture_and_design"

--- a/lm_eval/tasks/kmmlu/kmmlu_korean_language.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_korean_language.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Korean Language"
+"dataset_name": "Korean-Language"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_korean_language"

--- a/lm_eval/tasks/kmmlu/kmmlu_korean_language.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_korean_language.yaml
@@ -1,3 +1,0 @@
-"dataset_name": "Korean-Language"
-"include": "_default_kmmlu_yaml"
-"task": "kmmlu_korean_language"

--- a/lm_eval/tasks/kmmlu/kmmlu_machine_design_and_manufacturing.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_machine_design_and_manufacturing.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Machine Design and Manufacturing"
+"dataset_name": "Machine-Design-and-Manufacturing"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_machine_design_and_manufacturing"

--- a/lm_eval/tasks/kmmlu/kmmlu_maritime_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_maritime_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Maritime Engineering"
+"dataset_name": "Maritime-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_maritime_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_materials_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_materials_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Materials Engineering"
+"dataset_name": "Materials-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_materials_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_mechanical_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_mechanical_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Mechanical Engineering"
+"dataset_name": "Mechanical-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_mechanical_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_nondestructive_testing.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_nondestructive_testing.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Nondestructive Testing"
+"dataset_name": "Nondestructive-Testing"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_nondestructive_testing"

--- a/lm_eval/tasks/kmmlu/kmmlu_political_science_and_sociology.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_political_science_and_sociology.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Political Science and Sociology"
+"dataset_name": "Political-Science-and-Sociology"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_political_science_and_sociology"

--- a/lm_eval/tasks/kmmlu/kmmlu_public_safety.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_public_safety.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Public Safety"
+"dataset_name": "Public-Safety"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_public_safety"

--- a/lm_eval/tasks/kmmlu/kmmlu_railway_and_automotive_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_railway_and_automotive_engineering.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Railway and Automotive Engineering"
+"dataset_name": "Railway-and-Automotive-Engineering"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_railway_and_automotive_engineering"

--- a/lm_eval/tasks/kmmlu/kmmlu_real_estate.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_real_estate.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Real Estate"
+"dataset_name": "Real-Estate"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_real_estate"

--- a/lm_eval/tasks/kmmlu/kmmlu_refrigerating_machinery.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_refrigerating_machinery.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Refrigerating Machinery"
+"dataset_name": "Refrigerating-Machinery"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_refrigerating_machinery"

--- a/lm_eval/tasks/kmmlu/kmmlu_social_welfare.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_social_welfare.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Social Welfare"
+"dataset_name": "Social-Welfare"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_social_welfare"

--- a/lm_eval/tasks/kmmlu/kmmlu_telecommunications_and_wireless_technology.yaml
+++ b/lm_eval/tasks/kmmlu/kmmlu_telecommunications_and_wireless_technology.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "Telecommunications and Wireless Technology"
+"dataset_name": "Telecommunications-and-Wireless-Technology"
 "include": "_default_kmmlu_yaml"
 "task": "kmmlu_telecommunications_and_wireless_technology"

--- a/lm_eval/tasks/kmmlu/utils.py
+++ b/lm_eval/tasks/kmmlu/utils.py
@@ -7,7 +7,7 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
             f"다음을 읽고 정답으로 알맞은 것을 고르시요.\n"
             f"### Question: {doc['question']}\n"
             f"### Options:\n"
-            f"(1) {doc['option#1']}\n(2) {doc['option#2']}\n(3) {doc['option#3']}\n(4) {doc['option#4']}\n"
+            f"(1) {doc['A']}\n(2) {doc['B']}\n(3) {doc['C']}\n(4) {doc['D']}\n"
             f"### Answer: 주어진 문제의 정답은"
         )
         out_doc = {


### PR DESCRIPTION
## Summary
This PR addresses two key inconsistencies found in the K-MMLU evaluation harness:

1. **Option Column Naming Mismatch:** 
   - The `Accounting-test.csv` in the K-MMLU dataset uses column names `A`, `B`, `C`, and `D` for options.
   - However, the `utils.py` file in the evaluation harness attempts to read options using different names (`option#1`, `option#2`, `option#3`, `option#4`).
   - This PR updates the `utils.py` file to align with the dataset's column naming convention.

2. **Dataset Naming Discrepancy:**
   - The dataset names in the K-MMLU dataset repository include hyphens (e.g., `Agricultural-Sciences`).
   - In contrast, dataset names in the configuration files use spaces (e.g., `Agricultural Sciences`).
   - This PR updates the configuration files to ensure consistency with the dataset repository naming convention.

## Changes Made
- Modified the column names referenced in `utils.py` to `A`, `B`, `C`, and `D`.
- Updated the configuration files to use hyphens instead of spaces in dataset names, matching the dataset repository's format.