### PR TITLE
Add compatibility for vLLM's new Logprob object

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -425,7 +425,7 @@ class VLLM(TemplateLM):
             {
                 token: coerce_logprob_to_num(logprob)
                 for token, logprob in logprob_dict.items()
-            } 
+            }
             if logprob_dict is not None
             else None
             for logprob_dict in continuation_logprobs_dicts

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -425,7 +425,7 @@ class VLLM(TemplateLM):
             {
                 token: coerce_logprob_to_num(logprob)
                 for token, logprob in logprob_dict.items()
-            }
+            } if logprob_dict is not None else None
             for logprob_dict in continuation_logprobs_dicts
         ]
 

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -425,7 +425,9 @@ class VLLM(TemplateLM):
             {
                 token: coerce_logprob_to_num(logprob)
                 for token, logprob in logprob_dict.items()
-            } if logprob_dict is not None else None
+            } 
+            if logprob_dict is not None
+            else None
             for logprob_dict in continuation_logprobs_dicts
         ]
 

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -421,10 +421,13 @@ class VLLM(TemplateLM):
             # for older versions of vLLM).
             return getattr(logprob, "logprob", logprob)
 
-        logprob_dict = {
-            token: coerce_logprob_to_num(logprob)
-            for token, logprob in logprob_dict.items()
-        }
+        continuation_logprobs_dicts = [
+            {
+                token: coerce_logprob_to_num(logprob)
+                for token, logprob in logprob_dict.items()
+            }
+            for logprob_dict in continuation_logprobs_dicts
+        ]
 
         # Calculate continuation_logprobs
         # assume ctxlen always >= 1


### PR DESCRIPTION
vLLM changed the return type of logprobs from float to a Logprob object storing the float value + extra data (https://github.com/vllm-project/vllm/pull/3065). This PR fixes the attribute error using the following logic:
If we are dealing with vllm's Logprob object, return the logprob value stored as an attribute. Otherwise, return the object itself (which should be a float for older versions of vLLM).