### PR TITLE
Add tokenizer backend

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -3,7 +3,7 @@ import os
 import time
 from collections import defaultdict
 from importlib.util import find_spec
-from typing import List, Optional, Tuple, Literal
+from typing import List, Literal, Optional, Tuple
 
 import transformers
 from tqdm import tqdm


### PR DESCRIPTION
I am running a local server that functions as a proxy for other models. On the client side the server is OpenAI compatible, i.e., it accepts code written against the OpenAI api. 

I would like to point lm_eval to this proxy in order to run evaluations.

Today if I set `base_url`, lm-eval assumes that the model is local and looks for the local model directory, which in my case does not exist given that it's just a proxy server.

With this change users can change base_url without requiring a local model.