### PR TITLE
add trust_remote_code  for piqa

### DIFF
--- a/lm_eval/tasks/piqa/piqa.yaml
+++ b/lm_eval/tasks/piqa/piqa.yaml
@@ -19,3 +19,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true


### PR DESCRIPTION
issue #1985 
when I run `piqa` tasks with datasets 2.20.0 and  enable `trust_remote_code`, 
```
lm-eval --model hf --model_args pretrained=facebook/opt-125m,trust_remote_code=True --tasks piqa --device cpu --batch_size 8 --limit 24
```
the warning raised
```
(Pdb) c
The repository for piqa contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/piqa.
You can avoid this prompt in future by passing the argument `trust_remote_code=True`.

Do you wish to run the custom code? [y/N] 
```

inspired from https://github.com/EleutherAI/lm-evaluation-harness/pull/1487,  I improved.