### PR TITLE
getting model class only when defined

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -304,7 +304,9 @@ class TemplateLM(LM):
             continuation = context[-n_spaces:] + continuation
             context = context[:-n_spaces]
 
-        if self.AUTO_MODEL_CLASS == transformers.AutoModelForCausalLM:
+        model_class = getattr(self, "AUTO_MODEL_CLASS", None)
+
+        if model_class == transformers.AutoModelForCausalLM:
             whole_enc = self.tok_encode(
                 context + continuation, add_special_tokens=False
             )
@@ -313,7 +315,7 @@ class TemplateLM(LM):
             context_enc_len = len(context_enc)
             continuation_enc = whole_enc[context_enc_len:]
 
-        elif self.AUTO_MODEL_CLASS == transformers.AutoModelForSeq2SeqLM:
+        elif model_class == transformers.AutoModelForSeq2SeqLM:
             # The encoder may require context end with special tokens
             context_enc = self.tok_encode(context)
             continuation_enc = self.tok_encode(continuation, add_special_tokens=False)

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -306,19 +306,15 @@ class TemplateLM(LM):
 
         model_class = getattr(self, "AUTO_MODEL_CLASS", None)
 
-        if model_class == transformers.AutoModelForCausalLM:
-            whole_enc = self.tok_encode(
-                context + continuation, add_special_tokens=False
-            )
-            context_enc = self.tok_encode(context, add_special_tokens=False)
+        if model_class == transformers.AutoModelForSeq2SeqLM:
+            context_enc = self.tok_encode(context)
+            continuation_enc = self.tok_encode(continuation, add_special_tokens=False)
+        else:
+            whole_enc = self.tok_encode(context + continuation)
+            context_enc = self.tok_encode(context)
 
             context_enc_len = len(context_enc)
             continuation_enc = whole_enc[context_enc_len:]
-
-        elif model_class == transformers.AutoModelForSeq2SeqLM:
-            # The encoder may require context end with special tokens
-            context_enc = self.tok_encode(context)
-            continuation_enc = self.tok_encode(continuation, add_special_tokens=False)
 
         return context_enc, continuation_enc
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -679,12 +679,21 @@ class HFLM(TemplateLM):
         self, string: str, left_truncate_len=None, add_special_tokens=None
     ) -> List[int]:
         """ """
+        # default for None - empty dict, use predefined tokenizer param
+        # used for all models except for CausalLM or predefined value
+        special_tokens_kwargs = {}
 
-        add_special_tokens = {}
-        if self.AUTO_MODEL_CLASS == transformers.AutoModelForCausalLM:
-            add_special_tokens = {"add_special_tokens": False or self.add_bos_token}
+        # by default for CausalLM - false or self.add_bos_token is set
+        if add_special_tokens is None:
+            if self.AUTO_MODEL_CLASS == transformers.AutoModelForCausalLM:
+                special_tokens_kwargs = {
+                    "add_special_tokens": False or self.add_bos_token
+                }
+        # otherwise the method explicitly defines the value
+        else:
+            special_tokens_kwargs = {"add_special_tokens": add_special_tokens}
 
-        encoding = self.tokenizer.encode(string, **add_special_tokens)
+        encoding = self.tokenizer.encode(string, **special_tokens_kwargs)
 
         # left-truncate the encoded context to be at most `left_truncate_len` tokens long
         if left_truncate_len:


### PR DESCRIPTION
As far as I can see the problem is that not all models that inherit from TemplateLM have `AUTO_MODEL_CLASS` attr. So, instead of copying the same code inside `huggingface.py` I suggest just checking the presence of the attr with default value if check fails. This way no repetition will be made and also if future models have some other `AUTO_MODEL_CLASS` vals and need different encoding strategy, there will be enough to add one more `elif` statement in base function instead of creating another copy.