### PR TITLE
Nit fix: Updated OpenBookQA Readme

### DIFF
--- a/lm_eval/tasks/openbookqa/README.md
+++ b/lm_eval/tasks/openbookqa/README.md
@@ -1,4 +1,4 @@
-# Task-name
+# OpenBookQA
 
 ### Paper
 


### PR DESCRIPTION
The Readme still had the template headline. This was changed to the task name.