### PR TITLE
Specify utf-8 encoding to properly save non-ascii samples to file

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -271,7 +271,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
                         default=_handle_non_serializable,
                         ensure_ascii=False,
                     )
-                    filename.open("w").write(samples_dumped)
+                    filename.write_text(samples_dumped, encoding="utf-8")
 
         print(
             f"{args.model} ({args.model_args}), gen_kwargs: ({args.gen_kwargs}), limit: {args.limit}, num_fewshot: {args.num_fewshot}, "


### PR DESCRIPTION
The samples might be non-ascii after #1246 and this PR explicitly sets the "utf-8" encoding while saving to file. Otherwise the previous default was to use the environment default which might not be compatible.