### PR TITLE
vllm lora support

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -355,7 +355,6 @@ class VLLM(TemplateLM):
             # cache generations
             for output, context in zip(cont, context):
                 generated_text = output.outputs[0].text
-                print(generated_text)
                 res.append(generated_text)
                 self.cache_hook.add_partial(
                     "generate_until", (context, gen_kwargs), generated_text


### PR DESCRIPTION
adds ability to use LoRA adapters with vLLM without creating merged models. this is useful for us because we needed to eval different LoRA checkpoints while avoiding merging the weights each time. 
usage example:
`lm_eval --model vllm --model_args pretrained=meta-llama/Meta-Llama-3-8B,lora_finetune_path=/mnt/data/llama3_8b_r16_a32_epoch1/checkpoint-8500,enable_lora=True --tasks hellaswag --device cuda`