### PR TITLE
Fix self.max_tokens in anthropic_llms.py

### DIFF
--- a/lm_eval/models/anthropic_llms.py
+++ b/lm_eval/models/anthropic_llms.py
@@ -307,7 +307,7 @@ please install anthropic via `pip install 'lm-eval[anthropic]'` or `pip install 
         # defaults to os.environ.get("ANTHROPIC_API_KEY")
         self.client = anthropic.Anthropic()
         self.temperature = temperature
-        self.max_token = max_tokens
+        self.max_tokens = max_tokens
         self.tokenizer = self.client.get_tokenizer()
         self.kwargs = kwargs
 


### PR DESCRIPTION
Fix bug where `self.max_tokens` was not set. 
The `AnthropicChatLM` uses everywhere `self.max_tokens` while in constructor is sets `self.max_token`. It doesn't call issues on smaller responses but I caught it while asking for bigger (>1000tokens) response. 