### PR TITLE
Update basque-glue

### DIFF
--- a/lm_eval/tasks/basqueglue/README.md
+++ b/lm_eval/tasks/basqueglue/README.md
@@ -52,11 +52,11 @@ Homepage: `https://github.com/hitz-zentroa/latxa`
 #### Tasks
 
 * `bhtc_v2`: Topic classification of news extracts with 12 categories.
-* `bec`: Sentiment analysis on tweets about the campaign for the 2016 Basque elections.
+* `bec2016eu`: Sentiment analysis on tweets about the campaign for the 2016 Basque elections.
 * `vaxx_stance`: Stance detection on tweets around the anti-vaccine movement.
 * `qnlieu`: Q&A NLI as in [glue/qnli](../glue/qnli).
 * `wiceu`: Word-in-Context as in [super_glue/wic](../super_glue/wic).
-* `epec_korref_bin`: Correference detection as in [super_glue/wsc](../super_glue/wsc).
+* `epec_koref_bin`: Correference detection as in [super_glue/wsc](../super_glue/wsc).
 
 ### Checklist
 

--- a/lm_eval/tasks/basqueglue/bec.yaml
+++ b/lm_eval/tasks/basqueglue/bec.yaml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: !function utils.micro_f1_score
     higher_is_better: true
 metadata:
-  - version: 1.0
+  version: 1.0

--- a/lm_eval/tasks/basqueglue/bhtc.yaml
+++ b/lm_eval/tasks/basqueglue/bhtc.yaml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: !function utils.micro_f1_score
     higher_is_better: true
 metadata:
-  - version: 1.0
+  version: 1.0

--- a/lm_eval/tasks/basqueglue/coref.yaml
+++ b/lm_eval/tasks/basqueglue/coref.yaml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  - version: 1.0
+  version: 1.0

--- a/lm_eval/tasks/basqueglue/qnli.yaml
+++ b/lm_eval/tasks/basqueglue/qnli.yaml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  - version: 1.0
+  version: 1.0

--- a/lm_eval/tasks/basqueglue/vaxx.yaml
+++ b/lm_eval/tasks/basqueglue/vaxx.yaml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: !function utils.vaxx_f1_score
     higher_is_better: true
 metadata:
-  - version: 1.0
+  version: 1.0

--- a/lm_eval/tasks/basqueglue/wic.yaml
+++ b/lm_eval/tasks/basqueglue/wic.yaml
@@ -14,4 +14,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  - version: 1.0
+  version: 1.0


### PR DESCRIPTION
The tasks `bec` and `epec_korref_bin` both have the issue of `Tasks not found`, after reviewing the YAML file, I found `bec2016eu` and `epec_koref_bin`.
According to the proposal by @minaremeli, the modification of the YAML file has enabled the task to run normally.