### PR TITLE
Modify pre-commit hook to check merge conflicts accidentally committed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: check-case-conflict
       - id: check-json
       - id: check-merge-conflict
+        args: [--assume-in-merge]
       - id: check-symlinks
       - id: check-yaml
         args: ["--unsafe"]


### PR DESCRIPTION
I've seen commits in pull requests to this repo with accidental merge conflicts. So, with the intention of reducing such accidents, this PR turns on merge conflict checking not only at merge time, but also on regular commits.