### PR TITLE
Update interface.md

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -102,11 +102,9 @@ results = lm_eval.simple_evaluate( # call simple_evaluate
 )
 ```
 
-See https://github.com/EleutherAI/lm-evaluation-harness/blob/365fcda9b85bbb6e0572d91976b8daf409164500/lm_eval/evaluator.py#L35 for a full description of all arguments available. All keyword arguments to simple_evaluate share the same role as the command-line flags described previously.
+See https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/evaluator.py#:~:text=simple_evaluate `simple_evaluate()` for a full description of all arguments available. All keyword arguments to simple_evaluate share the same role as the command-line flags described previously.
 
 Additionally, the `evaluate()` function offers the core evaluation functionality provided by the library, but without some of the special handling and simplification + abstraction provided by `simple_evaluate()`.
-
-See https://github.com/EleutherAI/lm-evaluation-harness/blob/365fcda9b85bbb6e0572d91976b8daf409164500/lm_eval/evaluator.py#L173 for more details.
 
 As a brief example usage of `evaluate()`:
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -102,7 +102,7 @@ results = lm_eval.simple_evaluate( # call simple_evaluate
 )
 ```
 
-See the `simple_evaluate()` and `evaluate()` functions in [lm_eval/evaluator.py](lm_eval/evaluator.py#:~:text=simple_evaluate) for a full description of all arguments available. All keyword arguments to simple_evaluate share the same role as the command-line flags described previously.
+See the `simple_evaluate()` and `evaluate()` functions in [lm_eval/evaluator.py](../lm_eval/evaluator.py#:~:text=simple_evaluate) for a full description of all arguments available. All keyword arguments to simple_evaluate share the same role as the command-line flags described previously.
 
 Additionally, the `evaluate()` function offers the core evaluation functionality provided by the library, but without some of the special handling and simplification + abstraction provided by `simple_evaluate()`.
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -102,7 +102,7 @@ results = lm_eval.simple_evaluate( # call simple_evaluate
 )
 ```
 
-See https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/evaluator.py#:~:text=simple_evaluate `simple_evaluate()` for a full description of all arguments available. All keyword arguments to simple_evaluate share the same role as the command-line flags described previously.
+See the `simple_evaluate()` and `evaluate()` functions in [lm_eval/evaluator.py](lm_eval/evaluator.py#:~:text=simple_evaluate) for a full description of all arguments available. All keyword arguments to simple_evaluate share the same role as the command-line flags described previously.
 
 Additionally, the `evaluate()` function offers the core evaluation functionality provided by the library, but without some of the special handling and simplification + abstraction provided by `simple_evaluate()`.
 


### PR DESCRIPTION
Could be just a me thing, but I found it pretty confusing that the interface doc was linking to a really outdated version of the evaluator.py file. I was looking for references to the newer keywords like `--apply_chat_template` and `--system_instruction` that were somehow not there.

I understand the intent of the older commit probably was to quickly link to an example of `simple_evaluate()` but it was hardly helpful for me in understanding the codebase, and I think its just better to have a link to the actual updated file instead of an outdated version.

There is a way to link exactly to the function through this hacky way https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/evaluator.py#:~:text=simple_evaluate but it doesnt work on all browsers.

welcome any suggestions, and of course feel free to reject this pr. thanks.