### PR TITLE
Add ability to inject OpenAI client to LM

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -107,7 +107,7 @@ class OpenaiCompletionsLM(TemplateLM):
     ) -> None:
         """
         :param model: str: name of openai model to use
-        :param client: OpenAIClientType: Could be AuzerClient or OpenAIClient
+        :param client: OpenAIClientType: Could be AzureClient or OpenAIClient
             or any client that implements .create and .chat.create methods.
         :param tokenizer: str: name of tokenizer to use.
         :param tokenizer_backend: Literal["tiktoken", "huggingface"]


### PR DESCRIPTION
Add abillity to inject OpenAI client into the OpenaiCompletionsLM class. This can be useful since the [official python client](https://github.com/openai/openai-python) library has multiple client implementations such as the AzureClient which can be used. 