### PR TITLE
Try to make existing tests run little bit faster

### DIFF
--- a/tests/models/test_gguf.py
+++ b/tests/models/test_gguf.py
@@ -15,11 +15,11 @@ base_url = "https://matthoffner-ggml-llm-api.hf.space"
 def gguf_completion_mock(base_url=None, **kwargs):
     # Generate a hash from the parameters
     hash_kwargs = {"base_url": base_url, **kwargs}
-    hash = hashlib.sha256(
+    parameters_hash = hashlib.sha256(
         json.dumps(hash_kwargs, sort_keys=True).encode("utf-8")
     ).hexdigest()
 
-    fname = f"./tests/testdata/gguf_test_{hash}.pkl"
+    fname = f"./tests/testdata/gguf_test_{parameters_hash}.pkl"
 
     if os.path.exists(fname):
         with open(fname, "rb") as fh:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 import numpy as np
 import torch
 
-import lm_eval.tasks as tasks
+from lm_eval import tasks
 from lm_eval.api.instance import Instance
 from lm_eval.models.huggingface import HFLM
 
 
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 task_manager = tasks.TaskManager()
+
+TEST_STRING = "foo bar"
 
 
 class Test_HFLM:
@@ -107,7 +111,7 @@ class Test_HFLM:
 
         file_path = dir_path / f"outputs_log_{self.version_minor}.txt"
         file_path = file_path.resolve()
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write("\n".join(str(x) for x in _res))
         assert np.allclose(_res, _RES, atol=1e-2)
         # check indices for Multiple Choice
@@ -126,19 +130,19 @@ class Test_HFLM:
         assert np.allclose(res, self.ROLLING_RES, atol=1e-1)
 
     def test_toc_encode(self) -> None:
-        res = self.LM.tok_encode("foo bar")
+        res = self.LM.tok_encode(TEST_STRING)
         assert res == [12110, 2534]
 
     def test_toc_decode(self) -> None:
         res = self.LM.tok_decode([12110, 2534])
-        assert res == "foo bar"
+        assert res == TEST_STRING
 
     def test_batch_encode(self) -> None:
-        res = self.LM.tok_batch_encode(["foo bar", "bar foo"])[0].tolist()
+        res = self.LM.tok_batch_encode([TEST_STRING, "bar foo"])[0].tolist()
         assert res == [[12110, 2534], [2009, 17374]]
 
     def test_model_generate(self) -> None:
-        context = self.LM.tok_batch_encode(["foo bar"])[0]
+        context = self.LM.tok_batch_encode([TEST_STRING])[0]
         res = self.LM._model_generate(context, max_length=10, stop=["\n\n"])
         res = self.LM.tok_decode(res[0])
         assert res == "foo bar\n<bazhang>!info bar"

--- a/tests/models/test_neuralmagic.py
+++ b/tests/models/test_neuralmagic.py
@@ -1,6 +1,6 @@
 import pytest
 
-import lm_eval.evaluator as evaluator
+from lm_eval import evaluator
 from lm_eval.api.registry import get_model
 
 

--- a/tests/models/test_openvino.py
+++ b/tests/models/test_openvino.py
@@ -6,7 +6,7 @@ import pytest
 from optimum.intel import OVModelForCausalLM
 from transformers import AutoTokenizer
 
-import lm_eval.evaluator as evaluator
+from lm_eval import evaluator
 from lm_eval.api.registry import get_model
 
 
@@ -46,7 +46,7 @@ def test_evaluator(model_id, task):
 
             random.seed(42)
             for _ in reqs:
-                res.append((-random.random(), False))
+                res.extend([(-random.random(), False)])
 
             return res
 
@@ -57,7 +57,7 @@ def test_evaluator(model_id, task):
             res = []
             random.seed(42)
             for _ in reqs:
-                res.append(-random.random())
+                res.extend([-random.random()])
 
             return res
 
@@ -79,7 +79,7 @@ def test_ov_config():
     model_id = "hf-internal-testing/tiny-random-gpt2"
     with tempfile.TemporaryDirectory() as tmpdirname:
         config_file = str(Path(tmpdirname) / "ov_config.json")
-        with open(Path(config_file), "w") as f:
+        with open(Path(config_file), "w", encoding="utf-8") as f:
             f.write('{"DYNAMIC_QUANTIZATION_GROUP_SIZE" : "32"}')
         lm = get_model("openvino").create_from_arg_string(
             f"pretrained={model_id},ov_config={config_file}"

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 import torch
 
-import lm_eval.tasks as tasks
+from lm_eval import tasks
 from lm_eval.api.instance import Instance
 
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,14 +1,14 @@
-# import lm_eval.base as base
+import os
 from typing import List
 
 import pytest
 
-# import lm_eval.models as models
 import lm_eval.api as api
 import lm_eval.evaluator as evaluator
 from lm_eval import tasks
 
 
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 # TODO: more fine grained unit tests rather than this big honking integration
 # test once we break evaluator into smaller, more manageable pieces
 

--- a/tests/test_requests_caching.py
+++ b/tests/test_requests_caching.py
@@ -1,14 +1,12 @@
-# import lm_eval.base as base
 import importlib
 import os
 import sys
 from datetime import datetime
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import pytest
 import torch
 
-# import lm_eval.models as models
 from lm_eval.caching.cache import PATH
 
 
@@ -43,7 +41,7 @@ def clear_cache():
 
 
 # leaving tasks here to allow for the option to select specific task files
-def get_cache_files(tasks: List[str] = None) -> Tuple[List[str], List[str]]:
+def get_cache_files(tasks: Optional[List[str]] = None) -> Tuple[List[str], List[str]]:
     cache_files = os.listdir(PATH)
 
     file_task_names = []
@@ -51,7 +49,7 @@ def get_cache_files(tasks: List[str] = None) -> Tuple[List[str], List[str]]:
     for file in cache_files:
         file_without_prefix = file.split("-")[1]
         file_without_prefix_and_suffix = file_without_prefix.split(".")[0]
-        file_task_names.append(file_without_prefix_and_suffix)
+        file_task_names.extend([file_without_prefix_and_suffix])
 
     return cache_files, file_task_names
 
@@ -113,10 +111,11 @@ if __name__ == "__main__":
             # test_requests_caching_refresh,
             # test_requests_caching_delete,
         ]
-
+        # Lookups of global names within a loop is inefficient, so copy to a local variable outside of the loop first
+        default_tasks = DEFAULT_TASKS
         for test_func in tests:
             clear_cache()
-            test_func(tasks=DEFAULT_TASKS)
+            test_func(tasks=default_tasks)
 
         print("Tests pass")
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import os
 from itertools import islice
 
 import pytest
@@ -8,6 +9,7 @@ from lm_eval.api.task import ConfigurableTask
 from .utils import new_tasks
 
 
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 task_manager = tasks.TaskManager()
 # Default Task
 TASKS = ["arc_easy"]
@@ -87,7 +89,6 @@ class TestNewTasks:
         )
         if "multiple_choice" in task._config.output_type:
             _array = [task.doc_to_choice(doc) for doc in arr]
-            # assert all(len(x) == 4 for x in _array)
             assert all(isinstance(x, list) for x in _array)
             assert all(isinstance(x[0], str) for x in _array)
 
@@ -101,9 +102,6 @@ class TestNewTasks:
         _array_target = [task.doc_to_target(doc) for doc in arr]
         if task._config.output_type == "multiple_choice":
             assert all(isinstance(label, int) for label in _array_target)
-        # _array_text = [task.doc_to_text(doc) for doc in arr]
-        # Not working
-        # assert all(tgt[0] == " " or txt[-1] == "\n" if  len(txt) != 0 else True for txt, tgt in zip(_array_text, _array_target))
 
     def test_build_all_requests(self, task_class, limit):
         task_class.build_all_requests(rank=1, limit=limit, world_size=1)
@@ -118,5 +116,4 @@ class TestNewTasks:
             else list(islice(task.validation_docs(), limit))
         )
         requests = [task.construct_requests(doc, task.doc_to_text(doc)) for doc in arr]
-        # assert all(isinstance(doc, list) for doc in requests)
         assert len(requests) == limit if limit else True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,9 +12,9 @@ from lm_eval.utils import load_yaml_config
 # reads a text file and returns a list of words
 # used to read the output of the changed txt from tj-actions/changed-files
 def load_changed_files(file_path: str) -> List[str]:
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
-        words_list = [x for x in content.split()]
+        words_list = list(content.split())
     return words_list
 
 
@@ -25,7 +25,7 @@ def load_changed_files(file_path: str) -> List[str]:
 def parser(full_path: List[str]) -> List[str]:
     _output = set()
     for x in full_path:
-        if os.path.exists(x) and x.endswith(".yaml"):
+        if x.endswith(".yaml") and os.path.exists(x):
             config = load_yaml_config(x, mode="simple")
             if isinstance(config["task"], str):
                 _output.add(config["task"])
@@ -40,10 +40,9 @@ def new_tasks() -> Union[List[str], None]:
         # If tasks folder has changed then we get the list of files from FILENAME
         # and parse the yaml files to get the task names.
         return parser(load_changed_files(FILENAME))
-    elif os.getenv("API") is not None:
+    if os.getenv("API") is not None:
         # Or if API has changed then we set the ENV variable API to True
         # and run  given tasks.
         return ["arc_easy", "hellaswag", "piqa", "wikitext"]
     # if both not true just do arc_easy
-    else:
-        return
+    return None


### PR DESCRIPTION
Checked with python 3.9 on Mac (intel) (not all packages installed)
platform darwin -- Python 3.9.18, pytest-8.2.1, pluggy-1.5.0 
`python -m pytest --showlocals -s -vv -n=auto`

Before: 
`5 failed, 63 passed, 1 skipped, 19 warnings, 1 error in 261.63s (0:04:21)`
After:
`5 failed, 63 passed, 1 skipped, 19 warnings, 1 error in 239.46s (0:03:59)`