### PR TITLE
Support jinja templating for task descriptions

### DIFF
--- a/docs/task_guide.md
+++ b/docs/task_guide.md
@@ -30,9 +30,10 @@ Dataset configuration options:
 
 Prompting / in-context formatting options:
 - **use_prompt** (`str`, *optional*) — Name of prompt in promptsource to use. if defined, will overwrite doc_to_text, doc_to_target, and doc_to_choice.
-- **doc_to_text** (`Union[Callable, str]`, *optional*) — Jinja2, f-string, or function to process a sample into the appropriate input for the model
-- **doc_to_target** (`Union[Callable, str]`, *optional*) — Jinja2, f-string, or function to process a sample into the appropriate target output for the model. For multiple choice tasks, this should return an index into
-- **doc_to_choice** (`Union[Callable, str]`, *optional*) — Jinja2, f-string, or function to process a sample into a list of possible string choices for `multiple_choice` tasks. Left undefined for `generate_until` tasks.
+- **description** (`str`, *optional*) — An optional prepended Jinja2 template or string which will be prepended to the few-shot examples passed into the model, often describing the task or providing instructions to a model, such as `"The following are questions (with answers) about {{subject}}.\n\n"`. No delimiters or spacing are inserted between the description and the first few-shot example.
+- **doc_to_text** (`Union[Callable, str]`, *optional*) — Jinja2 template, string, or function to process a sample into the appropriate input for the model
+- **doc_to_target** (`Union[Callable, str]`, *optional*) — Jinja2 template, string, or function to process a sample into the appropriate target output for the model. For multiple choice tasks, this should return an index into
+- **doc_to_choice** (`Union[Callable, str]`, *optional*) — Jinja2 template, string, or function to process a sample into a list of possible string choices for `multiple_choice` tasks. Left undefined for `generate_until` tasks.
 - **fewshot_delimiter** (`str`, *optional*, defaults to "\n\n") — String to insert between few-shot examples.
 - **target_delimiter** (`str`, *optional*, defaults to `" "`) — String to insert between input and target output for the datapoint being tested.
 

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -940,7 +940,7 @@ class ConfigurableTask(Task):
         :returns: str
             The fewshot context.
         """
-        if self.config.description:
+        if description := self.config.description:
             description = utils.apply_template(self.config.description, doc)
 
         if num_fewshot == 0:

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -941,7 +941,8 @@ class ConfigurableTask(Task):
             The fewshot context.
         """
 
-        description = utils.apply_template(self.config.description, doc)
+	if self.config.description:
+	        description = utils.apply_template(self.config.description, doc)
 
         if num_fewshot == 0:
             # always prepend the (possibly empty) task description

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -941,9 +941,9 @@ class ConfigurableTask(Task):
             The fewshot context.
         """
 	if self.config.description:
-            description = utils.apply_template(self.config.description, doc)
-
-        if num_fewshot == 0:
+	    description = utils.apply_template(self.config.description, doc)
+        
+	if num_fewshot == 0:
             # always prepend the (possibly empty) task description
             labeled_examples = description
         else:

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -940,10 +940,10 @@ class ConfigurableTask(Task):
         :returns: str
             The fewshot context.
         """
-	if self.config.description:
-	    description = utils.apply_template(self.config.description, doc)
-        
-	if num_fewshot == 0:
+        if self.config.description:
+            description = utils.apply_template(self.config.description, doc)
+
+        if num_fewshot == 0:
             # always prepend the (possibly empty) task description
             labeled_examples = description
         else:

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -940,9 +940,8 @@ class ConfigurableTask(Task):
         :returns: str
             The fewshot context.
         """
-
 	if self.config.description:
-	        description = utils.apply_template(self.config.description, doc)
+            description = utils.apply_template(self.config.description, doc)
 
         if num_fewshot == 0:
             # always prepend the (possibly empty) task description

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -941,13 +941,13 @@ class ConfigurableTask(Task):
             The fewshot context.
         """
 
+        description = utils.apply_template(self.config.description, doc)
+
         if num_fewshot == 0:
             # always prepend the (possibly empty) task description
-            labeled_examples = self.config.description
+            labeled_examples = description
         else:
-            labeled_examples = self.config.description + self.sampler.get_context(
-                doc, num_fewshot
-            )
+            labeled_examples = description + self.sampler.get_context(doc, num_fewshot)
 
         example = self.doc_to_text(doc)
         if self.multiple_input:


### PR DESCRIPTION
This PR allows for the use of jinja template string in task descriptions.

Implementing a task for the following dataset prompted the addition of this feature: [FreedomIntelligence/ACVA-Arabic-Cultural-Value-Alignment](https://huggingface.co/datasets/FreedomIntelligence/ACVA-Arabic-Cultural-Value-Alignment)

I wanted it so that the description of each request contains the document's domain, found in its "id" column, as follows:

```
group: arabic_cultural
dataset_path: "FreedomIntelligence/ACVA-Arabic-Cultural-Value-Alignment"
validation_split: validation
output_type: multiple_choice
description: "The following are questions on {{id.split('-')[0]}}. Answer with True or False"
doc_to_text: "Question:{{question}}\nAnswer:"
doc_to_choice: ["True", "False"]
doc_to_target: answer
metric_list:
  - metric: acc
    aggregation: mean
    higher_is_better: true
metadata:
  version: 1.0
```