### PR TITLE
Fix unintuitive `--gen_kwargs` behavior

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -138,9 +138,12 @@ def simple_evaluate(
                 )
             else:
                 default_num_fewshot = config["num_fewshot"]
-                eval_logger.warning(
-                    f"Overwriting default num_fewshot of {task_name} from {default_num_fewshot} to {num_fewshot}"
-                )
+                if default_num_fewshot:
+                    # warn a user, if a specific num_fewshot > 0 was specified.
+                    # if unspecified in config, no warning message
+                    eval_logger.warning(
+                        f"Overwriting default num_fewshot of {task_name} from {default_num_fewshot} to {num_fewshot}"
+                    )
 
                 task_obj._config["num_fewshot"] = num_fewshot
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -705,6 +705,9 @@ class HFLM(LM):
                 return self.model(inps).logits
 
     def _model_generate(self, context, max_length, stop, **generation_kwargs):
+        do_sample = kwargs.pop("do_sample", None)
+        if do_sample is False and "temperature" not in kwargs:
+            kwargs["temperature"] = 0.0
         # build stopping criteria
         stopping_criteria = stop_sequences_criteria(
             self.tokenizer, stop, context.shape[1], context.shape[0]

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -705,9 +705,12 @@ class HFLM(LM):
                 return self.model(inps).logits
 
     def _model_generate(self, context, max_length, stop, **generation_kwargs):
-        do_sample = kwargs.pop("do_sample", None)
-        if do_sample is False and "temperature" not in kwargs:
-            kwargs["temperature"] = 0.0
+        # if do_sample is false and temp==0.0: 
+        # remove temperature, as do_sample=False takes care of this
+        # and we don't want a warning from HF
+        do_sample = kwargs.get("do_sample", None)
+        if do_sample is False and "temperature" == 0.0:
+            kwargs.pop("temperature", 0.0)
         # build stopping criteria
         stopping_criteria = stop_sequences_criteria(
             self.tokenizer, stop, context.shape[1], context.shape[0]

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -705,7 +705,7 @@ class HFLM(LM):
                 return self.model(inps).logits
 
     def _model_generate(self, context, max_length, stop, **generation_kwargs):
-        # if do_sample is false and temp==0.0: 
+        # if do_sample is false and temp==0.0:
         # remove temperature, as do_sample=False takes care of this
         # and we don't want a warning from HF
         do_sample = generation_kwargs.get("do_sample", None)

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -708,9 +708,9 @@ class HFLM(LM):
         # if do_sample is false and temp==0.0: 
         # remove temperature, as do_sample=False takes care of this
         # and we don't want a warning from HF
-        do_sample = kwargs.get("do_sample", None)
+        do_sample = generation_kwargs.get("do_sample", None)
         if do_sample is False and "temperature" == 0.0:
-            kwargs.pop("temperature", 0.0)
+            generation_kwargs.pop("temperature", 0.0)
         # build stopping criteria
         stopping_criteria = stop_sequences_criteria(
             self.tokenizer, stop, context.shape[1], context.shape[0]

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -705,10 +705,6 @@ class HFLM(LM):
                 return self.model(inps).logits
 
     def _model_generate(self, context, max_length, stop, **generation_kwargs):
-        # we require users to pass do_sample=True explicitly
-        # for non-greedy gen. This should be reevaluated when considering beam search.
-        if "do_sample" not in generation_kwargs:
-            generation_kwargs["do_sample"] = False
         # build stopping criteria
         stopping_criteria = stop_sequences_criteria(
             self.tokenizer, stop, context.shape[1], context.shape[0]

--- a/lm_eval/tasks/gsm8k/gsm8k.yaml
+++ b/lm_eval/tasks/gsm8k/gsm8k.yaml
@@ -24,6 +24,7 @@ generation_kwargs:
     - "\n\n"
     - "Question:"
   do_sample: false
+  temperature: 0.0
 repeats: 1
 num_fewshot: 5
 filter_list:


### PR DESCRIPTION
This PR removes an override we had that would set `do_sample=False` if no value for it were set. 

Users using `--model hf` with `--gen_kwargs` in the CLI will still have to pass `--gen_kwargs do_sample=True` alongside their other sampling parameters for tasks where greedy generation is expected, still, but this should lead to less weird unintuitive behavior where the gen kwargs seem not respected.

Addresses #1274 but won't close that issue yet.