### PR TITLE
Fix data-parallel evaluation with quantized models

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -205,7 +205,7 @@ class HFLM(LM):
 
         if isinstance(pretrained, str) and (gpus >= 1 or str(self.device) == "mps"):
             # TODO: can remove this whole snippet except in the mps case, perhaps?
-            if not (parallelize or autogptq or hasattr(self, "accelerator")): 
+            if not (parallelize or autogptq or hasattr(self, "accelerator")):
                 # place model onto device requested manually,
                 # if not using HF Accelerate or device_map
                 # or any other option that preloads model onto device

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -469,12 +469,12 @@ class HFLM(LM):
             # this is needed because it seems that the default behavior
             # for quantized models now seems to be device_map="auto"
             # which breaks data-parallel mode.
-            if getattr(self, "accelerator"):
+            if hasattr(self, "accelerator"):
                 model_kwargs.update(
                     {"device_map": {"": f"cuda:{self.accelerator.local_process_index}"}}
                 )
             else:
-                model_kwargs.update({"device_map", {"": self.device}})
+                model_kwargs.update({"device_map": {"": str(self.device)}})
 
         if not autogptq:
             if model_kwargs.get("load_in_4bit", None):

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -204,15 +204,16 @@ class HFLM(LM):
         self.model.tie_weights()
 
         if isinstance(pretrained, str) and (gpus >= 1 or str(self.device) == "mps"):
-            if not (parallelize or autogptq or ("device_map" in kwargs)):
+            # TODO: can remove this whole snippet except in the mps case, perhaps?
+            if not (parallelize or autogptq or hasattr(self, "accelerator")): 
                 # place model onto device requested manually,
                 # if not using HF Accelerate or device_map
                 # or any other option that preloads model onto device
                 try:
                     self.model.to(self.device)
                 except ValueError:
-                    eval_logger.info(
-                        "Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes` or `device_map` is provided`. If the desired GPU is being used, this message is safe to ignore."
+                    eval_logger.debug(
+                        "Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes` or `device_map` is provided. If the desired GPU is being used, this message is safe to ignore."
                     )
 
         self._create_tokenizer(


### PR DESCRIPTION
This is a PR aiming to fix data-parallel (`accelerate launch`) inference using a `device_map` override to ensure models are only placed on their single correct device.


As best as I can tell, at some point the default behavior of AutoGPTQ models changed such that it would default to `device_map='auto'`, splitting the model across all available devices. I could be wrong about this, as it's a bit hard to find documentation on this, but it seems to match up with what has been reported in issues.

This PR ensures that models receive a device_map which assigns them to the (correct) user device, overriding this default, so that data-parallel with `accelerate launch` can be used.


cc @kirayomato @JeevanBhoot @DavidePaglieri


closes #1250 #1220 #1247 