### PR TITLE
Proposed approach for testing CLI arg parsing

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -151,7 +151,6 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--check_integrity",
         action="store_true",
-        default=False,
         help="Whether to run the relevant part of the test suite for the tasks.",
     )
     parser.add_argument(
@@ -226,7 +225,6 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--trust_remote_code",
-        default=True,
         action="store_true",
         help="Sets trust_remote_code to True to execute code to create HF Datasets from the Hub",
     )

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -55,7 +55,7 @@ def _int_or_none_list_arg_type(max_len: int, value: str, split_char: str = ","):
 
 def check_argument_types(parser: argparse.ArgumentParser):
     """
-    Check to make sure all CLI args are typed
+    Check to make sure all CLI args are typed, raises error if not
     """
     for action in parser._actions:
         if action.dest != "help" and not action.const:
@@ -63,6 +63,8 @@ def check_argument_types(parser: argparse.ArgumentParser):
                 raise ValueError(
                     f"Argument '{action.dest}' doesn't have a type specified."
                 )
+            else:
+                continue
 
 
 def setup_parser() -> argparse.ArgumentParser:
@@ -240,7 +242,8 @@ def parse_eval_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
 def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if not args:
         # we allow for args to be passed externally, else we parse them ourselves
-        args = parse_eval_args()
+        parser = setup_parser()
+        args = parse_eval_args(parser)
 
     if args.wandb_args:
         wandb_logger = WandbLogger(**simple_parse_args_string(args.wandb_args))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,30 +9,25 @@ def parser():
 
 
 def test_model(parser):
-    parser = parser
     result = parser.parse_args(["--model", "hf"])
     assert "hf" == result.model
 
 
 def test_model_args(parser):
-    parser = parser
     result = parser.parse_args(["--model_args", "pretrained=EleutherAI/gpt-j-6B"])
     assert "pretrained=EleutherAI/gpt-j-6B" == result.model_args
 
 
 def test_num_fewshot(parser):
-    parser = parser
     result = parser.parse_args(["--num_fewshot", "5"])
     assert 5 == result.num_fewshot
 
 
 def test_tasks(parser):
-    parser = parser
     result = parser.parse_args(["--tasks", "hellaswag"])
     assert "hellaswag" == result.tasks
 
 
 def test_trust_remote_code(parser):
-    parser = parser
     result = parser.parse_args(["--trust_remote_code"])
     assert result.trust_remote_code is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,33 +1,24 @@
+import argparse
+
 import pytest
 
 import lm_eval.__main__
 
 
-@pytest.fixture()
-def parser():
-    yield lm_eval.__main__.setup_parser()
-
-
-def test_model(parser):
-    result = parser.parse_args(["--model", "hf"])
-    assert "hf" == result.model
-
-
-def test_model_args(parser):
-    result = parser.parse_args(["--model_args", "pretrained=EleutherAI/gpt-j-6B"])
-    assert "pretrained=EleutherAI/gpt-j-6B" == result.model_args
-
-
-def test_num_fewshot(parser):
-    result = parser.parse_args(["--num_fewshot", "5"])
-    assert 5 == result.num_fewshot
-
-
-def test_tasks(parser):
-    result = parser.parse_args(["--tasks", "hellaswag"])
-    assert "hellaswag" == result.tasks
-
-
-def test_trust_remote_code(parser):
-    result = parser.parse_args(["--trust_remote_code"])
-    assert result.trust_remote_code is True
+def test_model():
+    """
+    Assert error raised if cli args argument doesn't have type
+    """
+    with pytest.raises(ValueError):
+        parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+        parser.add_argument(
+            "--model", "-m", type=str, default="hf", help="Name of model e.g. `hf`"
+        )
+        parser.add_argument(
+            "--tasks",
+            "-t",
+            default=None,
+            metavar="task1,task2",
+            help="To get full list of tasks, use the command lm-eval --tasks list",
+        )
+        lm_eval.__main__.check_argument_types(parser)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,38 @@
+import pytest
+
+import lm_eval.__main__
+
+
+@pytest.fixture()
+def parser():
+    yield lm_eval.__main__.setup_parser()
+
+
+def test_model(parser):
+    parser = parser
+    result = parser.parse_args(["--model", "hf"])
+    assert "hf" == result.model
+
+
+def test_model_args(parser):
+    parser = parser
+    result = parser.parse_args(["--model_args", "pretrained=EleutherAI/gpt-j-6B"])
+    assert "pretrained=EleutherAI/gpt-j-6B" == result.model_args
+
+
+def test_num_fewshot(parser):
+    parser = parser
+    result = parser.parse_args(["--num_fewshot", "5"])
+    assert 5 == result.num_fewshot
+
+
+def test_tasks(parser):
+    parser = parser
+    result = parser.parse_args(["--tasks", "hellaswag"])
+    assert "hellaswag" == result.tasks
+
+
+def test_trust_remote_code(parser):
+    parser = parser
+    result = parser.parse_args(["--trust_remote_code"])
+    assert result.trust_remote_code is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import pytest
 import lm_eval.__main__
 
 
-def test_model():
+def test_cli_parse_error():
     """
     Assert error raised if cli args argument doesn't have type
     """
@@ -22,3 +22,22 @@ def test_model():
             help="To get full list of tasks, use the command lm-eval --tasks list",
         )
         lm_eval.__main__.check_argument_types(parser)
+
+
+def test_cli_parse_no_error():
+    """
+    Assert typed arguments are parsed correctly
+    """
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "--model", "-m", type=str, default="hf", help="Name of model e.g. `hf`"
+    )
+    parser.add_argument(
+        "--tasks",
+        "-t",
+        type=str,
+        default=None,
+        metavar="task1,task2",
+        help="To get full list of tasks, use the command lm-eval --tasks list",
+    )
+    lm_eval.__main__.check_argument_types(parser)


### PR DESCRIPTION
See discussion here: https://github.com/EleutherAI/lm-evaluation-harness/issues/1518

Here's an approach to start testing CLI argument parsing:

1. Separate out setting up the argument parser in `parse_eval_args` into a separate method, `setup_parser` that gets called in `parse_eval_args`
2. Create unit tests that call the parser for each of the command line arguments 
3. Adding specific TypeError exceptions at each argument entrypoint in the `cli_evaluate` method

Let me know what you think about this approach. If it seems reasonable, I'll add the tests for the rest of the methods and exceptions where it's reasonable.  

@LSinev @haileyschoelkopf 