### PR TITLE
Hardcode IFEval to 0-shot

### DIFF
--- a/lm_eval/tasks/ifeval/ifeval.yaml
+++ b/lm_eval/tasks/ifeval/ifeval.yaml
@@ -12,6 +12,7 @@ generation_kwargs:
   temperature: 0.0
   max_gen_toks: 1280
 process_results: !function utils.process_results
+num_fewshot: 0
 metric_list:
   - metric: prompt_level_strict_acc
     aggregation: mean


### PR DESCRIPTION
IFEval only really makes sense zero-shot, so hardcoding to ensure users can't accidentally run it few-shot.