### PR TITLE
Fix `--gen_kwargs` and VLLM (`temperature` not respected)

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -499,7 +499,9 @@ class VLLM(TemplateLM):
         # sampling_params
         do_sample = kwargs.pop("do_sample", None)
         if do_sample is False and "temperature" not in kwargs:
-            eval_logger.debug("Got `do_sample=False` and no temperature value, setting VLLM temperature to 0.0 ...")
+            eval_logger.debug(
+                "Got `do_sample=False` and no temperature value, setting VLLM temperature to 0.0 ..."
+            )
             kwargs["temperature"] = 0.0
         # hf defaults
         kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -498,7 +498,8 @@ class VLLM(TemplateLM):
     def modify_gen_kwargs(kwargs: dict) -> dict:
         # sampling_params
         do_sample = kwargs.pop("do_sample", None)
-        if do_sample is False or "temperature" not in kwargs:
+        if do_sample is False and "temperature" not in kwargs:
+            eval_logger.debug("Got `do_sample=False` and no temperature value, setting VLLM temperature to 0.0 ...")
             kwargs["temperature"] = 0.0
         # hf defaults
         kwargs["skip_special_tokens"] = kwargs.get("skip_special_tokens", False)


### PR DESCRIPTION
Fixes a bug in which if one passed `--gen_kwargs temperature=0.8` via the CLI and ran a task that uses `do_sample: False` in its default generation kwargs, the temperature setting would be ignored.