### PR TITLE
Addition of BedrockChatModel

### DIFF
--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     anthropic_llms,
+    bedrock,
     dummy,
     gguf,
     huggingface,

--- a/lm_eval/models/bedrock.py
+++ b/lm_eval/models/bedrock.py
@@ -1,0 +1,223 @@
+from typing import Any, List, Tuple
+
+from tqdm import tqdm
+
+from lm_eval import utils
+from lm_eval.api.model import LM
+from lm_eval.api.registry import register_model
+from lm_eval.models.utils import retry_on_specific_exceptions
+import json
+
+eval_logger = utils.eval_logger
+
+
+def bedrock_chat(
+    client,  # boto3.client("bedrock-runtime")
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    stop: List[str],
+    **kwargs: Any,
+) -> str:
+    """Wrapper function around the Bedrock chat completion API client with exponential back-off
+    in case of RateLimitError.
+
+    params:
+        client: boto3.Client
+            Bedrock runtime client
+        model: str
+            Bedrock model e.g. 'anthropic.claude-3-haiku-20240307-v1:0'
+        prompt: str
+            Prompt to feed to the model
+        max_tokens: int
+            Maximum number of tokens to sample from the model
+        temperature: float
+            Sampling temperature
+        stop: List[str]
+            List of stop sequences
+        kwargs: Any
+            Additional model_args to pass to the API client
+    """
+
+    try:
+        import boto3
+    except ModuleNotFoundError:
+        raise Exception(
+            "attempted to use 'bedrock' LM type, but package `boto3` is not installed. \
+please install boto3 via `pip install 'lm-eval[bedrock]'` or `pip install -e '.[bedrock]'`",
+        )
+
+    def _exception_callback(e: Exception, sleep_time: float) -> None:
+        eval_logger.warning(
+            f"RateLimitError occurred: {e.__cause__}\n Retrying in {sleep_time} seconds"
+        )
+
+    @retry_on_specific_exceptions(
+        on_exceptions=[
+            client.ThrottlingException,
+            client.ModelTimeoutException,
+            client.InternalServerException,
+        ],
+        max_retries=None,  # retry forever, consider changing
+        on_exception_callback=_exception_callback,
+    )
+    def messages():
+        # structured payload for request
+
+        formatted_messages =  [{"role": "user", "content": [{"type": "text", "text": prompt}]}]
+        body = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": formatted_messages
+        }
+
+        # update body with params then encode
+        body.update(kwargs)
+        body_bytes = json.dumps(body).encode("utf-8")
+
+        response = client.invoke_model(
+                    body=body_bytes, contentType="application/json", accept="application/json", modelId=model
+                )
+        response_body = json.loads(response.get("body").read())
+
+        return response_body["content"][0]["text"]
+
+    return messages()
+
+
+@register_model("bedrock")
+class BedrockChatLM(LM):
+
+    def __init__(
+        self,
+        batch_size: int = 1,
+        model: str = "anthropic.claude-3-haiku-20240307-v1:0",
+        max_tokens: int = 256,
+        temperature: float = 0,  # defaults to 1
+        **kwargs,  # top_p, top_k, etc.
+    ) -> None:
+        """Bedrock API wrapper.
+
+        :param model: str
+            Bedrock model e.g. 'anthropic.claude-3-haiku-20240307-v1:0'
+        :param max_tokens: int
+            Maximum number of tokens to sample from the model
+        :param temperature: float
+            Sampling temperature
+        :param kwargs: Any
+            Additional model_args to pass to the API client
+        """
+        super().__init__()
+
+        try:
+            import boto3
+        except ModuleNotFoundError:
+            raise Exception(
+                "attempted to use 'bedrock' LM type, but package `boto3` is not installed. \
+please install boto3 via `pip install 'lm-eval[bedrock]'` or `pip install -e '.[boto3]'`",
+            )
+
+        self.model = model
+        # defaults to using os.environ.get("AWS_REGION"), os.environ.get("AWS_ACCESS_KEY_ID"),
+        # os.environ.get("AWS_SECRET_ACCESS_KEY")
+        self.client = boto3.client("bedrock-runtime")
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.tokenizer = None # no tokenizer available
+        self.kwargs = kwargs
+
+    @property
+    def eot_token_id(self):
+        # Not sure but anthropic.HUMAN_PROMPT ?
+        raise NotImplementedError("Tokenizer not available.")
+
+    @property
+    def max_length(self) -> int:
+        return 2048
+
+    @property
+    def max_gen_toks(self) -> int:
+        return self.max_tokens
+
+    @property
+    def batch_size(self):
+        # Isn't used because we override _loglikelihood_tokens
+        raise NotImplementedError("No support for logits.")
+
+    @property
+    def device(self):
+        # Isn't used because we override _loglikelihood_tokens
+        raise NotImplementedError("No support for logits.")
+
+    def tok_encode(self, string: str) -> List[int]:
+        return self.tokenizer.encode(string).ids
+
+    def tok_decode(self, tokens: List[int]) -> str:
+        return self.tokenizer.decode(tokens)
+
+    def _loglikelihood_tokens(self, requests, disable_tqdm: bool = False):
+        raise NotImplementedError("No support for logits.")
+
+    def generate_until(self, requests, disable_tqdm: bool = False) -> List[str]:
+        try:
+            import boto3
+            import botocore
+        except ModuleNotFoundError:
+            raise Exception(
+                "attempted to use 'bedrock' LM type, but package `boto3` is not installed. \
+please install boto3 via `pip install 'lm-eval[bedrock]'` or `pip install -e '.[bedrock]'`",
+            )
+
+        if not requests:
+            return []
+
+        _requests: List[Tuple[str, dict]] = [req.args for req in requests]
+
+        res = []
+        for request in tqdm(_requests, disable=disable_tqdm):
+            try:
+                inp = request[0]
+                request_args = request[1]
+                # generation_kwargs
+                until = request_args.get("until")
+                max_gen_toks = request_args.get("max_gen_toks", self.max_length)
+                temperature = request_args.get("temperature", self.temperature)
+                response = bedrock_chat(
+                    client=self.client,
+                    model=self.model,
+                    prompt=inp,
+                    max_tokens=max_gen_toks,
+                    temperature=temperature,  # TODO: implement non-greedy sampling for bedrock
+                    stop=until,  # type: ignore
+                    **self.kwargs,
+                )
+                res.append(response)
+
+                self.cache_hook.add_partial("generate_until", request, response)
+
+            except botocore.exceptions.ClientError as error: # type: ignore # noqa: F821
+                eval_logger.critical(f"Boto client error: {error}")
+                break
+
+            except botocore.exceptions.ParamValidationError as error:  # type: ignore # noqa: F821
+                eval_logger.critical(f'The parameters you provided are incorrect: {error}')
+                break
+
+        return res
+
+    def _model_call(self, inps):
+        # Isn't used because we override _loglikelihood_tokens
+        raise NotImplementedError()
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        # Isn't used because we override generate_until
+        raise NotImplementedError()
+
+    def loglikelihood(self, requests, disable_tqdm: bool = False):
+        raise NotImplementedError("No support for logits.")
+
+    def loglikelihood_rolling(self, requests, disable_tqdm: bool = False):
+        raise NotImplementedError("No support for logits.")
+

--- a/lm_eval/models/bedrock.py
+++ b/lm_eval/models/bedrock.py
@@ -7,7 +7,6 @@ from tqdm import tqdm
 from lm_eval import utils
 from lm_eval.api.model import LM
 from lm_eval.api.registry import register_model
-from lm_eval.models.utils import retry_on_specific_exceptions
 
 
 eval_logger = utils.eval_logger
@@ -53,15 +52,15 @@ please install boto3 via `pip install 'lm-eval[bedrock]'` or `pip install -e '.[
             f"RateLimitError occurred: {e.__cause__}\n Retrying in {sleep_time} seconds"
         )
 
-    @retry_on_specific_exceptions(
-        on_exceptions=[
-            client.ThrottlingException,
-            client.ModelTimeoutException,
-            client.InternalServerException,
-        ],
-        max_retries=None,  # retry forever, consider changing
-        on_exception_callback=_exception_callback,
-    )
+    # @retry_on_specific_exceptions(
+    #     on_exceptions=[
+    #         client.ThrottlingException,
+    #         client.ModelTimeoutException,
+    #         client.InternalServerException,
+    #     ],
+    #     max_retries=None,  # retry forever, consider changing
+    #     on_exception_callback=_exception_callback,
+    # )
     def messages():
         # structured payload for request
 
@@ -69,7 +68,6 @@ please install boto3 via `pip install 'lm-eval[bedrock]'` or `pip install -e '.[
             {"role": "user", "content": [{"type": "text", "text": prompt}]}
         ]
         body = {
-            "anthropic_version": "bedrock-2023-05-31",
             "max_tokens": max_tokens,
             "temperature": temperature,
             "messages": formatted_messages,
@@ -170,6 +168,7 @@ please install boto3 via `pip install 'lm-eval[bedrock]'` or `pip install -e '.[
                 "attempted to use 'bedrock' LM type, but package `boto3` is not installed. \
 please install boto3 via `pip install 'lm-eval[bedrock]'` or `pip install -e '.[bedrock]'`",
             )
+        import botocore
 
         if not requests:
             return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ testing = ["pytest", "pytest-cov", "pytest-xdist"]
 vllm = ["vllm==0.3.2"]
 zeno = ["pandas", "zeno-client"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
+bedrock = ["boto3"]
 all = [
     "lm_eval[anthropic]",
     "lm_eval[dev]",
@@ -90,6 +91,7 @@ all = [
     "lm_eval[vllm]",
     "lm_eval[zeno]",
     "lm_eval[wandb]",
+    "lm_eval[bedrock]",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
This PR is a minimum implementation of a Bedrock chat model. I don't know if this is comprehensive enough to merge, but I thought I'd share because this might be a good jump-off point for someone looking to do a full implementation. 

There are some limitations:
1. I've only tested using the Claude models 
2. Could use better handling of missing AWS config via AWS_ env. The error messages are a little unclear.
3. Bedrock models appear to have an additional, model org keyword arg. In the case of Anthropic's Claude, this is `anthropic_version=bedrock-2023-05-31`. This could probably be handled more gracefully across models, but for now, I'm passing to the constructor on initialization.
```python
model = BedrockChatLM(
   model="anthropic.claude-3-haiku-20240307-v1:0"
   anthropic_version="bedrock-2023-05-31", model="anthropic.claude-3-haiku-20240307-v1:0"
)
```