### PR TITLE
Log which subtasks were called with which groups

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -636,7 +636,7 @@ def evaluate(
         results_dict = {
             "results": dict(results_agg.items()),
             **({"groups": dict(groups_agg.items())} if bool(groups_agg) else {}),
-            "group_membership": {k: v for k, v in reversed(task_hierarchy.items())},
+            "group_subtasks": {k: v for k, v in reversed(task_hierarchy.items())},
             "configs": dict(sorted(configs.items())),
             "versions": dict(sorted(versions.items())),
             "n-shot": dict(sorted(num_fewshot.items())),

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -517,6 +517,7 @@ def evaluate(
                 )
 
         if bool(results):
+            print(list(reversed(task_hierarchy.items())))
             for group, task_list in reversed(task_hierarchy.items()):
                 if len(task_list) == 0:
                     # task_hierarchy entries are either
@@ -636,6 +637,7 @@ def evaluate(
         results_dict = {
             "results": dict(results_agg.items()),
             **({"groups": dict(groups_agg.items())} if bool(groups_agg) else {}),
+            "group_membership": {k: v for k, v in reversed(task_hierarchy.items())},
             "configs": dict(sorted(configs.items())),
             "versions": dict(sorted(versions.items())),
             "n-shot": dict(sorted(num_fewshot.items())),

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -517,7 +517,6 @@ def evaluate(
                 )
 
         if bool(results):
-            print(list(reversed(task_hierarchy.items())))
             for group, task_list in reversed(task_hierarchy.items()):
                 if len(task_list) == 0:
                     # task_hierarchy entries are either


### PR DESCRIPTION
This PR adds logging to `results.jsonl` of what subtasks belonged to which groups when they were called, as requested by @Sparkier !

I am not sure if the name for this attribute is self-explanatory enough or if there is perhaps a better one.

We will need to ensure addressing #1436 doesn't break this.