### PR TITLE
Fix local completion huggingface tokenizer

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -87,6 +87,7 @@ class OpenaiCompletionsLM(TemplateLM):
         batch_size: int = 1,
         seed: int = 1234,
         max_length: Optional[int] = None,
+        huggingface_tokenizer_trust_remote_code: bool = False,
     ) -> None:
         """
 
@@ -118,7 +119,8 @@ class OpenaiCompletionsLM(TemplateLM):
             import transformers  # noqa: E401
 
             self.tokenizer = transformers.AutoTokenizer.from_pretrained(
-                tokenizer if tokenizer else self.model
+                tokenizer if tokenizer else self.model,
+                trust_remote_code=huggingface_tokenizer_trust_remote_code,
             )
             self.vocab_size = self.tokenizer.vocab
             self.end_of_text_token_id = self.tokenizer.eos_token

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -122,7 +122,7 @@ class OpenaiCompletionsLM(TemplateLM):
                 tokenizer if tokenizer else self.model,
                 trust_remote_code=huggingface_tokenizer_trust_remote_code,
             )
-            self.vocab_size = self.tokenizer.vocab
+            self.vocab_size = self.tokenizer.vocab_size
             self.end_of_text_token_id = self.tokenizer.eos_token
         elif self.tokenizer_backend == "tiktoken":
             if self.base_url:


### PR DESCRIPTION
Fixes related to the tokenizer in the constructor of the OpenaiCompletionsLM class

Added the `huggingface_tokenizer_trust_remote_code` argument to the `__init__` method, allowing the `trust_remote_code` option to be set when initializing the tokenizer. This enables control over whether remote code execution is allowed.
Updated the retrieval of the tokenizer's vocabulary size to use `self.tokenizer.vocab_size` instead of `self.tokenizer.vocab`. This ensures that the correct vocabulary size is obtained.