### PR TITLE
Add LegalBench tasks

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -125,6 +125,12 @@ def brier_score(items):  # This is a passthrough function
     return np.mean(np.sum((predictions - gold_one_hot) ** 2, axis=1))
 
 
+@register_aggregation("balanced_accuracy")
+def balanced_accuracy(items):
+    golds, preds = list(zip(*items))
+    return sklearn.metrics.balanced_accuracy_score(golds, preds)
+
+
 @register_metric(
     metric="brier_score",
     higher_is_better=False,
@@ -315,6 +321,16 @@ def acc_all(items):
         question_scoring_dict[(paragraph_id, question_id)].append(gold_label == pred)
     acc = np.mean([int(all(x)) for x in question_scoring_dict.values()])
     return acc
+
+
+@register_metric(
+    metric="balanced_acc",
+    higher_is_better=True,
+    output_type=["loglikelihood", "multiple_choice"],
+    aggregation="balanced_accuracy",
+)
+def balanced_acc_fn(items):  # This is a passthrough function
+    return items
 
 
 def acc_all_stderr(items):

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1300,6 +1300,11 @@ class ConfigurableTask(Task):
                     if "brier_score" in use_metric
                     else {}
                 ),
+                **(
+                    {"balanced_acc": (gold, pred)}
+                    if "balanced_acc" in use_metric
+                    else {}
+                ),
             }
 
             if "acc_mutual_info" in use_metric:

--- a/lm_eval/tasks/legalbench/legalbench_abercrombie.yaml
+++ b/lm_eval/tasks/legalbench/legalbench_abercrombie.yaml
@@ -1,0 +1,18 @@
+task: legalbench_abercrombie
+group:
+  - legalbench
+dataset_path: nguha/legalbench
+dataset_name: abercrombie
+training_split: train
+test_split: test
+output_type: multiple_choice
+num_fewshot: 5
+# Template from: https://github.com/HazyResearch/legalbench/blob/main/tasks/abercrombie/rule_description_prompt.txt
+description: "A mark is generic if it is the common name for the product. A mark is descriptive if it describes a purpose, nature, or attribute of the product. A mark is suggestive if it suggests or implies a quality or characteristic of the product. A mark is arbitrary if it is a real English word that has no relation to the product. A mark is fanciful if it is an invented word. Determine the type of each mark (generic, descriptive, suggestive, arbitrary, fanciful) under the Abercrombie factors.\n\n"
+doc_to_text: "Q: {{text}} What is this type of mark?\nA:"
+doc_to_target: answer
+doc_to_choice: ['descriptive', 'fanciful', 'suggestive', 'generic', 'arbitrary']
+metric_list:
+  - metric: balanced_acc
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/legalbench/legalbench_corporate_lobbying.yaml
+++ b/lm_eval/tasks/legalbench/legalbench_corporate_lobbying.yaml
@@ -1,0 +1,18 @@
+task: legalbench_corporate_lobbying
+group:
+  - legalbench
+dataset_path: nguha/legalbench
+dataset_name: corporate_lobbying
+training_split: train
+test_split: test
+output_type: multiple_choice
+num_fewshot: 0
+# Template from: https://github.com/HazyResearch/legalbench/blob/main/tasks/corporate_lobbying/base_prompt.txt
+description: "You are a lobbyist analyzing Congressional bills for their impacts on companies.\nGiven the title and summary of the bill, plus information on the company from its 10K SEC filing, it is your job to determine if a bill is at least somewhat relevant to a company in terms of whether it could impact the company's bottom-line if it was enacted (by saying Yes or No).\n"
+doc_to_text: "Official title of bill: {{bill_title}}\nOfficial summary of bill: {{bill_summary}}\nCompany name: {{company_name}}\nCompany business description: {{company_description}}\nIs this bill potentially relevant to the company? FINAL ANSWER:"
+doc_to_target: answer
+doc_to_choice: ['Yes', 'No']
+metric_list:
+  - metric: balanced_acc
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/legalbench/legalbench_function_of_decision_section.yaml
+++ b/lm_eval/tasks/legalbench/legalbench_function_of_decision_section.yaml
@@ -1,0 +1,18 @@
+task: legalbench_function_of_decision_section
+group:
+  - legalbench
+dataset_path: nguha/legalbench
+dataset_name: function_of_decision_section
+training_split: train
+test_split: test
+output_type: multiple_choice
+num_fewshot: 7
+# Template from: https://github.com/HazyResearch/legalbench/blob/main/tasks/function_of_decision_section/base_prompt.txt
+description: "Classify the following text using the following definitions.\n\n- Facts: The paragraph describes the faction background that led up to the present lawsuit.\n- Procedural History: The paragraph describes the course of litigation that led to the current proceeding before the court.\n- Issue: The paragraph describes the legal or factual issue that must be resolved by the court.\n- Rule: The paragraph describes a rule of law relevant to resolving the issue.\n- Analysis: The paragraph analyzes the legal issue by applying the relevant legal principles to the facts of the present dispute.\n- Conclusion: The paragraph presents a conclusion of the court.\n- Decree: The paragraph constitutes a decree resolving the dispute.\n\n"
+doc_to_text: "Text: {{Paragraph}}\nLabel:"
+doc_to_target: answer
+doc_to_choice: ['Decree', 'Conclusion', 'Issue', 'Facts', 'Procedural History', 'Rule', 'Analysis']
+metric_list:
+  - metric: balanced_acc
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/legalbench/legalbench_international_citizenship_questions.yaml
+++ b/lm_eval/tasks/legalbench/legalbench_international_citizenship_questions.yaml
@@ -1,0 +1,18 @@
+task: legalbench_international_citizenship_questions
+group:
+  - legalbench
+dataset_path: nguha/legalbench
+dataset_name: international_citizenship_questions
+training_split: train
+test_split: test
+output_type: multiple_choice
+num_fewshot: 0
+# Template from: https://github.com/HazyResearch/legalbench/blob/main/tasks/international_citizenship_questions/base_prompt.txt
+description: "Answer the following questions considering the state of international law on January 1st, 2020.\n\n"
+doc_to_text: "Question: {{question}} Answer Yes or No.\nAnswer:"
+doc_to_target: answer
+doc_to_choice: ['Yes', 'No']
+metric_list:
+  - metric: balanced_acc
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/legalbench/legalbench_proa.yaml
+++ b/lm_eval/tasks/legalbench/legalbench_proa.yaml
@@ -1,0 +1,18 @@
+task: legalbench_proa
+group:
+  - legalbench
+dataset_path: nguha/legalbench
+dataset_name: proa
+training_split: train
+test_split: test
+output_type: multiple_choice
+num_fewshot: 5
+# Template from: https://github.com/HazyResearch/legalbench/blob/main/tasks/proa/base_prompt.txt
+description: "A private right of action is when a regular person, a private citizen, is legally entitled to enforce their rights under a given statute. Does the clause specify a private right of action? Answer Yes or No.\n\n"
+doc_to_text: "Clause: {{text}}\nA:"
+doc_to_target: answer
+doc_to_choice: ['Yes', 'No']
+metric_list:
+  - metric: balanced_acc
+metadata:
+  version: 0.0


### PR DESCRIPTION
# What does this PR do?

This PR extends the evaluation suite with LegalBench. 

From the large set of tasks, I have added the 5 which are reported by [HELM](https://crfm.stanford.edu/helm/lite/latest/#/groups/legalbench).

Addresses #1754

Implementation notes:
- I needed to implement a `balanced_acc` metric, since this is the reported score in the paper / HELM. From the paper: 
> 5.1.3 Evaluation
Classification tasks are evaluated using "exact-match" (following HELM [80]). Because some tasks contain significant label imbalances, we use balanced-accuracy as a metric.

- I set the `num_fewshot` parameter according to those reported in the paper (see "Table 58: Number of in-context demonstrations used for each type")
- The prompt templates closely follow those in the repo. In each `yaml` file, there is a link pointing to the template used for the task. 

# Results

## `google/flan-t5-xl`

| Task                                        | Balanced Accuracy (paper) | Balanced Accuracy (measured)|
|---------------------------------------------|----------------------------|----------------------------|
| legalbench_abercrombie                      | 31.6                       | 28.42                      |
| legalbench_corporate_lobbying               | 51.9                       | 50.67                      |
| legalbench_function_of_decision_section     | 34.8                       | 28.51                      |
| legalbench_international_citizenship_questions | 50.0                    | 50.01                      |
| legalbench_proa                             | 80.1                       | 88.41                      |


## `meta-llama/LLaMA-2-7b-hf`

Since the HELM repo doesn't report results on the Flan-T5 model, I also evaluated Llama 7B

| Task                                        | Balanced Accuracy (paper) | Balanced Accuracy (HELM) | Balanced Accuracy (measured) |
|---------------------------------------------|-------------------------|------------------------|----------------------------|
| legalbench_abercrombie                      | 32.6                    | 27.4                   | 32.63                      |
| legalbench_corporate_lobbying               | 50.0                    | 67.6                   | 50.00                      |
| legalbench_function_of_decision_section     | 16.7                    | 24.5                   | 16.33                      |
| legalbench_international_citizenship_questions | 27.2                  | 56.6                   | 50.07                      |
| legalbench_proa                             | 52.1                    | 74.7                   | 73.83                      |