### PR TITLE
Fix CLI --batch_size arg for openai-completions/local-completions

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -111,7 +111,7 @@ class OpenaiCompletionsLM(TemplateLM):
         self.base_url = base_url
         self.tokenizer_backend = tokenizer_backend
         self.truncate = truncate
-        self._batch_size = batch_size
+        self._batch_size = int(batch_size)
         self._max_gen_toks = max_gen_toks
         self._max_length = max_length
 


### PR DESCRIPTION
The OpenAI interface supports batch size as an argument to the completions API, but does not seem to support specification of this on the CLI i.e. `lm_eval --model openai-completions --batch_size 16 ...` because of a simple lack of str->int conversion.

This is confirmed by my usage and stacktrace from running `OPENAI_API_KEY=dummy lm_eval --model local-completions --tasks gsm8k --batch_size 16 --model_args model=nm- testing/zephyr-beta-7b-gptq-g128,tokenizer_backend=huggingface,base_url=http://localhost:8000/v1`:
```
Traceback (most recent call last):
  File "/home/michael/venv/bin/lm_eval", line 8, in <module>
    sys.exit(cli_evaluate())
  File "/home/michael/code/lm-evaluation-harness/lm_eval/__main__.py", line 341, in cli_evaluate
    results = evaluator.simple_evaluate(
  File "/home/michael/code/lm-evaluation-harness/lm_eval/utils.py", line 288, in _wrapper
    return fn(*args, **kwargs)
  File "/home/michael/code/lm-evaluation-harness/lm_eval/evaluator.py", line 251, in simple_evaluate
    results = evaluate(
  File "/home/michael/code/lm-evaluation-harness/lm_eval/utils.py", line 288, in _wrapper
    return fn(*args, **kwargs)
  File "/home/michael/code/lm-evaluation-harness/lm_eval/evaluator.py", line 390, in evaluate
    resps = getattr(lm, reqtype)(cloned_reqs)
  File "/home/michael/code/lm-evaluation-harness/lm_eval/models/openai_completions.py", line 263, in generate_until
    list(sameuntil_chunks(re_ord.get_reordered(), self.batch_size)),
  File "/home/michael/code/lm-evaluation-harness/lm_eval/models/openai_completions.py", line 251, in sameuntil_chunks
    if len(ret) >= size or x[1] != lastuntil:
TypeError: '>=' not supported between instances of 'int' and 'str'
```

With this change, it seems to start sending batched requests properly:
```
OPENAI_API_KEY=dummy lm_eval --model local-completions --tasks gsm8k --batch_size 16 --model_args model=nm-testing/zephyr-beta-7b-gptq-g128,tokenizer_backend=huggingface,base_url=http://localhost:8000/v1
2024-04-01:15:15:22,986 INFO     [__main__.py:251] Verbosity set to INFO
2024-04-01:15:15:27,585 INFO     [__main__.py:335] Selected Tasks: ['gsm8k']
2024-04-01:15:15:27,586 INFO     [evaluator.py:131] Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2024-04-01:15:15:27,586 INFO     [evaluator.py:177] Initializing local-completions model, with arguments: {'model': 'nm-testing/zephyr-beta-7b-gptq-g128', 'tokenizer_backend': 'huggingface', 'base_url': 'http://localhost:8000/v1'}
2024-04-01:15:15:31,550 INFO     [task.py:395] Building contexts for gsm8k on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:04<00:00, 266.83it/s]
2024-04-01:15:15:36,513 INFO     [evaluator.py:379] Running generate_until requests
  0%|                                                                                                                                                   | 0/83 [00:00<?, ?it/s]2024-04-01:15:15:52,056 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
  1%|█▋                                                                                                                                         | 1/83 [00:13<18:08, 13.28s/it]2024-04-01:15:16:05,478 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
  2%|███▎                                                                                                                                       | 2/83 [00:26<18:02, 13.36s/it]2024-04-01:15:16:18,689 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
  4%|█████                                                                                                                                      | 3/83 [00:39<17:43, 13.29s/it]2024-04-01:15:16:31,294 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
  5%|██████▋                                                                                                                                    | 4/83 [00:52<17:08, 13.02s/it]2024-04-01:15:16:44,960 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
  6%|████████▎                                                                                                                                  | 5/83 [01:06<17:13, 13.25s/it]2024-04-01:15:16:57,550 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
  7%|██████████                                                                                                                                 | 6/83 [01:18<16:43, 13.03s/it]2024-04-01:15:17:11,950 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
  8%|███████████▋                                                                                                                               | 7/83 [01:33<17:04, 13.48s/it]2024-04-01:15:17:26,205 INFO     [_client.py:1026] HTTP Request: POST http://localhost:8000/v1/completions "HTTP/1.1 200 OK"
 10%|█████████████▍                                                                                                                             | 8/83 [01:47<17:09, 13.72s/it]
  ...
  ```