### PR TITLE
fix gen_kwargs arg reading

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -182,7 +182,7 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--gen_kwargs",
-        type=dict,
+        type=str,
         default=None,
         help=(
             "String arguments for model generation on greedy_until tasks,"


### PR DESCRIPTION
Quite short PR :)
After one of recent PRs harness can no longer read `gen_kwargs` param. Help says `temperature=0,top_k=0,top_p=0` is example. But type is set to `dict`. Something is wrong. All other code is meant to handle --gen_kwargs as a string, so this is a PR to bring back the usual behaviour.

Right now I see `lm_eval: error: argument --gen_kwargs: invalid dict value: 'temperature=0.6,do_sample=True'` error.