### PR TITLE
Fix incorrect `max_gen_toks` generation kwarg default in code2_text.

### DIFF
--- a/lm_eval/tasks/code_x_glue/code-text/go.yaml
+++ b/lm_eval/tasks/code_x_glue/code-text/go.yaml
@@ -8,7 +8,7 @@ test_split: test
 output_type: generate_until
 generation_kwargs:
   num_beams: 10
-  max_length: 128
+  max_gen_toks: 128
   until:
     - "</s>"
 doc_to_text: !function utils.doc_to_text

--- a/lm_eval/tasks/code_x_glue/code-text/java.yaml
+++ b/lm_eval/tasks/code_x_glue/code-text/java.yaml
@@ -8,7 +8,7 @@ test_split: test
 output_type: generate_until
 generation_kwargs:
   num_beams: 10
-  max_length: 128
+  max_gen_toks: 128
   until:
     - "</s>"
 doc_to_text: !function utils.doc_to_text

--- a/lm_eval/tasks/code_x_glue/code-text/javascript.yaml
+++ b/lm_eval/tasks/code_x_glue/code-text/javascript.yaml
@@ -8,7 +8,7 @@ test_split: test
 output_type: generate_until
 generation_kwargs:
   num_beams: 10
-  max_length: 128
+  max_gen_toks: 128
   until:
     - "</s>"
 doc_to_text: !function utils.doc_to_text

--- a/lm_eval/tasks/code_x_glue/code-text/php.yaml
+++ b/lm_eval/tasks/code_x_glue/code-text/php.yaml
@@ -8,7 +8,7 @@ test_split: test
 output_type: generate_until
 generation_kwargs:
   num_beams: 10
-  max_length: 128
+  max_gen_toks: 128
   until:
     - "</s>"
 doc_to_text: !function utils.doc_to_text

--- a/lm_eval/tasks/code_x_glue/code-text/python.yaml
+++ b/lm_eval/tasks/code_x_glue/code-text/python.yaml
@@ -8,7 +8,7 @@ test_split: test
 output_type: generate_until
 generation_kwargs:
   num_beams: 10
-  max_length: 128
+  max_gen_toks: 128
   until:
     - "</s>"
 doc_to_text: !function utils.doc_to_text

--- a/lm_eval/tasks/code_x_glue/code-text/ruby.yaml
+++ b/lm_eval/tasks/code_x_glue/code-text/ruby.yaml
@@ -8,7 +8,7 @@ test_split: test
 output_type: generate_until
 generation_kwargs:
   num_beams: 10
-  max_length: 128
+  max_gen_toks: 128
   until:
     - "</s>"
 doc_to_text: !function utils.doc_to_text


### PR DESCRIPTION
Taking this as reference [PR](https://github.com/EleutherAI/lm-evaluation-harness/pull/1546) and to resolve this [issue](https://github.com/EleutherAI/lm-evaluation-harness/issues/1513), raising a PR.

@haileyschoelkopf 