### PR TITLE
Update migrated HF dataset paths

### DIFF
--- a/lm_eval/tasks/arc/arc_easy.yaml
+++ b/lm_eval/tasks/arc/arc_easy.yaml
@@ -1,7 +1,7 @@
 group:
   - ai2_arc
 task: arc_easy
-dataset_path: ai2_arc
+dataset_path: allenai/ai2_arc
 dataset_name: ARC-Easy
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/benchmarks/flan/flan_cot.yaml
+++ b/lm_eval/tasks/benchmarks/flan/flan_cot.yaml
@@ -1,7 +1,7 @@
 group: flan_cot
 task:
   - include: yaml_templates/cot_template_yaml
-    dataset_path: gsmk
+    dataset_path: gsm8k
     dataset_name: boolq
     use_prompt: promptsource:*
     validation_split: validation

--- a/lm_eval/tasks/benchmarks/flan/flan_cot.yaml
+++ b/lm_eval/tasks/benchmarks/flan/flan_cot.yaml
@@ -2,7 +2,6 @@ group: flan_cot
 task:
   - include: yaml_templates/cot_template_yaml
     dataset_path: gsm8k
-    dataset_name: boolq
     use_prompt: promptsource:*
     validation_split: validation
   - include: yaml_templates/cot_template_yaml

--- a/lm_eval/tasks/qasper/bool.yaml
+++ b/lm_eval/tasks/qasper/bool.yaml
@@ -1,6 +1,6 @@
 group: qasper
 task: qasper_bool
-dataset_path: qasper
+dataset_path: allenai/qasper
 output_type: multiple_choice
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/qasper/freeform.yaml
+++ b/lm_eval/tasks/qasper/freeform.yaml
@@ -1,6 +1,6 @@
 group: qasper
 task: qasper_freeform
-dataset_path: qasper
+dataset_path: allenai/qasper
 output_type: generate_until
 training_split: train
 validation_split: validation


### PR DESCRIPTION
Some datasets have been migrated to AllenAI's HF org, probably as part of HF's effort to phase out "canonical models" (ones with no HF org attached).

This PR updates the dataset paths to point to their new locations. Went through and did not find any others that were affected.