### PR TITLE
Patch QQP prompt (#1648 )

### DIFF
--- a/lm_eval/tasks/glue/qqp/default.yaml
+++ b/lm_eval/tasks/glue/qqp/default.yaml
@@ -5,11 +5,11 @@ dataset_name: qqp
 output_type: multiple_choice
 training_split: train
 validation_split: validation
-doc_to_text: "\nSentence 1: {{question1}}\nSentence 2: {{question2}}\nAnswer:"
+doc_to_text: "Question 1: {{question1}}\nQuestion 2: {{question2}}\nQuestion: Do both questions ask the same thing?\nAnswer:"
 doc_to_target: label
 doc_to_choice: ["no", "yes"]
 metric_list:
   - metric: acc
   - metric: f1
 metadata:
-  version: 1.0
+  version: 2.0


### PR DESCRIPTION
Brings QQP prompt back in line with v0.3 : https://github.com/EleutherAI/lm-evaluation-harness/blob/0bf683b4e6a9df359b3156ba9ba8d62bdd47e0c0/lm_eval/tasks/glue.py#L456

fixes #1648 