### PR TITLE
add arc_challenge_mt

### DIFF
--- a/lm_eval/tasks/arc_mt/README.md
+++ b/lm_eval/tasks/arc_mt/README.md
@@ -1,0 +1,12 @@
+# arc mt
+
+arc mt is an implementation of tasks to support machine translated arc
+challenge evals, to improve eval support across a number of additional
+languages.
+
+The main page for the effort is
+[here](https://huggingface.co/datasets/LumiOpen/arc_challenge_mt) and we will
+include more data and analysis there.
+
+Initial datasets include a number of European languages, and we plan to expand
+more in the future.

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_da.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_da.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_da
+dataset_name: da

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_de.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_de.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_de
+dataset_name: de

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_el.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_el.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_el
+dataset_name: el

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_es.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_es.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_es
+dataset_name: es

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_fi.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_fi.yaml
@@ -1,0 +1,23 @@
+group:
+  - arc_challenge_mt
+task: arc_challenge_mt_fi
+dataset_path: LumiOpen/arc_challenge_mt
+dataset_name: fi
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "Question: {{question}}\nAnswer:"
+doc_to_target: "{{choices.label.index(answerKey)}}"
+doc_to_choice: "{{choices.text}}"
+should_decontaminate: true
+doc_to_decontamination_query: "Question: {{question}}\nAnswer:"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_hu.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_hu.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_hu
+dataset_name: hu

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_is.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_is.yaml
@@ -1,0 +1,22 @@
+group:
+  - arc_challenge_mt
+task: arc_challenge_mt_is
+dataset_path: mideind/icelandic-arc-challenge
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "Question: {{question}}\nAnswer:"
+doc_to_target: "{{choices.label.index(answerKey)}}"
+doc_to_choice: "{{choices.text}}"
+should_decontaminate: true
+doc_to_decontamination_query: "Question: {{question}}\nAnswer:"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_it.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_it.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_it
+dataset_name: it

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_nb.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_nb.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_nb
+dataset_name: nb

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_pl.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_pl.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_pl
+dataset_name: pl

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_pt.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_pt.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_pt
+dataset_name: pt

--- a/lm_eval/tasks/arc_mt/arc_challenge_mt_sv.yaml
+++ b/lm_eval/tasks/arc_mt/arc_challenge_mt_sv.yaml
@@ -1,0 +1,3 @@
+include: arc_challenge_mt_fi.yaml
+task: arc_challenge_mt_sv
+dataset_name: sv


### PR DESCRIPTION
This PR adds tasks for machine-translated versions of arc challenge for 11 languages.  We will also be adding more languages in the future.