### PR TITLE
Vllm get tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ We also support using your own local inference server with servers that mirror t
 ```bash
 lm_eval --model local-chat-completions --tasks gsm8k --model_args model=facebook/opt-125m,base_url=http://{yourip}:8000/v1
 ```
+
+Particularly for llm, it is possible to run the tests without knowing the model behind it a priori. Under the hood, we request the tokenizer to the vllm-server by setting the `tokenizer_backend=vllm` argument.
+
+```bash
+lm_eval --model local-completions --tasks gsm8k --model_args model={vllm_model_name},base_url=http://{yourip}:8000/v1,tokenizer_backend=vllm
+```
+
 Note that for externally hosted models, configs such as `--device` and `--batch_size` should not be used and do not function. Just like you can use `--model_args` to pass arbitrary arguments to the model constructor for local models, you can use it to pass arbitrary arguments to the model API for hosted models. See the documentation of the hosting service for information on what arguments they support.
 
 | API or Inference Server                                                                                                   | Implemented?                    | `--model <xxx>` name                                                | Models supported:                                                                             | Request Types:                                             |

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -1,7 +1,11 @@
 import copy
+import json
 import os
+import shutil
+import requests
 from collections import defaultdict
 from importlib.util import find_spec
+from pathlib import Path
 from typing import List, Literal, Optional, Tuple
 
 from tqdm import tqdm
@@ -81,7 +85,7 @@ class OpenaiCompletionsLM(TemplateLM):
         model: str,
         base_url: str = None,
         tokenizer: Optional[str] = None,
-        tokenizer_backend: Literal["tiktoken", "huggingface"] = "tiktoken",
+        tokenizer_backend: Literal["tiktoken", "huggingface", "vllm"] = "tiktoken",
         truncate: bool = False,
         max_gen_toks: int = 256,
         batch_size: int = 1,
@@ -112,6 +116,8 @@ class OpenaiCompletionsLM(TemplateLM):
         self._batch_size = int(batch_size)
         self._max_gen_toks = max_gen_toks
         self._max_length = max_length
+        # Path to current file folder
+        self.tokenizer_ephimeral_path =  Path(__file__).resolve().parent / "tokenizer_ephimeral"
 
         # if we have a local model, use HF tokenizer over tiktoken
         if self.tokenizer_backend == "huggingface":
@@ -122,6 +128,28 @@ class OpenaiCompletionsLM(TemplateLM):
             )
             self.vocab_size = self.tokenizer.vocab
             self.end_of_text_token_id = self.tokenizer.eos_token
+        if self.tokenizer_backend == "vllm":
+            import transformers  # noqa: E401
+
+            response = requests.get(base_url+"/get_tokenizer")
+            tokenizer_objects = json.loads(response.content)    
+            # save into files
+            for key, value in tokenizer_objects.items():
+                # create folder if not exists
+                if not os.path.exists(self.tokenizer_ephimeral_path):
+                    os.mkdir(self.tokenizer_ephimeral_path)
+                with open(os.path.join(self.tokenizer_ephimeral_path, key + ".json"), "w") as f:
+                    json.dump(value, f)
+                    f.close()
+            self.tokenizer = transformers.AutoTokenizer.from_pretrained(self.tokenizer_ephimeral_path)            
+            self.vocab_size = self.tokenizer.vocab
+            self.end_of_text_token_id = self.tokenizer.eos_token
+            try:
+                shutil.rmtree(self.tokenizer_ephimeral_path)
+                eval_logger.debug(f"Ephimeral '{self.tokenizer_ephimeral_path.name}' directory removed successfully.")
+                eval_logger.debug(f"Tokenizer objects availables: {str(tokenizer_objects.keys())}")
+            except OSError as e:
+                raise RuntimeError(f"Error removing '{self.tokenizer_ephimeral_path.name}' directory: {e}")
         elif self.tokenizer_backend == "tiktoken":
             if self.base_url:
                 eval_logger.warning(
@@ -212,7 +240,7 @@ class OpenaiCompletionsLM(TemplateLM):
                 prompt=inps,
                 max_tokens=0,
                 temperature=0.0,
-                logprobs=10,
+                logprobs=5,
                 seed=self.seed,
             )
 


### PR DESCRIPTION
# Issue:
It is possible to change the model names served by `vllm`, and then have it not respond to any Huggingface repository making it impossible to obtain the tokenizer and therefore run `lm-eval-harness`.

# Features:

This PR works in conjunction with another [PR](https://github.com/vllm-project/vllm/pull/2643) in the vllm repository to enable such features. The `vllm` server (optionally for whoever runs it) will send the `*.json` generated after using `tokenizer.save_pretrained()` and then the tokenizer is instantiated locally.

When running the tests, simply add the `tokenizer_backend=vllm` option to the model arguments.