### PR TITLE
Setting trust_remote_code to `True` for HuggingFace datasets compatibility

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -96,7 +96,7 @@ class HFLM(TemplateLM):
         dtype: Optional[Union[str, torch.dtype]] = "auto",
         batch_size: Optional[Union[int, str]] = 1,
         max_batch_size: Optional[int] = 64,
-        trust_remote_code: Optional[bool] = False,
+        trust_remote_code: Optional[bool] = True,
         use_fast_tokenizer: Optional[bool] = True,
         # arguments used for splitting a model across GPUs naively.
         # only used if `parallelize=True`.

--- a/lm_eval/tasks/asdiv/default.yaml
+++ b/lm_eval/tasks/asdiv/default.yaml
@@ -12,3 +12,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true


### PR DESCRIPTION
See this issue for context: https://github.com/EleutherAI/lm-evaluation-harness/issues/1135#issuecomment-1961928695

We'd like to be able to use the latest datasets version, 2.16 in lm-evaluation-harness. We currently [use 2.15](https://github.com/EleutherAI/lm-evaluation-harness/pull/1312) . 

In order to accommodate this, we'd like to:

1. add a `trust_remote_code` dataset kwarg to each dataset that requires it and pass through  - including a sample for now based on a dataset that I [know requires remote code execution](https://huggingface.co/datasets/EleutherAI/asdiv).  
Let me know if it looks ok and I'll do a scan through the datasets to see which ones do and add this? 

2. Include `trust_remote_code` as True by default in the model constructor, to be overriden by -model_args when evaluating from the command line.