### PR TITLE
Add XNLIeu: a dataset for cross-lingual NLI in Basque

### DIFF
--- a/lm_eval/tasks/xnli_eu/README.md
+++ b/lm_eval/tasks/xnli_eu/README.md
@@ -1,0 +1,50 @@
+# XNLIeu
+
+### Paper
+
+Title: XNLIeu: a dataset for cross-lingual NLI in Basque
+
+Abstract: https://arxiv.org/abs/2404.06996
+
+XNLI is a popular Natural Language Inference (NLI) benchmark widely used to evaluate cross-lingual Natural Language Understanding (NLU) capabilities across languages. In this paper, we expand XNLI to include Basque, a low-resource language that can greatly benefit from transfer-learning approaches. The new dataset, dubbed XNLIeu, has been developed by first machine-translating the English XNLI corpus into Basque, followed by a manual post-edition step. We have conducted a series of experiments using mono- and multilingual LLMs to assess a) the effect of professional post-edition on the MT system; b) the best cross-lingual strategy for NLI in Basque; and c) whether the choice of the best cross-lingual strategy is influenced by the fact that the dataset is built by translation. The results show that post-edition is necessary and that the translate-train cross-lingual strategy obtains better results overall, although the gain is lower when tested in a dataset that has been built natively from scratch. Our code and datasets are publicly available under open licenses at https://github.com/hitz-zentroa/xnli-eu.
+
+Homepage: https://github.com/hitz-zentroa/xnli-eu
+
+
+### Citation
+
+```bibtex
+@misc{heredia2024xnlieu,
+    title={XNLIeu: a dataset for cross-lingual NLI in Basque},
+    author={Maite Heredia and Julen Etxaniz and Muitze Zulaika and Xabier Saralegi and Jeremy Barnes and Aitor Soroa},
+    year={2024},
+    eprint={2404.06996},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `xnli_eu_mt_native`: Includes MT and Native variants of the XNLIeu dataset.
+
+#### Tasks
+
+* `xnli_eu`:
+* `xnli_eu_mt`: ...
+* `xnli_eu_native`: ...
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/xnli_eu/README.md
+++ b/lm_eval/tasks/xnli_eu/README.md
@@ -32,9 +32,9 @@ Homepage: https://github.com/hitz-zentroa/xnli-eu
 
 #### Tasks
 
-* `xnli_eu`:
-* `xnli_eu_mt`: ...
-* `xnli_eu_native`: ...
+* `xnli_eu`: XNLI in Basque postedited from MT.
+* `xnli_eu_mt`: XNLI in Basque machine translated from English.
+* `xnli_eu_native`: XNLI in Basque natively created.
 
 ### Checklist
 

--- a/lm_eval/tasks/xnli_eu/README.md
+++ b/lm_eval/tasks/xnli_eu/README.md
@@ -39,9 +39,9 @@ Homepage: https://github.com/hitz-zentroa/xnli-eu
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:
-* [ ] Is the task an existing benchmark in the literature?
-  * [ ] Have you referenced the original paper that introduced the task?
-  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
 
 
 If other tasks on this dataset are already supported:

--- a/lm_eval/tasks/xnli_eu/xnli_common_yaml
+++ b/lm_eval/tasks/xnli_eu/xnli_common_yaml
@@ -1,0 +1,16 @@
+group: xnli
+task: null
+dataset_path: xnli
+dataset_name: null
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+doc_to_text: null
+doc_to_target: label
+doc_to_choice: null
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/xnli_eu/xnli_eu.yaml
+++ b/lm_eval/tasks/xnli_eu/xnli_eu.yaml
@@ -1,0 +1,8 @@
+include: xnli_common_yaml
+task: xnli_eu
+dataset_path: HiTZ/xnli-eu
+dataset_name: eu
+doc_to_choice: '{{[premise+", ezta? Bai, "+hypothesis,premise+", ezta? Gainera,
+"+hypothesis,premise+", ezta? Ez, "+hypothesis]}}'
+doc_to_text: ""
+test_split: test

--- a/lm_eval/tasks/xnli_eu/xnli_eu_mt.yaml
+++ b/lm_eval/tasks/xnli_eu/xnli_eu_mt.yaml
@@ -1,0 +1,4 @@
+include: xnli_eu.yaml
+group: xnli_eu_mt_native
+task: xnli_eu_mt
+dataset_name: eu_mt

--- a/lm_eval/tasks/xnli_eu/xnli_eu_native.yaml
+++ b/lm_eval/tasks/xnli_eu/xnli_eu_native.yaml
@@ -1,0 +1,6 @@
+include: xnli_eu.yaml
+group: xnli_eu_mt_native
+task: xnli_eu_native
+training_split: null
+validation_split: null
+dataset_name: eu_native


### PR DESCRIPTION
Includes 3 tasks from our recent paper [XNLIeu: a dataset for cross-lingual NLI in Basque](https://arxiv.org/abs/2404.06996)
* `xnli_eu`: XNLI in Basque postedited from MT.
* `xnli_eu_mt`: XNLI in Basque machine translated from English.
* `xnli_eu_native`: XNLI in Basque natively created.

We have doubts about whether we should include `xnli_eu` task in the `xnli` group and folder. For now I have included it in the `xnli` group in a separate folder.

Abstract: 
XNLI is a popular Natural Language Inference (NLI) benchmark widely used to evaluate cross-lingual Natural Language Understanding (NLU) capabilities across languages. In this paper, we expand XNLI to include Basque, a low-resource language that can greatly benefit from transfer-learning approaches. The new dataset, dubbed XNLIeu, has been developed by first machine-translating the English XNLI corpus into Basque, followed by a manual post-edition step. We have conducted a series of experiments using mono- and multilingual LLMs to assess a) the effect of professional post-edition on the MT system; b) the best cross-lingual strategy for NLI in Basque; and c) whether the choice of the best cross-lingual strategy is influenced by the fact that the dataset is built by translation. The results show that post-edition is necessary and that the translate-train cross-lingual strategy obtains better results overall, although the gain is lower when tested in a dataset that has been built natively from scratch. Our code and datasets are publicly available under open licenses at https://github.com/hitz-zentroa/xnli-eu.