### PR TITLE
Force BOS token usage in 'gemma' models for VLLM

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -124,6 +124,12 @@ class VLLM(TemplateLM):
             tokenizer_revision=tokenizer_revision,
         )
         self.add_bos_token = add_bos_token
+        if "gemma" in pretrained.lower():
+            self.add_bos_token = True
+            eval_logger.info(
+                "Found 'gemma' in model name, a BOS token will be used as Gemma underperforms without it."
+            )
+
         self.custom_prefix_token_id = prefix_token_id
         if prefix_token_id is not None:
             eval_logger.info(


### PR DESCRIPTION
closes #1854 . 

As with Huggingface models, forces `add_bos_token=True` (and logs an info message) if a Gemma model is used, since Gemma models.

This current version just does this for models which have 'gemma' in their lowercased name. Unsure if VLLM provides a way to programmatically get the equivalent of `config.model_type` from a HF AutoConfig.

