### PR TITLE
Fix SuperGlue's ReCoRD task following regression in v0.4 refactoring

### DIFF
--- a/lm_eval/tasks/super_glue/record/default.yaml
+++ b/lm_eval/tasks/super_glue/record/default.yaml
@@ -7,8 +7,9 @@ output_type: multiple_choice
 training_split: train
 validation_split: validation
 doc_to_text: !function util.doc_to_text
-doc_to_target: "{{answers}}"
-doc_to_choice: "{{entities}}"
+doc_to_target: !function util.doc_to_target
+doc_to_choice: !function util.doc_to_choice
+process_docs: !function util.process_docs
 process_results: !function util.process_results
 metric_list:
   - metric: f1
@@ -17,4 +18,4 @@ metric_list:
     higher_is_better: True
     aggregation: mean
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/super_glue/record/util.py
+++ b/lm_eval/tasks/super_glue/record/util.py
@@ -1,3 +1,4 @@
+import datasets
 import numpy as np
 import transformers.data.metrics.squad_metrics as squad_metrics
 
@@ -19,6 +20,21 @@ def format_answer(query, entity):
 def doc_to_target(doc):
     # We only output the first correct entity in a doc
     return format_answer(query=doc["query"], entity=doc["answers"][0])
+
+
+def doc_to_choice(doc):
+    return [format_answer(query=doc["query"], entity=ans) for ans in doc["entities"]]
+
+
+def process_docs(dataset: datasets.Dataset):
+    def _process_doc(doc):
+        return {
+            "passage": doc["passage"],
+            "query": doc["query"],
+            "entities": sorted(list(set(doc["entities"]))),
+            "answers": sorted(list(set(doc["answers"]))),
+        }
+    return dataset.map(_process_doc)
 
 
 def process_results(doc, results):


### PR DESCRIPTION
In prior library versions (v0.3), ReCoRD's scores were comparable to official results on various models, but since v0.4 there's a regression to low scores. For example, when testing Llama2 7B (base model), I previously got 90.42 EM, while in the latest version only 26.6 (basically a random guess).

Examining the issue, the bug was introduced by not copying all the formatting functions of prior versions and including them in the YAML + util file. This pull request corrects the bug, and now I receive a comparable score of 90.75 EM.

