### PR TITLE
Use Pooled rather than Combined Variance for calculating stderr of task groupings

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -10,7 +10,7 @@ from typing import Union
 import numpy as np
 
 from lm_eval import evaluator, utils
-from lm_eval.tasks import TaskManager, include_path, initialize_tasks
+from lm_eval.tasks import TaskManager, include_path
 from lm_eval.utils import make_table
 
 
@@ -167,7 +167,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if (args.log_samples or args.predict_only) and not args.output_path:
         assert args.output_path, "Specify --output_path"
 
-    initialize_tasks(args.verbosity)
     task_manager = TaskManager(args.verbosity, include_path=args.include_path)
 
     if args.limit:

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -10,7 +10,7 @@ from typing import Union
 import numpy as np
 
 from lm_eval import evaluator, utils
-from lm_eval.tasks import TaskManager, include_path
+from lm_eval.tasks import TaskManager, include_path, initialize_tasks
 from lm_eval.utils import make_table
 
 
@@ -167,6 +167,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if (args.log_samples or args.predict_only) and not args.output_path:
         assert args.output_path, "Specify --output_path"
 
+    initialize_tasks(args.verbosity)
     task_manager = TaskManager(args.verbosity, include_path=args.include_path)
 
     if args.limit:

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -2,6 +2,7 @@ import logging
 import math
 import random
 from collections.abc import Iterable
+from typing import List
 
 import evaluate
 import numpy as np
@@ -425,3 +426,64 @@ def stderr_for_metric(metric, bootstrap_iters):
     stderr = {mean: mean_stderr, acc_all: acc_all_stderr}
 
     return stderr.get(metric, None)
+
+
+def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
+    # Used to aggregate bootstrapped stderrs across subtasks in a group,
+    # when we are weighting by the size of each subtask.
+    #
+
+    assert len(stderrs) == len(sizes)
+
+    # formula source: https://en.wikipedia.org/wiki/Pooled_variance
+    # this empirically matches running `stderr_for_metric` on all instances
+    # from the subtasks concatenated with each other.
+    pooled_sample_var = (
+        sum([(size - 1) * stderr**2 for size, stderr in zip(sizes, stderrs)])
+    ) / (sum(sizes) - len(sizes))
+
+    return np.sqrt(pooled_sample_var)
+
+
+def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None):
+    assert (
+        metrics is not None
+    ), "Need to pass a list of each subtask's metric for this stderr aggregation"
+    assert len(stderrs) == len(sizes) and len(sizes) == len(metrics)
+
+    # See https://github.com/EleutherAI/lm-evaluation-harness/pull/1390 for more documentation.
+    # This formula depends on sample means.
+    # removed because it seems to give erroneously huge stderrs for groupings of tasks
+    # and does not seem to match up with bootstrap-calculated stderrs for groups.
+
+    ### don't use this unless a statistician has told you it's the right thing to do ###
+
+    # accumulators: we'll aggregate pairwise N times
+    variance = stderrs[0] ** 2
+    curr_size = sizes[0]
+    curr_score = metrics[0]
+
+    for stderr, size, score in zip(stderrs[1:], sizes[1:], metrics[1:]):
+        curr_score = ((curr_score * curr_size) + (score * size)) / (
+            curr_size + size
+        )  # NOTE: this assumes our aggregation fn is "mean"
+
+        variance = ((curr_size - 1) * variance + (size - 1) * (stderr**2)) / (
+            curr_size + size - 1
+        ) + curr_size * size / ((curr_size + size) * (curr_size + size - 1)) * (
+            curr_score - score
+        ) ** 2
+
+    return np.sqrt(variance)
+
+
+def aggregate_subtask_metrics(metrics, sizes, weight_by_size=True):
+    # A helper function that is used to aggregate
+    # subtask scores cross-task.
+    # TODO: does not hold for non-mean aggregations
+    if weight_by_size:
+        sizes = [1] * len(sizes)
+
+    assert len(metrics) == len(sizes)
+
+    return sum([metric * size for metric, size in zip(metrics, sizes)]) / sum(sizes)

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -458,7 +458,7 @@ def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None)
 
     ### don't use this unless a statistician has told you it's the right thing to do ###
 
-    # accumulators: we'll aggregate pairwise N times
+    # accumulators: we'll aggregate pairwise N - 1 times
     variance = stderrs[0] ** 2
     curr_size = sizes[0]
     curr_score = metrics[0]

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -540,6 +540,7 @@ def evaluate(
                     else:
                         results[group][stderr] = lm_eval.api.metrics.pooled_sample_stderr(stderrs, sizes)
                         # TODO: allow GroupConfigs to choose which variance formula is used, for back-compatibility
+                        # To use the old (likely incorrect) variance formula, comment out the above and uncomment this line: 
                         # results[group][stderr] = lm_eval.api.metrics.combined_sample_stderr(stderrs, sizes, metrics=metrics)
 
                     results[group]["samples"] = sum(sizes)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -536,24 +536,14 @@ def evaluate(
                     metrics = [results[task][metric] for task in task_list] # TODO: copy?
                     stderrs = [results[task][stderr] for task in task_list]
                     sizes = [results[task]["samples"] for task in task_list]
+
                     # compute group's pooled metric and stderr
                     results[group][metric] = aggregate_metrics(metrics, sizes)
                     # TODO: calculate grouped metric using aggregation fn
                     if "N/A" in stderrs:
                         results[group][stderr] = "N/A"
                     else:
-                        print(metrics)
-                        stderr_fn = lm_eval.api.metrics.stderr_for_metric(
-                            metric=task_dict[task_list[0]][1].aggregation()[metric.split(",")[0]],
-                            bootstrap_iters=min(bootstrap_iters, 100)
-                            if metric in ["bleu", "chrf", "ter"]
-                            else bootstrap_iters,
-                        )
-
-                        items = [vals[(task, metric.split(",")[1], metric.split(",")[0])] for task in task_list]
-                        print(items, len(items))
-                        results[group][stderr] = stderr_fn(list(itertools.chain.from_iterable(items)))
-                        #results[group][stderr] = pooled_sample_err(stderrs, sizes)
+                        results[group][stderr] = pooled_sample_err(stderrs, sizes)
 
                     results[group]["samples"] = sum(sizes)
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -540,7 +540,7 @@ def evaluate(
                     else:
                         results[group][stderr] = lm_eval.api.metrics.pooled_sample_stderr(stderrs, sizes)
                         # TODO: allow GroupConfigs to choose which variance formula is used, for back-compatibility
-                        # To use the old (likely incorrect) variance formula, comment out the above and uncomment this line: 
+                        # To use the old (likely incorrect) variance formula, comment out the above and uncomment this line:
                         # results[group][stderr] = lm_eval.api.metrics.combined_sample_stderr(stderrs, sizes, metrics=metrics)
 
                     results[group]["samples"] = sum(sizes)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -282,7 +282,6 @@ def evaluate(
 
     # get lists of each type of request
     for task_name, task in task_dict.items():
-        print(task_name, task, task_dict)
         if isinstance(task, tuple):
             group_name, task = task
             task_hierarchy[group_name].append(task_name)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -536,14 +536,24 @@ def evaluate(
                     metrics = [results[task][metric] for task in task_list] # TODO: copy?
                     stderrs = [results[task][stderr] for task in task_list]
                     sizes = [results[task]["samples"] for task in task_list]
-
                     # compute group's pooled metric and stderr
                     results[group][metric] = aggregate_metrics(metrics, sizes)
                     # TODO: calculate grouped metric using aggregation fn
                     if "N/A" in stderrs:
                         results[group][stderr] = "N/A"
                     else:
-                        results[group][stderr] = pooled_sample_err(stderrs, sizes)
+                        print(metrics)
+                        stderr_fn = lm_eval.api.metrics.stderr_for_metric(
+                            metric=task_dict[task_list[0]][1].aggregation()[metric.split(",")[0]],
+                            bootstrap_iters=min(bootstrap_iters, 100)
+                            if metric in ["bleu", "chrf", "ter"]
+                            else bootstrap_iters,
+                        )
+
+                        items = [vals[(task, metric.split(",")[1], metric.split(",")[0])] for task in task_list]
+                        print(items, len(items))
+                        results[group][stderr] = stderr_fn(list(itertools.chain.from_iterable(items)))
+                        #results[group][stderr] = pooled_sample_err(stderrs, sizes)
 
                     results[group]["samples"] = sum(sizes)
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -514,66 +514,38 @@ def evaluate(
                 else:
                     results[task_name][metric + "_stderr" + "," + key] = "N/A"
 
+        def pooled_sample_err(stderrs, sizes):
+            # https://en.wikipedia.org/wiki/Pooled_variance
+            # TODO: should we instead apply the same bootstrapping to groups, for those which weight by size?
+            pooled_sample_var = (sum([(size - 1) * stderr ** 2 for size, stderr in zip(sizes, stderrs)])) / (sum(sizes) - len(sizes))
+
+            return np.sqrt(pooled_sample_var)
+
+        def aggregate_metrics(metrics, sizes):
+            # TODO: does not hold for non-agg metrics
+            return sum([metric * size for metric, size in zip(metrics, sizes)]) / sum(sizes)
+
         if bool(results):
             for group, task_list in reversed(task_hierarchy.items()):
-                if task_list == []:
-                    # TODO: No samples when bypass
-                    total_size = results[group].get("samples", 999)
-                else:
-                    total_size = 0
+                for metric in [
+                    key for key in results[task_list[0]].keys() if "_stderr" not in key and key not in ["alias", "samples"]
+                ]: # TODO: what if tasks don't all share the same metrics
+                    stderr = "_stderr,".join(metric.split(","))
 
-                    for task in task_list:
-                        metrics = results[task].copy()
+                    # gather metrics, sizes, and stderrs from subtasks
+                    metrics = [results[task][metric] for task in task_list] # TODO: copy?
+                    stderrs = [results[task][stderr] for task in task_list]
+                    sizes = [results[task]["samples"] for task in task_list]
 
-                        if "alias" in metrics:
-                            metrics.pop("alias")
+                    # compute group's pooled metric and stderr
+                    results[group][metric] = aggregate_metrics(metrics, sizes)
+                    # TODO: calculate grouped metric using aggregation fn
+                    if "N/A" in stderrs:
+                        results[group][stderr] = "N/A"
+                    else:
+                        results[group][stderr] = pooled_sample_err(stderrs, sizes)
 
-                        current_size = metrics.pop("samples")
-
-                        all_stderr = []
-                        for metric in [
-                            key for key in metrics.keys() if "_stderr" not in key
-                        ]:
-                            stderr = "_stderr,".join(metric.split(","))
-                            stderr_score = results[task][stderr]
-                            if stderr_score == "N/A":
-                                var_score = "N/A"
-                            else:
-                                var_score = stderr_score**2
-                                all_stderr.append(stderr)
-
-                            metric_score = results[task][metric]
-
-                            if metric in results[group]:
-                                results[group][metric] = (
-                                    results[group][metric] * total_size
-                                    + metric_score * current_size
-                                ) / (total_size + current_size)
-                                # $$s_z^2 = \frac{(n-1) s_x^2 + (m-1) s_y^2}{n+m-1} + \frac{nm(\bar x - \bar y)^2}{(n+m)(n+m-1)}.$$
-                                if var_score == "N/A" or results[group][stderr] == "N/A":
-                                    results[group][stderr] = "N/A"
-                                else:
-                                    results[group][stderr] = (
-                                        (total_size - 1) * results[group][stderr]
-                                        + (current_size - 1) * var_score
-                                    ) / (
-                                        total_size + current_size - 1
-                                    ) + total_size * current_size / (
-                                        (total_size + current_size)
-                                        * (total_size + current_size - 1)
-                                    ) * (
-                                        results[group][metric] - metric_score
-                                    ) ** 2
-                            else:
-                                results[group][metric] = metric_score
-                                results[group][stderr] = var_score
-
-                        total_size += current_size
-
-                    for stderr in all_stderr:
-                        results[group][stderr] = np.sqrt(results[group][stderr])
-
-                results[group]["samples"] = total_size
+                    results[group]["samples"] = sum(sizes)
 
         def print_tasks(task_hierarchy, results, tab=0):
             results_agg = collections.defaultdict(dict)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -282,6 +282,7 @@ def evaluate(
 
     # get lists of each type of request
     for task_name, task in task_dict.items():
+        print(task_name, task, task_dict)
         if isinstance(task, tuple):
             group_name, task = task
             task_hierarchy[group_name].append(task_name)
@@ -515,7 +516,13 @@ def evaluate(
                     results[task_name][metric + "_stderr" + "," + key] = "N/A"
 
         if bool(results):
-            for group, task_list in reversed(task_hierarchy.items()):
+            for group, task_list in task_hierarchy.items():
+                if len(task_list) == 0:
+                    # task_hierarchy entries are either
+                    # `group_name: [subtask1, subtask2, ...]`
+                    # or `task_name: []`.
+                    # we only want to operate on groups here.
+                    continue
                 for metric in [
                     key for key in results[task_list[0]].keys() if "_stderr" not in key and key not in ["alias", "samples"]
                 ]: # TODO: what if tasks don't all share the same metrics


### PR DESCRIPTION
This PR updates the formula we use for aggregating stderrs / sample std. deviations across groups of tasks. 

In this PR: 

formula:
![image](https://github.com/EleutherAI/lm-evaluation-harness/assets/65563625/1c6131f5-2bea-4fc4-be83-878fcb4a344e)

result:
```
hf (pretrained=mistralai/Mistral-7B-v0.1), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 8
|                 Tasks                 |Version|Filter|n-shot|Metric|Value |   |Stderr|
|---------------------------------------|-------|------|-----:|------|-----:|---|-----:|
|mmlu                                   |N/A    |none  |     0|acc   |0.5957|±  |0.0293|
| - humanities                          |N/A    |none  |     0|acc   |0.5343|±  |0.0233|
|  - formal_logic                       |      0|none  |     0|acc   |0.3492|±  |0.0426|
|  - high_school_european_history       |      0|none  |     0|acc   |0.7515|±  |0.0337|
|  - high_school_us_history             |      0|none  |     0|acc   |0.7647|±  |0.0298|
|  - high_school_world_history          |      0|none  |     0|acc   |0.7764|±  |0.0271|
|  - international_law                  |      0|none  |     0|acc   |0.7603|±  |0.0390|
|  - jurisprudence                      |      0|none  |     0|acc   |0.7500|±  |0.0419|
|  - logical_fallacies                  |      0|none  |     0|acc   |0.7546|±  |0.0338|
|  - moral_disputes                     |      0|none  |     0|acc   |0.6792|±  |0.0251|
|  - moral_scenarios                    |      0|none  |     0|acc   |0.2413|±  |0.0143|
|  - philosophy                         |      0|none  |     0|acc   |0.6817|±  |0.0265|
|  - prehistory                         |      0|none  |     0|acc   |0.7130|±  |0.0252|
|  - professional_law                   |      0|none  |     0|acc   |0.4413|±  |0.0127|
|  - world_religions                    |      0|none  |     0|acc   |0.8129|±  |0.0299|
| - other                               |N/A    |none  |     0|acc   |0.6798|±  |0.0299|
|  - business_ethics                    |      0|none  |     0|acc   |0.5800|±  |0.0496|
|  - clinical_knowledge                 |      0|none  |     0|acc   |0.6830|±  |0.0286|
|  - college_medicine                   |      0|none  |     0|acc   |0.6012|±  |0.0373|
|  - global_facts                       |      0|none  |     0|acc   |0.3900|±  |0.0490|
|  - human_aging                        |      0|none  |     0|acc   |0.6547|±  |0.0319|
|  - management                         |      0|none  |     0|acc   |0.7767|±  |0.0412|
|  - marketing                          |      0|none  |     0|acc   |0.8547|±  |0.0231|
|  - medical_genetics                   |      0|none  |     0|acc   |0.7000|±  |0.0461|
|  - miscellaneous                      |      0|none  |     0|acc   |0.7918|±  |0.0145|
|  - nutrition                          |      0|none  |     0|acc   |0.7026|±  |0.0262|
|  - professional_accounting            |      0|none  |     0|acc   |0.4574|±  |0.0297|
|  - professional_medicine              |      0|none  |     0|acc   |0.6875|±  |0.0282|
|  - virology                           |      0|none  |     0|acc   |0.5000|±  |0.0389|
| - social_sciences                     |N/A    |none  |     0|acc   |0.6945|±  |0.0275|
|  - econometrics                       |      0|none  |     0|acc   |0.4298|±  |0.0466|
|  - high_school_geography              |      0|none  |     0|acc   |0.7525|±  |0.0307|
|  - high_school_government_and_politics|      0|none  |     0|acc   |0.8394|±  |0.0265|
|  - high_school_macroeconomics         |      0|none  |     0|acc   |0.5872|±  |0.0250|
|  - high_school_microeconomics         |      0|none  |     0|acc   |0.6176|±  |0.0316|
|  - high_school_psychology             |      0|none  |     0|acc   |0.7798|±  |0.0178|
|  - human_sexuality                    |      0|none  |     0|acc   |0.7634|±  |0.0373|
|  - professional_psychology            |      0|none  |     0|acc   |0.6127|±  |0.0197|
|  - public_relations                   |      0|none  |     0|acc   |0.6636|±  |0.0453|
|  - security_studies                   |      0|none  |     0|acc   |0.6980|±  |0.0294|
|  - sociology                          |      0|none  |     0|acc   |0.8607|±  |0.0245|
|  - us_foreign_policy                  |      0|none  |     0|acc   |0.8400|±  |0.0368|
| - stem                                |N/A    |none  |     0|acc   |0.5081|±  |0.0375|
|  - abstract_algebra                   |      0|none  |     0|acc   |0.3000|±  |0.0461|
|  - anatomy                            |      0|none  |     0|acc   |0.5630|±  |0.0428|
|  - astronomy                          |      0|none  |     0|acc   |0.6250|±  |0.0394|
|  - college_biology                    |      0|none  |     0|acc   |0.6806|±  |0.0390|
|  - college_chemistry                  |      0|none  |     0|acc   |0.4800|±  |0.0502|
|  - college_computer_science           |      0|none  |     0|acc   |0.5500|±  |0.0500|
|  - college_mathematics                |      0|none  |     0|acc   |0.3400|±  |0.0476|
|  - college_physics                    |      0|none  |     0|acc   |0.4412|±  |0.0494|
|  - computer_security                  |      0|none  |     0|acc   |0.7400|±  |0.0441|
|  - conceptual_physics                 |      0|none  |     0|acc   |0.5362|±  |0.0326|
|  - electrical_engineering             |      0|none  |     0|acc   |0.5862|±  |0.0410|
|  - elementary_mathematics             |      0|none  |     0|acc   |0.4021|±  |0.0253|
|  - high_school_biology                |      0|none  |     0|acc   |0.7290|±  |0.0253|
|  - high_school_chemistry              |      0|none  |     0|acc   |0.4877|±  |0.0352|
|  - high_school_computer_science       |      0|none  |     0|acc   |0.6400|±  |0.0482|
|  - high_school_mathematics            |      0|none  |     0|acc   |0.3444|±  |0.0290|
|  - high_school_physics                |      0|none  |     0|acc   |0.3046|±  |0.0376|
|  - high_school_statistics             |      0|none  |     0|acc   |0.4722|±  |0.0340|
|  - machine_learning                   |      0|none  |     0|acc   |0.4821|±  |0.0474|

|      Groups      |Version|Filter|n-shot|Metric|Value |   |Stderr|
|------------------|-------|------|-----:|------|-----:|---|-----:|
|mmlu              |N/A    |none  |     0|acc   |0.5957|±  |0.0293|
| - humanities     |N/A    |none  |     0|acc   |0.5343|±  |0.0233|
| - other          |N/A    |none  |     0|acc   |0.6798|±  |0.0299|
| - social_sciences|N/A    |none  |     0|acc   |0.6945|±  |0.0275|
| - stem           |N/A    |none  |     0|acc   |0.5081|±  |0.0375|
```


Old behavior: 

formula:
![image](https://github.com/EleutherAI/lm-evaluation-harness/assets/65563625/44b6e54b-48b1-467c-913e-a58cbf319f65)

result:
```
hf (pretrained=mistralai/Mistral-7B-v0.1), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 8
|                 Tasks                 |Version|Filter|n-shot|Metric|Value |   |Stderr|
|---------------------------------------|-------|------|-----:|------|-----:|---|-----:|
|mmlu                                   |N/A    |none  |     0|acc   |0.5957|±  |0.1440|
| - humanities                          |N/A    |none  |     0|acc   |0.5343|±  |0.1719|
|  - formal_logic                       |      0|none  |     0|acc   |0.3492|±  |0.0426|
|  - high_school_european_history       |      0|none  |     0|acc   |0.7515|±  |0.0337|
|  - high_school_us_history             |      0|none  |     0|acc   |0.7647|±  |0.0298|
|  - high_school_world_history          |      0|none  |     0|acc   |0.7764|±  |0.0271|
|  - international_law                  |      0|none  |     0|acc   |0.7603|±  |0.0390|
|  - jurisprudence                      |      0|none  |     0|acc   |0.7500|±  |0.0419|
|  - logical_fallacies                  |      0|none  |     0|acc   |0.7546|±  |0.0338|
|  - moral_disputes                     |      0|none  |     0|acc   |0.6792|±  |0.0251|
|  - moral_scenarios                    |      0|none  |     0|acc   |0.2413|±  |0.0143|
|  - philosophy                         |      0|none  |     0|acc   |0.6817|±  |0.0265|
|  - prehistory                         |      0|none  |     0|acc   |0.7130|±  |0.0252|
|  - professional_law                   |      0|none  |     0|acc   |0.4413|±  |0.0127|
|  - world_religions                    |      0|none  |     0|acc   |0.8129|±  |0.0299|
| - other                               |N/A    |none  |     0|acc   |0.6798|±  |0.1015|
|  - business_ethics                    |      0|none  |     0|acc   |0.5800|±  |0.0496|
|  - clinical_knowledge                 |      0|none  |     0|acc   |0.6830|±  |0.0286|
|  - college_medicine                   |      0|none  |     0|acc   |0.6012|±  |0.0373|
|  - global_facts                       |      0|none  |     0|acc   |0.3900|±  |0.0490|
|  - human_aging                        |      0|none  |     0|acc   |0.6547|±  |0.0319|
|  - management                         |      0|none  |     0|acc   |0.7767|±  |0.0412|
|  - marketing                          |      0|none  |     0|acc   |0.8547|±  |0.0231|
|  - medical_genetics                   |      0|none  |     0|acc   |0.7000|±  |0.0461|
|  - miscellaneous                      |      0|none  |     0|acc   |0.7918|±  |0.0145|
|  - nutrition                          |      0|none  |     0|acc   |0.7026|±  |0.0262|
|  - professional_accounting            |      0|none  |     0|acc   |0.4574|±  |0.0297|
|  - professional_medicine              |      0|none  |     0|acc   |0.6875|±  |0.0282|
|  - virology                           |      0|none  |     0|acc   |0.5000|±  |0.0389|
| - social_sciences                     |N/A    |none  |     0|acc   |0.6945|±  |0.0975|
|  - econometrics                       |      0|none  |     0|acc   |0.4298|±  |0.0466|
|  - high_school_geography              |      0|none  |     0|acc   |0.7525|±  |0.0307|
|  - high_school_government_and_politics|      0|none  |     0|acc   |0.8394|±  |0.0265|
|  - high_school_macroeconomics         |      0|none  |     0|acc   |0.5872|±  |0.0250|
|  - high_school_microeconomics         |      0|none  |     0|acc   |0.6176|±  |0.0316|
|  - high_school_psychology             |      0|none  |     0|acc   |0.7798|±  |0.0178|
|  - human_sexuality                    |      0|none  |     0|acc   |0.7634|±  |0.0373|
|  - professional_psychology            |      0|none  |     0|acc   |0.6127|±  |0.0197|
|  - public_relations                   |      0|none  |     0|acc   |0.6636|±  |0.0453|
|  - security_studies                   |      0|none  |     0|acc   |0.6980|±  |0.0294|
|  - sociology                          |      0|none  |     0|acc   |0.8607|±  |0.0245|
|  - us_foreign_policy                  |      0|none  |     0|acc   |0.8400|±  |0.0368|
| - stem                                |N/A    |none  |     0|acc   |0.5081|±  |0.1220|
|  - abstract_algebra                   |      0|none  |     0|acc   |0.3000|±  |0.0461|
|  - anatomy                            |      0|none  |     0|acc   |0.5630|±  |0.0428|
|  - astronomy                          |      0|none  |     0|acc   |0.6250|±  |0.0394|
|  - college_biology                    |      0|none  |     0|acc   |0.6806|±  |0.0390|
|  - college_chemistry                  |      0|none  |     0|acc   |0.4800|±  |0.0502|
|  - college_computer_science           |      0|none  |     0|acc   |0.5500|±  |0.0500|
|  - college_mathematics                |      0|none  |     0|acc   |0.3400|±  |0.0476|
|  - college_physics                    |      0|none  |     0|acc   |0.4412|±  |0.0494|
|  - computer_security                  |      0|none  |     0|acc   |0.7400|±  |0.0441|
|  - conceptual_physics                 |      0|none  |     0|acc   |0.5362|±  |0.0326|
|  - electrical_engineering             |      0|none  |     0|acc   |0.5862|±  |0.0410|
|  - elementary_mathematics             |      0|none  |     0|acc   |0.4021|±  |0.0253|
|  - high_school_biology                |      0|none  |     0|acc   |0.7290|±  |0.0253|
|  - high_school_chemistry              |      0|none  |     0|acc   |0.4877|±  |0.0352|
|  - high_school_computer_science       |      0|none  |     0|acc   |0.6400|±  |0.0482|
|  - high_school_mathematics            |      0|none  |     0|acc   |0.3444|±  |0.0290|
|  - high_school_physics                |      0|none  |     0|acc   |0.3046|±  |0.0376|
|  - high_school_statistics             |      0|none  |     0|acc   |0.4722|±  |0.0340|
|  - machine_learning                   |      0|none  |     0|acc   |0.4821|±  |0.0474|

|      Groups      |Version|Filter|n-shot|Metric|Value |   |Stderr|
|------------------|-------|------|-----:|------|-----:|---|-----:|
|mmlu              |N/A    |none  |     0|acc   |0.5957|±  |0.1440|
| - humanities     |N/A    |none  |     0|acc   |0.5343|±  |0.1719|
| - other          |N/A    |none  |     0|acc   |0.6798|±  |0.1015|
| - social_sciences|N/A    |none  |     0|acc   |0.6945|±  |0.0975|
| - stem           |N/A    |none  |     0|acc   |0.5081|±  |0.1220|
```

Best reference for the difference between these two formulas that I could find: 
https://stats.stackexchange.com/questions/557469/difference-between-pooled-variance-and-combined-variance
https://en.wikipedia.org/wiki/Pooled_variance

From the stackexchange post: 
In particular, [combined variance] asks "if I drew a random observation from the entire population (i.e. where my draws could randomly come from group 1 or group 2), what is the variance of that draw" whereas [pooled variance]
 asks the question "if I drew a random observation from the population but also recorded whether the observation was from group 1 or from group 2, how much variance would the prediction error of that draw be if I took the mean from the respective group as my prediction?"

I am slightly unsure because I'm not a statistician, but I believe Pooled Variance is much more in line with what we actually want: it accounts for the fact that if we were to leave out / flip a prediction on a document, we know what sub-task this document was drawn from always in our setting, and we know what the empirical mean on that sub-task is. 
For example, on a benchmark like `gpt4all` where the tasks are an assortment of differently-scoring tasks using accuracy metrics, the old formula would show a crazy-high variance that doesn't seem to really represent something that makes sense.

Additionally, the Pooled Variances look much more reasonable. Intuitively, if we simply tossed all MMLU scores into a bucket, and calculated bootstrap stderr on MMLU overall, we'd expect it to be similar to calculating stderr on a single MMLU subtask (just with more documents).