### PR TITLE
Add delta weights model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ lm_eval --model hf \
     --device cuda:0
 ```
 
-Models that are provided as delta weights relative to a base model can be loaded with the Hugging Face `transformers` using the `delta` argument in `model_args`:
+Models provided as delta weights can be easily loaded using the Hugging Face transformers library. Within --model_args, set the delta argument to specify the delta weights, and use the pretrained argument to designate the relative base model to which they will be applied:
 ```bash
 lm_eval --model hf \
     --model_args pretrained=Ejafa/llama_7B,delta=lmsys/vicuna-7b-delta-v1.1 \

--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ lm_eval --model hf \
     --device cuda:0
 ```
 
+Models that are provided as delta weights relative to a base model can be loaded with the Hugging Face `transformers` using the `delta` argument in `model_args`:
+```bash
+lm_eval --model hf \
+    --model_args pretrained=Ejafa/llama_7B,delta=lmsys/vicuna-7b-delta-v1.1 \
+    --tasks hellaswag
+```
+
 [GPTQ](https://github.com/PanQiWei/AutoGPTQ) quantized models can be loaded by specifying their file names in `,autogptq=NAME` (or `,autogptq=True` for default names) in the `model_args` argument:
 
 ```bash

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -360,7 +360,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         torch_random_seed=args.seed[2],
         **request_caching_args,
     )
-    print(results)
 
     if results is not None:
         if args.log_samples:

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -360,6 +360,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         torch_random_seed=args.seed[2],
         **request_caching_args,
     )
+    print(results)
 
     if results is not None:
         if args.log_samples:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -582,8 +582,12 @@ class HFLM(TemplateLM):
                 **model_kwargs,
             )
             for name, param in self._model.state_dict().items():
-                assert name in _model_delta.state_dict(), f"Missing {name} in delta model"
-                param.data += _model_delta.state_dict()[name]
+                try:
+                    param.data += _model_delta.state_dict()[name]
+                except KeyError:
+                    raise KeyError(f"Delta model is missing weights for layer: {name}")
+                except Exception as e:
+                    raise RuntimeError(f"Failed to add delta weights to layer {name}. Error: {e}")
 
         return None
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -566,6 +566,9 @@ class HFLM(TemplateLM):
                 **model_kwargs,
             )
 
+        if peft and delta:
+            raise ValueError("Cannot use both 'peft' and 'delta' options at the same time.")
+
         if peft:
             if model_kwargs.get("load_in_4bit", None):
                 if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
@@ -592,6 +595,8 @@ class HFLM(TemplateLM):
                     raise KeyError(f"Delta model is missing weights for layer: {name}")
                 except Exception as e:
                     raise RuntimeError(f"Failed to add delta weights to layer {name}. Error: {e}")
+
+            del _model_delta
 
         return None
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -567,7 +567,9 @@ class HFLM(TemplateLM):
             )
 
         if peft and delta:
-            raise ValueError("Cannot use both 'peft' and 'delta' options at the same time.")
+            raise ValueError(
+                "Cannot use both 'peft' and 'delta' options at the same time."
+            )
 
         if peft:
             if model_kwargs.get("load_in_4bit", None):
@@ -579,7 +581,7 @@ class HFLM(TemplateLM):
         elif delta:
             if autogptq:
                 eval_logger.warning(
-                    f"Delta weights might trigger unexpected behavior when used with AutoGPTQ."
+                    "Delta weights might trigger unexpected behavior when used with AutoGPTQ."
                 )
             _model_delta = self.AUTO_MODEL_CLASS.from_pretrained(
                 delta,
@@ -594,7 +596,9 @@ class HFLM(TemplateLM):
                 except KeyError:
                     raise KeyError(f"Delta model is missing weights for layer: {name}")
                 except Exception as e:
-                    raise RuntimeError(f"Failed to add delta weights to layer {name}. Error: {e}")
+                    raise RuntimeError(
+                        f"Failed to add delta weights to layer {name}. Error: {e}"
+                    )
 
             del _model_delta
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -574,6 +574,8 @@ class HFLM(TemplateLM):
                 self._model, peft, revision=revision
             )
         elif delta:
+            if autogptq:
+                eval_logger.warning(f"Delta weights might trigger an unexpected behavior AutoGPTQ.")
             _model_delta = self.AUTO_MODEL_CLASS.from_pretrained(
                 delta,
                 revision=revision,

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -575,7 +575,9 @@ class HFLM(TemplateLM):
             )
         elif delta:
             if autogptq:
-                eval_logger.warning(f"Delta weights might trigger an unexpected behavior AutoGPTQ.")
+                eval_logger.warning(
+                    f"Delta weights might trigger unexpected behavior when used with AutoGPTQ."
+                )
             _model_delta = self.AUTO_MODEL_CLASS.from_pretrained(
                 delta,
                 revision=revision,


### PR DESCRIPTION
This PR adds support for loading models provided as delta weights for the base model from the Hugging Face transformers library.
- No additional packages required
- `delta` parameter in `model_args` following `peft` implementation

Tested with:
```
python3 -m lm_eval --model hf --model_args pretrained=Ejafa/llama_7B,parallelize=True --tasks hellaswag --output_path results/ --batch_size 1 --num_fewshot 5
|  Tasks  |Version|Filter|n-shot| Metric |Value |   |Stderr|
|---------|------:|------|-----:|--------|-----:|---|-----:|
|hellaswag|      1|none  |     5|acc     |0.5747|±  |0.0049|
|         |       |none  |     5|acc_norm|0.7734|±  |0.0042|

python3 -m lm_eval --model hf --model_args pretrained=Ejafa/llama_7B,parallelize=True,delta=lmsys/vicuna-7b-delta-v1.1 --tasks hellaswag --output_path results/ --batch_size 1 --num_fewshot 5
|  Tasks  |Version|Filter|n-shot| Metric |Value |   |Stderr|
|---------|------:|------|-----:|--------|-----:|---|-----:|
|hellaswag|      1|none  |     5|acc     |0.5811|±  |0.0049|
|         |       |none  |     5|acc_norm|0.7697|±  |0.0042|
```

@clefourrier @NathanHB