### PR TITLE
Pin `datasets` dependency at 2.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { "text" = "MIT" }
 dependencies = [
     "accelerate>=0.21.0",
     "evaluate",
-    "datasets>=2.0.0",
+    "datasets>=2.0.0,<2.16",
     "evaluate>=0.4.0",
     "jsonlines",
     "numexpr",


### PR DESCRIPTION
It seems as though many users are receiving errors when upgrading to `datasets` versions 2.16 and above, and also because datasets on the HF hub are being replaced with Parquets in the background. 

We should fix this alongside accomodating #1135 , but in the meantime pinning datasets version in the hopes it will minimize pain for users for now.


#1217 #1311 #1307 