### PR TITLE
Fix polemo2_in.yaml subset name

### DIFF
--- a/lm_eval/tasks/polemo2/polemo2_in.yaml
+++ b/lm_eval/tasks/polemo2/polemo2_in.yaml
@@ -2,7 +2,7 @@ group:
   - polemo2
 task: polemo2_in
 dataset_path: allegro/klej-polemo2-in
-dataset_name: klej-polemo2-in
+dataset_name: null
 output_type: generate_until
 training_split: train
 validation_split: validation


### PR DESCRIPTION
The dataset at https://huggingface.co/datasets/allegro/klej-polemo2-in doesn't have any subset named "klej-polemo2-in"

fix https://github.com/EleutherAI/lm-evaluation-harness/issues/1307