### PR TITLE
fix until arg processing

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1163,7 +1163,7 @@ class HFLM(TemplateLM):
                 if "until" in kwargs.keys():
                     until = kwargs.pop("until")
                     if isinstance(until, str):
-                        until = [kwargs]
+                        until = [until]
                     elif not isinstance(until, list):
                         raise ValueError(
                             f"Expected `kwargs['until']` to be of type Union[str,list] but got {until}"

--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -664,7 +664,7 @@ class NEURON_HF(TemplateLM):
                     if "until" in kwargs.keys():
                         until = kwargs.pop("until")
                         if isinstance(until, str):
-                            until = [kwargs]
+                            until = [until]
                         elif not isinstance(until, list):
                             raise ValueError(
                                 f"Expected `kwargs['until']` to be of type Union[str,list] but got {until}"


### PR DESCRIPTION
Small change. Now if I pass until in task config as not list but simple string, like until="\n", huggingface.py (as example) processes it, it is a string, so it takes gen_kwargs (without until) and makes `until=[kwargs]`. So, if I pass `until="\n"` in a task and `--gen_kwargs="temperature=0.6,do_sample=True"`, I will have an error: `TypeError: TextEncodeInput must be Union[TextInputSequence, Tuple[InputSequence, InputSequence]]`. Reason: until will be equal to `[{'do_sample': True, 'temperature': 0.6}]`. This is defifnitely not the expected behaviour. If until is not list, it shoud be packed in a list. This PR does this very feature.