### PR TITLE
Fix AttributeError in huggingface.py When 'model_type' is Missing

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -250,7 +250,7 @@ class HFLM(TemplateLM):
         elif self.tokenizer.eos_token:
             self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
         else:
-            if self.config.model_type == "qwen":
+            if getattr(self.config, "model_type", None) == "qwen":
                 # Qwen's trust_remote_code tokenizer does not allow for adding special tokens
                 self.tokenizer.pad_token = "<|endoftext|>"
             elif (
@@ -268,11 +268,9 @@ class HFLM(TemplateLM):
 
         # TODO: override this for Gemma
         self.add_bos_token = add_bos_token
-        if hasattr(self.config, 'model_type'):
-            model_type = self.config.model_type
-            if model_type == "gemma":
-                self.add_bos_token = True
-                eval_logger.info(
+        if getattr(self.config, "model_type", None) == "gemma":
+            self.add_bos_token = True
+            eval_logger.info(
                 f"Model type is '{model_type}', a BOS token will be used as Gemma underperforms without it."
             )
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -268,12 +268,13 @@ class HFLM(TemplateLM):
 
         # TODO: override this for Gemma
         self.add_bos_token = add_bos_token
-        model_type = self.config.get('model_type')
-        if model_type == "gemma":
-            self.add_bos_token = True
-            eval_logger.info(
-            f"Model type is '{model_type}', a BOS token will be used as Gemma underperforms without it."
-        )
+        if hasattr(self.config, 'model_type'):
+            model_type = self.config.model_type
+            if model_type == "gemma":
+                self.add_bos_token = True
+                eval_logger.info(
+                f"Model type is '{model_type}', a BOS token will be used as Gemma underperforms without it."
+            )
 
         self._max_length = max_length
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -268,11 +268,12 @@ class HFLM(TemplateLM):
 
         # TODO: override this for Gemma
         self.add_bos_token = add_bos_token
-        if self.config.model_type == "gemma":
-            eval_logger.info(
-                "Model is of type 'gemma', will use a BOS token as Gemma underperforms without it."
-            )
+        model_type = self.config.get('model_type')
+        if model_type == "gemma":
             self.add_bos_token = True
+            eval_logger.info(
+            f"Model type is '{model_type}', a BOS token will be used as Gemma underperforms without it."
+        )
 
         self._max_length = max_length
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -271,7 +271,7 @@ class HFLM(TemplateLM):
         if getattr(self.config, "model_type", None) == "gemma":
             self.add_bos_token = True
             eval_logger.info(
-                f"Model type is '{model_type}', a BOS token will be used as Gemma underperforms without it."
+                f"Model type is '{self.config.model_type}', a BOS token will be used as Gemma underperforms without it."
             )
 
         self._max_length = max_length


### PR DESCRIPTION
AttributeError in the huggingface.py occurs when a model's configuration dictionary lacks the 'model_type' key, which is currently assumed to be always present. 

AttributeError: 'dict' object has no attribute 'model_type'
at:
  - "/content/lm-evaluation-harness/lm_eval/models/huggingface.py"

You can replicate with:
lm_eval --model mamba_ssm \
    --model_args pretrained=state-spaces/mamba-130m \
    --tasks lambada_openai,hellaswag \
    --device cuda:0 \
    --batch_size 8
    
After implementing the changes, I re-ran model configuration that previously triggered the error and several configurations that did not. Seems to be running fine now.


  