### PR TITLE
vllm: change default gen_kwargs behaviour; prompt_logprobs=1

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -175,7 +175,7 @@ class VLLM(LM):
             sampling_params = SamplingParams(max_tokens=max_tokens, stop=stop, **kwargs)
         else:
             sampling_params = SamplingParams(
-                temperature=0, prompt_logprobs=2, max_tokens=1
+                temperature=0, prompt_logprobs=1, max_tokens=1
             )
         if self.data_parallel_size > 1:
             requests = [list(x) for x in divide(requests, self.data_parallel_size)]
@@ -436,8 +436,8 @@ class VLLM(LM):
     @staticmethod
     def modify_gen_kwargs(kwargs: dict) -> dict:
         # sampling_params
-        do_sample = kwargs.pop("do_sample", False)
-        if do_sample is not True:
+        do_sample = kwargs.pop("do_sample", None)
+        if do_sample is False or "temperature" not in kwargs:
             kwargs["temperature"] = 0.0
         # hf defaults
         kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)


### PR DESCRIPTION
Minor adjustment to #1341 to mirror #1329.

Also changed prompt_logprobs=1 as the input token log_probs are always provided (and this provides another if that has the highest logprob)