### PR TITLE
LMJudge

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1313,7 +1313,7 @@ class ConfigurableTask(Task):
             return request_list
 
         elif self.OUTPUT_TYPE == "generate_until":
-            arguments = (ctx, deepcopy(self.config.generation_kwargs))
+            arguments: Tuple[str, dict] = (ctx, deepcopy(self.config.generation_kwargs))
 
         return Instance(
             request_type=self.OUTPUT_TYPE, doc=doc, arguments=arguments, idx=0, **kwargs

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -1,3 +1,4 @@
+import gc
 import itertools
 import json
 import logging
@@ -450,6 +451,8 @@ def evaluate(
 
     RANK = lm.rank
     WORLD_SIZE = lm.world_size
+    del lm
+    gc.collect()
     ### Postprocess outputs ###
     # TODO: del model here, maybe (idea: allow user to specify device of e.g. reward model separately)
     for task_output in eval_tasks:

--- a/lm_eval/filters/__init__.py
+++ b/lm_eval/filters/__init__.py
@@ -4,7 +4,7 @@ from typing import List
 from lm_eval.api.filter import FilterEnsemble
 from lm_eval.api.registry import get_filter
 
-from . import extraction, selection, transformation
+from . import extraction, prediction, selection, transformation
 
 
 def build_filter_ensemble(

--- a/lm_eval/filters/prediction.py
+++ b/lm_eval/filters/prediction.py
@@ -1,0 +1,40 @@
+from typing import List
+
+import lm_eval
+from lm_eval.api.filter import Filter
+from lm_eval.api.instance import Instance
+from lm_eval.api.registry import register_filter
+from lm_eval.utils import eval_logger, simple_parse_args_string
+
+
+@register_filter("lmjudge")
+class LmJudge(Filter):
+    def __init__(
+        self, model, model_args, batch_size, max_batch_size, device, reqtype
+    ) -> None:
+        eval_logger.info(
+            f"Initializing {model} model, with arguments: {simple_parse_args_string(model_args)}"
+        )
+        self.lm = lm_eval.api.registry.get_model(model).create_from_arg_string(
+            model_args,
+            {
+                "batch_size": batch_size,
+                "max_batch_size": max_batch_size,
+                "device": device,
+            },
+        )
+        self.reqtype = reqtype
+
+    def apply(self, resps, docs) -> List[List[str]]:
+        resps = [
+            Instance(
+                request_type="generate_until",
+                doc=None,
+                arguments=(x[0], {"max_gen_toks": 10}),
+                idx=i,
+            )
+            for i, x in enumerate(resps)
+        ]
+
+        resps = getattr(self.lm, self.reqtype)(resps)
+        return [[x] for x in resps]

--- a/lm_eval/tasks/gsm8k/gsm8k.yaml
+++ b/lm_eval/tasks/gsm8k/gsm8k.yaml
@@ -26,20 +26,31 @@ generation_kwargs:
     - "</s>"
     - "<|im_end|>"
   do_sample: false
+  max_gen_toks: 10
   temperature: 0.0
 repeats: 1
 num_fewshot: 5
 filter_list:
-  - name: "strict-match"
+#  - name: "strict-match"
+#    filter:
+#      - function: "regex"
+#        regex_pattern: "#### (\\-?[0-9\\.\\,]+)"
+#      - function: "take_first"
+#  - name: "flexible-extract"
+#    filter:
+#      - function: "regex"
+#        group_select: -1
+#        regex_pattern: "(-?[$0-9.,]{2,})|(-?[0-9]+)"
+#      - function: "take_first"
+  - name: "friend"
     filter:
-      - function: "regex"
-        regex_pattern: "#### (\\-?[0-9\\.\\,]+)"
-      - function: "take_first"
-  - name: "flexible-extract"
-    filter:
-      - function: "regex"
-        group_select: -1
-        regex_pattern: "(-?[$0-9.,]{2,})|(-?[0-9]+)"
+      - function: "lmjudge"
+        model: "hf"
+        model_args: "pretrained=EleutherAI/pythia-160m"
+        batch_size: 8
+        max_batch_size: 8
+        device: "mps"
+        reqtype: "generate_until"
       - function: "take_first"
 metadata:
   version: 3.0


### PR DESCRIPTION
working on #1831. Still a very rough draft but suggestions welcome! Couple of things I'm thinking of:

- [ ] Best way to parameterize the evaluating model. Currently can only be set in the filter constructor.
- [ ] see how well this works with `accelerate`.
- [ ] wrapper around the `resps` to structure the new `args`. Maybe LMJudge yaml task templates?
- [ ] should be modular so that it can resume from previously generated `resps`.

@haileyschoelkopf @lintangsutawika 