### PR TITLE
Results filenames handling fix

### DIFF
--- a/lm_eval/loggers/evaluation_tracker.py
+++ b/lm_eval/loggers/evaluation_tracker.py
@@ -24,6 +24,7 @@ from lm_eval.utils import (
     handle_non_serializable,
     hash_string,
     sanitize_list,
+    sanitize_model_name,
     sanitize_task_name,
 )
 
@@ -83,9 +84,7 @@ class GeneralConfigTracker:
         """Logs model parameters and job ID."""
         self.model_source = model_source
         self.model_name = GeneralConfigTracker._get_model_name(model_args)
-        self.model_name_sanitized = re.sub(
-            r"[\"<>:/\|\\?\*\[\]]+", "__", self.model_name
-        )
+        self.model_name_sanitized = sanitize_model_name(self.model_name)
         self.system_instruction = system_instruction
         self.system_instruction_sha = (
             hash_string(system_instruction) if system_instruction else None

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -166,6 +166,13 @@ def get_file_datetime(filename: str) -> str:
     return filename[filename.rfind("_") + 1 :].replace(".json", "")
 
 
+def sanitize_model_name(model_name: str) -> str:
+    """
+    Given the model name, returns a sanitized version of it.
+    """
+    return re.sub(r"[\"<>:/\|\\?\*\[\]]+", "__", model_name)
+
+
 def sanitize_task_name(task_name: str) -> str:
     """
     Given the task name, returns a sanitized version of it.

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -152,6 +152,48 @@ def general_detokenize(string):
     return string
 
 
+def get_file_task_name(filename: str) -> str:
+    """
+    Given the sample results filenames, extracts and returns the task name.
+    """
+    return filename[filename.find("_") + 1 : filename.rfind("_")]
+
+
+def get_file_datetime(filename: str) -> str:
+    """
+    Given the results and sample results filenames, extracts and returns the datetime.
+    """
+    return filename[filename.rfind("_") + 1 :].replace(".json", "")
+
+
+def sanitize_task_name(task_name: str) -> str:
+    """
+    Given the task name, returns a sanitized version of it.
+    """
+    return re.sub(r"\W", "_", task_name)
+
+
+def get_latest_filename(filenames: List[str]) -> str:
+    """
+    Given a list of filenames, returns the filename with the latest datetime.
+    """
+    return max(filenames, key=lambda f: get_file_datetime(f))
+
+
+def get_results_filenames(filenames: List[str]) -> List[str]:
+    """
+    Extracts filenames that correspond to aggregated results.
+    """
+    return [f for f in filenames if "/results_" in f and ".json" in f]
+
+
+def get_sample_results_filenames(filenames: List[str]) -> List[str]:
+    """
+    Extracts filenames that correspond to sample results.
+    """
+    return [f for f in filenames if "/samples_" in f and ".json" in f]
+
+
 def get_rolling_token_windows(token_list, prefix_token, max_seq_len, context_len):
     """
     - context_len allows for a rolling window context, allowing each prediction window to potentially

--- a/scripts/zeno_visualize.py
+++ b/scripts/zeno_visualize.py
@@ -56,7 +56,7 @@ def main():
     model_files = [f.as_posix() for f in model_dir.iterdir() if f.is_file()]
     model_results_filenames = get_results_filenames(model_files)
     latest_results = get_latest_filename(model_results_filenames)
-    tasks = set(tasks_for_model(latest_results))
+    tasks = set(tasks_for_results(latest_results))
 
     # Get tasks names from the latest results file for each model
     # Get intersection of tasks for all models
@@ -67,7 +67,7 @@ def main():
         model_files = [f.as_posix() for f in model_dir.iterdir() if f.is_file()]
         model_results_filenames = get_results_filenames(model_files)
         latest_results = get_latest_filename(model_results_filenames)
-        model_tasks = set(tasks_for_model(Path(latest_results)))
+        model_tasks = set(tasks_for_results(Path(latest_results)))
         tasks.intersection(set(model_tasks))
 
         if task_count != len(tasks):
@@ -145,7 +145,7 @@ def main():
             )
 
 
-def tasks_for_model(results_filename: str) -> List[str]:
+def tasks_for_results(results_filename: str) -> List[str]:
     """Get the tasks from a specific results file.
 
     Args:
@@ -155,6 +155,23 @@ def tasks_for_model(results_filename: str) -> List[str]:
         list: A list of tasks for the model.
     """
     config = (json.load(open(results_filename, encoding="utf-8"))["configs"],)
+    return list(config[0].keys())
+
+
+def tasks_for_model(model: str, data_path: str):
+    """Get the tasks for a specific model.
+
+    Args:
+        model (str): The name of the model.
+        data_path (str): The path to the data.
+
+    Returns:
+        list: A list of tasks for the model.
+    """
+    dir_path = Path(data_path, model)
+    config = (
+        json.load(open(Path(dir_path, "results.json"), encoding="utf-8"))["configs"],
+    )
     return list(config[0].keys())
 
 

--- a/scripts/zeno_visualize.py
+++ b/scripts/zeno_visualize.py
@@ -3,11 +3,17 @@ import json
 import os
 import re
 from pathlib import Path
+from typing import List
 
 import pandas as pd
 from zeno_client import ZenoClient, ZenoMetric
 
-from lm_eval.utils import eval_logger
+from lm_eval.utils import (
+    eval_logger,
+    get_latest_filename,
+    get_results_filenames,
+    get_sample_results_filenames,
+)
 
 
 def parse_args():
@@ -45,13 +51,23 @@ def main():
 
     assert len(models) > 0, "No model directories found in the data_path."
 
-    tasks = set(tasks_for_model(models[0], args.data_path))
+    # Get the tasks from the latest results file of the first model.
+    model_dir = Path(args.data_path, models[0])
+    model_files = [f.as_posix() for f in model_dir.iterdir() if f.is_file()]
+    model_results_filenames = get_results_filenames(model_files)
+    latest_results = get_latest_filename(model_results_filenames)
+    tasks = set(tasks_for_model(latest_results))
 
-    for model in models:  # Make sure that all models have the same tasks.
+    # Get tasks names from the latest results file for each model
+    # Get intersection of tasks for all models
+    for model in models:
         old_tasks = tasks.copy()
         task_count = len(tasks)
-
-        model_tasks = tasks_for_model(model, args.data_path)
+        model_dir = Path(args.data_path, model)
+        model_files = [f.as_posix() for f in model_dir.iterdir() if f.is_file()]
+        model_results_filenames = get_results_filenames(model_files)
+        latest_results = get_latest_filename(model_results_filenames)
+        model_tasks = set(tasks_for_model(Path(latest_results)))
         tasks.intersection(set(model_tasks))
 
         if task_count != len(tasks):
@@ -66,22 +82,36 @@ def main():
     for task in tasks:
         # Upload data for all models
         for model_index, model in enumerate(models):
+            # Get latest results and sample results for a model
+            model_dir = Path(args.data_path, model)
+            model_files = [f.as_posix() for f in model_dir.iterdir() if f.is_file()]
+            model_results_filenames = get_results_filenames(model_files)
+            model_sample_filenames = get_sample_results_filenames(model_files)
+            latest_results = get_latest_filename(
+                [Path(f).name for f in model_results_filenames]
+            )
+            latest_sample_results = get_latest_filename(
+                [Path(f).name for f in model_sample_filenames if task in f]
+            )
             model_args = re.sub(
                 r"[\"<>:/\|\\?\*\[\]]+",
                 "__",
                 json.load(
-                    open(Path(args.data_path, model, "results.json"), encoding="utf-8")
+                    open(Path(args.data_path, model, latest_results), encoding="utf-8")
                 )["config"]["model_args"],
             )
+            print(model_args)
+            data = []
             with open(
-                Path(args.data_path, model, f"{model_args}_{task}.jsonl"),
+                Path(args.data_path, model, latest_sample_results),
                 "r",
                 encoding="utf-8",
             ) as file:
-                data = json.loads(file.read())
+                for line in file:
+                    data.append(json.loads(line.strip()))
 
             configs = json.load(
-                open(Path(args.data_path, model, "results.json"), encoding="utf-8")
+                open(Path(args.data_path, model, latest_results), encoding="utf-8")
             )["configs"]
             config = configs[task]
 
@@ -115,20 +145,16 @@ def main():
             )
 
 
-def tasks_for_model(model: str, data_path: str):
-    """Get the tasks for a specific model.
+def tasks_for_model(results_filename: str) -> List[str]:
+    """Get the tasks from a specific results file.
 
     Args:
-        model (str): The name of the model.
-        data_path (str): The path to the data.
+        results_filename (str): The path to the results file.
 
     Returns:
         list: A list of tasks for the model.
     """
-    dir_path = Path(data_path, model)
-    config = (
-        json.load(open(Path(dir_path, "results.json"), encoding="utf-8"))["configs"],
-    )
+    config = (json.load(open(results_filename, encoding="utf-8"))["configs"],)
     return list(config[0].keys())
 
 


### PR DESCRIPTION
This PR focuses on addressing:
- #1918 - by moving functions for handling results filenames to utils, so they can be used in other parts of the codebase
- #1842 - by refactoring the Zeno script to work with the new results filenames

@clefourrier @NathanHB