### PR TITLE
Fix the argument order in `utils.divide` doc

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -682,7 +682,7 @@ def divide(iterable, n) -> List[Iterator]:
     """Divide the elements from *iterable* into *n* parts, maintaining
     order.
 
-        >>> group_1, group_2 = divide(2, [1, 2, 3, 4, 5, 6])
+        >>> group_1, group_2 = divide([1, 2, 3, 4, 5, 6], 2)
         >>> list(group_1)
         [1, 2, 3]
         >>> list(group_2)
@@ -691,14 +691,14 @@ def divide(iterable, n) -> List[Iterator]:
     If the length of *iterable* is not evenly divisible by *n*, then the
     length of the returned iterables will not be identical:
 
-        >>> children = divide(3, [1, 2, 3, 4, 5, 6, 7])
+        >>> children = divide([1, 2, 3, 4, 5, 6, 7], 3)
         >>> [list(c) for c in children]
         [[1, 2, 3], [4, 5], [6, 7]]
 
     If the length of the iterable is smaller than n, then the last returned
     iterables will be empty:
 
-        >>> children = divide(5, [1, 2, 3])
+        >>> children = divide([1, 2, 3], 5)
         >>> [list(c) for c in children]
         [[1], [2], [3], [], []]
 


### PR DESCRIPTION
The argument order in`utils.divide`'s signature is `iterable` then `n`. But in the examples in documentation, the order is `n` then `iterable`