### PR TITLE
mmlu-pro for the  Italian language

### DIFF
--- a/lm_eval/tasks/okapi/mmlu_pro_multilingual/_default_template.yaml
+++ b/lm_eval/tasks/okapi/mmlu_pro_multilingual/_default_template.yaml
@@ -1,0 +1,17 @@
+group:
+  - m_mmlu_pro
+dataset_path: efederici/MMLU-Pro-ita 
+test_split: test
+fewshot_split: validation
+fewshot_config:
+  sampler: first_n
+output_type: multiple_choice
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: !function utils.doc_to_choice  #["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+doc_to_target: answer
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/okapi/mmlu_pro_multilingual/m_mmlu_pro_it.yaml
+++ b/lm_eval/tasks/okapi/mmlu_pro_multilingual/m_mmlu_pro_it.yaml
@@ -1,0 +1,2 @@
+include: _default_template.yaml
+task: m_mmlu_pro_it

--- a/lm_eval/tasks/okapi/mmlu_pro_multilingual/utils.py
+++ b/lm_eval/tasks/okapi/mmlu_pro_multilingual/utils.py
@@ -1,0 +1,18 @@
+voc = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+
+
+def doc_to_text(x):
+    question = x["question"].strip()
+    choices = x["options"]
+    inp = f"{question}"
+    for idx, choice in enumerate(choices):
+        inp = inp + f"\\n{voc[idx]}. {choice}"
+    return inp + "\\nRisposta:"
+
+
+def doc_to_choice(x):
+    choices = x["options"]
+    answers = []
+    for idx, _ in enumerate(choices):
+        answers.append(voc[idx])
+    return answers


### PR DESCRIPTION
In this PR I add the evaluation for the new mmlu_pro task translated to the Italian Language. The dataset used is a curated translation [here](https://huggingface.co/datasets/efederici/MMLU-Pro-ita). The way the dataset is translated is specified in the model card and if someone else would do in other languages we could easily expands in other languages. This is the reason I used the okapi folder.