### PR TITLE
[New Task] Add Paloma benchmark

### DIFF
--- a/lm_eval/tasks/README.md
+++ b/lm_eval/tasks/README.md
@@ -70,6 +70,7 @@
 | okapi/mmlu_multilingual | Tasks that involve reading comprehension and information retrieval challenges. | Multiple (34 languages) |
 | [okapi/truthfulqa_multilingual](okapi/truthfulqa_multilingual/README.md) | Tasks that involve reading comprehension and information retrieval challenges. | Multiple (31 languages) |
 | [openbookqa](openbookqa/README.md) | Open-book question answering tasks that require external knowledge and reasoning. | English |
+| [paloma](paloma/README.md) | Paloma is a comprehensive benchmark designed to evaluate open language models across a wide range of domains, ranging from niche artist communities to mental health forums on Reddit. | English |
 | [paws-x](paws-x/README.md) | Paraphrase Adversaries from Word Scrambling, focusing on cross-lingual capabilities. | English, French, Spanish, German, Chinese, Japanese, Korean |
 | [pile](pile/README.md) | Open source language modelling data set that consists of 22 smaller, high-quality datasets. | English |
 | [pile_10k](pile_10k/README.md) | The first 10K elements of The Pile, useful for debugging models trained on it. | English |

--- a/lm_eval/tasks/paloma/README.md
+++ b/lm_eval/tasks/paloma/README.md
@@ -1,0 +1,59 @@
+# Paloma
+
+### Paper
+Title: Paloma: A Benchmark for Evaluating Language Model Fit
+
+Abstract: https://arxiv.org/abs/2312.10523v1
+
+Paloma is a comprehensive benchmark designed to evaluate open language models across a wide range of domains, ranging from niche artist communities to mental health forums on Reddit. It assesses the performance of various models across 585 distinct domains.
+
+Homepage: https://allenai.org/olmo
+
+### Citation
+```
+@article{paloma,
+  title={{Paloma}: A Benchmark for Evaluating Language Model Fit},
+  author={Magnusson, Ian and Bhagia, Akshita and Hofmann, Valentin and Soldaini, Luca and Harsh Jha, Ananya and Tafjord, Oyvind and Schwenk,Dustin and Walsh, Evan Pete and Elazar, Yanai and Lo, Kyle and Groenveld,Dirk and Beltagy,Iz and  Hajishirz,Hanneneh and Smith, Noah A. and Richardson,Kyle and Dodge,Jesse},
+  journal={technical report},
+  year={2023},
+  url={https://paloma.allen.ai/}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `paloma`
+
+#### Tasks
+
+* `paloma_4chan_meta_sep`
+* `paloma_c4_100_domains`
+* `paloma_c4_en`
+* `paloma_dolma_100_programing_languages`
+* `paloma_dolma_100_subreddits`
+* `paloma_dolma-v1_5`
+* `paloma_falcon-refinedweb`
+* `paloma_gab`
+* `paloma_m2d2_s2orc_unsplit`
+* `paloma_m2d2_wikipedia_unsplit`
+* `paloma_manosphere_meta_sep`
+* `paloma_mc4`
+* `paloma_ptb`
+* `paloma_redpajama`
+* `paloma_twitterAAE_HELM_fixed`
+* `paloma_wikitext_103`
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/paloma/README.md
+++ b/lm_eval/tasks/paloma/README.md
@@ -9,6 +9,15 @@ Paloma is a comprehensive benchmark designed to evaluate open language models ac
 
 Homepage: https://allenai.org/olmo
 
+
+### Note
+
+If you are running the entire `paloma` benchmark (or just `paloma_dolma_100_programing_languages`) with a HuggingFace model, make sure to pass `logits_cache=False` to `--model_args`, for example:
+```
+lm_eval --model hf --model_args pretrained=EleutherAI/pythia-160m,logits_cache=False --tasks paloma
+```
+
+
 ### Citation
 ```
 @article{paloma,

--- a/lm_eval/tasks/paloma/paloma.yaml
+++ b/lm_eval/tasks/paloma/paloma.yaml
@@ -1,0 +1,22 @@
+group:
+  - paloma
+dataset_path: allenai/paloma
+output_type: loglikelihood_rolling
+validation_split: val
+test_split: test
+doc_to_text: ""
+doc_to_target: "{{text}}"
+should_decontaminate: true
+doc_to_decontamination_query: "{{text}}"
+metric_list:
+  - metric: word_perplexity
+    aggregation: weighted_perplexity
+    higher_is_better: false
+  - metric: byte_perplexity
+    aggregation: weighted_perplexity
+    higher_is_better: false
+  - metric: bits_per_byte
+    aggregation: bits_per_byte
+    higher_is_better: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/paloma/paloma.yaml
+++ b/lm_eval/tasks/paloma/paloma.yaml
@@ -5,9 +5,9 @@ output_type: loglikelihood_rolling
 validation_split: val
 test_split: test
 doc_to_text: ""
-doc_to_target: "{{text}}"
+doc_to_target: !function paloma_utils.doc_to_target
 should_decontaminate: true
-doc_to_decontamination_query: "{{text}}"
+doc_to_decontamination_query: !function paloma_utils.doc_to_target
 metric_list:
   - metric: word_perplexity
     aggregation: weighted_perplexity

--- a/lm_eval/tasks/paloma/paloma_4chan_meta_sep.yaml
+++ b/lm_eval/tasks/paloma/paloma_4chan_meta_sep.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_4chan_meta_sep
+task_alias: 4chan_meta_sep
 dataset_name: 4chan_meta_sep

--- a/lm_eval/tasks/paloma/paloma_4chan_meta_sep.yaml
+++ b/lm_eval/tasks/paloma/paloma_4chan_meta_sep.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_4chan_meta_sep
-task_alias: 4chan_meta_sep
+task_alias: 4chan Corpus
 dataset_name: 4chan_meta_sep

--- a/lm_eval/tasks/paloma/paloma_4chan_meta_sep.yaml
+++ b/lm_eval/tasks/paloma/paloma_4chan_meta_sep.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_4chan_meta_sep
+dataset_name: 4chan_meta_sep

--- a/lm_eval/tasks/paloma/paloma_c4_100_domains.yaml
+++ b/lm_eval/tasks/paloma/paloma_c4_100_domains.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_c4_100_domains
+dataset_name: c4_100_domains

--- a/lm_eval/tasks/paloma/paloma_c4_100_domains.yaml
+++ b/lm_eval/tasks/paloma/paloma_c4_100_domains.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_c4_100_domains
+task_alias: c4_100_domains
 dataset_name: c4_100_domains

--- a/lm_eval/tasks/paloma/paloma_c4_100_domains.yaml
+++ b/lm_eval/tasks/paloma/paloma_c4_100_domains.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_c4_100_domains
-task_alias: c4_100_domains
+task_alias: C4-100-domains
 dataset_name: c4_100_domains

--- a/lm_eval/tasks/paloma/paloma_c4_en.yaml
+++ b/lm_eval/tasks/paloma/paloma_c4_en.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_c4_en
-task_alias: c4_en
+task_alias: C4
 dataset_name: c4_en

--- a/lm_eval/tasks/paloma/paloma_c4_en.yaml
+++ b/lm_eval/tasks/paloma/paloma_c4_en.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_c4_en
+dataset_name: c4_en

--- a/lm_eval/tasks/paloma/paloma_c4_en.yaml
+++ b/lm_eval/tasks/paloma/paloma_c4_en.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_c4_en
+task_alias: c4_en
 dataset_name: c4_en

--- a/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_dolma-v1_5
+dataset_name: dolma-v1_5

--- a/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_dolma-v1_5
+task_alias: dolma-v1_5
 dataset_name: dolma-v1_5

--- a/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_dolma-v1_5
-task_alias: dolma-v1_5
+task_alias: Dolma
 dataset_name: dolma-v1_5

--- a/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma-v1_5.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_dolma-v1_5
-task_alias: Dolma
+task_alias: Dolma V1.5
 dataset_name: dolma-v1_5

--- a/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_dolma_100_programing_languages
+task_alias: dolma_100_programing_languages
 dataset_name: dolma_100_programing_languages

--- a/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
@@ -1,4 +1,4 @@
-include: paloma.yaml
+include: _paloma_template
 task: paloma_dolma_100_programing_languages
-task_alias: Dolma-100-programming-languages
+task_alias: 100 PLs
 dataset_name: dolma_100_programing_languages

--- a/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_dolma_100_programing_languages
-task_alias: dolma_100_programing_languages
+task_alias: Dolma-100-programming-languages
 dataset_name: dolma_100_programing_languages

--- a/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_dolma_100_programing_languages
+dataset_name: dolma_100_programing_languages

--- a/lm_eval/tasks/paloma/paloma_dolma_100_subreddits.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_subreddits.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_dolma_100_subreddits
+task_alias: dolma_100_subreddits
 dataset_name: dolma_100_subreddits

--- a/lm_eval/tasks/paloma/paloma_dolma_100_subreddits.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_subreddits.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_dolma_100_subreddits
-task_alias: dolma_100_subreddits
+task_alias: Dolma-100-subreddits
 dataset_name: dolma_100_subreddits

--- a/lm_eval/tasks/paloma/paloma_dolma_100_subreddits.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_subreddits.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_dolma_100_subreddits
+dataset_name: dolma_100_subreddits

--- a/lm_eval/tasks/paloma/paloma_falcon-refinedweb.yaml
+++ b/lm_eval/tasks/paloma/paloma_falcon-refinedweb.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_falcon-refinedweb
+task_alias: falcon-refinedweb
 dataset_name: falcon-refinedweb

--- a/lm_eval/tasks/paloma/paloma_falcon-refinedweb.yaml
+++ b/lm_eval/tasks/paloma/paloma_falcon-refinedweb.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_falcon-refinedweb
-task_alias: falcon-refinedweb
+task_alias: Falcon Refinedweb
 dataset_name: falcon-refinedweb

--- a/lm_eval/tasks/paloma/paloma_falcon-refinedweb.yaml
+++ b/lm_eval/tasks/paloma/paloma_falcon-refinedweb.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_falcon-refinedweb
+dataset_name: falcon-refinedweb

--- a/lm_eval/tasks/paloma/paloma_gab.yaml
+++ b/lm_eval/tasks/paloma/paloma_gab.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_gab
+dataset_name: gab

--- a/lm_eval/tasks/paloma/paloma_gab.yaml
+++ b/lm_eval/tasks/paloma/paloma_gab.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_gab
+task_alias: gab
 dataset_name: gab

--- a/lm_eval/tasks/paloma/paloma_gab.yaml
+++ b/lm_eval/tasks/paloma/paloma_gab.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_gab
-task_alias: gab
+task_alias: Gab Corpus
 dataset_name: gab

--- a/lm_eval/tasks/paloma/paloma_m2d2_s2orc_unsplit.yaml
+++ b/lm_eval/tasks/paloma/paloma_m2d2_s2orc_unsplit.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_m2d2_s2orc_unsplit
+task_alias: m2d2_s2orc_unsplit
 dataset_name: m2d2_s2orc_unsplit

--- a/lm_eval/tasks/paloma/paloma_m2d2_s2orc_unsplit.yaml
+++ b/lm_eval/tasks/paloma/paloma_m2d2_s2orc_unsplit.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_m2d2_s2orc_unsplit
-task_alias: m2d2_s2orc_unsplit
+task_alias: M2D2 S2ORC
 dataset_name: m2d2_s2orc_unsplit

--- a/lm_eval/tasks/paloma/paloma_m2d2_s2orc_unsplit.yaml
+++ b/lm_eval/tasks/paloma/paloma_m2d2_s2orc_unsplit.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_m2d2_s2orc_unsplit
+dataset_name: m2d2_s2orc_unsplit

--- a/lm_eval/tasks/paloma/paloma_m2d2_wikipedia_unsplit.yaml
+++ b/lm_eval/tasks/paloma/paloma_m2d2_wikipedia_unsplit.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_m2d2_wikipedia_unsplit
-task_alias: m2d2_wikipedia_unsplit
+task_alias: M2D2 Wikipedia
 dataset_name: m2d2_wikipedia_unsplit

--- a/lm_eval/tasks/paloma/paloma_m2d2_wikipedia_unsplit.yaml
+++ b/lm_eval/tasks/paloma/paloma_m2d2_wikipedia_unsplit.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_m2d2_wikipedia_unsplit
+task_alias: m2d2_wikipedia_unsplit
 dataset_name: m2d2_wikipedia_unsplit

--- a/lm_eval/tasks/paloma/paloma_m2d2_wikipedia_unsplit.yaml
+++ b/lm_eval/tasks/paloma/paloma_m2d2_wikipedia_unsplit.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_m2d2_wikipedia_unsplit
+dataset_name: m2d2_wikipedia_unsplit

--- a/lm_eval/tasks/paloma/paloma_manosphere_meta_sep.yaml
+++ b/lm_eval/tasks/paloma/paloma_manosphere_meta_sep.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_manosphere_meta_sep
+task_alias: manosphere_meta_sep
 dataset_name: manosphere_meta_sep

--- a/lm_eval/tasks/paloma/paloma_manosphere_meta_sep.yaml
+++ b/lm_eval/tasks/paloma/paloma_manosphere_meta_sep.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_manosphere_meta_sep
+dataset_name: manosphere_meta_sep

--- a/lm_eval/tasks/paloma/paloma_manosphere_meta_sep.yaml
+++ b/lm_eval/tasks/paloma/paloma_manosphere_meta_sep.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_manosphere_meta_sep
-task_alias: manosphere_meta_sep
+task_alias: Manosphere Corpus
 dataset_name: manosphere_meta_sep

--- a/lm_eval/tasks/paloma/paloma_mc4.yaml
+++ b/lm_eval/tasks/paloma/paloma_mc4.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_mc4
-task_alias: mc4
+task_alias: mC4-en
 dataset_name: mc4

--- a/lm_eval/tasks/paloma/paloma_mc4.yaml
+++ b/lm_eval/tasks/paloma/paloma_mc4.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_mc4
+dataset_name: mc4

--- a/lm_eval/tasks/paloma/paloma_mc4.yaml
+++ b/lm_eval/tasks/paloma/paloma_mc4.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_mc4
+task_alias: mc4
 dataset_name: mc4

--- a/lm_eval/tasks/paloma/paloma_ptb.yaml
+++ b/lm_eval/tasks/paloma/paloma_ptb.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_ptb
-task_alias: ptb
+task_alias: Penn Treebank
 dataset_name: ptb

--- a/lm_eval/tasks/paloma/paloma_ptb.yaml
+++ b/lm_eval/tasks/paloma/paloma_ptb.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_ptb
+dataset_name: ptb

--- a/lm_eval/tasks/paloma/paloma_ptb.yaml
+++ b/lm_eval/tasks/paloma/paloma_ptb.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_ptb
+task_alias: ptb
 dataset_name: ptb

--- a/lm_eval/tasks/paloma/paloma_redpajama.yaml
+++ b/lm_eval/tasks/paloma/paloma_redpajama.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_redpajama
+task_alias: redpajama
 dataset_name: redpajama

--- a/lm_eval/tasks/paloma/paloma_redpajama.yaml
+++ b/lm_eval/tasks/paloma/paloma_redpajama.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_redpajama
-task_alias: redpajama
+task_alias: RedPajama
 dataset_name: redpajama

--- a/lm_eval/tasks/paloma/paloma_redpajama.yaml
+++ b/lm_eval/tasks/paloma/paloma_redpajama.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_redpajama
+dataset_name: redpajama

--- a/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
+++ b/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_twitterAAE_HELM_fixed
+task_alias: twitterAAE_HELM_fixed
 dataset_name: twitterAAE_HELM_fixed

--- a/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
+++ b/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_twitterAAE_HELM_fixed
-task_alias: TwitterAAE
+task_alias: Twitter AAE
 dataset_name: twitterAAE_HELM_fixed

--- a/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
+++ b/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_twitterAAE_HELM_fixed
-task_alias: twitterAAE_HELM_fixed
+task_alias: TwitterAAE
 dataset_name: twitterAAE_HELM_fixed

--- a/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
+++ b/lm_eval/tasks/paloma/paloma_twitterAAE_HELM_fixed.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_twitterAAE_HELM_fixed
+dataset_name: twitterAAE_HELM_fixed

--- a/lm_eval/tasks/paloma/paloma_utils.py
+++ b/lm_eval/tasks/paloma/paloma_utils.py
@@ -1,0 +1,2 @@
+def doc_to_target(doc):
+    return str(doc["text"])

--- a/lm_eval/tasks/paloma/paloma_wikitext_103.yaml
+++ b/lm_eval/tasks/paloma/paloma_wikitext_103.yaml
@@ -1,0 +1,3 @@
+include: paloma.yaml
+task: paloma_wikitext_103
+dataset_name: wikitext_103

--- a/lm_eval/tasks/paloma/paloma_wikitext_103.yaml
+++ b/lm_eval/tasks/paloma/paloma_wikitext_103.yaml
@@ -1,4 +1,4 @@
 include: paloma.yaml
 task: paloma_wikitext_103
-task_alias: wikitext_103
+task_alias: Wikitext-103
 dataset_name: wikitext_103

--- a/lm_eval/tasks/paloma/paloma_wikitext_103.yaml
+++ b/lm_eval/tasks/paloma/paloma_wikitext_103.yaml
@@ -1,3 +1,4 @@
 include: paloma.yaml
 task: paloma_wikitext_103
+task_alias: wikitext_103
 dataset_name: wikitext_103


### PR DESCRIPTION
### What does this PR do?

This PR adds the Paloma benchmark.

Addresses: #1176

### Results

I ran Pythia-160m on all the tasks, and obtained the following results:

|                 Tasks                  |Version|Filter|n-shot|    Metric     |   |  Value   |   |Stderr|
|----------------------------------------|-------|------|-----:|---------------|---|---------:|---|------|
|paloma                                  |N/A    |none  |     0|word_perplexity|↓  | 7612.5253|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.6948|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    3.5885|±  |N/A   |
| - paloma_4chan_meta_sep                |      1|none  |     0|word_perplexity|↓  |  507.3582|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.3897|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.2569|±  |N/A   |
| - paloma_c4_100_domains                |      1|none  |     0|word_perplexity|↓  |   76.1698|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.0607|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.0431|±  |N/A   |
| - paloma_c4_en                         |      1|none  |     0|word_perplexity|↓  |   93.2241|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.1293|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.0904|±  |N/A   |
| - paloma_dolma-v1_5                    |      1|none  |     0|word_perplexity|↓  |   93.5155|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.0096|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.0069|±  |N/A   |
| - paloma_dolma_100_programing_languages|      1|none  |     0|word_perplexity|↓  |  234.0130|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    1.6754|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    0.7445|±  |N/A   |
| - paloma_dolma_100_subreddits          |      1|none  |     0|word_perplexity|↓  |  123.0999|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.3528|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.2344|±  |N/A   |
| - paloma_falcon-refinedweb             |      1|none  |     0|word_perplexity|↓  |  109.9636|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.2045|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.1405|±  |N/A   |
| - paloma_gab                           |      1|none  |     0|word_perplexity|↓  |11224.6201|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    3.5095|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.8113|±  |N/A   |
| - paloma_m2d2_s2orc_unsplit            |      1|none  |     0|word_perplexity|↓  |   52.5905|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.0007|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.0005|±  |N/A   |
| - paloma_m2d2_wikipedia_unsplit        |      1|none  |     0|word_perplexity|↓  |   80.5937|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.0271|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.0194|±  |N/A   |
| - paloma_manosphere_meta_sep           |      1|none  |     0|word_perplexity|↓  |  130.2093|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.4211|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.2757|±  |N/A   |
| - paloma_mc4                           |      1|none  |     0|word_perplexity|↓  |  160.2042|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.1935|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.1332|±  |N/A   |
| - paloma_ptb                           |      1|none  |     0|word_perplexity|↓  |  130.0697|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.3424|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.2280|±  |N/A   |
| - paloma_redpajama                     |      1|none  |     0|word_perplexity|↓  |  106.7431|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    1.9124|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    0.9354|±  |N/A   |
| - paloma_twitterAAE_HELM_fixed         |      1|none  |     0|word_perplexity|↓  |18104.7114|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    5.8745|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    2.5545|±  |N/A   |
| - paloma_wikitext_103                  |      1|none  |     0|word_perplexity|↓  |   47.3002|±  |N/A   |
|                                        |       |none  |     0|byte_perplexity|↓  |    2.0560|±  |N/A   |
|                                        |       |none  |     0|bits_per_byte  |↓  |    1.0398|±  |N/A   |

|Groups|Version|Filter|n-shot|    Metric     |   |  Value  |   |Stderr|
|------|-------|------|-----:|---------------|---|--------:|---|------|
|paloma|N/A    |none  |     0|word_perplexity|↓  |7612.5253|±  |N/A   |
|      |       |none  |     0|bits_per_byte  |↓  |   1.6948|±  |N/A   |
|      |       |none  |     0|byte_perplexity|↓  |   3.5885|±  |N/A   |

Although, since the authors fine-tune the baselines, it is a bit tricky to compare to any results in the [paper](https://arxiv.org/abs/2312.10523), so the closest comparison would be the figure below:

<img width="749" alt="image" src="https://github.com/EleutherAI/lm-evaluation-harness/assets/20532523/b5a848ec-5271-4113-8bdd-546b916e8723">

Also, it should be noted that on huggingface the [dataset](https://huggingface.co/datasets/allenai/paloma) only has 16 tasks, whereas in the paper they evaluate on 18. 


### Caution

If you are running the entire `paloma` benchmark (or just `paloma_dolma_100_programing_languages`) with a HuggingFace model, make sure to pass `logits_cache=False` to `--model_args`, for example:
```
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-160m,logits_cache=False --tasks paloma
```

This is because there is one sample in `paloma_dolma_100_programing_languages` that looks like this:

```
object FormSplash: TFormSplash
 Left = 221
 Top = 252
 BorderStyle = bsNone
 ClientHeight = 242
 ClientWidth = 366
 Color = clBlack
 Font.Charset = DEFAULT_CHARSET
 Font.Color = clWindowText
 Font.Height = -14
 Font.Name = 'System'
 Font.Style = []
 OldCreateOrder = True
 Visible = True
 OnCreate = FormCreate
 PixelsPerInch = 96
 TextHeight = 16
 object Image1: TImage
 Left = 0
 Top = 0
 Width = 366
 Height = 242
 Margins.Left = 2
 Margins.Top = 2
 Margins.Right = 2
 Margins.Bottom = 2
 Align = alClient
 Picture.Data = {
 |||PHONE_NUMBER||| 6D61701E980400424D1E980400000000003600000028000000C401
 0000DE0000000100180000000000E89704000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 |||PHONE_NUMBER||| 000000000000000000000000000000000000000000000000000000
 [continued for ~1000 more times...]
```
which according to my understanding, breaks the caching of the logits when computing the log likelihoods, since the context for multiple chunks is the same, but the output continuation is different for the last chunk (2048 tokens vs 520 or so).
The error can be reproduced by running the benchmark without passing `logits_cache=False` to `--model_args`. 

