### PR TITLE
Correct typo in task name in ARC documentation

### DIFF
--- a/lm_eval/tasks/arc/README.md
+++ b/lm_eval/tasks/arc/README.md
@@ -38,7 +38,7 @@ Homepage: https://allenai.org/data/arc
 #### Tasks
 
 * `arc_easy`
-* `arc_challange`
+* `arc_challenge`
 
 ### Checklist
 


### PR DESCRIPTION
Misspelling causes error if the task name is copied straight.