### PR TITLE
Fix eval_logger import for mmlu/_generate_configs.py

### DIFF
--- a/lm_eval/tasks/mmlu/_generate_configs.py
+++ b/lm_eval/tasks/mmlu/_generate_configs.py
@@ -2,12 +2,13 @@
 Take in a YAML, and output all "other" splits with this YAML
 """
 import argparse
+import logging
 import os
 
 import yaml
 from tqdm import tqdm
 
-import logging
+
 eval_logger = logging.getLogger("lm-eval")
 
 

--- a/lm_eval/tasks/mmlu/_generate_configs.py
+++ b/lm_eval/tasks/mmlu/_generate_configs.py
@@ -7,7 +7,8 @@ import os
 import yaml
 from tqdm import tqdm
 
-from lm_eval.logger import eval_logger
+import logging
+eval_logger = logging.getLogger("lm-eval")
 
 
 SUBJECTS = {


### PR DESCRIPTION
After the verbosity rework changes (#958), fix the import of eval_logger for mmlu/_generate_configs.py.