### PR TITLE
Refix issue regarding stderr

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -511,7 +511,7 @@ def evaluate(
                                     + metric_score * current_size
                                 ) / (total_size + current_size)
                                 # $$s_z^2 = \frac{(n-1) s_x^2 + (m-1) s_y^2}{n+m-1} + \frac{nm(\bar x - \bar y)^2}{(n+m)(n+m-1)}.$$
-                                if var_score == "N/A":
+                                if var_score == "N/A" or results[group][stderr] == "N/A":
                                     results[group][stderr] = "N/A"
                                 else:
                                     results[group][stderr] = (


### PR DESCRIPTION
https://github.com/EleutherAI/lm-evaluation-harness/blob/52f48e8ca835c5d9a57295a856b8dc4450427eb0/lm_eval/evaluator.py#L514-L518

stderr calculation gets error here when `results[group][stderr]` is already "N/A" (line 518). This PR quick-fixes that.