### PR TITLE
Minor KMMLU cleanup

### DIFF
--- a/lm_eval/tasks/kmmlu/cot_hard/_cot_kmmlu_yaml
+++ b/lm_eval/tasks/kmmlu/cot_hard/_cot_kmmlu_yaml
@@ -3,6 +3,7 @@ group:
     - kmmlu_hard_cot
 dataset_path: HAERAE-HUB/KMMLU-HARD
 output_type: generate_until
+validation_split: dev # not meant to be used, only here to silence warnings
 test_split: test
 doc_to_target: "{{['A', 'B', 'C', 'D'][answer-1]}}"
 metric_list:
@@ -17,6 +18,7 @@ generation_kwargs:
   do_sample: false
   max_gen_toks: 2048
   temperature: 0.0
+num_fewshot: 0
 filter_list:
   - name: "get-answer"
     filter:
@@ -26,3 +28,4 @@ filter_list:
       - function: "take_first"
 metadata:
   version: 2.0
+  num_fewshot: 5


### PR DESCRIPTION
Ensuring that we won't mess up the hardcoded 5-shot prompt in CoT-hard. 

@h-albert-lee by the way, does KMMLU have a "canonical" 5 shots + their ordering that were used, as in the CoT section?

If so, I can add a `fewshot_config` to make the order respected, as we do for MMLU (https://github.com/EleutherAI/lm-evaluation-harness/blob/b177c82cb3ef4a8f03ff77341970ab9d77ffadb4/lm_eval/tasks/mmlu/default/_default_template_yaml#L4-L5)