### PR TITLE
log_samples with multi args in model_args #1664

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -388,7 +388,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
             if args.log_samples:
                 for task_name, config in results["configs"].items():
                     output_name = "{}_{}".format(
-                        re.sub("/|=", "__", args.model_args), task_name
+                        re.sub("/|=|:", "__", args.model_args), task_name
                     )
                     filename = path.joinpath(f"{output_name}.jsonl")
                     samples_dumped = json.dumps(

--- a/scripts/zeno_visualize.py
+++ b/scripts/zeno_visualize.py
@@ -67,7 +67,7 @@ def main():
         # Upload data for all models
         for model_index, model in enumerate(models):
             model_args = re.sub(
-                "/|=",
+                "/|=|:",
                 "__",
                 json.load(
                     open(Path(args.data_path, model, "results.json"), encoding="utf-8")


### PR DESCRIPTION
if you have for example an url in model_args :  --model_args model=sn/mistral-7b-instruct-v0.2-LG,base_url=http://10.2.42.198:1234/v1
":" can't be in file name