### PR TITLE
[HFLM]Add support for Ascend NPU

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -153,12 +153,16 @@ class HFLM(TemplateLM):
             if accelerator.num_processes > 1:
                 self.accelerator = accelerator
 
+            if "npu" in accelerator.device.type:
+                gpus = torch.npu.device_count()
+
             if not (parallelize or accelerator.num_processes > 1):
                 # use user-passed device
                 device_list = set(
                     ["cuda", "cpu"]
                     + [f"cuda:{i}" for i in range(gpus)]
                     + ["mps", "mps:0"]
+                    + [f"npu:{i}" for i in range(gpus)]
                 )
                 if device and device in device_list:
                     self._device = torch.device(device)
@@ -323,6 +327,7 @@ class HFLM(TemplateLM):
                         in [
                             DistributedType.FSDP,
                             DistributedType.MULTI_GPU,
+                            DistributedType.MULTI_NPU,
                         ]
                     ), "Unsupported distributed type provided. Only DDP and FSDP are supported."
                     if accelerator.distributed_type == DistributedType.FSDP:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.8"
 license = { "text" = "MIT" }
 dependencies = [
-    "accelerate>=0.21.0",
+    "accelerate>=0.26.0",
     "evaluate",
     "datasets>=2.16.0",
     "evaluate>=0.4.0",


### PR DESCRIPTION
### What does this PR do?
fix https://github.com/EleutherAI/lm-evaluation-harness/issues/1470

Thanks for creating this repository.  We are using this repository to evaluate the performance of models fine-tuned via Ascend NPUs and hence the reason for this PR. This change will help us run HFLM without issues.(Because [accelerate](https://github.com/huggingface/accelerate/pull/1676)/[peft](https://github.com/huggingface/peft/pull/772) and [transformers](https://github.com/huggingface/transformers/pull/24879) has enabled NPU support).

As of `accelerate` version 0.21.0 (which is consistent with the `accelerate` version that lm-evaluation-harness relies on), Ascend NPU is supported. Therefore, we can determine whether there is an available NPU through the `Accelerator` object instantiated by the `accelerate`.

That is to say, if `if "npu" in accelerator.device.type` returns `True`, it indicates that there is an available NPU in the running environment. And then, we can use a set of APIs similar to `torch.cuda` provided by `torch_npu`(FYI, `torch_npu` has been harded-coded into `accelerate`, [see](https://github.com/huggingface/accelerate/blob/c3f422699a5cb7665edd5420b8b106512c09a85d/src/accelerate/accelerator.py#L143-L144)), such as `torch.npu.device_count`.  The API currently supported by `torch_npu` can be obtained from [here](https://github.com/Ascend/pytorch/blob/master/docs/api/torch_npu_apis.md).


---

### What is Ascend and `torch_npu`
The following information is quoted from: https://github.com/Lightning-AI/pytorch-lightning/issues/19498#issue-2143434187
1. Ascend is a full-stack AI computing infrastructure for industry applications and services based on Huawei Ascend processors and software. For more information about Ascend, see [Ascend Community](https://www.hiascend.com/en/).
2. `torch_npu` is an [officially recognized pytorch integration plugin](https://pytorch.org/blog/pytorch-2-1/) to support Ascend NPU using the pytorch framework(through key PRivateUse1), please see the PrivateUse1 tutorial [here](https://pytorch.org/tutorials/advanced/privateuseone.html).
3. Ascend is currently one of the premier members of the [PyTorch Foundation](https://pytorch.org/blog/huawei-joins-pytorch/).
