### PR TITLE
Update `nq_open` / NaturalQs whitespacing

### DIFF
--- a/lm_eval/tasks/nq_open/nq_open.yaml
+++ b/lm_eval/tasks/nq_open/nq_open.yaml
@@ -3,7 +3,7 @@ dataset_path: nq_open
 output_type: generate_until
 training_split: train
 validation_split: validation
-description: "Answer these questions:\n"
+description: "Answer these questions:\n\n"
 doc_to_text: "Q: {{question}}?\nA:"
 doc_to_target: "{{answer}}" # TODO: should be multi-target
 fewshot_delimiter: "\n"
@@ -29,4 +29,4 @@ metric_list:
     regexes_to_ignore:
     - "\ban|a|the\b"
 metadata:
-  version: 1.0
+  version: 2.0


### PR DESCRIPTION
closes #1288 . 

Due to a missing second newline in the prepended task description, results were significantly affected!

Thank you to @Hannibal046 for catching this!