### PR TITLE
custom sampler for ConfigurableTask

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -212,14 +212,16 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--seed",
-        type=partial(_int_or_none_list_arg_type, 3),
-        default="0,1234,1234",  # for backward compatibility
+        type=partial(_int_or_none_list_arg_type, 4),
+        default="0,1234,1234,1234",  # for backward compatibility
         help=(
-            "Set seed for python's random, numpy and torch.\n"
-            "Accepts a comma-separated list of 3 values for python's random, numpy, and torch seeds, respectively, "
-            "or a single integer to set the same seed for all three.\n"
-            "The values are either an integer or 'None' to not set the seed. Default is `0,1234,1234` (for backward compatibility).\n"
-            "E.g. `--seed 0,None,8` sets `random.seed(0)` and `torch.manual_seed(8)`. Here numpy's seed is not set since the second value is `None`.\n"
+            "Set seed for python's random, numpy, torch, and fewshot sampling.\n"
+            "Accepts a comma-separated list of 4 values for python's random, numpy, torch, and fewshot sampling seeds, "
+            "respectively, or a single integer to set the same seed for all three.\n"
+            "The values are either an integer or 'None' to not set the seed. Default is `0,1234,1234` "
+            "(for backward compatibility).\n"
+            "E.g. `--seed 0,None,8` sets `random.seed(0)` and `torch.manual_seed(8)`. Here numpy's seed is not set "
+            "since the second value is `None`.\n"
             "E.g, `--seed 42` sets all three seeds to 42."
         ),
     )
@@ -359,6 +361,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         random_seed=args.seed[0],
         numpy_random_seed=args.seed[1],
         torch_random_seed=args.seed[2],
+        fewshot_random_seed=args.seed[3],
         **request_caching_args,
     )
 

--- a/lm_eval/api/samplers.py
+++ b/lm_eval/api/samplers.py
@@ -1,7 +1,10 @@
 class ContextSampler:
     def __init__(self, docs, task, fewshot_indices=None, rnd=None) -> None:
         self.rnd = rnd
-        assert self.rnd, "must pass rnd to FewShotSampler!"
+        if not self.rnd:
+            raise ValueError(
+                "A `random.Random` generator argument must be provided to `rnd` of FewShotSampler!"
+            )
 
         self.task = task
         self.config = task._config

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -229,6 +229,9 @@ class Task(abc.ABC):
         self._config: TaskConfig = TaskConfig({**config}) if config else TaskConfig()
 
         self._filters = [build_filter_ensemble("none", [["take_first", None]])]
+        self.fewshot_rnd: Optional[
+            random.Random
+        ] = None  # purposely induce errors in case of improper usage
 
     def download(
         self,
@@ -520,7 +523,7 @@ class Task(abc.ABC):
         self,
         doc,
         num_fewshot,
-        rnd=random.Random(1234),
+        rnd=None,
         description=None,
     ):
         """Returns a fewshot context string that is made up of a prepended description
@@ -539,9 +542,12 @@ class Task(abc.ABC):
             The fewshot context.
         """
         if rnd is None:
-            raise ValueError(
-                "A `random.Random` generator argument must be provided to `rnd`"
-            )
+            if self.fewshot_rnd is not None:
+                rnd = self.fewshot_rnd
+            else:
+                raise ValueError(
+                    "A `random.Random` generator argument must be provided to `rnd`"
+                )
 
         description = description if description else ""
 
@@ -631,6 +637,11 @@ class Task(abc.ABC):
             }
         setattr(self._config, "metric_list", [{"metric": metric_name}])
         setattr(self._config, "process_results", None)
+
+    def set_fewshot_seed(self, seed: Optional[int] = None) -> None:
+        self.fewshot_rnd = random.Random(seed)
+        if hasattr(self, "sampler"):
+            self.sampler.rnd = self.fewshot_rnd
 
     @property
     def eval_docs(self) -> Union[datasets.Dataset, List[dict]]:
@@ -808,11 +819,14 @@ class ConfigurableTask(Task):
             self.prompt = None
 
         if self.fewshot_docs() is not None:
+            self.fewshot_rnd = (
+                random.Random()
+            )  # setting with no seed, to be overridden at a later time
             self.sampler = samplers.get_sampler(
                 self.config.fewshot_config.get("sampler", "default")
                 if self.config.fewshot_config
                 else "default"
-            )(list(self.fewshot_docs()), self, rnd=random.Random(1234))
+            )(list(self.fewshot_docs()), self, rnd=self.fewshot_rnd)
 
         self.task_docs = self.eval_docs
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -55,6 +55,7 @@ def simple_evaluate(
     random_seed: int = 0,
     numpy_random_seed: int = 1234,
     torch_random_seed: int = 1234,
+    fewshot_random_seed: int = 1234,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -102,6 +103,8 @@ def simple_evaluate(
         Random seed for numpy. If set to None, the seed will not be set.
     :param torch_random_seed: int
         Random seed for torch. If set to None, the seed will not be set.
+    :param fewshot_random_seed: int
+        Random seed for fewshot sampler random generator. If set to None, the seed of generator will be set to None.
 
     :return
         Dictionary of results
@@ -223,6 +226,10 @@ def simple_evaluate(
                     f"Overwriting default num_fewshot of {task_name} from {default_num_fewshot} to {num_fewshot}"
                 )
                 task_obj.set_config(key="num_fewshot", value=num_fewshot)
+            task_obj.set_fewshot_seed(seed=fewshot_random_seed)
+            eval_logger.info(
+                f"Setting fewshot random generator seed to {fewshot_random_seed}"
+            )
         else:
             # if num_fewshot not provided, and the task does not define a default one, default to 0
             if (default_num_fewshot := task_obj.get_config("num_fewshot")) is None:


### PR DESCRIPTION
* Way to control seed of fewshot sampling (may help with https://github.com/EleutherAI/lm-evaluation-harness/issues/1591)
* Added ability for custom sampler for ConfigurableTask

Python tasks can use customized fewshots strategy (slightly modifiable fewshots or any other ideas) by using child classes of `Task` and modification of `fewshot_context`. Migration of such tasks to `ConfigurableTask` with yaml config was not possible due to a lack of fewshot customization. After this PR, a custom fewshot sampler may be set in the config like
```
fewshot_config:
  sampler: !function utils.MyFewshotSampler
```