### PR TITLE
Fix evaluation for the belebele dataset

### DIFF
--- a/lm_eval/tasks/belebele/_default_template_yaml
+++ b/lm_eval/tasks/belebele/_default_template_yaml
@@ -1,7 +1,5 @@
 group: belebele
 dataset_path: facebook/belebele
-test_split: test
-fewshot_split: test
 fewshot_config:
   sampler: first_n
 output_type: multiple_choice

--- a/lm_eval/tasks/belebele/_generate_configs.py
+++ b/lm_eval/tasks/belebele/_generate_configs.py
@@ -8,7 +8,7 @@ import requests
 
 from tqdm import tqdm
 
-from lm_eval.logger import eval_logger
+from lm_eval.utils import logging
 
 API_URL = "https://datasets-server.huggingface.co/splits?dataset=facebook/belebele"
 
@@ -39,8 +39,8 @@ if __name__ == "__main__":
     def query():
         response = requests.get(API_URL)
         return response.json()["splits"]
-
-    languages = [split["config"] for split in query()]
+    print(query())
+    languages = [split["split"] for split in query()]
 
     for lang in tqdm(languages):
         yaml_dict = {
@@ -48,11 +48,12 @@ if __name__ == "__main__":
             "task": f"belebele_{args.task_prefix}_{lang}"
             if args.task_prefix != ""
             else f"belebele_{lang}",
-            "dataset_name": lang,
+            "test_split": lang,
+            "fewshot_split":lang,
         }
 
         file_save_path = args.save_prefix_path + f"_{lang}.yaml"
-        eval_logger.info(f"Saving yaml for subset {lang} to {file_save_path}")
+        logging.info(f"Saving yaml for subset {lang} to {file_save_path}")
         with open(file_save_path, "w") as yaml_file:
             yaml.dump(
                 yaml_dict,

--- a/lm_eval/tasks/belebele/belebele_acm_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_acm_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "acm_Arab"
+"fewshot_split": "acm_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_acm_Arab"
+"test_split": "acm_Arab"

--- a/lm_eval/tasks/belebele/belebele_afr_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_afr_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "afr_Latn"
+"fewshot_split": "afr_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_afr_Latn"
+"test_split": "afr_Latn"

--- a/lm_eval/tasks/belebele/belebele_als_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_als_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "als_Latn"
+"fewshot_split": "als_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_als_Latn"
+"test_split": "als_Latn"

--- a/lm_eval/tasks/belebele/belebele_amh_Ethi.yaml
+++ b/lm_eval/tasks/belebele/belebele_amh_Ethi.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "amh_Ethi"
+"fewshot_split": "amh_Ethi"
 "include": "_default_template_yaml"
 "task": "belebele_amh_Ethi"
+"test_split": "amh_Ethi"

--- a/lm_eval/tasks/belebele/belebele_apc_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_apc_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "apc_Arab"
+"fewshot_split": "apc_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_apc_Arab"
+"test_split": "apc_Arab"

--- a/lm_eval/tasks/belebele/belebele_arb_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_arb_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "arb_Arab"
+"fewshot_split": "arb_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_arb_Arab"
+"test_split": "arb_Arab"

--- a/lm_eval/tasks/belebele/belebele_arb_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_arb_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "arb_Latn"
+"fewshot_split": "arb_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_arb_Latn"
+"test_split": "arb_Latn"

--- a/lm_eval/tasks/belebele/belebele_ars_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_ars_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ars_Arab"
+"fewshot_split": "ars_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_ars_Arab"
+"test_split": "ars_Arab"

--- a/lm_eval/tasks/belebele/belebele_ary_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_ary_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ary_Arab"
+"fewshot_split": "ary_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_ary_Arab"
+"test_split": "ary_Arab"

--- a/lm_eval/tasks/belebele/belebele_arz_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_arz_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "arz_Arab"
+"fewshot_split": "arz_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_arz_Arab"
+"test_split": "arz_Arab"

--- a/lm_eval/tasks/belebele/belebele_asm_Beng.yaml
+++ b/lm_eval/tasks/belebele/belebele_asm_Beng.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "asm_Beng"
+"fewshot_split": "asm_Beng"
 "include": "_default_template_yaml"
 "task": "belebele_asm_Beng"
+"test_split": "asm_Beng"

--- a/lm_eval/tasks/belebele/belebele_azj_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_azj_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "azj_Latn"
+"fewshot_split": "azj_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_azj_Latn"
+"test_split": "azj_Latn"

--- a/lm_eval/tasks/belebele/belebele_bam_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_bam_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "bam_Latn"
+"fewshot_split": "bam_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_bam_Latn"
+"test_split": "bam_Latn"

--- a/lm_eval/tasks/belebele/belebele_ben_Beng.yaml
+++ b/lm_eval/tasks/belebele/belebele_ben_Beng.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ben_Beng"
+"fewshot_split": "ben_Beng"
 "include": "_default_template_yaml"
 "task": "belebele_ben_Beng"
+"test_split": "ben_Beng"

--- a/lm_eval/tasks/belebele/belebele_ben_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ben_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ben_Latn"
+"fewshot_split": "ben_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ben_Latn"
+"test_split": "ben_Latn"

--- a/lm_eval/tasks/belebele/belebele_bod_Tibt.yaml
+++ b/lm_eval/tasks/belebele/belebele_bod_Tibt.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "bod_Tibt"
+"fewshot_split": "bod_Tibt"
 "include": "_default_template_yaml"
 "task": "belebele_bod_Tibt"
+"test_split": "bod_Tibt"

--- a/lm_eval/tasks/belebele/belebele_bul_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_bul_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "bul_Cyrl"
+"fewshot_split": "bul_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_bul_Cyrl"
+"test_split": "bul_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_cat_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_cat_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "cat_Latn"
+"fewshot_split": "cat_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_cat_Latn"
+"test_split": "cat_Latn"

--- a/lm_eval/tasks/belebele/belebele_ceb_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ceb_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ceb_Latn"
+"fewshot_split": "ceb_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ceb_Latn"
+"test_split": "ceb_Latn"

--- a/lm_eval/tasks/belebele/belebele_ces_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ces_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ces_Latn"
+"fewshot_split": "ces_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ces_Latn"
+"test_split": "ces_Latn"

--- a/lm_eval/tasks/belebele/belebele_ckb_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_ckb_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ckb_Arab"
+"fewshot_split": "ckb_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_ckb_Arab"
+"test_split": "ckb_Arab"

--- a/lm_eval/tasks/belebele/belebele_dan_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_dan_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "dan_Latn"
+"fewshot_split": "dan_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_dan_Latn"
+"test_split": "dan_Latn"

--- a/lm_eval/tasks/belebele/belebele_default.yaml
+++ b/lm_eval/tasks/belebele/belebele_default.yaml
@@ -1,0 +1,4 @@
+"fewshot_split": "default"
+"include": "_default_template_yaml"
+"task": "belebele_default"
+"test_split": "default"

--- a/lm_eval/tasks/belebele/belebele_deu_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_deu_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "deu_Latn"
+"fewshot_split": "deu_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_deu_Latn"
+"test_split": "deu_Latn"

--- a/lm_eval/tasks/belebele/belebele_ell_Grek.yaml
+++ b/lm_eval/tasks/belebele/belebele_ell_Grek.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ell_Grek"
+"fewshot_split": "ell_Grek"
 "include": "_default_template_yaml"
 "task": "belebele_ell_Grek"
+"test_split": "ell_Grek"

--- a/lm_eval/tasks/belebele/belebele_eng_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_eng_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "eng_Latn"
+"fewshot_split": "eng_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_eng_Latn"
+"test_split": "eng_Latn"

--- a/lm_eval/tasks/belebele/belebele_est_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_est_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "est_Latn"
+"fewshot_split": "est_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_est_Latn"
+"test_split": "est_Latn"

--- a/lm_eval/tasks/belebele/belebele_eus_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_eus_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "eus_Latn"
+"fewshot_split": "eus_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_eus_Latn"
+"test_split": "eus_Latn"

--- a/lm_eval/tasks/belebele/belebele_fin_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_fin_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "fin_Latn"
+"fewshot_split": "fin_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_fin_Latn"
+"test_split": "fin_Latn"

--- a/lm_eval/tasks/belebele/belebele_fra_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_fra_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "fra_Latn"
+"fewshot_split": "fra_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_fra_Latn"
+"test_split": "fra_Latn"

--- a/lm_eval/tasks/belebele/belebele_fuv_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_fuv_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "fuv_Latn"
+"fewshot_split": "fuv_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_fuv_Latn"
+"test_split": "fuv_Latn"

--- a/lm_eval/tasks/belebele/belebele_gaz_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_gaz_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "gaz_Latn"
+"fewshot_split": "gaz_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_gaz_Latn"
+"test_split": "gaz_Latn"

--- a/lm_eval/tasks/belebele/belebele_grn_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_grn_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "grn_Latn"
+"fewshot_split": "grn_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_grn_Latn"
+"test_split": "grn_Latn"

--- a/lm_eval/tasks/belebele/belebele_guj_Gujr.yaml
+++ b/lm_eval/tasks/belebele/belebele_guj_Gujr.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "guj_Gujr"
+"fewshot_split": "guj_Gujr"
 "include": "_default_template_yaml"
 "task": "belebele_guj_Gujr"
+"test_split": "guj_Gujr"

--- a/lm_eval/tasks/belebele/belebele_hat_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_hat_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "hat_Latn"
+"fewshot_split": "hat_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_hat_Latn"
+"test_split": "hat_Latn"

--- a/lm_eval/tasks/belebele/belebele_hau_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_hau_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "hau_Latn"
+"fewshot_split": "hau_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_hau_Latn"
+"test_split": "hau_Latn"

--- a/lm_eval/tasks/belebele/belebele_heb_Hebr.yaml
+++ b/lm_eval/tasks/belebele/belebele_heb_Hebr.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "heb_Hebr"
+"fewshot_split": "heb_Hebr"
 "include": "_default_template_yaml"
 "task": "belebele_heb_Hebr"
+"test_split": "heb_Hebr"

--- a/lm_eval/tasks/belebele/belebele_hin_Deva.yaml
+++ b/lm_eval/tasks/belebele/belebele_hin_Deva.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "hin_Deva"
+"fewshot_split": "hin_Deva"
 "include": "_default_template_yaml"
 "task": "belebele_hin_Deva"
+"test_split": "hin_Deva"

--- a/lm_eval/tasks/belebele/belebele_hin_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_hin_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "hin_Latn"
+"fewshot_split": "hin_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_hin_Latn"
+"test_split": "hin_Latn"

--- a/lm_eval/tasks/belebele/belebele_hrv_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_hrv_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "hrv_Latn"
+"fewshot_split": "hrv_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_hrv_Latn"
+"test_split": "hrv_Latn"

--- a/lm_eval/tasks/belebele/belebele_hun_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_hun_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "hun_Latn"
+"fewshot_split": "hun_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_hun_Latn"
+"test_split": "hun_Latn"

--- a/lm_eval/tasks/belebele/belebele_hye_Armn.yaml
+++ b/lm_eval/tasks/belebele/belebele_hye_Armn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "hye_Armn"
+"fewshot_split": "hye_Armn"
 "include": "_default_template_yaml"
 "task": "belebele_hye_Armn"
+"test_split": "hye_Armn"

--- a/lm_eval/tasks/belebele/belebele_ibo_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ibo_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ibo_Latn"
+"fewshot_split": "ibo_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ibo_Latn"
+"test_split": "ibo_Latn"

--- a/lm_eval/tasks/belebele/belebele_ilo_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ilo_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ilo_Latn"
+"fewshot_split": "ilo_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ilo_Latn"
+"test_split": "ilo_Latn"

--- a/lm_eval/tasks/belebele/belebele_ind_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ind_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ind_Latn"
+"fewshot_split": "ind_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ind_Latn"
+"test_split": "ind_Latn"

--- a/lm_eval/tasks/belebele/belebele_isl_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_isl_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "isl_Latn"
+"fewshot_split": "isl_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_isl_Latn"
+"test_split": "isl_Latn"

--- a/lm_eval/tasks/belebele/belebele_ita_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ita_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ita_Latn"
+"fewshot_split": "ita_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ita_Latn"
+"test_split": "ita_Latn"

--- a/lm_eval/tasks/belebele/belebele_jav_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_jav_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "jav_Latn"
+"fewshot_split": "jav_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_jav_Latn"
+"test_split": "jav_Latn"

--- a/lm_eval/tasks/belebele/belebele_jpn_Jpan.yaml
+++ b/lm_eval/tasks/belebele/belebele_jpn_Jpan.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "jpn_Jpan"
+"fewshot_split": "jpn_Jpan"
 "include": "_default_template_yaml"
 "task": "belebele_jpn_Jpan"
+"test_split": "jpn_Jpan"

--- a/lm_eval/tasks/belebele/belebele_kac_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_kac_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kac_Latn"
+"fewshot_split": "kac_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_kac_Latn"
+"test_split": "kac_Latn"

--- a/lm_eval/tasks/belebele/belebele_kan_Knda.yaml
+++ b/lm_eval/tasks/belebele/belebele_kan_Knda.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kan_Knda"
+"fewshot_split": "kan_Knda"
 "include": "_default_template_yaml"
 "task": "belebele_kan_Knda"
+"test_split": "kan_Knda"

--- a/lm_eval/tasks/belebele/belebele_kat_Geor.yaml
+++ b/lm_eval/tasks/belebele/belebele_kat_Geor.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kat_Geor"
+"fewshot_split": "kat_Geor"
 "include": "_default_template_yaml"
 "task": "belebele_kat_Geor"
+"test_split": "kat_Geor"

--- a/lm_eval/tasks/belebele/belebele_kaz_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_kaz_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kaz_Cyrl"
+"fewshot_split": "kaz_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_kaz_Cyrl"
+"test_split": "kaz_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_kea_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_kea_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kea_Latn"
+"fewshot_split": "kea_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_kea_Latn"
+"test_split": "kea_Latn"

--- a/lm_eval/tasks/belebele/belebele_khk_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_khk_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "khk_Cyrl"
+"fewshot_split": "khk_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_khk_Cyrl"
+"test_split": "khk_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_khm_Khmr.yaml
+++ b/lm_eval/tasks/belebele/belebele_khm_Khmr.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "khm_Khmr"
+"fewshot_split": "khm_Khmr"
 "include": "_default_template_yaml"
 "task": "belebele_khm_Khmr"
+"test_split": "khm_Khmr"

--- a/lm_eval/tasks/belebele/belebele_kin_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_kin_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kin_Latn"
+"fewshot_split": "kin_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_kin_Latn"
+"test_split": "kin_Latn"

--- a/lm_eval/tasks/belebele/belebele_kir_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_kir_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kir_Cyrl"
+"fewshot_split": "kir_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_kir_Cyrl"
+"test_split": "kir_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_kor_Hang.yaml
+++ b/lm_eval/tasks/belebele/belebele_kor_Hang.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "kor_Hang"
+"fewshot_split": "kor_Hang"
 "include": "_default_template_yaml"
 "task": "belebele_kor_Hang"
+"test_split": "kor_Hang"

--- a/lm_eval/tasks/belebele/belebele_lao_Laoo.yaml
+++ b/lm_eval/tasks/belebele/belebele_lao_Laoo.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "lao_Laoo"
+"fewshot_split": "lao_Laoo"
 "include": "_default_template_yaml"
 "task": "belebele_lao_Laoo"
+"test_split": "lao_Laoo"

--- a/lm_eval/tasks/belebele/belebele_lin_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_lin_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "lin_Latn"
+"fewshot_split": "lin_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_lin_Latn"
+"test_split": "lin_Latn"

--- a/lm_eval/tasks/belebele/belebele_lit_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_lit_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "lit_Latn"
+"fewshot_split": "lit_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_lit_Latn"
+"test_split": "lit_Latn"

--- a/lm_eval/tasks/belebele/belebele_lug_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_lug_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "lug_Latn"
+"fewshot_split": "lug_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_lug_Latn"
+"test_split": "lug_Latn"

--- a/lm_eval/tasks/belebele/belebele_luo_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_luo_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "luo_Latn"
+"fewshot_split": "luo_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_luo_Latn"
+"test_split": "luo_Latn"

--- a/lm_eval/tasks/belebele/belebele_lvs_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_lvs_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "lvs_Latn"
+"fewshot_split": "lvs_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_lvs_Latn"
+"test_split": "lvs_Latn"

--- a/lm_eval/tasks/belebele/belebele_mal_Mlym.yaml
+++ b/lm_eval/tasks/belebele/belebele_mal_Mlym.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "mal_Mlym"
+"fewshot_split": "mal_Mlym"
 "include": "_default_template_yaml"
 "task": "belebele_mal_Mlym"
+"test_split": "mal_Mlym"

--- a/lm_eval/tasks/belebele/belebele_mar_Deva.yaml
+++ b/lm_eval/tasks/belebele/belebele_mar_Deva.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "mar_Deva"
+"fewshot_split": "mar_Deva"
 "include": "_default_template_yaml"
 "task": "belebele_mar_Deva"
+"test_split": "mar_Deva"

--- a/lm_eval/tasks/belebele/belebele_mkd_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_mkd_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "mkd_Cyrl"
+"fewshot_split": "mkd_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_mkd_Cyrl"
+"test_split": "mkd_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_mlt_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_mlt_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "mlt_Latn"
+"fewshot_split": "mlt_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_mlt_Latn"
+"test_split": "mlt_Latn"

--- a/lm_eval/tasks/belebele/belebele_mri_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_mri_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "mri_Latn"
+"fewshot_split": "mri_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_mri_Latn"
+"test_split": "mri_Latn"

--- a/lm_eval/tasks/belebele/belebele_mya_Mymr.yaml
+++ b/lm_eval/tasks/belebele/belebele_mya_Mymr.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "mya_Mymr"
+"fewshot_split": "mya_Mymr"
 "include": "_default_template_yaml"
 "task": "belebele_mya_Mymr"
+"test_split": "mya_Mymr"

--- a/lm_eval/tasks/belebele/belebele_nld_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_nld_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "nld_Latn"
+"fewshot_split": "nld_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_nld_Latn"
+"test_split": "nld_Latn"

--- a/lm_eval/tasks/belebele/belebele_nob_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_nob_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "nob_Latn"
+"fewshot_split": "nob_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_nob_Latn"
+"test_split": "nob_Latn"

--- a/lm_eval/tasks/belebele/belebele_npi_Deva.yaml
+++ b/lm_eval/tasks/belebele/belebele_npi_Deva.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "npi_Deva"
+"fewshot_split": "npi_Deva"
 "include": "_default_template_yaml"
 "task": "belebele_npi_Deva"
+"test_split": "npi_Deva"

--- a/lm_eval/tasks/belebele/belebele_npi_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_npi_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "npi_Latn"
+"fewshot_split": "npi_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_npi_Latn"
+"test_split": "npi_Latn"

--- a/lm_eval/tasks/belebele/belebele_nso_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_nso_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "nso_Latn"
+"fewshot_split": "nso_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_nso_Latn"
+"test_split": "nso_Latn"

--- a/lm_eval/tasks/belebele/belebele_nya_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_nya_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "nya_Latn"
+"fewshot_split": "nya_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_nya_Latn"
+"test_split": "nya_Latn"

--- a/lm_eval/tasks/belebele/belebele_ory_Orya.yaml
+++ b/lm_eval/tasks/belebele/belebele_ory_Orya.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ory_Orya"
+"fewshot_split": "ory_Orya"
 "include": "_default_template_yaml"
 "task": "belebele_ory_Orya"
+"test_split": "ory_Orya"

--- a/lm_eval/tasks/belebele/belebele_pan_Guru.yaml
+++ b/lm_eval/tasks/belebele/belebele_pan_Guru.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "pan_Guru"
+"fewshot_split": "pan_Guru"
 "include": "_default_template_yaml"
 "task": "belebele_pan_Guru"
+"test_split": "pan_Guru"

--- a/lm_eval/tasks/belebele/belebele_pbt_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_pbt_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "pbt_Arab"
+"fewshot_split": "pbt_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_pbt_Arab"
+"test_split": "pbt_Arab"

--- a/lm_eval/tasks/belebele/belebele_pes_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_pes_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "pes_Arab"
+"fewshot_split": "pes_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_pes_Arab"
+"test_split": "pes_Arab"

--- a/lm_eval/tasks/belebele/belebele_plt_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_plt_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "plt_Latn"
+"fewshot_split": "plt_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_plt_Latn"
+"test_split": "plt_Latn"

--- a/lm_eval/tasks/belebele/belebele_pol_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_pol_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "pol_Latn"
+"fewshot_split": "pol_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_pol_Latn"
+"test_split": "pol_Latn"

--- a/lm_eval/tasks/belebele/belebele_por_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_por_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "por_Latn"
+"fewshot_split": "por_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_por_Latn"
+"test_split": "por_Latn"

--- a/lm_eval/tasks/belebele/belebele_ron_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ron_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ron_Latn"
+"fewshot_split": "ron_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ron_Latn"
+"test_split": "ron_Latn"

--- a/lm_eval/tasks/belebele/belebele_rus_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_rus_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "rus_Cyrl"
+"fewshot_split": "rus_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_rus_Cyrl"
+"test_split": "rus_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_shn_Mymr.yaml
+++ b/lm_eval/tasks/belebele/belebele_shn_Mymr.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "shn_Mymr"
+"fewshot_split": "shn_Mymr"
 "include": "_default_template_yaml"
 "task": "belebele_shn_Mymr"
+"test_split": "shn_Mymr"

--- a/lm_eval/tasks/belebele/belebele_sin_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_sin_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "sin_Latn"
+"fewshot_split": "sin_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_sin_Latn"
+"test_split": "sin_Latn"

--- a/lm_eval/tasks/belebele/belebele_sin_Sinh.yaml
+++ b/lm_eval/tasks/belebele/belebele_sin_Sinh.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "sin_Sinh"
+"fewshot_split": "sin_Sinh"
 "include": "_default_template_yaml"
 "task": "belebele_sin_Sinh"
+"test_split": "sin_Sinh"

--- a/lm_eval/tasks/belebele/belebele_slk_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_slk_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "slk_Latn"
+"fewshot_split": "slk_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_slk_Latn"
+"test_split": "slk_Latn"

--- a/lm_eval/tasks/belebele/belebele_slv_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_slv_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "slv_Latn"
+"fewshot_split": "slv_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_slv_Latn"
+"test_split": "slv_Latn"

--- a/lm_eval/tasks/belebele/belebele_sna_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_sna_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "sna_Latn"
+"fewshot_split": "sna_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_sna_Latn"
+"test_split": "sna_Latn"

--- a/lm_eval/tasks/belebele/belebele_snd_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_snd_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "snd_Arab"
+"fewshot_split": "snd_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_snd_Arab"
+"test_split": "snd_Arab"

--- a/lm_eval/tasks/belebele/belebele_som_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_som_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "som_Latn"
+"fewshot_split": "som_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_som_Latn"
+"test_split": "som_Latn"

--- a/lm_eval/tasks/belebele/belebele_sot_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_sot_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "sot_Latn"
+"fewshot_split": "sot_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_sot_Latn"
+"test_split": "sot_Latn"

--- a/lm_eval/tasks/belebele/belebele_spa_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_spa_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "spa_Latn"
+"fewshot_split": "spa_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_spa_Latn"
+"test_split": "spa_Latn"

--- a/lm_eval/tasks/belebele/belebele_srp_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_srp_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "srp_Cyrl"
+"fewshot_split": "srp_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_srp_Cyrl"
+"test_split": "srp_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_ssw_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_ssw_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ssw_Latn"
+"fewshot_split": "ssw_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_ssw_Latn"
+"test_split": "ssw_Latn"

--- a/lm_eval/tasks/belebele/belebele_sun_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_sun_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "sun_Latn"
+"fewshot_split": "sun_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_sun_Latn"
+"test_split": "sun_Latn"

--- a/lm_eval/tasks/belebele/belebele_swe_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_swe_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "swe_Latn"
+"fewshot_split": "swe_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_swe_Latn"
+"test_split": "swe_Latn"

--- a/lm_eval/tasks/belebele/belebele_swh_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_swh_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "swh_Latn"
+"fewshot_split": "swh_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_swh_Latn"
+"test_split": "swh_Latn"

--- a/lm_eval/tasks/belebele/belebele_tam_Taml.yaml
+++ b/lm_eval/tasks/belebele/belebele_tam_Taml.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tam_Taml"
+"fewshot_split": "tam_Taml"
 "include": "_default_template_yaml"
 "task": "belebele_tam_Taml"
+"test_split": "tam_Taml"

--- a/lm_eval/tasks/belebele/belebele_tel_Telu.yaml
+++ b/lm_eval/tasks/belebele/belebele_tel_Telu.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tel_Telu"
+"fewshot_split": "tel_Telu"
 "include": "_default_template_yaml"
 "task": "belebele_tel_Telu"
+"test_split": "tel_Telu"

--- a/lm_eval/tasks/belebele/belebele_tgk_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_tgk_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tgk_Cyrl"
+"fewshot_split": "tgk_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_tgk_Cyrl"
+"test_split": "tgk_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_tgl_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_tgl_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tgl_Latn"
+"fewshot_split": "tgl_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_tgl_Latn"
+"test_split": "tgl_Latn"

--- a/lm_eval/tasks/belebele/belebele_tha_Thai.yaml
+++ b/lm_eval/tasks/belebele/belebele_tha_Thai.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tha_Thai"
+"fewshot_split": "tha_Thai"
 "include": "_default_template_yaml"
 "task": "belebele_tha_Thai"
+"test_split": "tha_Thai"

--- a/lm_eval/tasks/belebele/belebele_tir_Ethi.yaml
+++ b/lm_eval/tasks/belebele/belebele_tir_Ethi.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tir_Ethi"
+"fewshot_split": "tir_Ethi"
 "include": "_default_template_yaml"
 "task": "belebele_tir_Ethi"
+"test_split": "tir_Ethi"

--- a/lm_eval/tasks/belebele/belebele_tsn_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_tsn_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tsn_Latn"
+"fewshot_split": "tsn_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_tsn_Latn"
+"test_split": "tsn_Latn"

--- a/lm_eval/tasks/belebele/belebele_tso_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_tso_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tso_Latn"
+"fewshot_split": "tso_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_tso_Latn"
+"test_split": "tso_Latn"

--- a/lm_eval/tasks/belebele/belebele_tur_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_tur_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "tur_Latn"
+"fewshot_split": "tur_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_tur_Latn"
+"test_split": "tur_Latn"

--- a/lm_eval/tasks/belebele/belebele_ukr_Cyrl.yaml
+++ b/lm_eval/tasks/belebele/belebele_ukr_Cyrl.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "ukr_Cyrl"
+"fewshot_split": "ukr_Cyrl"
 "include": "_default_template_yaml"
 "task": "belebele_ukr_Cyrl"
+"test_split": "ukr_Cyrl"

--- a/lm_eval/tasks/belebele/belebele_urd_Arab.yaml
+++ b/lm_eval/tasks/belebele/belebele_urd_Arab.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "urd_Arab"
+"fewshot_split": "urd_Arab"
 "include": "_default_template_yaml"
 "task": "belebele_urd_Arab"
+"test_split": "urd_Arab"

--- a/lm_eval/tasks/belebele/belebele_urd_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_urd_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "urd_Latn"
+"fewshot_split": "urd_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_urd_Latn"
+"test_split": "urd_Latn"

--- a/lm_eval/tasks/belebele/belebele_uzn_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_uzn_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "uzn_Latn"
+"fewshot_split": "uzn_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_uzn_Latn"
+"test_split": "uzn_Latn"

--- a/lm_eval/tasks/belebele/belebele_vie_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_vie_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "vie_Latn"
+"fewshot_split": "vie_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_vie_Latn"
+"test_split": "vie_Latn"

--- a/lm_eval/tasks/belebele/belebele_war_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_war_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "war_Latn"
+"fewshot_split": "war_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_war_Latn"
+"test_split": "war_Latn"

--- a/lm_eval/tasks/belebele/belebele_wol_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_wol_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "wol_Latn"
+"fewshot_split": "wol_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_wol_Latn"
+"test_split": "wol_Latn"

--- a/lm_eval/tasks/belebele/belebele_xho_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_xho_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "xho_Latn"
+"fewshot_split": "xho_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_xho_Latn"
+"test_split": "xho_Latn"

--- a/lm_eval/tasks/belebele/belebele_yor_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_yor_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "yor_Latn"
+"fewshot_split": "yor_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_yor_Latn"
+"test_split": "yor_Latn"

--- a/lm_eval/tasks/belebele/belebele_zho_Hans.yaml
+++ b/lm_eval/tasks/belebele/belebele_zho_Hans.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "zho_Hans"
+"fewshot_split": "zho_Hans"
 "include": "_default_template_yaml"
 "task": "belebele_zho_Hans"
+"test_split": "zho_Hans"

--- a/lm_eval/tasks/belebele/belebele_zho_Hant.yaml
+++ b/lm_eval/tasks/belebele/belebele_zho_Hant.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "zho_Hant"
+"fewshot_split": "zho_Hant"
 "include": "_default_template_yaml"
 "task": "belebele_zho_Hant"
+"test_split": "zho_Hant"

--- a/lm_eval/tasks/belebele/belebele_zsm_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_zsm_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "zsm_Latn"
+"fewshot_split": "zsm_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_zsm_Latn"
+"test_split": "zsm_Latn"

--- a/lm_eval/tasks/belebele/belebele_zul_Latn.yaml
+++ b/lm_eval/tasks/belebele/belebele_zul_Latn.yaml
@@ -1,3 +1,4 @@
-"dataset_name": "zul_Latn"
+"fewshot_split": "zul_Latn"
 "include": "_default_template_yaml"
 "task": "belebele_zul_Latn"
+"test_split": "zul_Latn"


### PR DESCRIPTION
Fixes two issues with the current implementation of the `belebele` task:

1. In the HF repository for the belebele dataset (`facebook/belebele`), the different languages are implemented as splits rather than dataset subsets. This PR deals with this by labelling each language-specific subset as a `test_split` in each `.yaml` file rather than a `dataset_name` (which looks for a data subset/`config`). In order to align with the original `_default_template_yaml` file, the language-specific subsets are also used as the `fewshot_split` for each language.
2. `lm_eval.logger.eval_logger` no longer appears to exist in the `main` branch. This is replaced by `lm_eval.utils.logging` in `generate_configs.py`.