### PR TITLE
Fix: support PEFT/LoRA with added tokens

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -494,6 +494,7 @@ class HFLM(TemplateLM):
         offload_folder: Optional[str] = "./offload",
         # PEFT, delta weights and quantization options
         peft: Optional[str] = None,
+        resize_model_vocab: Optional[int] = None,
         delta: Optional[str] = None,
         autogptq: Optional[Union[bool, str]] = False,
         **kwargs,
@@ -579,6 +580,8 @@ class HFLM(TemplateLM):
             if model_kwargs.get("load_in_4bit", None):
                 if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
                     raise AssertionError("load_in_4bit requires peft >= 0.4.0")
+            if resize_model_vocab is not None:
+                self._model.resize_token_embeddings(resize_model_vocab)
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision
             )

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -494,7 +494,6 @@ class HFLM(TemplateLM):
         offload_folder: Optional[str] = "./offload",
         # PEFT, delta weights and quantization options
         peft: Optional[str] = None,
-        resize_model_vocab: Optional[int] = None,
         delta: Optional[str] = None,
         autogptq: Optional[Union[bool, str]] = False,
         **kwargs,
@@ -580,8 +579,8 @@ class HFLM(TemplateLM):
             if model_kwargs.get("load_in_4bit", None):
                 if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
                     raise AssertionError("load_in_4bit requires peft >= 0.4.0")
-            if resize_model_vocab is not None:
-                self._model.resize_token_embeddings(resize_model_vocab)
+            if self._model.config.vocab_size != len(self.tokenizer):
+                self._model.resize_token_embeddings(len(self.tokenizer))
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision
             )

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -581,6 +581,7 @@ class HFLM(TemplateLM):
                 if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
                     raise AssertionError("load_in_4bit requires peft >= 0.4.0")
             if self._model.config.vocab_size != len(self.tokenizer):
+                # resize model for LoRAs with added tokens
                 self._model.resize_token_embeddings(len(self.tokenizer))
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -199,6 +199,15 @@ class HFLM(TemplateLM):
             config=self.config, backend=backend, trust_remote_code=trust_remote_code
         )
 
+        # load tokenizer so we know tokenizer vocabulary size before loading model and PEFT
+        self._create_tokenizer(
+            pretrained,
+            tokenizer,
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+            use_fast_tokenizer=use_fast_tokenizer,
+        )
+
         # if we passed `pretrained` as a string, initialize our model now
         if isinstance(pretrained, str):
             self._create_model(
@@ -234,14 +243,6 @@ class HFLM(TemplateLM):
                     eval_logger.debug(
                         "Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes` or `device_map` is provided. If the desired GPU is being used, this message is safe to ignore."
                     )
-
-        self._create_tokenizer(
-            pretrained,
-            tokenizer,
-            revision=revision,
-            trust_remote_code=trust_remote_code,
-            use_fast_tokenizer=use_fast_tokenizer,
-        )
 
         self.truncation = truncation
         self.logits_cache = logits_cache
@@ -579,12 +580,8 @@ class HFLM(TemplateLM):
             if model_kwargs.get("load_in_4bit", None):
                 if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
                     raise AssertionError("load_in_4bit requires peft >= 0.4.0")
-            if self.tokenizer is not None:
-                assert isinstance(
-                    tokenizer, transformers.PreTrainedTokenizer
-                ) or isinstance(tokenizer, transformers.PreTrainedTokenizerFast)
-                if self._model.config.vocab_size != len(self.tokenizer):
-                    self._model.resize_token_embeddings(len(self.tokenizer))
+            if self._model.config.vocab_size != len(self.tokenizer):
+                self._model.resize_token_embeddings(len(self.tokenizer))
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision
             )

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -579,8 +579,12 @@ class HFLM(TemplateLM):
             if model_kwargs.get("load_in_4bit", None):
                 if version.parse(PEFT_VERSION) < version.parse("0.4.0"):
                     raise AssertionError("load_in_4bit requires peft >= 0.4.0")
-            if self._model.config.vocab_size != len(self.tokenizer):
-                self._model.resize_token_embeddings(len(self.tokenizer))
+            if self.tokenizer is not None:
+                assert isinstance(
+                    tokenizer, transformers.PreTrainedTokenizer
+                ) or isinstance(tokenizer, transformers.PreTrainedTokenizerFast)
+                if self._model.config.vocab_size != len(self.tokenizer):
+                    self._model.resize_token_embeddings(len(self.tokenizer))
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision
             )

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -583,6 +583,7 @@ class HFLM(TemplateLM):
             if self._model.config.vocab_size != len(self.tokenizer):
                 # resize model for LoRAs with added tokens
                 self._model.resize_token_embeddings(len(self.tokenizer))
+                eval_logger.info(f"Model config indicates vocab_size='{self._model.config.vocab_size}', but found tokenizer with vocab size '{len(self.tokenizer)}'. Resizing model embedding layer...") 
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision
             )


### PR DESCRIPTION
PEFT supports adding tokens/embeddings: https://github.com/huggingface/peft/blob/main/examples/causal_language_modeling/peft_lora_clm_with_additional_tokens.ipynb

When loading a pretrained model, tokenizer, and PEFT including new tokens, the model fails because the model and adapter have a different number of embeddings:

```
! lm_eval --model hf \
    --model_args pretrained=gradientai/Llama-3-8B-Instruct-262k,
       tokenizer=monsoon-nlp/llama3-biotokenpretrain-kaniwa,
       load_in_4bit=True,
       peft=monsoon-nlp/llama3-biotokenpretrain-kaniwa \
    --tasks hellaswag \
    --device cuda:0 \
    --batch_size 1
```

```
  File "/content/lm-evaluation-harness/lm_eval/models/huggingface.py", line 204, in __init__
    self._create_model(
  File "/content/lm-evaluation-harness/lm_eval/models/huggingface.py", line 582, in _create_model
    self._model = PeftModel.from_pretrained(
  File "/usr/local/lib/python3.10/dist-packages/peft/peft_model.py", line 356, in from_pretrained
    model.load_adapter(model_id, adapter_name, is_trainable=is_trainable, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/peft/peft_model.py", line 730, in load_adapter
    load_result = set_peft_model_state_dict(self, adapters_weights, adapter_name=adapter_name)
  File "/usr/local/lib/python3.10/dist-packages/peft/utils/save_and_load.py", line 249, in set_peft_model_state_dict
    load_result = model.load_state_dict(peft_model_state_dict, strict=False)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 2153, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for PeftModelForCausalLM:
	size mismatch for base_model.model.model.embed_tokens.modules_to_save.default.weight: copying a param with shape torch.Size([128260, 4096]) from checkpoint, the shape in current model is torch.Size([128256, 4096]).
	size mismatch for base_model.model.lm_head.weight: copying a param with shape torch.Size([128260, 4096]) from checkpoint, the shape in current model is torch.Size([128256, 4096]).
```

In this case we want to run `self._model.resize_token_embeddings(len(self.tokenizer))`

The core fix is:
```python
if peft:
  if self._model.config.vocab_size != len(self.tokenizer):
    # resize model for LoRAs with added tokens
    self._model.resize_token_embeddings(len(self.tokenizer))
  self._model = PeftModel.from_pretrained( ...)
```

The other change is moving initialization of `self.tokenizer` earlier in the script, so we have access to the tokenizer at this point in time.

CoLab proof of concept:
https://colab.research.google.com/drive/12NaNeDHRCMVhyIHL4_Z6AZQq6q_E2cP8