### PR TITLE
Add option to set OpenVINO config

### DIFF
--- a/lm_eval/models/optimum_lm.py
+++ b/lm_eval/models/optimum_lm.py
@@ -1,13 +1,13 @@
 import json
-import logging
 from importlib.util import find_spec
 from pathlib import Path
 
+from lm_eval import utils
 from lm_eval.api.registry import register_model
 from lm_eval.models.huggingface import HFLM
 
 
-logger = logging.getLogger(__name__)
+eval_logger = utils.eval_logger
 
 
 @register_model("openvino")
@@ -64,7 +64,7 @@ class OptimumLM(HFLM):
                 )
             with open(model_kwargs["ov_config"]) as f:
                 model_kwargs["ov_config"] = json.load(f)
-                logger.info(
+                eval_logger.info(
                     f"Using custom OpenVINO config: {model_kwargs['ov_config']}"
                 )
 

--- a/lm_eval/models/optimum_lm.py
+++ b/lm_eval/models/optimum_lm.py
@@ -1,8 +1,13 @@
+import json
+import logging
 from importlib.util import find_spec
 from pathlib import Path
 
 from lm_eval.api.registry import register_model
 from lm_eval.models.huggingface import HFLM
+
+
+logger = logging.getLogger(__name__)
 
 
 @register_model("openvino")
@@ -11,6 +16,10 @@ class OptimumLM(HFLM):
     Optimum Intel provides a simple interface to optimize Transformer models and convert them to \
     OpenVINO™ Intermediate Representation (IR) format to accelerate end-to-end pipelines on \
     Intel® architectures using OpenVINO™ runtime.
+
+    To use an OpenVINO config, use `--model_args ov_config` to point to a json file with an OpenVINO config:
+    `lm_eval --model openvino --model_args pretrained=gpt2,ov_config=config.json --task lambada_openai`
+    Example json file contents: {"INFERENCE_PRECISION_HINT": "f32", "CACHE_DIR": "model_cache"}
     """
 
     def __init__(
@@ -48,16 +57,25 @@ class OptimumLM(HFLM):
             from optimum.intel.openvino import OVModelForCausalLM
 
         model_kwargs = kwargs if kwargs else {}
+        if "ov_config" in model_kwargs:
+            if not Path(model_kwargs["ov_config"]).exists():
+                raise ValueError(
+                    "ov_config should point to a .json file containing an OpenVINO config"
+                )
+            with open(model_kwargs["ov_config"]) as f:
+                model_kwargs["ov_config"] = json.load(f)
+                logger.info(
+                    f"Using custom OpenVINO config: {model_kwargs['ov_config']}"
+                )
+
+        else:
+            model_kwargs["ov_config"] = {}
+        model_kwargs["ov_config"].setdefault("CACHE_DIR", "")
         model_file = Path(pretrained) / "openvino_model.xml"
         if model_file.exists():
             export = False
         else:
             export = True
-        kwargs["ov_config"] = {
-            "PERFORMANCE_HINT": "LATENCY",
-            "NUM_STREAMS": "1",
-            "CACHE_DIR": "",
-        }
 
         self._model = OVModelForCausalLM.from_pretrained(
             pretrained,


### PR DESCRIPTION
This PR adds an option to specify a custom config for OpenVINO models, with `--model_args ov_config=/path/to/config.json`. This allows users to set options that may affect accuracy, or for example enable model caching to speed up model loading on GPU. 

I added a test to check that the config is being used by OpenVINO. This can also be confirmed in the console by setting environment variable OPENVINO_LOG_LEVE L to 3. This shows the compilation properties. Example, ran on a CPU where default INFERENCE_PRECISION_HINT is bf16, overridden with ov_config to f32 (only relevant output shown):

```
$ export OPENVINO_LOG_LEVEL=3
$ lm_eval --model openvino --model_args pretrained=gpt2-ov,ov_config=config.json --task lambada_openai --limit 5
2024-04-19:18:24:20,576 INFO     [evaluator.py:177] Initializing openvino model, with arguments: {'pretrained': 'gpt2-ov', 2024-04-
19:18:24:21,574 INFO     [optimum_lm.py:63] Using custom OpenVINO config: {'INFERENCE_PRECISION_HINT': 'f32', 'CACHE_DIR': 'model_cache'}
  INFERENCE_PRECISION_HINT: <Type: 'float32'>
```

Previous settings for PERFORMANCE_HINT and NUM_STREAMS are no longer needed because they are now the defaults in both optimum-intel and OpenVINO. 

cc @NoushNabi