### PR TITLE
Fix printing bug in #1390

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -515,7 +515,7 @@ def evaluate(
                     results[task_name][metric + "_stderr" + "," + key] = "N/A"
 
         if bool(results):
-            for group, task_list in task_hierarchy.items():
+            for group, task_list in reversed(task_hierarchy.items()):
                 if len(task_list) == 0:
                     # task_hierarchy entries are either
                     # `group_name: [subtask1, subtask2, ...]`


### PR DESCRIPTION
https://github.com/EleutherAI/lm-evaluation-harness/pull/1390#issuecomment-1935364968

from @vraychev
> It appears that after this change, the complete mmlu results stop being reported. I see the order of computations get flipped from reversed(task_hierarchy.items()) to task_hierarchy.items() in the evaluator. The table looks like:
