### PR TITLE
vllm: handle max_length better and substitute Collator

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -86,7 +86,11 @@ class VLLM(LM):
             "quantization": quantization,
             "seed": int(seed),
         }
-        self.batch_size = "auto" if batch_size.startswith("auto:") else batch_size
+        self.batch_size = (
+            "auto"
+            if isinstance(batch_size, str) and "auto" in batch_size
+            else batch_size
+        )
         if self.data_parallel_size <= 1:
             self.model = LLM(**self.model_args)
         else:

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -17,6 +17,7 @@ from lm_eval.utils import (
 
 
 try:
+    import ray
     from ray.util.multiprocessing import Pool
     from vllm import LLM, SamplingParams
     from vllm.transformers_utils.tokenizer import get_tokenizer
@@ -188,6 +189,8 @@ class VLLM(LM):
 
             with Pool(self.data_parallel_size) as pool:
                 results = pool.starmap(run_inference_one_model, inputs)
+            # Invoke ray.shutdown() to prevent hang-ups if subsequent calls required.
+            ray.shutdown()
             # flatten results
             return [item for sublist in results for item in sublist]
 

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -86,10 +86,14 @@ class VLLM(LM):
             "quantization": quantization,
             "seed": int(seed),
         }
+        self.batch_size = "auto" if batch_size.startswith("auto:") else batch_size
         if self.data_parallel_size <= 1:
             self.model = LLM(**self.model_args)
         else:
             self.model_args["worker_use_ray"] = True
+            self.batch_size = "auto"
+            eval_logger.info("Manual batching is not compatible with data parallelism.")
+
             from transformers import AutoConfig
 
             self._config = AutoConfig.from_pretrained(
@@ -102,7 +106,6 @@ class VLLM(LM):
             tokenizer_revision=tokenizer_revision,
         )
 
-        self.batch_size = "auto" if batch_size.startswith("auto:") else batch_size
         self._max_gen_toks = max_gen_toks
 
     @property

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -398,7 +398,7 @@ class VLLM(LM):
         """Process logprobs and tokens.
 
         :param tokens: list
-            Input tokens (potentially left truncated)
+            Input tokens (potentially left-truncated)
         :param outputs: RequestOutput
             Contains prompt_logprobs
         :param ctxlen: int
@@ -410,7 +410,7 @@ class VLLM(LM):
                 Whether argmax matches given continuation exactly
         """
 
-        # The first prompt_logprobs is None
+        # The first entry of prompt_logprobs is None because the model has no previous tokens to condition on.
         continuation_logprobs_dicts = outputs.prompt_logprobs
 
         # Calculate continuation_logprobs


### PR DESCRIPTION
Updated the max_length estimation to more closely mirror HF and handle case where the tokenizer has an implausibly large `max_length`. This allows the inputs to be truncated to the proper length: fixes #1234 and similar bugs where vllm will not provide log_probs if the inputs exceed its internally [calculated](https://github.com/vllm-project/vllm/blob/9140561059904f133a3c146f04afe13d1cdd5a6c/vllm/config.py#L468) model max length.

Also substituted Collator for Reorderer. Also fixed a lingering `batch_size` bug from #1229.

