### PR TITLE
Add support for RWKV models with World tokenizer

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -239,7 +239,10 @@ class HFLM(LM):
             if self.config.model_type == "qwen":
                 # Qwen's trust_remote_code tokenizer does not allow for adding special tokens
                 self.tokenizer.pad_token = "<|endoftext|>"
-            elif self.tokenizer.__class__.__name__ == "RWKVWorldTokenizer" or self.tokenizer.__class__.__name__ == "Rwkv5Tokenizer":
+            elif (
++                self.tokenizer.__class__.__name__ == "RWKVWorldTokenizer"
++                or self.tokenizer.__class__.__name__ == "Rwkv5Tokenizer"
++            ):
                 # The RWKV world tokenizer, does not allow for adding special tokens / setting the pad token (which is set as 0)
                 # The additional tokenizer name check is needed, as there exists rwkv4 models with neox tokenizer
                 # ---

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -239,6 +239,13 @@ class HFLM(LM):
             if self.config.model_type == "qwen":
                 # Qwen's trust_remote_code tokenizer does not allow for adding special tokens
                 self.tokenizer.pad_token = "<|endoftext|>"
+            elif (self.config.model_type == "rwkv4" or self.config.model_type == "rwkv5") and self.tokenizer.__class__.__name__ == "RWKVWorldTokenizer":
+                # The RWKV world tokenizer, does not allow for adding special tokens / setting the pad token (which is set as 0)
+                # The additional tokenizer name check is needed, as there exists rwkv4 models with neox tokenizer
+                # ---
+                # Note that the world tokenizer class name, might change in the future for the final huggingface merge
+                # https://github.com/huggingface/transformers/pull/26963
+                assert self.tokenizer.pad_token_id == 0
             else:
                 self.tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -239,7 +239,7 @@ class HFLM(LM):
             if self.config.model_type == "qwen":
                 # Qwen's trust_remote_code tokenizer does not allow for adding special tokens
                 self.tokenizer.pad_token = "<|endoftext|>"
-            elif (self.config.model_type == "rwkv4" or self.config.model_type == "rwkv5") and self.tokenizer.__class__.__name__ == "RWKVWorldTokenizer":
+            elif self.tokenizer.__class__.__name__ == "RWKVWorldTokenizer" or self.tokenizer.__class__.__name__ == "Rwkv5Tokenizer":
                 # The RWKV world tokenizer, does not allow for adding special tokens / setting the pad token (which is set as 0)
                 # The additional tokenizer name check is needed, as there exists rwkv4 models with neox tokenizer
                 # ---

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -240,9 +240,9 @@ class HFLM(LM):
                 # Qwen's trust_remote_code tokenizer does not allow for adding special tokens
                 self.tokenizer.pad_token = "<|endoftext|>"
             elif (
-+                self.tokenizer.__class__.__name__ == "RWKVWorldTokenizer"
-+                or self.tokenizer.__class__.__name__ == "Rwkv5Tokenizer"
-+            ):
+                self.tokenizer.__class__.__name__ == "RWKVWorldTokenizer"
+                or self.tokenizer.__class__.__name__ == "Rwkv5Tokenizer"
+            ):
                 # The RWKV world tokenizer, does not allow for adding special tokens / setting the pad token (which is set as 0)
                 # The additional tokenizer name check is needed, as there exists rwkv4 models with neox tokenizer
                 # ---


### PR DESCRIPTION
The RWKV line of model with the World tokenizer, does not allow the padding token to be configured, and has its value preset as 0

This however fails all the "if set" checks, and would cause the tokenizer to crash.

A tokenizer class name check was added, in addition to a model type check, as there exists RWKV models which uses the neox tokenizers

You can run this presently, using our model implementation, with HF remote code execution
```
accelerate launch -m lm_eval --model hf --model_args pretrained=RWKV/rwkv-5-world-7b,trust_remote_code=True --tasks hellaswag --batch_size 64 --log_samples --output_path ./results/Eagle-7B-1T
```

After the merger of https://github.com/huggingface/transformers/pull/26963
The trust_remote_code may no longer be needed!