### PR TITLE
Add Ascend NPU for huggingface.py

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1284,3 +1284,4 @@ class HFLM(TemplateLM):
         pbar.close()
 
         return res
+        


### PR DESCRIPTION
here I just add the NPU support for huggingface.py.

Currently, `accelerate` is trying to provide more support for different device backend, and  `accelerate` has alreay support NPU after version `0.26.0`(https://github.com/huggingface/accelerate/releases/tag/v0.26.0). 

So this PR just do some fix of existing code to support NPU device.

Currently, the class `HFLM` just support three different ways to do evaluations:
- using single card just set `cuda:0`
- using accelerate to do evaluation on multiple cards
- using device_map = 'auto' to do evaluation on multiple cards


Here are explanation of my code:

**- using single card just set `cuda:0`**

Just simply add `["npu"]` and `[f"npu:{i}" for i in range(device_counts)]`  to device_list as `mps`. 


**- using accelerate to do evaluation on multiple cards**

The major change is just replace  `f"cuda:{accelerator.local_process_index}"`  with `f"{accelerator.device}"`, it does the same thing, and I think it may help adapt more different devices later if accelerate supports.


**- using device_map = 'auto' to do evaluation on multiple cards**

For `device_map = 'auto'`, there is something different. If people want to use `device_map = 'auto'` in NPUs, they can use following code

```
lm_eval --model hf \
    --tasks lambada_openai,arc_easy \
    --model_args parallelize=True \
    --device npu:0 \
    --batch_size 16
```

the card info should be set. I do this because of this [issue](https://github.com/EleutherAI/lm-evaluation-harness/issues/1575), I met same problem in NPUs. And the problem could be solved by setting specific card. I think it's better just set the device.