### PR TITLE
Fixed generation args issue affection OpenAI completion model

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -4,10 +4,10 @@ import logging
 import random
 import re
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import asdict, dataclass
 from inspect import getsource
 from typing import Any, List, Literal, Tuple, Union
-from copy import deepcopy
 
 import datasets
 import numpy as np

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from inspect import getsource
 from typing import Any, List, Literal, Tuple, Union
+from copy import deepcopy
 
 import datasets
 import numpy as np
@@ -1064,7 +1065,7 @@ class ConfigurableTask(Task):
             return request_list
 
         elif self.OUTPUT_TYPE == "generate_until":
-            arguments = (ctx, self.config.generation_kwargs)
+            arguments = (ctx, deepcopy(self.config.generation_kwargs))
 
         return Instance(
             request_type=self.OUTPUT_TYPE, doc=doc, arguments=arguments, idx=0, **kwargs

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -261,14 +261,13 @@ class OpenaiCompletionsLM(TemplateLM):
             list(sameuntil_chunks(re_ord.get_reordered(), self.batch_size))
         ):
             inps = []
-            self._max_gen_toks = request_args.pop("max_gen_toks", self.max_gen_toks)
+            self._max_gen_toks = request_args.get("max_gen_toks", self.max_gen_toks)
             for context, _ in chunk:
                 context_enc = self.tok_encode(context)
                 inp = context_enc[-(self.max_length - self.max_gen_toks) :]
                 inps.append(inp)
 
-            until = request_args.pop("until", ["<|endoftext|>"])
-            request_args.pop("do_sample", None)
+            until = request_args.get("until", ["<|endoftext|>"])
             request_args["temperature"] = request_args.get("temperature", 0)
 
             response = oa_completion(
@@ -278,7 +277,7 @@ class OpenaiCompletionsLM(TemplateLM):
                 max_tokens=self.max_gen_toks,
                 stop=until,
                 seed=self.seed,
-                **request_args,
+                **{k: v for k, v in request_args.items() if k not in ["do_sample", "max_gen_toks"]},
             )
             for resp, (context, args_) in zip(response.choices, chunk):
                 s = getattr(resp, "text")

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -277,7 +277,11 @@ class OpenaiCompletionsLM(TemplateLM):
                 max_tokens=self.max_gen_toks,
                 stop=until,
                 seed=self.seed,
-                **{k: v for k, v in request_args.items() if k not in ["do_sample", "max_gen_toks"]},
+                **{
+                    k: v
+                    for k, v in request_args.items()
+                    if k not in ["do_sample", "max_gen_toks"]
+                },
             )
             for resp, (context, args_) in zip(response.choices, chunk):
                 s = getattr(resp, "text")

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -22,8 +22,8 @@ class Test_HFLM:
     multiple_choice_task.build_all_requests(limit=10, rank=0, world_size=1)
     MULTIPLE_CH: list[Instance] = multiple_choice_task.instances
     generate_until_task = task_list["gsm8k"]  # type: ignore
-    generate_until_task.build_all_requests(limit=10, rank=0, world_size=1)
     generate_until_task._config.generation_kwargs["max_gen_toks"] = 10
+    generate_until_task.build_all_requests(limit=10, rank=0, world_size=1)
     generate_until: list[Instance] = generate_until_task.instances
     rolling_task = task_list["wikitext"]  # type: ignore
     rolling_task.build_all_requests(limit=10, rank=0, world_size=1)


### PR DESCRIPTION
The task's requests use the generation kwargs as request args when the task type is `generate_until` as shown below

https://github.com/EleutherAI/lm-evaluation-harness/blob/a72babbfbddd9195748351892dced4f82fccbc0d/lm_eval/api/task.py#L1067

Then, in the OpenAI Completion model, the `until`  attribute is poped from the request args:

https://github.com/EleutherAI/lm-evaluation-harness/blob/a72babbfbddd9195748351892dced4f82fccbc0d/lm_eval/models/openai_completions.py#L270

Since the object (`self.config.generation_kwargs`) is mutable, once the attribute is poped on the next request it will not be found and default in this case to `["<|endoftext|>"]` instead to what every value was in `until` (provided from the task config file or the `--gen_kwargs` argument.

This means that only the first request will have the correct `until` value and any subsequent request will use the default.