### PR TITLE
Add environment and transformers version logging in results dump

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -13,7 +13,7 @@ import numpy as np
 from lm_eval import evaluator, utils
 from lm_eval.logging_utils import WandbLogger
 from lm_eval.tasks import TaskManager, include_path, initialize_tasks
-from lm_eval.utils import make_table
+from lm_eval.utils import add_env_info, make_table
 
 
 def _handle_non_serializable(o):
@@ -310,6 +310,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if results is not None:
         if args.log_samples:
             samples = results.pop("samples")
+        add_env_info(results)  # place this after popping out samples and before dumping
         dumped = json.dumps(
             results, indent=2, default=_handle_non_serializable, ensure_ascii=False
         )

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -11,7 +11,7 @@ from typing import Union
 import numpy as np
 
 from lm_eval import evaluator, utils
-from lm_eval.logging_utils import WandbLogger, add_env_info
+from lm_eval.logging_utils import WandbLogger
 from lm_eval.tasks import TaskManager, include_path, initialize_tasks
 from lm_eval.utils import make_table
 
@@ -310,7 +310,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if results is not None:
         if args.log_samples:
             samples = results.pop("samples")
-        add_env_info(results)  # place this after popping out samples and before dumping
         dumped = json.dumps(
             results, indent=2, default=_handle_non_serializable, ensure_ascii=False
         )

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -11,9 +11,9 @@ from typing import Union
 import numpy as np
 
 from lm_eval import evaluator, utils
-from lm_eval.logging_utils import WandbLogger
+from lm_eval.logging_utils import WandbLogger, add_env_info
 from lm_eval.tasks import TaskManager, include_path, initialize_tasks
-from lm_eval.utils import add_env_info, make_table
+from lm_eval.utils import make_table
 
 
 def _handle_non_serializable(o):

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -10,7 +10,7 @@ import torch
 import lm_eval.api.metrics
 import lm_eval.api.registry
 import lm_eval.models
-from lm_eval.logging_utils import get_git_commit_hash
+from lm_eval.logging_utils import add_env_info, get_git_commit_hash
 from lm_eval.tasks import TaskManager, get_task_dict
 from lm_eval.utils import (
     eval_logger,
@@ -221,6 +221,7 @@ def simple_evaluate(
             "gen_kwargs": gen_kwargs,
         }
         results["git_hash"] = get_git_commit_hash()
+        add_env_info(results)  # additional environment info to results
         return results
     else:
         return None

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -10,10 +10,10 @@ import torch
 import lm_eval.api.metrics
 import lm_eval.api.registry
 import lm_eval.models
+from lm_eval.logging_utils import get_git_commit_hash
 from lm_eval.tasks import TaskManager, get_task_dict
 from lm_eval.utils import (
     eval_logger,
-    get_git_commit_hash,
     positional_deprecated,
     run_task_tests,
     simple_parse_args_string,

--- a/lm_eval/logging_utils.py
+++ b/lm_eval/logging_utils.py
@@ -429,7 +429,7 @@ def add_env_info(storage: Dict[str, Any]):
         pretty_env_info = get_pretty_env_info()
     except Exception as err:
         pretty_env_info = str(err)
-    transformers_version = "Transformers: %s" % trans_version
+    transformers_version = trans_version
     upper_dir_commit = get_commit_from_path(
         Path(os.getcwd(), "..")
     )  # git hash of upper repo if exists

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -10,12 +10,12 @@ import subprocess
 import sys
 from itertools import islice
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List
 
 import yaml
 from jinja2 import BaseLoader, Environment, StrictUndefined
-from torch.utils.collect_env import get_pretty_env_info
-from transformers import __version__ as trans_version
+
+from lm_eval.logging_utils import get_commit_from_path
 
 
 logging.basicConfig(
@@ -329,21 +329,6 @@ def run_task_tests(task_list: List[str]):
         )
 
 
-def get_commit_from_path(repo_path: Path) -> Optional[str]:
-    git_folder = Path(repo_path, ".git")
-    if git_folder.is_file():
-        git_folder = Path(
-            git_folder.parent, git_folder.read_text().split("\n")[0].split(" ")[-1]
-        )
-    if Path(git_folder, "HEAD").exists():
-        head_name = Path(git_folder, "HEAD").read_text().split("\n")[0].split(" ")[-1]
-        head_ref = Path(git_folder, head_name)
-        git_hash = head_ref.read_text().replace("\n", "")
-    else:
-        git_hash = None
-    return git_hash
-
-
 def get_git_commit_hash():
     """
     Gets the git commit hash of your current repo (if it exists).
@@ -356,23 +341,6 @@ def get_git_commit_hash():
         # FileNotFoundError occurs when git not installed on system
         git_hash = get_commit_from_path(os.getcwd())  # git hash of repo if exists
     return git_hash
-
-
-def add_env_info(storage: Dict[str, Any]):
-    try:
-        pretty_env_info = get_pretty_env_info()
-    except Exception as err:
-        pretty_env_info = str(err)
-    transformers_version = "Transformers: %s" % trans_version
-    upper_dir_commit = get_commit_from_path(
-        Path(os.getcwd(), "..")
-    )  # git hash of upper repo if exists
-    added_info = {
-        "pretty_env_info": pretty_env_info,
-        "transformers_version": transformers_version,
-        "upper_git_hash": upper_dir_commit,  # in case this repo is submodule
-    }
-    storage.update(added_info)
 
 
 def ignore_constructor(loader, node):

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -6,7 +6,6 @@ import inspect
 import logging
 import os
 import re
-import subprocess
 import sys
 from itertools import islice
 from pathlib import Path
@@ -14,8 +13,6 @@ from typing import Any, Callable, List
 
 import yaml
 from jinja2 import BaseLoader, Environment, StrictUndefined
-
-from lm_eval.logging_utils import get_commit_from_path
 
 
 logging.basicConfig(
@@ -327,20 +324,6 @@ def run_task_tests(task_list: List[str]):
         raise ValueError(
             f"Not all tests for the specified tasks ({task_list}) ran successfully! Error code: {pytest_return_val}"
         )
-
-
-def get_git_commit_hash():
-    """
-    Gets the git commit hash of your current repo (if it exists).
-    Source: https://github.com/EleutherAI/gpt-neox/blob/b608043be541602170bfcfb8ec9bf85e8a0799e0/megatron/neox_arguments/neox_args.py#L42
-    """
-    try:
-        git_hash = subprocess.check_output(["git", "describe", "--always"]).strip()
-        git_hash = git_hash.decode()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        # FileNotFoundError occurs when git not installed on system
-        git_hash = get_commit_from_path(os.getcwd())  # git hash of repo if exists
-    return git_hash
 
 
 def ignore_constructor(loader, node):

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -10,10 +10,12 @@ import subprocess
 import sys
 from itertools import islice
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import yaml
 from jinja2 import BaseLoader, Environment, StrictUndefined
+from torch.utils.collect_env import get_pretty_env_info
+from transformers import __version__ as trans_version
 
 
 logging.basicConfig(
@@ -354,6 +356,23 @@ def get_git_commit_hash():
         # FileNotFoundError occurs when git not installed on system
         git_hash = get_commit_from_path(os.getcwd())  # git hash of repo if exists
     return git_hash
+
+
+def add_env_info(storage: Dict[str, Any]):
+    try:
+        pretty_env_info = get_pretty_env_info()
+    except Exception as err:
+        pretty_env_info = str(err)
+    transformers_version = "Transformers: %s" % trans_version
+    upper_dir_commit = get_commit_from_path(
+        Path(os.getcwd(), "..")
+    )  # git hash of upper repo if exists
+    added_info = {
+        "pretty_env_info": pretty_env_info,
+        "transformers_version": transformers_version,
+        "upper_git_hash": upper_dir_commit,  # in case this repo is submodule
+    }
+    storage.update(added_info)
 
 
 def ignore_constructor(loader, node):


### PR DESCRIPTION
To help researchers detect inconsistencies caused by different versions of drivers or packages:
* added logging transformers version in results dump
* added environment info (with the help of pytorch helper function) to results dump
* improved git_hash storage for case when no git is available to call in the system
* store also git hash of upper directory for cases when this repo is submoduled

Was not sure where to place functions. Seems that all of these can be moved to `logging_utils` if it is not wandb only.