### PR TITLE
Added seeds to `evaluator.simple_evaluate` signature

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -46,6 +46,8 @@ This mode supports a number of command-line arguments, the details of which can 
 
 * `--predict_only`: Generates the model outputs without computing metrics. Use with `--log_samples` to retrieve decoded results.
 
+* `--seed`: Set seed for python's random, numpy and torch.  Accepts a comma-separated list of 3 values for python's random, numpy, and torch seeds, respectively, or a single integer to set the same seed for all three.  The values are either an integer or 'None' to not set the seed. Default is `0,1234,1234` (for backward compatibility).  E.g. `--seed 0,None,8` sets `random.seed(0)` and `torch.manual_seed(8)`. Here numpy's seed is not set since the second value is `None`.  E.g, `--seed 42` sets all three seeds to 42.
+
 ## External Library Usage
 
 We also support using the library's external API for use within model training loops or other scripts.

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -93,16 +93,20 @@ def simple_evaluate(
     :return
         Dictionary of results
     """
+    eval_logger.setLevel(getattr(logging, f"{verbosity}"))
+
     if random_seed is not None:
+        # See https://github.com/EleutherAI/lm-evaluation-harness/pull/1412
+        eval_logger.info(f"Setting random seed to {random_seed}")
         random.seed(random_seed)
 
     if numpy_random_seed is not None:
+        eval_logger.info(f"Setting numpy seed to {numpy_random_seed}")
         np.random.seed(numpy_random_seed)
 
     if torch_random_seed is not None:
+        eval_logger.info(f"Setting torch manual seed to {torch_random_seed}")
         torch.manual_seed(torch_random_seed)
-
-    eval_logger.setLevel(getattr(logging, f"{verbosity}"))
 
     if tasks is None:
         tasks = []

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -45,6 +45,9 @@ def simple_evaluate(
     task_manager: TaskManager = None,
     verbosity: str = "INFO",
     predict_only: bool = False,
+    random_seed: int = 0,
+    numpy_random_seed: int = 1234,
+    torch_random_seed: int = 1234,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -80,15 +83,24 @@ def simple_evaluate(
         Ignored for all tasks with loglikelihood output_type
     :param predict_only: bool
         If true only model outputs will be generated and returned. Metrics will not be evaluated
+    :param random_seed: int
+        Random seed for python's random module. If set to None, the seed will not be set.
+    :param numpy_random_seed: int
+        Random seed for numpy. If set to None, the seed will not be set.
+    :param torch_random_seed: int
+        Random seed for torch. If set to None, the seed will not be set.
 
     :return
         Dictionary of results
     """
-    random.seed(0)
-    np.random.seed(1234)
-    torch.manual_seed(
-        1234
-    )  # TODO: this may affect training runs that are run with evaluation mid-run.
+    if random_seed is not None:
+        random.seed(random_seed)
+
+    if numpy_random_seed is not None:
+        np.random.seed(numpy_random_seed)
+
+    if torch_random_seed is not None:
+        torch.manual_seed(torch_random_seed)
 
     eval_logger.setLevel(getattr(logging, f"{verbosity}"))
 


### PR DESCRIPTION
With the latest changes (e.g., `TaskManager`) it is much easier to integrate `lm_eval` into existing code.
However, the `evaluator.simple_evalute` function sets `random`, `numpy`, and `torch` seeds with hard-coded values.

Basically this PR addresses this TODO item:

https://github.com/EleutherAI/lm-evaluation-harness/blob/4c17c55c9ae3b22280daf4046f70c176e62706d4/lm_eval/evaluator.py#L91

Changes in this PR:

- Make seed values as parameters so the user can choose the values, or set it to `None` if setting the seed is done outside of `lm-eval` when it is used as a library.
- Keep the same values as default values for backward compatibility.


