### PR TITLE
Expand docs, update CITATION.bib

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,26 +1,10 @@
-@software{eval-harness,
-  author       = {Gao, Leo and
-                  Tow, Jonathan and
-                  Biderman, Stella and
-                  Black, Sid and
-                  DiPofi, Anthony and
-                  Foster, Charles and
-                  Golding, Laurence and
-                  Hsu, Jeffrey and
-                  McDonell, Kyle and
-                  Muennighoff, Niklas and
-                  Phang, Jason and
-                  Reynolds, Laria and
-                  Tang, Eric and
-                  Thite, Anish and
-                  Wang, Ben and
-                  Wang, Kevin and
-                  Zou, Andy},
+@misc{eval-harness,
+  author       = {Gao, Leo and Tow, Jonathan and Abbasi, Baber and Biderman, Stella and Black, Sid and DiPofi, Anthony and Foster, Charles and Golding, Laurence and Hsu, Jeffrey and Le Noac'h, Alain and Li, Haonan and McDonell, Kyle and Muennighoff, Niklas and Ociepa, Chris and Phang, Jason and Reynolds, Laria and Schoelkopf, Hailey and Skowron, Aviya and Sutawika, Lintang and Tang, Eric and Thite, Anish and Wang, Ben and Wang, Kevin and Zou, Andy},
   title        = {A framework for few-shot language model evaluation},
-  month        = sep,
-  year         = 2021,
+  month        = 12,
+  year         = 2023,
   publisher    = {Zenodo},
-  version      = {v0.0.1},
-  doi          = {10.5281/zenodo.5371628},
-  url          = {https://doi.org/10.5281/zenodo.5371628}
+  version      = {v0.4.0},
+  doi          = {10.5281/zenodo.10256836},
+  url          = {https://zenodo.org/records/10256836}
 }

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,10 +1,26 @@
-@misc{eval-harness,
-  author       = {Gao, Leo and Tow, Jonathan and Abbasi, Baber and Biderman, Stella and Black, Sid and DiPofi, Anthony and Foster, Charles and Golding, Laurence and Hsu, Jeffrey and Le Noac'h, Alain and Li, Haonan and McDonell, Kyle and Muennighoff, Niklas and Ociepa, Chris and Phang, Jason and Reynolds, Laria and Schoelkopf, Hailey and Skowron, Aviya and Sutawika, Lintang and Tang, Eric and Thite, Anish and Wang, Ben and Wang, Kevin and Zou, Andy},
+@software{eval-harness,
+  author       = {Gao, Leo and
+                  Tow, Jonathan and
+                  Biderman, Stella and
+                  Black, Sid and
+                  DiPofi, Anthony and
+                  Foster, Charles and
+                  Golding, Laurence and
+                  Hsu, Jeffrey and
+                  McDonell, Kyle and
+                  Muennighoff, Niklas and
+                  Phang, Jason and
+                  Reynolds, Laria and
+                  Tang, Eric and
+                  Thite, Anish and
+                  Wang, Ben and
+                  Wang, Kevin and
+                  Zou, Andy},
   title        = {A framework for few-shot language model evaluation},
-  month        = 12,
-  year         = 2023,
+  month        = sep,
+  year         = 2021,
   publisher    = {Zenodo},
-  version      = {v0.4.0},
-  doi          = {10.5281/zenodo.10256836},
-  url          = {https://zenodo.org/records/10256836}
+  version      = {v0.0.1},
+  doi          = {10.5281/zenodo.5371628},
+  url          = {https://doi.org/10.5281/zenodo.5371628}
 }

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ accelerate launch --no_python lm-eval --model ...
 ```
 
 
+**Note: we do not currently support multi-node evaluations natively, and advise using either an externally hosted server to run inference requests against, or creating a custom integration with your distributed framework [as is done for the GPT-NeoX library](https://github.com/EleutherAI/gpt-neox/blob/main/eval_tasks/eval_adapter.py).**
+
+
 ### Tensor + Data Parallel and Optimized Inference with `vLLM`
 
 We also support vLLM for faster inference on [supported model types](https://docs.vllm.ai/en/latest/models/supported_models.html). For single-GPU or multi-GPU — tensor parallel, data parallel, or a combination of both — inference, for example:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,21 +1,45 @@
-# How to Contribute to LM Evaluation Harness
+# Contributing to LM Evaluation Harness
 
-Welcome and thank you for your interest in the LM Evaluation Harness! 
-
+Welcome and thank you for your interest in the LM Evaluation Harness! We welcome contributions and feedback and appreciate your time spent with our library, and hope you find it useful!
 
 ## Important Resources
 
-- docs pages (and where to find a summary of their contents)
-- Milestones
-- Project board and its different views
+There are several places information about LM Evaluation Harness is located: 
 
+- Our [documentation pages](https://github.com/EleutherAI/lm-evaluation-harness/tree/main/docs) 
+- We occasionally use [GitHub Milestones](https://github.com/EleutherAI/lm-evaluation-harness/milestones) to track progress toward specific near-term version releases.
+- We maintain a [Project Board](https://github.com/orgs/EleutherAI/projects/25) for tracking current work items and PRs, and for future roadmap items or feature requests. 
+- Further discussion and support conversations are located in the #lm-thunderdome channel of the [EleutherAI discord](discord.gg/eleutherai).
+
+## Code Style
+
+LM Evaluation Harness uses [ruff](https://github.com/astral-sh/ruff) for linting via [pre-commit](https://pre-commit.com/). 
+
+You can install linters and dev tools via 
+
+```pip install lm_eval[dev]```
+
+Then, run 
+
+```pre-commit install```
+
+in order to ensure linters and other checks will be run upon committing.
+
+## Testing
+
+We use [pytest](https://docs.pytest.org/en/latest/) for running unit tests. All library unit tests can be run via:
+
+```
+python -m pytest --ignore=tests/tests_master --ignore=tests/extra
+```
+
+## Contributor License Agreement
+
+We ask that new contributors agree to a Contributor License Agreement affirming that EleutherAI has the rights to use your contribution to our library. 
+First-time pull requests will have a reply added by @CLAassistant containing instructions for how to confirm this, and we require it before merging your PR. 
 
 ## Guide to contributing
 
-- precommit
-- testing
-- documentation
-- descriptive PR naming / describe your change and the reasons for it
 
 ## Different Contribution Types
 
@@ -26,6 +50,8 @@ Welcome and thank you for your interest in the LM Evaluation Harness!
 - new internal/external model library integrations
 
 
-## How Can I Get Started? 
+## How Can I Get Involved?
+
+There are a number of ways to 
 
 - Good First Issues board / adding new tasks

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# How to Contribute to LM Evaluation Harness
+
+Welcome and thank you for your interest in the LM Evaluation Harness! 
+
+
+## Important Resources
+
+- docs pages (and where to find a summary of their contents)
+- Milestones
+- Project board and its different views
+
+
+## Guide to contributing
+
+- precommit
+- testing
+- documentation
+- descriptive PR naming / describe your change and the reasons for it
+
+## Different Contribution Types
+
+- Implementing and verifying new tasks
+- Improving documentation + testing + automation / devops
+- New features--coordinate with us
+- Proposing new features / additions
+- new internal/external model library integrations
+
+
+## How Can I Get Started? 
+
+- Good First Issues board / adding new tasks

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Welcome and thank you for your interest in the LM Evaluation Harness! We welcome contributions and feedback and appreciate your time spent with our library, and hope you find it useful!
 
+We intend LM Evaluation Harness to be a broadly useful and 
+
 ## Important Resources
 
 There are several places information about LM Evaluation Harness is located: 
@@ -38,20 +40,42 @@ python -m pytest --ignore=tests/tests_master --ignore=tests/extra
 We ask that new contributors agree to a Contributor License Agreement affirming that EleutherAI has the rights to use your contribution to our library. 
 First-time pull requests will have a reply added by @CLAassistant containing instructions for how to confirm this, and we require it before merging your PR. 
 
-## Guide to contributing
 
+## Contribution Best Practices
 
-## Different Contribution Types
+We recommend a few best practices to make your contributions or reported errors easier to assist with.
 
-- Implementing and verifying new tasks
-- Improving documentation + testing + automation / devops
-- New features--coordinate with us
-- Proposing new features / additions
-- new internal/external model library integrations
+**For Pull Requests:**
+- PRs should be titled descriptively, and be opened with a brief description of the scope and intent of the new contribution.
+- New features should have appropriate documentation added alongside them.
+- Aim for code maintainability, and minimize code copying.
+- If opening a task, try to share test results on the task using a publicly-available model, and if any public results are available on the task, compare to them.
 
+**For Feature Requests:**
+- Provide a short paragraph's worth of description. What is the feature you are requesting? What is its motivation, and an example use case of it? How does this differ from what is currently supported?
+
+**For Bug Reports**:
+- Provide a short description of the bug.
+- Provide a *reproducible example*--what is the command you run with our library that results in this error? Have you tried any other steps to resolve it?
+- Provide a *full error traceback* of the error that occurs, if applicable. A one-line error message or small screenshot snippet is unhelpful without the surrounding context.
+- Note what version of the codebase you are using, and any specifics of your environment and setup that may be relevant.
+
+**For Requesting New Tasks**:
+- Provide a 1-2 sentence description of what the task is and what it evaluates.
+- Provide a link to the paper introducing the task.
+- Provide a link to where the dataset can be found.
+- Provide a link to a paper containing results on an open-source model on the task, for use in comparisons and implementation validation.
+- If applicable, link to any codebase that has implemented the task (especially the original publication's codebase, if existent).
 
 ## How Can I Get Involved?
 
-There are a number of ways to 
+To quickly get started, we maintain a list of good first issues, which can be found [on our project board](https://github.com/orgs/EleutherAI/projects/25/views/8) or by [filtering GH Issues](https://github.com/EleutherAI/lm-evaluation-harness/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3A%22help+wanted%22). These are typically smaller code changes or self-contained features which can be added without extensive familiarity with library internals, and we recommend new contributors consider taking a stab at one of these first if they are feeling uncertain where to begin.
 
-- Good First Issues board / adding new tasks
+There are a number of distinct ways to contribute to LM Evaluation Harness, and all are extremely helpful! A sampling of ways to contribute include:
+- **Implementing and verifying new evaluation tasks**: Is there a task you'd like to see LM Evaluation Harness support? Consider opening an issue requesting it, or helping add it! Verifying and cross-checking task implementations with their original versions is also a very valuable form of assistance in ensuring standardized evaluation.
+- **Improving documentation** - Improvements to the documentation, or noting pain points / gaps in documentation, are helpful in order for us to improve the user experience of the library and clarity + coverage of documentation.
+- **Testing and devops** - We are very grateful for any assistance in adding tests for the library that can be run for new PRs, and other devops workflows.
+- **Adding new modeling / inference library integrations** - We hope to support a broad range of commonly-used inference libraries popular among the community, and welcome PRs for new integrations, so long as they are documented properly and maintainable.
+- **Proposing or Contributing New Features** - We want LM Evaluation Harness to support a broad range of evaluation usecases. If you have a feature that is not currently supported but desired, feel free to open an issue describing the feature and, if applicable, how you intend to implement it. We would be happy to give feedback on the cleanest way to implement new functionalities and are happy to coordinate with interested contributors via GH discussions or via discord.
+
+We hope that this has been helpful, and appreciate your interest in contributing! Further questions can be directed to [our Discord](discord.gg/eleutherai).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,26 +2,26 @@
 
 Welcome and thank you for your interest in the LM Evaluation Harness! We welcome contributions and feedback and appreciate your time spent with our library, and hope you find it useful!
 
-We intend LM Evaluation Harness to be a broadly useful and 
+We intend LM Evaluation Harness to be a broadly useful and
 
 ## Important Resources
 
-There are several places information about LM Evaluation Harness is located: 
+There are several places information about LM Evaluation Harness is located:
 
-- Our [documentation pages](https://github.com/EleutherAI/lm-evaluation-harness/tree/main/docs) 
+- Our [documentation pages](https://github.com/EleutherAI/lm-evaluation-harness/tree/main/docs)
 - We occasionally use [GitHub Milestones](https://github.com/EleutherAI/lm-evaluation-harness/milestones) to track progress toward specific near-term version releases.
-- We maintain a [Project Board](https://github.com/orgs/EleutherAI/projects/25) for tracking current work items and PRs, and for future roadmap items or feature requests. 
+- We maintain a [Project Board](https://github.com/orgs/EleutherAI/projects/25) for tracking current work items and PRs, and for future roadmap items or feature requests.
 - Further discussion and support conversations are located in the #lm-thunderdome channel of the [EleutherAI discord](discord.gg/eleutherai).
 
 ## Code Style
 
-LM Evaluation Harness uses [ruff](https://github.com/astral-sh/ruff) for linting via [pre-commit](https://pre-commit.com/). 
+LM Evaluation Harness uses [ruff](https://github.com/astral-sh/ruff) for linting via [pre-commit](https://pre-commit.com/).
 
-You can install linters and dev tools via 
+You can install linters and dev tools via
 
 ```pip install lm_eval[dev]```
 
-Then, run 
+Then, run
 
 ```pre-commit install```
 
@@ -37,8 +37,8 @@ python -m pytest --ignore=tests/tests_master --ignore=tests/extra
 
 ## Contributor License Agreement
 
-We ask that new contributors agree to a Contributor License Agreement affirming that EleutherAI has the rights to use your contribution to our library. 
-First-time pull requests will have a reply added by @CLAassistant containing instructions for how to confirm this, and we require it before merging your PR. 
+We ask that new contributors agree to a Contributor License Agreement affirming that EleutherAI has the rights to use your contribution to our library.
+First-time pull requests will have a reply added by @CLAassistant containing instructions for how to confirm this, and we require it before merging your PR.
 
 
 ## Contribution Best Practices


### PR DESCRIPTION
closes #1187  #1081  #947 .

This PR will go through and make some misc. docs changes, and will add a CONTRIBUTING.md file to help onboard new contributors or collaborators.


TODO: 
- go from skeleton contributing.md -> full document
- mention contributing.md in main README
- consider consolidating some main-readme stuff?
- Add a list of papers in a docs file that use lm-eval?
- Add a list of broadly scoped future directions that might be up for grabs