### PR TITLE
fix: add directory filter to os.walk to ignore 'ipynb_checkpoints'

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -313,7 +313,8 @@ class TaskManager:
             Dictionary of task names as key and task metadata
         """
         tasks_and_groups = collections.defaultdict()
-        for root, _, file_list in os.walk(task_dir):
+        for root, dirs, file_list in os.walk(task_dir):
+            dirs[:] = [d for d in dirs if d != ".ipynb_checkpoints"]
             for f in file_list:
                 if f.endswith(".yaml"):
                     yaml_path = os.path.join(root, f)

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -318,7 +318,7 @@ class TaskManager:
         ]
         tasks_and_groups = collections.defaultdict()
         for root, dirs, file_list in os.walk(task_dir):
-            dirs[:] = [d for d in dirs if d in ignore_dirs]
+            dirs[:] = [d for d in dirs if d not in ignore_dirs]
             for f in file_list:
                 if f.endswith(".yaml"):
                     yaml_path = os.path.join(root, f)

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -312,9 +312,13 @@ class TaskManager:
         :return
             Dictionary of task names as key and task metadata
         """
+        ignore_dirs = [
+            "__pycache__",
+            ".ipynb_checkpoints",
+        ]
         tasks_and_groups = collections.defaultdict()
         for root, dirs, file_list in os.walk(task_dir):
-            dirs[:] = [d for d in dirs if d != ".ipynb_checkpoints"]
+            dirs[:] = [d for d in dirs if d in ignore_dirs]
             for f in file_list:
                 if f.endswith(".yaml"):
                     yaml_path = os.path.join(root, f)


### PR DESCRIPTION
#1952 

I had time to add a short line that fixes this issue by omitting all `.ipynb_checkpoints` directories during `os.walk()`.

the slice operator in the assignment `dir[:] = [...]` modifies the dir list in place. afaik this is the only part of the script that does os.walk to get files in the directory.
