### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To call a hosted model, use:
 ```bash
 export OPENAI_API_KEY=YOUR_KEY_HERE
 lm_eval --model openai-completions \
-    --model_args engine=davinci \
+    --model_args model=davinci \
     --tasks lambada_openai,hellaswag
 ```
 


### PR DESCRIPTION
Got this error:
```
lm_eval --model openai-completions \
    --model_args engine=davinci \
    --tasks lambada_openai,hellaswag
2023-12-21:10:15:00,031 INFO     [utils.py:148] Note: NumExpr detected 10 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2023-12-21:10:15:00,031 INFO     [utils.py:160] NumExpr defaulting to 8 threads.
2023-12-21:10:15:02,243 INFO     [__main__.py:156] Verbosity set to INFO
2023-12-21:10:15:04,945 INFO     [__main__.py:229] Selected Tasks: ['hellaswag', 'lambada_openai']
Traceback (most recent call last):
  File "/Users/anjorkanekar/repos/EleutherAI/lm-evaluation-harness/venv/bin/lm_eval", line 8, in <module>
    sys.exit(cli_evaluate())
             ^^^^^^^^^^^^^^
  File "/Users/anjorkanekar/repos/EleutherAI/lm-evaluation-harness/lm_eval/__main__.py", line 231, in cli_evaluate
    results = evaluator.simple_evaluate(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anjorkanekar/repos/EleutherAI/lm-evaluation-harness/lm_eval/utils.py", line 402, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/anjorkanekar/repos/EleutherAI/lm-evaluation-harness/lm_eval/evaluator.py", line 98, in simple_evaluate
    lm = lm_eval.api.registry.get_model(model).create_from_arg_string(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anjorkanekar/repos/EleutherAI/lm-evaluation-harness/lm_eval/api/model.py", line 134, in create_from_arg_string
    return cls(**args, **args2)
           ^^^^^^^^^^^^^^^^^^^^
TypeError: OpenaiCompletionsLM.__init__() got an unexpected keyword argument 'engine'
```

looks like the parameter got renamed to model.