### PR TITLE
Physics GRE task added

### DIFF
--- a/lm_eval/tasks/physics_gre/README.md
+++ b/lm_eval/tasks/physics_gre/README.md
@@ -1,0 +1,147 @@
+# Physics GRE
+
+### Source
+
+The Physics GRE dataset is released as a part of the [Inflection Benchmark](https://github.com/InflectionAI/Inflection-Benchmarks). It contains four processed Physics GRE exams, a common graduate school entrance exam for physics students. Each question in this dataset has five options and only one answer is correct.
+
+
+
+<!-- Title: `paper titles goes here` -->
+
+<!-- Abstract: `link to paper PDF or arXiv abstract goes here` -->
+
+<!-- `Short description of paper / benchmark goes here:` -->
+
+<!-- Homepage: `homepage to the benchmark's website goes here, if applicable` -->
+
+
+### Tasks
+
+<!-- #### Groups
+
+* `group_name`: `Short description` -->
+
+#### Task List
+
+* `physics_gre`: `Exam GR8677`
+* `physics_gre_additional`: `GRE exams (GR9277, GR9677, and GR0177)`
+* `physics_gre_all`: `GRE exams (GR9277, GR9677, GR0177, and GR8677)`
+
+#### Evaluation Setup and Metrics
+
+We evaluate `Raw Score` and `Percentile` in `score-first`, `maj@8`, and `maj@32` setups with generation `temperature=0.2`. We include only questions without an image in our scoring.
+
+
+#### Exam Scoring Details
+For the Physics GRE, each correct answer is worth 1 point and each incorrect answer results in a -0.25 reduction.
+To compute the score, we make the following assumption:
+```
+Raw_Score = Percentage_Correct - 0.25 * (1 - Percentage_Correct)
+```
+where `Percentage_Correct` is computed purely on questions without images. For simplicity, we do not use heuristics to allow the model not to answer.
+
+| Raw Score    | Percentile |
+| -----------: | ---------: |
+| 81 &ndash; 100       | 98         |
+| 77 &ndash; 80        | 97         |
+| 75 &ndash; 76        | 96         |
+| 72 &ndash; 74        | 95         |
+| 71           | 94         |
+| 69 &ndash; 70        | 93         |
+| 67 &ndash; 68        | 92         |
+| 65 &ndash; 66        | 91         |
+| 64           | 90         |
+| 63           | 89         |
+| 61 &ndash; 62        | 87         |
+| 60           | 86         |
+| 59           | 85         |
+| 57 &ndash; 58        | 84         |
+| 56           | 82         |
+| 55           | 80         |
+| 53 &ndash; 54        | 78         |
+| 52           | 77         |
+| 51           | 75         |
+| 49 &ndash; 50        | 72         |
+| 48           | 70         |
+| 47           | 69         |
+| 45 &ndash; 46        | 66         |
+| 44           | 64         |
+| 43           | 62         |
+| 41 &ndash; 42        | 59         |
+| 40           | 57         |
+| 39           | 54         |
+| 37 &ndash; 38        | 52         |
+| 36           | 48         |
+| 35           | 46         |
+| 33 &ndash; 34        | 43         |
+| 32           | 41         |
+| 30 &ndash; 31        | 38         |
+| 29           | 35         |
+| 28           | 32         |
+| 26 &ndash; 27        | 30         |
+| 25           | 27         |
+| 24           | 25         |
+| 22 &ndash; 23        | 22         |
+| 21           | 20         |
+| 20           | 18         |
+| 18 &ndash; 19        | 16         |
+| 17           | 14         |
+| 16           | 12         |
+| 14 &ndash; 15        | 10         |
+| 13           | 9          |
+| 12           | 8          |
+| 10 &ndash; 11        | 6          |
+| 9            | 5          |
+| 8            | 4          |
+| 6 &ndash; 7          | 3          |
+| 5            | 2          |
+| 1 &ndash; 4          | 1          |
+| 0            | 0          |
+
+### Performance
+
+Model: `mistralai/Mistral-7B-Instruct-v0.2`
+
+#### Reported by Inflection
+
+| Model                 | Percentile |
+| ----------------------| ---------: |
+| Inflection-2.5 maj@8  | 85         |
+| Inflection-2.5 maj@32 | 95         |
+| GPT-4 maj@8           | 97         |
+
+
+### Using this benchmark
+
+```bash
+lm_eval --model hf --model_args pretrained=mistralai/Mistral-7B-Instruct-v0.2 \
+	--tasks physics_gre,physics_gre_additional,physics_gre_all \
+	--device cuda:0 --batch_size 8 --output_path ./output --log_samples
+```
+
+### Citation
+
+```
+@misc{Kuttler2024,
+  author = {Kuttler, H},
+  title = {Public Inflection Benchmarks },
+  year = {2024},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/InflectionAI/Inflection-Benchmarks}},
+  commit = {706d0f22e5dd2c8ac670c472bd98fb2f93af19ca}
+}
+```
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/physics_gre/README.md
+++ b/lm_eval/tasks/physics_gre/README.md
@@ -98,9 +98,9 @@ where `Percentage_Correct` is computed purely on questions without images. For s
 | 1 &ndash; 4          | 1          |
 | 0            | 0          |
 
-### Performance
+### Reference Performance of Models
 
-Model: `mistralai/Mistral-7B-Instruct-v0.2`
+<!-- Model: `mistralai/Mistral-7B-Instruct-v0.2` -->
 
 #### Reported by Inflection
 

--- a/lm_eval/tasks/physics_gre/default.yaml
+++ b/lm_eval/tasks/physics_gre/default.yaml
@@ -1,0 +1,52 @@
+dataset_kwargs: null # any extra keyword arguments that should be passed to the dataset constructor, e.g. `data_dir`.
+
+training_split: null
+validation_split: null
+test_split: test
+
+process_docs: !function utils.process_docs
+doc_to_text: "Question: {{input}}\nAnswer:"
+doc_to_target: label
+doc_to_choice: ["A", "B", "C", "D", "E"]
+
+generation_kwargs:
+  do_sample: true
+  temperature: 0.2
+repeats: 32
+
+filter_list:
+  - name: "score-first" # pick only the first response, and report metrics on that
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "\\b(A|B|C|D|E)\\b"
+      - function: "take_first"
+
+  - name: "maj@8"
+    filter:
+      - function: "take_first_k"
+        k: 8
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "\\b(A|B|C|D|E)\\b"
+      - function: "majority_vote"
+      - function: "take_first"
+  - name: "maj@32"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "\\b(A|B|C|D|E)\\b"
+      - function: "majority_vote"
+      - function: "take_first"
+
+metric_list:
+  - metric: !function utils.raw_score
+    aggregation: !function utils.raw_score_agg
+    higher_is_better: true
+
+  - metric: !function utils.percentile
+    aggregation: !function utils.percentile_agg
+    higher_is_better: true
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/physics_gre/physics_gre.yaml
+++ b/lm_eval/tasks/physics_gre/physics_gre.yaml
@@ -1,0 +1,5 @@
+task: physics_gre
+dataset_path: shayekh/physics_gre
+dataset_name: physics_gre
+
+include: "default.yaml"

--- a/lm_eval/tasks/physics_gre/physics_gre_additional.yaml
+++ b/lm_eval/tasks/physics_gre/physics_gre_additional.yaml
@@ -1,0 +1,5 @@
+task: physics_gre_additional
+dataset_path: shayekh/physics_gre
+dataset_name: physics_gre_additional
+
+include: "default.yaml"

--- a/lm_eval/tasks/physics_gre/physics_gre_all.yaml
+++ b/lm_eval/tasks/physics_gre/physics_gre_all.yaml
@@ -1,0 +1,5 @@
+task: physics_gre_all
+dataset_path: shayekh/physics_gre
+dataset_name: physics_gre_all
+
+include: "default.yaml"

--- a/lm_eval/tasks/physics_gre/utils.py
+++ b/lm_eval/tasks/physics_gre/utils.py
@@ -1,0 +1,113 @@
+import datasets
+from sklearn.metrics import accuracy_score
+
+
+def process_docs(dataset: datasets.Dataset):
+    # Remove the data points that have images in the input. 100 -> 76
+    dataset = dataset.filter(lambda x: x["has_image"] is False)
+    # Remove the data points without groud truth label. 76 -> 75
+    dataset = dataset.filter(lambda x: x["target_scores"] is not None)
+    # All questions must have one and only one correct answer.
+    assert (
+        len(dataset.filter(lambda x: sum(x["target_scores"].values()) != 1)) == 0
+    ), "Zero or More than one correct answers."
+    dataset = dataset.select([0])  # TODO: Remove
+    # dataset = dataset.select([0, 1]) #TODO: Remove
+    # dataset = dataset.select(list(range(10))) #TODO: Remove
+
+    def _helper(doc):
+        label = next(key for key, value in doc["target_scores"].items() if value == 1)
+        doc["label"] = ["A", "B", "C", "D", "E"].index(label)
+        return doc
+
+    return dataset.map(_helper)
+
+
+def raw_score(references, predictions):
+    return accuracy_score(references, predictions)
+
+
+def percentile(references, predictions):
+    return accuracy_score(references, predictions)
+
+
+def raw_score_agg(items):
+    score_agg = sum(items) / len(items)
+    # For the Physics GRE, each correct answer is worth 1 point
+    #   and each incorrect answer results in a -0.25 reduction.
+    score_agg = max(0, score_agg - 0.25 * (1 - score_agg))
+    score_agg = round(score_agg * 100)
+    return int(score_agg)
+
+
+def percentile_agg(items):
+    score_agg = raw_score_agg(items)
+    return raw_score_to_percentile(score_agg)
+
+
+def raw_score_to_percentile(score_agg):
+    score_percentile_mapping = {
+        range(81, 101): 98,
+        range(77, 81): 97,
+        range(75, 77): 96,
+        range(72, 75): 95,
+        71: 94,
+        range(69, 71): 93,
+        range(67, 69): 92,
+        range(65, 67): 91,
+        64: 90,
+        63: 89,
+        range(61, 63): 87,
+        60: 86,
+        59: 85,
+        range(57, 59): 84,
+        56: 82,
+        55: 80,
+        range(53, 55): 78,
+        52: 77,
+        51: 75,
+        range(49, 51): 72,
+        48: 70,
+        47: 69,
+        range(45, 47): 66,
+        44: 64,
+        43: 62,
+        range(41, 43): 59,
+        40: 57,
+        39: 54,
+        range(37, 39): 52,
+        36: 48,
+        35: 46,
+        range(33, 35): 43,
+        32: 41,
+        range(30, 32): 38,
+        29: 35,
+        28: 32,
+        range(26, 28): 30,
+        25: 27,
+        24: 25,
+        range(22, 24): 22,
+        21: 20,
+        20: 18,
+        range(18, 20): 16,
+        17: 14,
+        16: 12,
+        range(14, 16): 10,
+        13: 9,
+        12: 8,
+        range(10, 12): 6,
+        9: 5,
+        8: 4,
+        range(6, 8): 3,
+        5: 2,
+        range(1, 5): 1,
+        0: 0,
+    }
+
+    for key, value in score_percentile_mapping.items():
+        if isinstance(key, int) and score_agg == key:
+            return value
+        elif isinstance(key, range) and score_agg in key:
+            return value
+
+    raise ValueError("Invalid Raw Score {}".format(score_agg))

--- a/lm_eval/tasks/physics_gre/utils.py
+++ b/lm_eval/tasks/physics_gre/utils.py
@@ -11,9 +11,6 @@ def process_docs(dataset: datasets.Dataset):
     assert (
         len(dataset.filter(lambda x: sum(x["target_scores"].values()) != 1)) == 0
     ), "Zero or More than one correct answers."
-    dataset = dataset.select([0])  # TODO: Remove
-    # dataset = dataset.select([0, 1]) #TODO: Remove
-    # dataset = dataset.select(list(range(10))) #TODO: Remove
 
     def _helper(doc):
         label = next(key for key, value in doc["target_scores"].items() if value == 1)


### PR DESCRIPTION
This PR adds the [Physics GRE dataset](https://github.com/InflectionAI/Inflection-Benchmarks/tree/main?tab=readme-ov-file#physics-gre) released in the Public Inflection Benchmark by @InflectionAI. Please refer [here](https://github.com/ShayekhBinIslam/lm-evaluation-harness/tree/physics_gre/lm_eval/tasks/physics_gre) for the details.

 It solved the issue #1554. 