### PR TITLE
update parsing logic of mgsm following gsm8k (mgsm en 0 -> 50%)

### DIFF
--- a/lm_eval/tasks/mgsm/direct/direct_yaml
+++ b/lm_eval/tasks/mgsm/direct/direct_yaml
@@ -19,6 +19,12 @@ filter_list:
     filter:
       - function: remove_whitespace
       - function: take_first
+  - filter:
+    - function: regex
+      group_select: -1
+      regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+    - function: take_first
+    name: flexible-extract
 metric_list:
   - metric: exact_match
     aggregation: mean
@@ -26,4 +32,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_bn.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_bn.yaml
@@ -2,5 +2,11 @@
 dataset_name: bn
 doc_to_target: '{% if answer is not none %}{{answer[17:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"প্রশ্ন: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'প্রশ্ন:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_bn

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_de.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_de.yaml
@@ -2,5 +2,11 @@
 dataset_name: de
 doc_to_target: '{% if answer is not none %}{{answer[29:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAntwort:"}}{% else %}{{"Frage: "+question+"\nAntwort:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Frage:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_de

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_en.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_en.yaml
@@ -2,5 +2,11 @@
 dataset_name: en
 doc_to_target: '{% if answer is not none %}{{answer[21:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"Question: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Question:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_en

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_es.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_es.yaml
@@ -2,5 +2,11 @@
 dataset_name: es
 doc_to_target: '{% if answer is not none %}{{answer[23:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nRespuesta:"}}{% else %}{{"Pregunta: "+question+"\nRespuesta:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Pregunta:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_es

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_fr.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_fr.yaml
@@ -2,5 +2,11 @@
 dataset_name: fr
 doc_to_target: '{% if answer is not none %}{{answer[26:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nRéponse :"}}{% else %}{{"Question : "+question+"\nRéponse :"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Question :'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_fr

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_ja.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_ja.yaml
@@ -2,5 +2,11 @@
 dataset_name: ja
 doc_to_target: '{% if answer is not none %}{{answer[11:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"問題: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - '問題:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_ja

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_ru.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_ru.yaml
@@ -2,5 +2,11 @@
 dataset_name: ru
 doc_to_target: '{% if answer is not none %}{{answer[18:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"Задача: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Задача:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_ru

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_sw.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_sw.yaml
@@ -2,5 +2,11 @@
 dataset_name: sw
 doc_to_target: '{% if answer is not none %}{{answer[25:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"Swali: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Swali:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_sw

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_te.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_te.yaml
@@ -2,5 +2,11 @@
 dataset_name: te
 doc_to_target: '{% if answer is not none %}{{answer[19:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"ప్రశ్న: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'ప్రశ్న:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_te

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_th.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_th.yaml
@@ -2,5 +2,11 @@
 dataset_name: th
 doc_to_target: '{% if answer is not none %}{{answer[18:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"โจทย์: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'โจทย์:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_th

--- a/lm_eval/tasks/mgsm/direct/mgsm_direct_zh.yaml
+++ b/lm_eval/tasks/mgsm/direct/mgsm_direct_zh.yaml
@@ -2,5 +2,11 @@
 dataset_name: zh
 doc_to_target: '{% if answer is not none %}{{answer[6:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nAnswer:"}}{% else %}{{"问题: "+question+"\nAnswer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - '问题:'
+  - </s>
+  - <|im_end|>
 include: direct_yaml
 task: mgsm_direct_zh

--- a/lm_eval/tasks/mgsm/en_cot/cot_yaml
+++ b/lm_eval/tasks/mgsm/en_cot/cot_yaml
@@ -21,10 +21,16 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 filter_list:
-  - name: "get-answer"
+  - name: "strict-match"
     filter:
       - function: "regex"
         regex_pattern: "The answer is (\\-?[0-9\\.\\,]+)"
       - function: "take_first"
+  - filter:
+    - function: regex
+      group_select: -1
+      regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+    - function: take_first
+    name: flexible-extract
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_bn.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_bn.yaml
@@ -2,5 +2,11 @@
 dataset_name: bn
 doc_to_target: '{% if answer is not none %}{{answer[17:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"প্রশ্ন: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'প্রশ্ন:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_bn

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_de.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_de.yaml
@@ -2,5 +2,11 @@
 dataset_name: de
 doc_to_target: '{% if answer is not none %}{{answer[29:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"Frage: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Frage:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_de

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_en.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_en.yaml
@@ -2,5 +2,11 @@
 dataset_name: en
 doc_to_target: '{% if answer is not none %}{{answer[21:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"Question: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Question:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_en

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_es.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_es.yaml
@@ -2,5 +2,11 @@
 dataset_name: es
 doc_to_target: '{% if answer is not none %}{{answer[23:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"Pregunta: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Pregunta:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_es

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_fr.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_fr.yaml
@@ -2,5 +2,11 @@
 dataset_name: fr
 doc_to_target: '{% if answer is not none %}{{answer[26:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"Question : "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Question :'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_fr

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_ja.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_ja.yaml
@@ -2,5 +2,11 @@
 dataset_name: ja
 doc_to_target: '{% if answer is not none %}{{answer[11:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"問題: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - '問題:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_ja

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_ru.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_ru.yaml
@@ -2,5 +2,11 @@
 dataset_name: ru
 doc_to_target: '{% if answer is not none %}{{answer[18:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"Задача: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Задача:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_ru

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_sw.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_sw.yaml
@@ -2,5 +2,11 @@
 dataset_name: sw
 doc_to_target: '{% if answer is not none %}{{answer[25:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"Swali: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Swali:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_sw

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_te.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_te.yaml
@@ -2,5 +2,11 @@
 dataset_name: te
 doc_to_target: '{% if answer is not none %}{{answer[19:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"ప్రశ్న: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'ప్రశ్న:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_te

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_th.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_th.yaml
@@ -2,5 +2,11 @@
 dataset_name: th
 doc_to_target: '{% if answer is not none %}{{answer[18:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"โจทย์: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'โจทย์:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_th

--- a/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_zh.yaml
+++ b/lm_eval/tasks/mgsm/en_cot/mgsm_en_cot_zh.yaml
@@ -2,5 +2,11 @@
 dataset_name: zh
 doc_to_target: '{% if answer is not none %}{{answer[6:]}}{% else %}{{answer_number|string}}{% endif %}'
 doc_to_text: '{% if answer is not none %}{{question+"\nStep-by-Step Answer:"}}{% else %}{{"问题: "+question+"\nStep-by-Step Answer:"}}{% endif %}'
+generation_kwargs:
+  do_sample: false
+  until:
+  - '问题:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_en_cot_zh

--- a/lm_eval/tasks/mgsm/native_cot/cot_yaml
+++ b/lm_eval/tasks/mgsm/native_cot/cot_yaml
@@ -28,4 +28,4 @@ filter_list:
         regex_pattern: "The answer is (\\-?[0-9\\.\\,]+)"
       - function: "take_first"
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_bn.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_bn.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: The answer is (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'প্রশ্ন:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_bn

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_de.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_de.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: Die Antwort lautet (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Frage:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_de

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_en.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_en.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: The answer is (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Question:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_en

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_es.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_es.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: La respuesta es (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Pregunta:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_es

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_fr.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_fr.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: La réponse est (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Question :'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_fr

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_ja.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_ja.yaml
@@ -7,7 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: 答えは(\-?[0-9\.\,]+)です。
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - '問題:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
-target_delimiter: ""
 task: mgsm_native_cot_ja

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_ru.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_ru.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: Ответ — (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Задача:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_ru

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_sw.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_sw.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: Jibu ni (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'Swali:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_sw

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_te.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_te.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: సమాధానం (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'ప్రశ్న:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_te

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_th.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_th.yaml
@@ -7,6 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: คำตอบคือ (\-?[0-9\.\,]+)
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - 'โจทย์:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
 task: mgsm_native_cot_th

--- a/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_zh.yaml
+++ b/lm_eval/tasks/mgsm/native_cot/mgsm_native_cot_zh.yaml
@@ -7,7 +7,18 @@ filter_list:
   - function: regex
     regex_pattern: 答案是 (\-?[0-9\.\,]+)。
   - function: take_first
-  name: get-answer
+  name: strict-match
+- filter:
+  - function: regex
+    group_select: -1
+    regex_pattern: (-?[$0-9.,]{2,})|(-?[0-9]+)
+  - function: take_first
+  name: flexible-extract
+generation_kwargs:
+  do_sample: false
+  until:
+  - '问题:'
+  - </s>
+  - <|im_end|>
 include: cot_yaml
-target_delimiter: ""
 task: mgsm_native_cot_zh


### PR DESCRIPTION
Updated mgsm following gsm8k logic. Evaluated with [xRFT-Mathoctopus](https://huggingface.co/Mathoctopus/Parallel_xRFT_7B).

|                 | bn    | de    | en    | es    | fr    | ja    | ru    | sw    | te    | th    | zh    | avg   |
| --------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| mgsm_direct     | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
| updated         | 0.196 | 0.380 | 0.500 | 0.444 | 0.336 | 0.332 | 0.364 | 0.384 | 0.000 | 0.288 | 0.408 | 0.330 |
| mgsm_en_cot     | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
| updated         | 0.188 | 0.388 | 0.492 | 0.452 | 0.356 | 0.324 | 0.400 | 0.328 | 0.004 | 0.284 | 0.436 | 0.332 |
| mgsm_native_cot | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
| updated         | 0.188 | 0.356 | 0.492 | 0.396 | 0.352 | 0.340 | 0.376 | 0.348 | 0.004 | 0.276 | 0.412 | 0.322 |

Note that due to the policy of this repo, I couldn't change the prompt thus couldn't reproduce the reported performance.

However this definitely improves the evaluation of mgsm.