### PR TITLE
add NPU support for huggingface.py

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -162,10 +162,10 @@ class HFLM(TemplateLM):
             if not (parallelize or accelerator.num_processes > 1):
                 # use user-passed device
                 device_list = set(
-                    ["cuda", "cpu", "npu"]
-                    + [f"cuda:{i}" for i in range(device_counts)]
-                    + [f"npu:{i}" for i in range(device_counts)]
+                    ["cuda", "cpu"]
+                    + [f"cuda:{i}" for i in range(torch.cuda.device_count())]
                     + ["mps", "mps:0"]
+                    + ["npu", "npu:0"]
                 )
                 if device and device in device_list:
                     self._device = torch.device(device)

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -13,7 +13,6 @@ from accelerate import (
     InitProcessGroupKwargs,
     find_executable_batch_size,
 )
-from accelerate.utils import is_npu_available
 from huggingface_hub import HfApi
 from packaging import version
 from peft import PeftModel
@@ -149,14 +148,12 @@ class HFLM(TemplateLM):
             assert isinstance(batch_size, (int, str))
 
             gpus = torch.cuda.device_count()
-
             accelerator_kwargs = InitProcessGroupKwargs(timeout=timedelta(weeks=52))
             accelerator = Accelerator(kwargs_handlers=[accelerator_kwargs])
-
             if accelerator.num_processes > 1:
                 self.accelerator = accelerator
 
-            if is_npu_available():
+            if "npu" in accelerator.device.type:
                 gpus = torch.npu.device_count()
 
             if not (parallelize or accelerator.num_processes > 1):


### PR DESCRIPTION
## what this PR do

issue: #1797
This PR add NPU support for huggingface.py. It just does some fix of existing code to support NPU device.

## what part to fix
Currently, the class `HFLM` just support three different ways to do evaluations:
- using single card just set `cuda:0`
- using accelerate to do evaluation on multiple cards
- using device_map = 'auto' to do evaluation on multiple cards

## how to fix and why 

Here are explanation of my code:

**- using single card just set `cuda:0`**

Just simply add `["npu"]` and `["npu:0"]`  to device_list as `mps`.  If users want to use in different card, they can export  `ASCEND_RT_VISIBLE_DEVICES =1 or 2 or 3` and `device npu` to run task.

**- using accelerate to do evaluation on multiple cards**

The major change is just replace  `f"cuda:{accelerator.local_process_index}"`  with `f"{accelerator.device}"`, it does the same thing, and I think it may help adapt more different devices later if accelerate supports.


**- using device_map = 'auto' to do evaluation on multiple cards**

For `device_map = 'auto'`, there is something different. If people want to use `device_map = 'auto'` in NPUs, they can use following code

```
lm_eval --model hf \
    --tasks lambada_openai,arc_easy \
    --model_args parallelize=True \
    --device npu:0 \
    --batch_size 16
```

the card info should be set. I do this because of this [issue](https://github.com/EleutherAI/lm-evaluation-harness/issues/1575), I met same problem in NPUs. And the problem could be solved by setting specific card. I think it's better just set the device.