### PR TITLE
Apply `process_docs()` to fewshot_split

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -759,6 +759,8 @@ class ConfigurableTask(Task):
 
     def fewshot_docs(self):
         if self.config.fewshot_split is not None:
+            if self.config.process_docs is not None:
+                return self.config.process_docs(self.dataset[self.config.fewshot_split])
             return self.dataset[self.config.fewshot_split]
         else:
             if (self.config.num_fewshot is not None) and (self.config.num_fewshot > 0):


### PR DESCRIPTION
closes #1179 

Previously, `process_docs` function, when supplied via a task config, did not get applied to the fewshot split. This PR applies it, re-unifying the handling of the fewshot split with the train/test splits.