### PR TITLE
modify `WandbLogger` to accept arbitrary kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ lm_eval \
     --log_samples
 ```
 
-In the stdout, you will find the link to the W&B run page as well as link to the generated report. You can find an example of this workflow in [examples/visualize-wandb.ipynb](examples/visualize-wandb.ipynb).
+In the stdout, you will find the link to the W&B run page as well as link to the generated report. You can find an example of this workflow in [examples/visualize-wandb.ipynb](examples/visualize-wandb.ipynb), and an example of how to integrate it beyond the CLI.
 
 ## How to Contribute or Learn More?
 

--- a/examples/visualize-wandb.ipynb
+++ b/examples/visualize-wandb.ipynb
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "id": "5178ca9445b844e4",
    "metadata": {},
-   "source": "W&B can also be initialized programmatically for use outside the CLI."
+   "source": "W&B can also be initialized programmatically for use outside the CLI to parse and log the results."
   },
   {
    "cell_type": "code",

--- a/examples/visualize-wandb.ipynb
+++ b/examples/visualize-wandb.ipynb
@@ -67,6 +67,7 @@
    "outputs": [],
    "source": [
     "import wandb\n",
+    "\n",
     "wandb.login()"
    ]
   },
@@ -103,6 +104,43 @@
     "    --limit 10 \\\n",
     "    --wandb_args project=lm-eval-harness-integration \\\n",
     "    --log_samples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e974cabdbe70b667",
+   "metadata": {},
+   "source": ""
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5178ca9445b844e4",
+   "metadata": {},
+   "source": "W&B can also be initialized programmatically for use outside the CLI."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6a421b2cf3ddac5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lm_eval\n",
+    "from lm_eval.logging_utils import WandbLogger\n",
+    "\n",
+    "results = lm_eval.simple_evaluate(\n",
+    "    model=\"hf\",\n",
+    "    model_args=\"pretrained=microsoft/phi-2,trust_remote_code=True\",\n",
+    "    tasks=\"hellaswag,mmlu_abstract_algebra\",\n",
+    "    log_samples=True,\n",
+    ")\n",
+    "\n",
+    "wandb_logger = WandbLogger(\n",
+    "    project=\"lm-eval-harness-integration\", job_type=\"eval\"\n",
+    ")  # or empty if wandb.init(...) already called before\n",
+    "wandb_logger.post_init(results)\n",
+    "wandb_logger.log_eval_result()\n",
+    "wandb_logger.log_eval_samples(results[\"samples\"])  # if log_samples"
    ]
   }
  ],

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -14,7 +14,7 @@ from lm_eval import evaluator, utils
 from lm_eval.evaluator import request_caching_arg_to_dict
 from lm_eval.logging_utils import WandbLogger
 from lm_eval.tasks import TaskManager, include_path, initialize_tasks
-from lm_eval.utils import make_table
+from lm_eval.utils import make_table, simple_parse_args_string
 
 
 def _handle_non_serializable(o):
@@ -210,7 +210,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         args = parse_eval_args()
 
     if args.wandb_args:
-        wandb_logger = WandbLogger(args)
+        wandb_logger = WandbLogger(**simple_parse_args_string(args.wandb_args))
 
     eval_logger = utils.eval_logger
     eval_logger.setLevel(getattr(logging, f"{args.verbosity}"))

--- a/lm_eval/logging_utils.py
+++ b/lm_eval/logging_utils.py
@@ -166,7 +166,9 @@ class WandbLogger:
         ]
 
         def make_table(columns: List[str], key: str = "results"):
-            table = wandb.Table(columns=columns)  # noqa: F821
+            import wandb
+
+            table = wandb.Table(columns=columns)
             results = copy.deepcopy(self.results)
 
             for k, dic in results.get(key).items():
@@ -204,10 +206,12 @@ class WandbLogger:
 
     def _log_results_as_artifact(self) -> None:
         """Log results as JSON artifact to W&B."""
+        import wandb
+
         dumped = json.dumps(
             self.results, indent=2, default=_handle_non_serializable, ensure_ascii=False
         )
-        artifact = wandb.Artifact("results", type="eval_results")  # noqa: F821
+        artifact = wandb.Artifact("results", type="eval_results")
         with artifact.new_file("results.json", mode="w", encoding="utf-8") as f:
             f.write(dumped)
         self.run.log_artifact(artifact)
@@ -322,6 +326,8 @@ class WandbLogger:
     def _log_samples_as_artifact(
         self, data: List[Dict[str, Any]], task_name: str
     ) -> None:
+        import wandb
+
         # log the samples as an artifact
         dumped = json.dumps(
             data,
@@ -329,7 +335,7 @@ class WandbLogger:
             default=_handle_non_serializable,
             ensure_ascii=False,
         )
-        artifact = wandb.Artifact(f"{task_name}", type="samples_by_task")  # noqa: F821
+        artifact = wandb.Artifact(f"{task_name}", type="samples_by_task")
         with artifact.new_file(
             f"{task_name}_eval_samples.json", mode="w", encoding="utf-8"
         ) as f:

--- a/lm_eval/logging_utils.py
+++ b/lm_eval/logging_utils.py
@@ -82,7 +82,7 @@ def get_wandb_printer() -> Literal["Printer"]:
 
 class WandbLogger:
     def __init__(self, **kwargs) -> None:
-        """Attaches to wandb runner if already initialized. Otherwise, passes kwargs to wandb.init()
+        """Attaches to wandb logger if already initialized. Otherwise, passes kwargs to wandb.init()
 
         Args:
             kwargs Optional[Any]: Arguments for configuration.
@@ -92,10 +92,8 @@ class WandbLogger:
             wandb_logger.log_eval_result()
             wandb_logger.log_eval_samples(results["samples"])
         """
-        if kwargs:
-            self.wandb_args: Dict[str, Any] = kwargs
-        else:
-            self.wandb_args = {}
+
+        self.wandb_args: Dict[str, Any] = kwargs
 
         # initialize a W&B run
         if wandb.run is None:

--- a/lm_eval/logging_utils.py
+++ b/lm_eval/logging_utils.py
@@ -87,7 +87,7 @@ class WandbLogger:
         Args:
             kwargs Optional[Any]: Arguments for configuration.
 
-        Parse and log the results returned from simple_evaluated with:
+        Parse and log the results returned from evaluator.simple_evaluate() with:
             wandb_logger.post_init(results)
             wandb_logger.log_eval_result()
             wandb_logger.log_eval_samples(results["samples"])

--- a/lm_eval/logging_utils.py
+++ b/lm_eval/logging_utils.py
@@ -16,19 +16,6 @@ from transformers import __version__ as trans_version
 
 logger = logging.getLogger(__name__)
 
-try:
-    import wandb
-
-    assert Version(wandb.__version__) >= Version("0.13.6")
-    if Version(wandb.__version__) < Version("0.13.6"):
-        wandb.require("report-editing:v0")
-except Exception as e:
-    logger.warning(
-        "To use the wandb reporting functionality please install wandb>=0.13.6.\n"
-        "To install the latest version of wandb run `pip install wandb --upgrade`\n"
-        f"{e}"
-    )
-
 
 def remove_none_pattern(input_string: str) -> Tuple[str, bool]:
     """Remove the ',none' substring from the input_string if it exists at the end.
@@ -92,6 +79,18 @@ class WandbLogger:
             wandb_logger.log_eval_result()
             wandb_logger.log_eval_samples(results["samples"])
         """
+        try:
+            import wandb
+
+            assert Version(wandb.__version__) >= Version("0.13.6")
+            if Version(wandb.__version__) < Version("0.13.6"):
+                wandb.require("report-editing:v0")
+        except Exception as e:
+            logger.warning(
+                "To use the wandb reporting functionality please install wandb>=0.13.6.\n"
+                "To install the latest version of wandb run `pip install wandb --upgrade`\n"
+                f"{e}"
+            )
 
         self.wandb_args: Dict[str, Any] = kwargs
 
@@ -167,7 +166,7 @@ class WandbLogger:
         ]
 
         def make_table(columns: List[str], key: str = "results"):
-            table = wandb.Table(columns=columns)
+            table = wandb.Table(columns=columns)  # noqa: F821
             results = copy.deepcopy(self.results)
 
             for k, dic in results.get(key).items():
@@ -208,7 +207,7 @@ class WandbLogger:
         dumped = json.dumps(
             self.results, indent=2, default=_handle_non_serializable, ensure_ascii=False
         )
-        artifact = wandb.Artifact("results", type="eval_results")
+        artifact = wandb.Artifact("results", type="eval_results")  # noqa: F821
         with artifact.new_file("results.json", mode="w", encoding="utf-8") as f:
             f.write(dumped)
         self.run.log_artifact(artifact)
@@ -330,7 +329,7 @@ class WandbLogger:
             default=_handle_non_serializable,
             ensure_ascii=False,
         )
-        artifact = wandb.Artifact(f"{task_name}", type="samples_by_task")
+        artifact = wandb.Artifact(f"{task_name}", type="samples_by_task")  # noqa: F821
         with artifact.new_file(
             f"{task_name}_eval_samples.json", mode="w", encoding="utf-8"
         ) as f:

--- a/lm_eval/logging_utils.py
+++ b/lm_eval/logging_utils.py
@@ -87,10 +87,10 @@ class WandbLogger:
         Args:
             kwargs Optional[Any]: Arguments for configuration.
 
-        Parse and log the  results returned from simple_evaluated with:
+        Parse and log the results returned from simple_evaluated with:
             wandb_logger.post_init(results)
             wandb_logger.log_eval_result()
-            wandb_logger.log_eval_samples(results[samples])
+            wandb_logger.log_eval_samples(results["samples"])
         """
         if kwargs:
             self.wandb_args: Dict[str, Any] = kwargs

--- a/lm_eval/logging_utils.py
+++ b/lm_eval/logging_utils.py
@@ -13,8 +13,6 @@ from packaging.version import Version
 from torch.utils.collect_env import get_pretty_env_info
 from transformers import __version__ as trans_version
 
-from lm_eval.utils import simple_parse_args_string
-
 
 logger = logging.getLogger(__name__)
 
@@ -83,14 +81,21 @@ def get_wandb_printer() -> Literal["Printer"]:
 
 
 class WandbLogger:
-    def __init__(self, args: Any) -> None:
-        """Initialize the WandbLogger.
+    def __init__(self, **kwargs) -> None:
+        """Attaches to wandb runner if already initialized. Otherwise, passes kwargs to wandb.init()
 
         Args:
-            results (Dict[str, Any]): The results dictionary.
-            args (Any): Arguments for configuration.
+            kwargs Optional[Any]: Arguments for configuration.
+
+        Parse and log the  results returned from simple_evaluated with:
+            wandb_logger.post_init(results)
+            wandb_logger.log_eval_result()
+            wandb_logger.log_eval_samples(results[samples])
         """
-        self.wandb_args: Dict[str, Any] = simple_parse_args_string(args.wandb_args)
+        if kwargs:
+            self.wandb_args: Dict[str, Any] = kwargs
+        else:
+            self.wandb_args = {}
 
         # initialize a W&B run
         if wandb.run is None:


### PR DESCRIPTION
instead of the `argparser` so it can be used outside of CLI. 

cc: @veekaybee 

closes #1478