### PR TITLE
Fix `datasets` dependency to >=2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { "text" = "MIT" }
 dependencies = [
     "accelerate>=0.21.0",
     "evaluate",
-    "datasets>=2.0.0,<2.16",
+    "datasets>=2.14.0",
     "evaluate>=0.4.0",
     "jsonlines",
     "numexpr",


### PR DESCRIPTION
I spoke with @lhoestq and he was quickly able to point out that actually, the issues being observed are due to `datasets` being too *low* of a version. 

Therefore this PR instead bumps to datasets version 2.14+ 

should close #1311 and probably some others. 