### PR TITLE
Revert "Setting trust_remote_code to `True` for HuggingFace datasets compatibility"

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -96,7 +96,7 @@ class HFLM(TemplateLM):
         dtype: Optional[Union[str, torch.dtype]] = "auto",
         batch_size: Optional[Union[int, str]] = 1,
         max_batch_size: Optional[int] = 64,
-        trust_remote_code: Optional[bool] = True,
+        trust_remote_code: Optional[bool] = False,
         use_fast_tokenizer: Optional[bool] = True,
         add_bos_token: Optional[bool] = False,
         # arguments used for splitting a model across GPUs naively.

--- a/lm_eval/tasks/asdiv/default.yaml
+++ b/lm_eval/tasks/asdiv/default.yaml
@@ -12,5 +12,3 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
-dataset_kwargs:
-  trust_remote_code: true


### PR DESCRIPTION
Reverts EleutherAI/lm-evaluation-harness#1467 since it was just a draft of how functionality would work!