### PR TITLE
Adding documentation for Weights and Biases CLI interface

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -47,8 +47,8 @@ This mode supports a number of command-line arguments, the details of which can 
 * `--predict_only`: Generates the model outputs without computing metrics. Use with `--log_samples` to retrieve decoded results.
 
 * `--seed`: Set seed for python's random, numpy and torch.  Accepts a comma-separated list of 3 values for python's random, numpy, and torch seeds, respectively, or a single integer to set the same seed for all three.  The values are either an integer or 'None' to not set the seed. Default is `0,1234,1234` (for backward compatibility).  E.g. `--seed 0,None,8` sets `random.seed(0)` and `torch.manual_seed(8)`. Here numpy's seed is not set since the second value is `None`.  E.g, `--seed 42` sets all three seeds to 42.
-*
-* `--wandb_args`:  Allows to include Weights and Biases logging for evaluation runs and includes args passed to `wandb.init`,  `project` and `job_type` Full list [here.](https://docs.wandb.ai/ref/python/init)
+
+* `--wandb_args`:  Tracks logging to Weights and Biases for evaluation runs and includes args passed to `wandb.init`, such as `project` and `job_type`. Full list (here.)[https://docs.wandb.ai/ref/python/init]
 
 ## External Library Usage
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -47,6 +47,8 @@ This mode supports a number of command-line arguments, the details of which can 
 * `--predict_only`: Generates the model outputs without computing metrics. Use with `--log_samples` to retrieve decoded results.
 
 * `--seed`: Set seed for python's random, numpy and torch.  Accepts a comma-separated list of 3 values for python's random, numpy, and torch seeds, respectively, or a single integer to set the same seed for all three.  The values are either an integer or 'None' to not set the seed. Default is `0,1234,1234` (for backward compatibility).  E.g. `--seed 0,None,8` sets `random.seed(0)` and `torch.manual_seed(8)`. Here numpy's seed is not set since the second value is `None`.  E.g, `--seed 42` sets all three seeds to 42.
+*
+* `--wandb_args`:  Allows to include Weights and Biases logging for evaluation runs and includes args passed to `wandb.init`,  `project` and `job_type` Full list [here.](https://docs.wandb.ai/ref/python/init)
 
 ## External Library Usage
 


### PR DESCRIPTION
Based on the feature merged here for Weights and Biases support, https://github.com/EleutherAI/lm-evaluation-harness/pull/1339, adding documentation to the command-line interface. 