### PR TITLE
fix unbounded local variable

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -201,7 +201,7 @@ class HFLM(LM):
         self.model.eval()
         self.model.tie_weights()
 
-        if (gpus >= 1 or str(self.device) == "mps") and isinstance(pretrained, str):
+        if isinstance(pretrained, str) and (gpus >= 1 or str(self.device) == "mps"):
             if not (parallelize or autogptq or ("device_map" in kwargs)):
                 # place model onto device requested manually,
                 # if not using HF Accelerate or device_map


### PR DESCRIPTION
It's a minor fix.

When we instantiate the `HFLM` class with already-initialized `transformers.PreTrainedModel`, it raises an `UnboundLocalError` for the local variable `gpus`, which is only defined when loading the model from a string.