### PR TITLE
Fix incorrect check for task type

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -413,7 +413,9 @@ def get_task_dict(
         )
 
     string_task_name_list = [task for task in task_name_list if isinstance(task, str)]
-    others_task_name_list = [task for task in task_name_list if ~isinstance(task, str)]
+    others_task_name_list = [
+        task for task in task_name_list if not isinstance(task, str)
+    ]
     if len(string_task_name_list) > 0:
         if task_manager is None:
             task_manager = TaskManager()


### PR DESCRIPTION
The non-string task type is incorrectly checked with `~` prepended to the `isinstance` function, which leads to incorrect behavior:

```
>>> isinstance("hello", str)
True
>>> ~isinstance("hello", str)
<stdin>:1: DeprecationWarning: Bitwise inversion '~' on bool is deprecated. This returns the bitwise inversion of the underlying int object and is usually not what you expect from negating a bool. Use the 'not' operator for boolean negation or ~int(x) if you really want the bitwise inversion of the underlying int.
-2
>>> bool(~isinstance("hello", str))
True  # <--- incorrect
>>> not isinstance("hello", str)
False # <--- correct
```

Simple fix by replacing `~` with `not`.