### PR TITLE
peft Version Assertion

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -34,7 +34,6 @@ from lm_eval.models.utils import (
     stop_sequences_criteria,
 )
 
-from packaging import version
 
 eval_logger = utils.eval_logger
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -34,6 +34,7 @@ from lm_eval.models.utils import (
     stop_sequences_criteria,
 )
 
+from packaging import version
 
 eval_logger = utils.eval_logger
 
@@ -565,7 +566,8 @@ class HFLM(TemplateLM):
 
         if peft:
             if model_kwargs.get("load_in_4bit", None):
-                assert PEFT_VERSION >= "0.4.0", "load_in_4bit requires peft >= 0.4.0"
+                if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
+                    raise AssertionError("load_in_4bit requires peft >= 0.4.0")
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision
             )


### PR DESCRIPTION
At first, I tried to use evaluation harness with lora adapter.

But I found out that they continuously say "load_in_4bit requires peft 

>= 0.4.0". So I checked the code.


if peft:
            if model_kwargs.get("load_in_4bit", None):
                assert PEFT_VERSION >= "0.4.0", "load_in_4bit requires peft >= 0.4.0"
            self._model = PeftModel.from_pretrained(
                self._model, peft, revision=revision
            )

 In this way, peft version like 0.10.0 can be recongnized as 
 under the 0.4.0 version. So it raised Error. So I changed the code

To BE

 if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
                    raise AssertionError("load_in_4bit requires peft >= 0.4.0")
            

 
 