### PR TITLE
Update nq_open.yaml

### DIFF
--- a/lm_eval/tasks/nq_open/nq_open.yaml
+++ b/lm_eval/tasks/nq_open/nq_open.yaml
@@ -29,4 +29,4 @@ metric_list:
     regexes_to_ignore:
     - "\\b(?:The |the |An |A |The |a |an )"
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/nq_open/nq_open.yaml
+++ b/lm_eval/tasks/nq_open/nq_open.yaml
@@ -27,6 +27,6 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
     regexes_to_ignore:
-    - "\ban|a|the\b"
+    - "\\b(?:The |the |An |A |The |a |an )"
 metadata:
   version: 2.0


### PR DESCRIPTION
change regex

see this issue: https://github.com/EleutherAI/lm-evaluation-harness/issues/1303

only change relevant part to `nq_open`. Other dataset using `exact_match` is unchanged for now.