### PR TITLE
Create a means for caching task registration and request building. Ad…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ temp
 # IPython
 profile_default/
 ipython_config.py
+
+Old/lm_eval
+lm_eval/caching/.cache

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -133,6 +133,28 @@ class LM(abc.ABC):
         args2 = {k: v for k, v in additional_config.items() if v is not None}
         return cls(**args, **args2)
 
+    @classmethod
+    def create_from_arg_obj(
+        cls: Type[T], arg_dict: dict, additional_config: Optional[dict] = None
+    ) -> T:
+        """
+        Creates an instance of the LM class using the given arg_obj
+
+        Parameters:
+        - arg_obj: A dict containing arguments in the format key1=value1,key2=value2.
+        - additional_config: Optional dictionary containing additional configuration parameters.
+
+        Returns:
+        - Instance of the LM class.
+        """
+
+        additional_config = {} if additional_config is None else additional_config
+        additional_config = {
+            k: v for k, v in additional_config.items() if v is not None
+        }
+
+        return cls(**arg_dict, **additional_config)
+
     @property
     def rank(self):
         # used in the case of parallelism. Hardcoded to

--- a/lm_eval/caching/cache.py
+++ b/lm_eval/caching/cache.py
@@ -1,0 +1,34 @@
+import os
+import dill
+
+
+MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
+
+OVERRIDE_PATH = os.getenv("LM_HARNESSS_CACHE_PATH")
+
+
+PATH = OVERRIDE_PATH if OVERRIDE_PATH else f"{MODULE_DIR}/.cache"
+
+
+def load_from_cache(file_name):
+    try:
+        path = f"{PATH}/{file_name}.pickle"
+
+        with open(path, "rb") as file:
+            cached_task_dict = dill.loads(file.read())
+            return cached_task_dict
+
+    except Exception as exception:
+        print(f"{file_name} is not cached, generating...")
+        pass
+
+
+def save_to_cache(file_name, obj):
+    if not os.path.exists(PATH):
+        os.mkdir(PATH)
+
+    file_path = f"{PATH}/{file_name}.pickle"
+
+    print(f"Saving {file_path} to cache...")
+    with open(file_path, "wb") as file:
+        file.write(dill.dumps(obj))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "tqdm-multiprocess",
     "transformers>=4.1",
     "zstandard",
+    "dill"
 ]
 
 [tool.setuptools.packages.find]

--- a/test_script.py
+++ b/test_script.py
@@ -1,0 +1,94 @@
+import os
+
+MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
+
+# Used to specify alternate cache path, useful if run in a docker container
+# NOTE raw datasets will break if you try to transfer the cache from your host to an image
+LM_HARNESSS_CACHE_PATH = os.getenv("LM_HARNESSS_CACHE_PATH")
+
+import torch
+from transformers import (
+    pipeline as trans_pipeline,
+)
+import torch
+
+from lm_eval import simple_evaluate, tasks as tasks_class
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+model = "gpt2"
+
+local_models_path = os.getenv("MODELS_PATH")
+
+task = "text-generation"
+
+print("\n\n\n")
+
+print("Model is: ", model)
+
+print("This task is: ", task)
+
+
+def run_model(model: str, device: str):
+    trans_pipe = trans_pipeline(
+        task=task, model=model, device=device, trust_remote_code=True
+    )
+
+    model = trans_pipe.model
+    tokenizer = trans_pipe.tokenizer
+
+    tasks = [
+        # "squadv2",
+        # "swag",
+        "hellaswag",
+        "lambada_openai",
+        # "glue",
+        # "super-glue-lm-eval-v1",
+        # "wikitext",
+        # "winogrande"
+    ]
+
+    print("Initializing tasks...")
+
+    tasks_class.initialize_tasks(use_cache=True, rewrite_cache=False)
+
+    print("Tasks initialized")
+
+    eval_data = simple_evaluate(
+        model="hf-auto",
+        # model_args=",".join(
+        #     [
+        #         f"pretrained={model}",
+        #         f"revision={revision}" if revision else "",
+        #         # "batch_size=16",
+        #         # "num_beams=5",
+        #         # "parallelize=True",
+        #     ]
+        # ),
+        model_arg_dict={
+            "pretrained": model,
+            "tokenizer": tokenizer,
+        },
+        limit=0.01,
+        device=device,
+        use_builder_cache=True,
+        rewrite_builder_cache=False,
+        tasks=tasks,
+        write_out=True,
+    )
+
+    return eval_data
+
+
+if __name__ == "__main__":
+    eval_data = run_model(model=model, device=device)
+
+    results: dict = eval_data["results"]
+
+    for dataset, metrics_dict in results.items():
+        for key, value in metrics_dict.items():
+            if key == "acc,none":
+                print(f"Dataset: {dataset}, Accuracy: {value}")
+
+
+pass


### PR DESCRIPTION
Hey all, here's the caching proposal for task registration and request building.

Caching is optional, and has rewrite capabilities for task building and for task registration.

It works by using pickles, and by default all pickles are stored in lm_harness/caching/.cache. You can specify an alternate path via the env var `LM_HARNESSS_CACHE_PATH`. Which is really useful for docker containers.

I also added some tqdm's to track the progress of these steps.

In addition to this, I extended simple_evaluate to allow for you to take in a model_arg_dict, and added a class method to the Model class to allow for this. Passing a bunch of strings was a frustrating DX.

I also added some type annotations, and fixed a bug with the limit, where it doesn't return results if you set your float really low. At least one item in a dataset is run now if you set limit super low.

This is a draft, so if something's off please LMK, but would love to merge this puppy! (Hence the test script, I'll clean up the commit.)

Best,
Aaron