### PR TITLE
Adding new task : KorMedMCQA

### DIFF
--- a/lm_eval/tasks/kormedmcqa/README.md
+++ b/lm_eval/tasks/kormedmcqa/README.md
@@ -25,6 +25,7 @@ Homepage: https://huggingface.co/datasets/sean0042/KorMedMCQA
 
 ### Groups and Tasks
 
+* `kormedmcqa`: Runs `kormedmcqa_doctor`, `kormedmcqa_nurse`, and `kormedmcqa_pharm`.
 
 #### Tasks
 

--- a/lm_eval/tasks/kormedmcqa/README.md
+++ b/lm_eval/tasks/kormedmcqa/README.md
@@ -1,0 +1,46 @@
+# KorMedMCQA
+
+### Paper
+
+Title: `KorMedMCQA: Multi-Choice Question Answering Benchmark for Korean Healthcare Professional Licensing Examinations`
+
+Abstract: `We introduce KorMedMCQA, the first Korean multiple-choice question answering (MCQA) benchmark derived from Korean healthcare professional licensing examinations, covering from the year 2012 to year 2023. This dataset consists of a selection of questions from the license examinations for doctors, nurses, and pharmacists, featuring a diverse array of subjects. We conduct baseline experiments on various large language models, including proprietary/open-source, multilingual/Korean-additional pretrained, and clinical context pretrained models, highlighting the potential for further enhancements. We make our data publicly available on HuggingFace and provide a evaluation script via LM-Harness, inviting further exploration and advancement in Korean healthcare environments.`
+
+
+Paper : https://arxiv.org/abs/2403.01469
+
+Homepage: https://huggingface.co/datasets/sean0042/KorMedMCQA
+
+
+### Citation
+
+```
+@article{kweon2024kormedmcqa,
+      title={KorMedMCQA: Multi-Choice Question Answering Benchmark for Korean Healthcare Professional Licensing Examinations},
+      author={Sunjun Kweon and Byungjin Choi and Minkyu Kim and Rae Woong Park and Edward Choi},
+      journal={arXiv preprint arXiv:2403.01469},
+      year={2024}
+}
+```
+
+### Groups and Tasks
+
+
+#### Tasks
+
+* `kormedmcqa_doctor`: `Official Korean Doctor Examination`
+* `kormedmcqa_nurse`: `Official Korean Nurse Examination`
+* `kormedmcqa_pharm`: `Official Korean Pharmacist Examination`
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/kormedmcqa/kormedmcqa_doctor.yaml
+++ b/lm_eval/tasks/kormedmcqa/kormedmcqa_doctor.yaml
@@ -1,0 +1,26 @@
+task : kormedmcqa_doctor
+dataset_path : sean0042/KorMedMCQA
+dataset_name : doctor
+test_split : test
+fewshot_split : dev
+fewshot_config:
+  sampler: first_n
+output_type: generate_until
+doc_to_text: "{{question.strip()}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nE. {{E}}\n정답："
+doc_to_target: "{{['A', 'B', 'C', 'D', 'E'][answer-1]}}"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    regexes_to_ignore:
+          - " "
+generation_kwargs:
+  until:
+    - "Q:"
+    - "\n\n"
+    - "</s>"
+    - "."
+  do_sample: false
+  temperature: 0.0

--- a/lm_eval/tasks/kormedmcqa/kormedmcqa_doctor.yaml
+++ b/lm_eval/tasks/kormedmcqa/kormedmcqa_doctor.yaml
@@ -1,3 +1,4 @@
+group: kormedmcqa
 task : kormedmcqa_doctor
 dataset_path : sean0042/KorMedMCQA
 dataset_name : doctor

--- a/lm_eval/tasks/kormedmcqa/kormedmcqa_nurse.yaml
+++ b/lm_eval/tasks/kormedmcqa/kormedmcqa_nurse.yaml
@@ -1,0 +1,26 @@
+task : kormedmcqa_nurse
+dataset_path : sean0042/KorMedMCQA
+dataset_name : nurse
+test_split : test
+fewshot_split : dev
+fewshot_config:
+  sampler: first_n
+output_type: generate_until
+doc_to_text: "{{question.strip()}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nE. {{E}}\n정답："
+doc_to_target: "{{['A', 'B', 'C', 'D', 'E'][answer-1]}}"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    regexes_to_ignore:
+          - " "
+generation_kwargs:
+  until:
+    - "Q:"
+    - "\n\n"
+    - "</s>"
+    - "."
+  do_sample: false
+  temperature: 0.0

--- a/lm_eval/tasks/kormedmcqa/kormedmcqa_nurse.yaml
+++ b/lm_eval/tasks/kormedmcqa/kormedmcqa_nurse.yaml
@@ -1,3 +1,4 @@
+group: kormedmcqa
 task : kormedmcqa_nurse
 dataset_path : sean0042/KorMedMCQA
 dataset_name : nurse

--- a/lm_eval/tasks/kormedmcqa/kormedmcqa_pharm.yaml
+++ b/lm_eval/tasks/kormedmcqa/kormedmcqa_pharm.yaml
@@ -1,0 +1,26 @@
+task : kormedmcqa_pharm
+dataset_path : sean0042/KorMedMCQA
+dataset_name : pharm
+test_split : test
+fewshot_split : dev
+fewshot_config:
+  sampler: first_n
+output_type: generate_until
+doc_to_text: "{{question.strip()}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\nE. {{E}}\n정답："
+doc_to_target: "{{['A', 'B', 'C', 'D', 'E'][answer-1]}}"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    regexes_to_ignore:
+          - " "
+generation_kwargs:
+  until:
+    - "Q:"
+    - "\n\n"
+    - "</s>"
+    - "."
+  do_sample: false
+  temperature: 0.0

--- a/lm_eval/tasks/kormedmcqa/kormedmcqa_pharm.yaml
+++ b/lm_eval/tasks/kormedmcqa/kormedmcqa_pharm.yaml
@@ -1,3 +1,4 @@
+group: kormedmcqa
 task : kormedmcqa_pharm
 dataset_path : sean0042/KorMedMCQA
 dataset_name : pharm


### PR DESCRIPTION
We've added a new task KorMedMCQA dataset into LM-Harness framework.
Below are link for paper and huggingface dataset

Paper : https://arxiv.org/abs/2403.01469
Homepage: https://huggingface.co/datasets/sean0042/KorMedMCQA

We referenced KMMLU methodology in evaluation. 

Thank you in advance