### PR TITLE
Update bbh, gsm8k, mmlu parsing logic and prompts (Orca2 bbh_cot_zeroshot 0% -> 42%)

### DIFF
--- a/lm_eval/filters/__init__.py
+++ b/lm_eval/filters/__init__.py
@@ -6,6 +6,7 @@ from . import transformation
 
 FILTER_REGISTRY = {
     "take_first": selection.TakeFirstFilter,
+    "take_last": selection.TakeLastFilter,
     "regex": extraction.RegexFilter,
     "majority_vote": selection.MajorityVoteFilter,
     "take_first_k": selection.TakeKFilter,

--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -7,7 +7,7 @@ class RegexFilter(Filter):
     """ """
 
     def __init__(
-        self, regex_pattern: str = r"#### (\-?[0-9\.\,]+)", fallback: str = "[invalid]"
+        self, regex_pattern: str = r"#### (\-?[0-9\.\,]+)", group_select=0, fallback: str = "[invalid]"
     ) -> None:
         """
         pass a string `regex` to run `re.compile(r"regex")` on.
@@ -15,6 +15,7 @@ class RegexFilter(Filter):
         """
         self.regex_pattern = regex_pattern
         self.regex = re.compile(regex_pattern)
+        self.group_select = group_select
         self.fallback = fallback
 
     def apply(self, resps, docs):
@@ -25,9 +26,12 @@ class RegexFilter(Filter):
         def filter_set(inst):
             filtered = []
             for resp in inst:
-                match = self.regex.search(resp)
+                match = self.regex.findall(resp)
                 if match:
-                    match = match.group(1).strip()
+                    match = match[self.group_select]
+                    if isinstance(match, tuple):
+                        match = [m for m in match if m][0]
+                    match = match.strip()
                 else:
                     match = self.fallback
                 filtered.append(match)

--- a/lm_eval/filters/selection.py
+++ b/lm_eval/filters/selection.py
@@ -15,6 +15,18 @@ class TakeFirstFilter(Filter):
         """
         return map(lambda r: r[0], resps)
 
+class TakeLastFilter(Filter):
+    def __init__(self) -> None:
+        """
+        Can define custom behavior here, if an individual instantiation of a Filter class should have state.
+        """
+
+    def apply(self, resps, docs):
+        """
+        Assuming each entry of `resps` is a list of model responses, we discard all but the first response.
+        """
+        return map(lambda r: r[-1], resps)
+
 
 class TakeKFilter(Filter):
     def __init__(self, *args, **kwargs) -> None:

--- a/lm_eval/tasks/bbh/cot_zeroshot/_cot_zeroshot_template_yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/_cot_zeroshot_template_yaml
@@ -7,21 +7,20 @@ metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
-    # ignore_case: true
+    ignore_case: true
     # ignore_punctuation: true
+    regexes_to_ignore:
+      - "\\.$"
+      - ","
+      - "\\\\"
+      - "\n"
+      - '"'
 generation_kwargs:
   until:
     - "</s>"
-    - "Q"
-    - "\n\n"
+    - "Q:"
   do_sample: false
   temperature: 0.0
-filter_list:
-  - name: "get-answer"
-    filter:
-      - function: "regex"
-        regex_pattern: "((?<=The answer is )(.*)(?=.)|(?<=the answer is )(.*)(?=.)|(?<=The answer: )(.*)(?=.)|(?<=The final answer: )(.*)(?=.))"
-      - function: "take_first"
 num_fewshot: 0
 metadata:
   version: 1.0

--- a/lm_eval/tasks/bbh/cot_zeroshot/boolean_expressions.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/boolean_expressions.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "boolean_expressions"
 "description": "Evaluate the result of a random Boolean expression.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_boolean_expressions"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(True|False)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/causal_judgement.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/causal_judgement.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "causal_judgement"
 "description": "Answer questions about causal attribution.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_causal_judgement"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/date_understanding.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "date_understanding"
 "description": "Infer the date from context.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_date_understanding"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/disambiguation_qa.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "disambiguation_qa"
 "description": "Clarify the meaning of sentences with ambiguous pronouns.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_disambiguation_qa"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/dyck_languages.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/dyck_languages.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "dyck_languages"
-"description": "Correctly close a Dyck-n word.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"description": "Correctly close a Dyck-n word. The answer should be the remaining part, without the input.\n\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_dyck_languages"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(?<= )([\" \\[\\(<{}>\\)\\]]+)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/formal_fallacies.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/formal_fallacies.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "formal_fallacies"
 "description": "Distinguish deductively valid arguments from formal fallacies.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_formal_fallacies"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(valid|invalid)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/geometric_shapes.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "geometric_shapes"
 "description": "Name geometric shapes from their SVG paths.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_geometric_shapes"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/hyperbaton.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "hyperbaton"
 "description": "Order adjectives correctly in English sentences.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_hyperbaton"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_five_objects.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "logical_deduction_five_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_logical_deduction_five_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_seven_objects.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "logical_deduction_seven_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_logical_deduction_seven_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_three_objects.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "logical_deduction_three_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_logical_deduction_three_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/movie_recommendation.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "movie_recommendation"
 "description": "Recommend movies similar to the given list of movies.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_movie_recommendation"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/multistep_arithmetic_two.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/multistep_arithmetic_two.yaml
@@ -1,5 +1,14 @@
 "dataset_name": "multistep_arithmetic_two"
-"description": "Solve multi-step arithmetic problems.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"description": "Solve multi-step arithmetic problems. Answer should be in digits.\n\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_multistep_arithmetic_two"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "([-0-9]+)"
+      - function: "take_last"
+

--- a/lm_eval/tasks/bbh/cot_zeroshot/navigate.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/navigate.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "navigate"
 "description": "Given a series of navigation instructions, determine whether one would end up back at the starting point.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_navigate"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/object_counting.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/object_counting.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "object_counting"
-"description": "Questions that involve enumerating objects and asking the model to count them.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"description": "Questions that involve enumerating objects and asking the model to count them. Answer should be in digits.\n\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_object_counting"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "([-0-9]+)"
+      - function: "take_last"
+

--- a/lm_eval/tasks/bbh/cot_zeroshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/penguins_in_a_table.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "penguins_in_a_table"
 "description": "Answer questions about a table of penguins and their attributes.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_penguins_in_a_table"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/reasoning_about_colored_objects.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "reasoning_about_colored_objects"
 "description": "Answer extremely simple questions about the colors of objects on a surface.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_reasoning_about_colored_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/ruin_names.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "ruin_names"
 "description": "Select the humorous edit that 'ruins' the input movie or musical artist name.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_ruin_names"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/salient_translation_error_detection.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "salient_translation_error_detection"
 "description": "Detect the type of error in an English translation of a German source sentence.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_salient_translation_error_detection"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/snarks.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "snarks"
 "description": "Determine which of two sentences is sarcastic.\n\nAccording to Cambridge University Dictionary, sarcasm is \"the use of remarks that clearly mean the opposite of what they say, made in order to hurt someone's feelings or to criticize something in a humorous way.\" Sarcastic sentences often contain satirical or ironic utterances, hyperboles, ambivalent or witty remarks.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_snarks"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/sports_understanding.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/sports_understanding.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "sports_understanding"
-"description": "Determine whether an artificially constructed sentence relating to sports is plausible or not.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"description": "Determine whether an artificially constructed sentence relating to sports is plausible or not. Answer in yes or no.\n\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_sports_understanding"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/temporal_sequences.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "temporal_sequences"
 "description": "Task description: Answer questions about which times certain events could have occurred.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_temporal_sequences"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_five_objects.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "tracking_shuffled_objects_five_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_tracking_shuffled_objects_five_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_seven_objects.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "tracking_shuffled_objects_seven_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_tracking_shuffled_objects_seven_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_three_objects.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "tracking_shuffled_objects_three_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_tracking_shuffled_objects_three_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/web_of_lies.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/web_of_lies.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "web_of_lies"
-"description": "Evaluate a random boolean function expressed as a word problem.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"description": "Evaluate a random boolean function expressed as a word problem. Answer in Yes or No.\n\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_web_of_lies"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/cot_zeroshot/word_sorting.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/word_sorting.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "word_sorting"
-"description": "Sort a list of words.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step.\n"
+"description": "Sort a list of words. You should end your response with the sorted list of word, seperated by comma.\n\n"
+"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_word_sorting"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: ":[\n` ]*([^\n]+)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/_zeroshot_template_yaml
+++ b/lm_eval/tasks/bbh/zeroshot/_zeroshot_template_yaml
@@ -7,13 +7,18 @@ metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
-    # ignore_case: true
+    ignore_case: true
     # ignore_punctuation: true
+    regexes_to_ignore:
+      - "\\.$"
+      - ","
+      - "\n"
+      - "\\\\"
+      - '"'
 generation_kwargs:
   until:
     - "</s>"
     - "Q:"
-    - "\n\n"
   do_sample: false
   temperature: 0.0
 num_fewshot: 0

--- a/lm_eval/tasks/bbh/zeroshot/boolean_expressions.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/boolean_expressions.yaml
@@ -3,3 +3,11 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_boolean_expressions"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(True|False)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/causal_judgement.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/causal_judgement.yaml
@@ -3,3 +3,11 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_causal_judgement"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/date_understanding.yaml
@@ -3,3 +3,11 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_date_understanding"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/disambiguation_qa.yaml
@@ -3,3 +3,11 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_disambiguation_qa"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/dyck_languages.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/dyck_languages.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "dyck_languages"
-"description": "Correctly close a Dyck-n word.\n\n"
+"description": "Correctly close a Dyck-n word. The answer should be the remaining part, without the input.\n\n"
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_dyck_languages"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(?<= )([\" \\[\\(<{}>\\)\\]]+)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/formal_fallacies.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/formal_fallacies.yaml
@@ -3,3 +3,11 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_formal_fallacies"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(valid|invalid)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/geometric_shapes.yaml
@@ -3,3 +3,11 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_geometric_shapes"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/hyperbaton.yaml
@@ -3,3 +3,11 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_hyperbaton"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_five_objects.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_logical_deduction_five_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_seven_objects.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_logical_deduction_seven_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_three_objects.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_logical_deduction_three_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/movie_recommendation.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_movie_recommendation"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/multistep_arithmetic_two.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/multistep_arithmetic_two.yaml
@@ -1,5 +1,14 @@
 "dataset_name": "multistep_arithmetic_two"
-"description": "Solve multi-step arithmetic problems.\n\n"
+"description": "Solve multi-step arithmetic problems. Answer should be in digits.\n\n"
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_multistep_arithmetic_two"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "([-0-9]+)"
+      - function: "take_last"
+

--- a/lm_eval/tasks/bbh/zeroshot/navigate.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/navigate.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_navigate"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/object_counting.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/object_counting.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "object_counting"
-"description": "Questions that involve enumerating objects and asking the model to count them.\n\n"
+"description": "Questions that involve enumerating objects and asking the model to count them. Answer should be in digits.\n\n"
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_object_counting"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "([-0-9]+)"
+      - function: "take_last"
+

--- a/lm_eval/tasks/bbh/zeroshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/penguins_in_a_table.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_penguins_in_a_table"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/reasoning_about_colored_objects.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_reasoning_about_colored_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/ruin_names.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_ruin_names"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/salient_translation_error_detection.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_salient_translation_error_detection"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/snarks.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_snarks"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/sports_understanding.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/sports_understanding.yaml
@@ -1,5 +1,13 @@
 "dataset_name": "sports_understanding"
-"description": "Determine whether an artificially constructed sentence relating to sports is plausible or not.\n\n"
+"description": "Determine whether an artificially constructed sentence relating to sports is plausible or not. Answer in yes or no.\n\n"
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_sports_understanding"
+
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/temporal_sequences.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_temporal_sequences"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_five_objects.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_tracking_shuffled_objects_five_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_seven_objects.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_tracking_shuffled_objects_seven_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_three_objects.yaml
@@ -3,3 +3,10 @@
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_tracking_shuffled_objects_three_objects"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/web_of_lies.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/web_of_lies.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "web_of_lies"
-"description": "Evaluate a random boolean function expressed as a word problem.\n\n"
+"description": "Evaluate a random boolean function expressed as a word problem. Answer in Yes or No.\n\n"
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_web_of_lies"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(Yes|No|yes|no)"
+      - function: "take_last"

--- a/lm_eval/tasks/bbh/zeroshot/word_sorting.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/word_sorting.yaml
@@ -1,5 +1,12 @@
 "dataset_name": "word_sorting"
-"description": "Sort a list of words.\n\n"
+"description": "Sort a list of words. You should end your response with the sorted list of word, seperated by comma.\n\n"
 "doc_to_text": "Q: {{input}}\nA:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_word_sorting"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: ":[\n` ]*([^\n]+)"
+      - function: "take_last"

--- a/lm_eval/tasks/gsm8k/gsm8k-cot.yaml
+++ b/lm_eval/tasks/gsm8k/gsm8k-cot.yaml
@@ -23,13 +23,14 @@ metric_list:
     ignore_punctuation: false
     regexes_to_ignore:
       - ","
+      - "\\.$"
       - "\\$"
       - "(?s).*#### "
       - "\n\n"
 generation_kwargs:
   until:
     - "Q:"
-    - "\n\n"
+    - "</s>"
   do_sample: false
 repeats: 1
 num_fewshot: 0
@@ -37,7 +38,7 @@ filter_list:
   - name: "get-answer"
     filter:
       - function: "regex"
-        regex_pattern: "The answer is (\\-?[0-9\\.\\,]+)."
+        regex_pattern: "The answer is (\\-?[$0-9\\.\\,]+)."
       - function: "take_first"
 metadata:
   version: 2.0

--- a/lm_eval/tasks/gsm8k/gsm8k.yaml
+++ b/lm_eval/tasks/gsm8k/gsm8k.yaml
@@ -19,10 +19,11 @@ metric_list:
       - ","
       - "\\$"
       - "(?s).*#### "
+      - "\\.$"
 generation_kwargs:
   until:
-    - "\n\n"
     - "Question:"
+    - "</s>"
   do_sample: false
 repeats: 1
 num_fewshot: 5
@@ -30,7 +31,8 @@ filter_list:
   - name: "get-answer"
     filter:
       - function: "regex"
-        regex_pattern: "#### (\\-?[0-9\\.\\,]+)"
-      - function: "take_first"
+        group_select: -1
+        regex_pattern: "(-?[$0-9.,]{2,})|(-?[$0-9,]+)"
+      - function: "take_last"
 metadata:
   version: 2.0

--- a/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
@@ -8,11 +8,12 @@ filter_list:
   - name: "get-answer"
     filter:
       - function: "regex"
-        regex_pattern: "(?<=The answer is )(.*)(?=.)"
+        regex_pattern: "(?<=answer is )(\\([A-Z]\\))(?=.)|(?<=answer: )(\\([A-Z]\\))(?=.)"
       - function: "take_first"
 generation_kwargs:
   until:
     - "</s>"
+    - "Q:"
   do_sample: false
   temperature: 0.0
 num_fewshot: 0

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
@@ -8,11 +8,16 @@ filter_list:
   - name: "get-answer"
     filter:
       - function: "regex"
-        regex_pattern: "((?<=The answer is )(.*)(?=.)|(?<=the answer is )(.*)(?=.)|(?<=The answer: )(.*)(?=.)|(?<=The final answer: )(.*)(?=.))"
-      - function: "take_first"
+        group_select: -1
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_last"
 generation_kwargs:
+  max_gen_toks: 2048
   until:
     - "</s>"
+    - "<|im_end|>"
+    - "[PAD]"
+    - "Q:"
   do_sample: false
   temperature: 0.0
 num_fewshot: 0
@@ -22,5 +27,9 @@ metric_list:
     higher_is_better: true
     ignore_case: true
     ignore_punctuation: true
+    regexes_to_ignore:
+      - "<\\|im_end\\|>"
+      - "<\\/s>"
+      - "\\[PAD\\]"
 metadata:
   version: 0.0

--- a/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
@@ -5,9 +5,16 @@ fewshot_split: dev
 output_type: generate_until
 doc_to_text: "Q: {{question.strip()}}\n(A) {{choices[0]}} (B) {{choices[1]}} (C) {{choices[2]}} (D) {{choices[3]}}\nA: "
 doc_to_target: "{{['(A)', '(B)', '(C)', '(D)'][answer]}}"
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        regex_pattern: "(\\([A-Z]\\))"
+      - function: "take_first"
 generation_kwargs:
   until:
     - "</s>"
+    - "Q:"
 metric_list:
   - metric: exact_match
     aggregation: mean


### PR DESCRIPTION
Hi, I find zero-shot performance of generative tasks with given prompts and parsing logic yields poor performance. 

For example, Orca2-7B yields **0%** on mmlu or bbh_cot_zeroshot (Llama2-7B, Mistral-7B also performed poor).

I tried to inspect the outputs and changed the parsing logic, and here is the updated performance (I added gsm8k_cot_zeroshot.yml):

|          | bbh_cot_zeroshot | gsm8k_cot_zeroshot | mmlu_flan_cot_zeroshot | bbh_zeroshot | gsm8k    | mmlu_flan_n_shot_generative |
| -------- | ---------------- | ------------------ | ---------------------- | ------------ | -------- | --------------------------- |
| original | 0.000461         | 0                  | 0                      | 0.086315     | 0.009856 | 0                           |
| changed  | 0.416219         | 0.428355           | 0.535598               | 0.376133     | 0.073541 | 0.485259                    |


To evaluate, ran the commands somewhat similar to the following (with bf16)

```bash
accelerate launch -m lm_eval --model hf --tasks bbh_cot_zeroshot --batch_size 1 --num_fewshot=0 --model_args pretrained=Orca-2-7b,attn_implementation=sdpa,dtype=bfloat16 --gen_kwargs temperature=0.2,do_sample=True,max_gen_toks=1024
```

I agree that the performance does not yet match those from paper, but this PR definitely improves the evaluation. Feel free to comment or change this commit. I believe we need to enhance the parsing logic and the prompts to evaluate zero-shot generative tasks with this repo.