### PR TITLE
Add natural questions in a the closedbook setup.

### DIFF
--- a/lm_eval/tasks/nq_closedbook/nq_closedbook.yaml
+++ b/lm_eval/tasks/nq_closedbook/nq_closedbook.yaml
@@ -23,7 +23,7 @@ filter_list:
       - function: take_first
 target_delimiter: " "
 metric_list:
-  - metric: !function nq_utils.squad_exact_match
+  - metric: !function nq_utils.nq_exact_match
     aggregation: mean
     higher_is_better: True
 metadata:

--- a/lm_eval/tasks/nq_closedbook/nq_closedbook.yaml
+++ b/lm_eval/tasks/nq_closedbook/nq_closedbook.yaml
@@ -3,6 +3,7 @@ dataset_path: iohadrubin/nq_closedbook
 output_type: generate_until
 training_split: train
 validation_split: validation
+test_split: test
 description: "Answer these questions:\n\n"
 doc_to_text: "Q: {{question}}?\nA:"
 

--- a/lm_eval/tasks/nq_closedbook/nq_closedbook.yaml
+++ b/lm_eval/tasks/nq_closedbook/nq_closedbook.yaml
@@ -1,0 +1,29 @@
+task: nq_closedbook
+dataset_path: iohadrubin/nq_closedbook
+output_type: generate_until
+training_split: train
+validation_split: validation
+description: "Answer these questions:\n\n"
+doc_to_text: "Q: {{question}}?\nA:"
+
+doc_to_target: !function nq_utils.doc_to_target
+fewshot_delimiter: "\n"
+generation_kwargs:
+  until:
+    - "\n"
+    - "."
+    - ","
+  do_sample: false
+  temperature: 0.0
+filter_list:
+  - name: remove_whitespace
+    filter:
+      - function: remove_whitespace
+      - function: take_first
+target_delimiter: " "
+metric_list:
+  - metric: !function nq_utils.squad_exact_match
+    aggregation: mean
+    higher_is_better: True
+metadata:
+  version: 3.0

--- a/lm_eval/tasks/nq_closedbook/nq_utils.py
+++ b/lm_eval/tasks/nq_closedbook/nq_utils.py
@@ -37,7 +37,7 @@ def normalize_answer(s):
         return text.lower()
 
     return white_space_fix(remove_articles(remove_punc(lower(s))))
-p
+
 def nq_exact_match_fn(prediction, ground_truth):
     return normalize_answer(prediction) == normalize_answer(ground_truth)
 
@@ -45,6 +45,7 @@ def nq_exact_match(references,predictions):
     assert isinstance(references, list) and len(references)==1
     assert isinstance(predictions, list) and len(predictions)==1
     return nq_exact_match_fn(predictions[0], references[0])
+
 
 
 

--- a/lm_eval/tasks/nq_closedbook/nq_utils.py
+++ b/lm_eval/tasks/nq_closedbook/nq_utils.py
@@ -1,0 +1,51 @@
+
+from typing import Dict, List
+# from lm_eval.api.registry import register_metric
+
+#Normalization from SQuAD evaluation script https://worksheets.codalab.org/rest/bundles/0x6b567e1cf2e041ec80d7098f031c5c9e/contents/blob/
+import regex
+import string
+
+
+import datasets
+import pandas as pd
+import ast
+def create_nq_closed(token):
+    PREFIX= "https://dl.fbaipublicfiles.com/dpr/data/retriever"
+    def parse_csv_into_dataset(path):
+        df = pd.read_csv(path, sep="\t",names=["question","answer"]).fillna("")
+        df.answer = df.apply(lambda x: ast.literal_eval(x["answer"]), axis=1)
+        return datasets.Dataset.from_pandas(df)
+    dataset = datasets.DatasetDict({"train":parse_csv_into_dataset(f"{PREFIX}/nq-train.qa.csv"),
+                                    "validation":parse_csv_into_dataset(f"{PREFIX}/nq-dev.qa.csv")})
+    dataset.push_to_hub("nq_closedbook",token=token)
+    
+def normalize_answer(s):
+    def remove_articles(text):
+        return regex.sub(r'\b(a|an|the)\b', ' ', text)
+
+    def white_space_fix(text):
+        return ' '.join(text.split())
+
+    def remove_punc(text):
+        exclude = set(string.punctuation)
+        return ''.join(ch for ch in text if ch not in exclude)
+
+    def lower(text):
+        return text.lower()
+
+    return white_space_fix(remove_articles(remove_punc(lower(s))))
+
+def squad_exact_match_fn(prediction, ground_truth):
+    return normalize_answer(prediction) == normalize_answer(ground_truth)
+
+def squad_exact_match(references,predictions):
+    assert isinstance(references, list) and len(references)==1
+    assert isinstance(predictions, list) and len(predictions)==1
+    return squad_exact_match_fn(predictions[0], references[0])
+
+
+
+def doc_to_target(doc: Dict) -> List[str]:
+    """Return list of indices of accepted answers (all of them)."""
+    return doc["answer"]

--- a/lm_eval/tasks/nq_closedbook/nq_utils.py
+++ b/lm_eval/tasks/nq_closedbook/nq_utils.py
@@ -17,7 +17,9 @@ def create_nq_closed(token):
         df.answer = df.apply(lambda x: ast.literal_eval(x["answer"]), axis=1)
         return datasets.Dataset.from_pandas(df)
     dataset = datasets.DatasetDict({"train":parse_csv_into_dataset(f"{PREFIX}/nq-train.qa.csv"),
-                                    "validation":parse_csv_into_dataset(f"{PREFIX}/nq-dev.qa.csv")})
+                                    "validation":parse_csv_into_dataset(f"{PREFIX}/nq-dev.qa.csv"),
+                                    "test":parse_csv_into_dataset(f"{PREFIX}/nq-test.qa.csv"),
+                                    })
     dataset.push_to_hub("nq_closedbook",token=token)
     
 def normalize_answer(s):
@@ -35,14 +37,14 @@ def normalize_answer(s):
         return text.lower()
 
     return white_space_fix(remove_articles(remove_punc(lower(s))))
-
-def squad_exact_match_fn(prediction, ground_truth):
+p
+def nq_exact_match_fn(prediction, ground_truth):
     return normalize_answer(prediction) == normalize_answer(ground_truth)
 
-def squad_exact_match(references,predictions):
+def nq_exact_match(references,predictions):
     assert isinstance(references, list) and len(references)==1
     assert isinstance(predictions, list) and len(predictions)==1
-    return squad_exact_match_fn(predictions[0], references[0])
+    return nq_exact_match_fn(predictions[0], references[0])
 
 
 


### PR DESCRIPTION
Add natural questions in a the closedbook setup.
btw, the current nq_open task you have is one derieved from the original nq, and only contains ~3k of the total ~8k validation examples of the original NQ.
The eval function added is from the FiD codebase https://github.com/facebookresearch/FiD (a well established baseline for NQ) that in turn was taken from squad.
Right now it is pointing to iohadrubin/nq_closedbook, but I also added the code for generating the datasets using the S3 links from the DPR repo (another well established retrieval baseline for NQ). So if you guys want it to point to EleutherAI/nq_closedbook maybe that's better.