### PR TITLE
Add remove_whitespace to FLD benchmark

### DIFF
--- a/lm_eval/tasks/fld/fld_default.yaml
+++ b/lm_eval/tasks/fld/fld_default.yaml
@@ -12,5 +12,10 @@ metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
+filter_list:
+  - name: remove_whitespace
+    filter:
+      - function: remove_whitespace
+      - function: take_first
 metadata:
   version: 0.0

--- a/lm_eval/tasks/fld/fld_default.yaml
+++ b/lm_eval/tasks/fld/fld_default.yaml
@@ -18,4 +18,4 @@ filter_list:
       - function: remove_whitespace
       - function: take_first
 metadata:
-  version: 0.0
+  version: 1.0


### PR DESCRIPTION
We noticed some small LLMs do not follow the instructions strictly and add spaces to the answer. This is not an essential problem, so we want to correct such answers.