### PR TITLE
manage default (greedy) gen_kwargs in vllm

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -438,8 +438,7 @@ class VLLM(LM):
         # sampling_params
         do_sample = kwargs.pop("do_sample", False)
         if do_sample is not True:
-            kwargs["temperature"] = 0
-            kwargs["top_k"] = -1
+            kwargs["temperature"] = 0.0
         # hf defaults
         kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)
         kwargs["spaces_between_special_tokens"] = kwargs.get(

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -436,14 +436,13 @@ class VLLM(LM):
     @staticmethod
     def modify_gen_kwargs(kwargs: dict) -> dict:
         # sampling_params
-        if "do_sample" in kwargs:
-            do_sample = kwargs.pop("do_sample")
-            if do_sample is False:
-                kwargs["temperature"] = 0
-                kwargs["top_k"] = -1
-            # hf defaults
-            kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)
-            kwargs["spaces_between_special_tokens"] = kwargs.get(
-                "spaces_between_special_tokens", False
-            )
+        do_sample = kwargs.pop("do_sample", False)
+        if do_sample is not True:
+            kwargs["temperature"] = 0
+            kwargs["top_k"] = -1
+        # hf defaults
+        kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)
+        kwargs["spaces_between_special_tokens"] = kwargs.get(
+            "spaces_between_special_tokens", False
+        )
         return kwargs

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -170,14 +170,8 @@ class VLLM(LM):
         stop: Optional[List[str]] = None,
         **kwargs,
     ):
-        if "do_sample" in kwargs.keys():
-            kwargs.pop("do_sample")
         if generate:
-            # hf defaults
-            kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)
-            kwargs["spaces_between_special_tokens"] = kwargs.get(
-                "spaces_between_special_tokens", False
-            )
+            kwargs = self.modify_gen_kwargs(kwargs)
             sampling_params = SamplingParams(max_tokens=max_tokens, stop=stop, **kwargs)
         else:
             sampling_params = SamplingParams(
@@ -438,3 +432,18 @@ class VLLM(LM):
                     break
 
         return continuation_logprobs, is_greedy
+
+    @staticmethod
+    def modify_gen_kwargs(kwargs: dict) -> dict:
+        # sampling_params
+        if "do_sample" in kwargs:
+            do_sample = kwargs.pop("do_sample")
+            if do_sample is False:
+                kwargs["temperature"] = 0
+                kwargs["top_k"] = -1
+            # hf defaults
+            kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)
+            kwargs["spaces_between_special_tokens"] = kwargs.get(
+                "spaces_between_special_tokens", False
+            )
+        return kwargs


### PR DESCRIPTION
Relates to #1274. This PR addresses the default sampling parameters of `vllm` if no specific values are provided in the yaml. It now does greedy sampling unless `do_sample` is given and set to `True` (following the HF implementation).