### PR TITLE
add context-based requests processing

### DIFF
--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Literal, Optional, Tuple
+from typing import Callable, Literal, Optional, Tuple
 
 
 OutputType = Literal[
@@ -36,3 +36,27 @@ class Instance:
         return (
             self.arguments if isinstance(self.arguments, tuple) else (self.arguments,)
         )
+
+
+class ContextInstance(Instance):
+    def __init__(
+        self,
+        requests_updater: Optional[Callable] = None,
+        storage_updater: Optional[Callable] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._update_request = requests_updater
+        self._update_storage = storage_updater
+
+    @property
+    def update_request(self):
+        if getattr(self, "_update_request") is not None:
+            return self._update_request
+        raise NotImplementedError("Method for updating request is not defined.")
+
+    @property
+    def update_storage(self):
+        if getattr(self, "_update_storage") is not None:
+            return self._update_storage
+        raise NotImplementedError("Method for updating storage is not defined.")


### PR DESCRIPTION
The PR add support for new type of tasks - context-based tasks.

Motivation. Some tasks and CoT strategies may require knowing the answer of the model for the previous question to form the current request. Till now it is impossible to implement such tasks without changing `evaluator.py` (or models/*.py file) which leads to inability to use lm-evaluation-harness as an external library (user cannot directly pass new evaluator.py instead of the default one while running the task). This PR changes it. 

How it works. All requests are split into two meta-groups: regular tasks and context-based tasks. Each group is processed separately. No changes in processing regular tasks. For context-based tasks after preparing requests each request is updated, processed through the model, the external storage is updated. If no context-based tasks claimed, the loop for processing them is not accessed. So, the workflow for all existing tasks has not been changed. 
Also, to encompass new functionality a new instance class is added: ContextInstance. It inherits from regular Instance and adds only two new methods: update_request that takes storage and request and does something to the request right before passing it into the model so that the changes are available with `--log_samples` flag. Old tasks that use Instance are not affected. New class is meant to avoid confusion between regular and context-based tasks instances.
To indicate that task is context-based the new attr is used. It shouldn't be False by defalut, as while running all tasks the presence of this attr and its value is checked. So, no changes needed to run existing tasks, no way old tasks will be run through a new loop.

All tests are passed successfully. No need in changes for different models. The only problem that may happen: each time while calling the model a new progress bar apears. This can be solved by merging #1569 

Closes: #1432 #1537