### PR TITLE
Added ArabicMMLU

### DIFF
--- a/lm_eval/tasks/ammlu/README.md
+++ b/lm_eval/tasks/ammlu/README.md
@@ -1,0 +1,40 @@
+# ArabicMMLU
+
+### Paper
+
+Title: ArabicMMLU: Assessing Massive Multitask Language Understanding in Arabic
+
+Abstract: https://arxiv.org/abs/2402.12840
+
+The focus of language model evaluation has
+transitioned towards reasoning and knowledge intensive tasks, driven by advancements in pretraining large models. While state-of-the-art models are partially trained on large Arabic texts, evaluating their performance in Arabic remains challenging due to the limited availability of relevant datasets. To bridge this gap, we present ArabicMMLU, the first multi-task language understanding benchmark for Arabic language, sourced from school exams across diverse educational levels in different countries spanning North Africa, the Levant, and the Gulf regions. Our data comprises 40 tasks and 14,575 multiple-choice questions in Modern Standard Arabic (MSA), and is carefully constructed by collaborating with native speakers in the region. Our comprehensive evaluations of 35 models reveal substantial room for improvement, particularly among the best open-source models. Notably, BLOOMZ, mT0, LLama2, and Falcon struggle to achieve a score of 50%, while even the top-performing Arabic centric model only achieves a score of 62.3%.
+
+Homepage: https://github.com/mbzuai-nlp/ArabicMMLU
+
+
+### Citation
+
+```
+@misc{koto2024arabicmmlu,
+      title={ArabicMMLU: Assessing Massive Multitask Language Understanding in Arabic}, 
+      author={Fajri Koto and Haonan Li and Sara Shatnawi and Jad Doughman and Abdelrahman Boda Sadallah and Aisha Alraeesi and Khalid Almubarak and Zaid Alyafeai and Neha Sengupta and Shady Shehata and Nizar Habash and Preslav Nakov and Timothy Baldwin},
+      year={2024},
+      eprint={2402.12840},
+      archivePrefix={arXiv},
+      primaryClass={id='cs.CL' full_name='Computation and Language' is_active=True alt_name='cmp-lg' in_archive='cs' is_general=False description='Covers natural language processing. Roughly includes material in ACM Subject Class I.2.7. Note that work on artificial languages (programming languages, logics, formal systems) that does not explicitly address natural-language issues broadly construed (natural-language processing, computational linguistics, speech, text retrieval, etc.) is not appropriate for this area.'}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `ammlu_stem`: evaluates STEM ArabicMMLU tasks.
+* `ammlu_social_science`: evaluates social science ArabicMMLU tasks.
+* `ammlu_humanities`: evaluates humanities ArabicMMLU tasks.
+* `ammlu_language`: evaluates Arabic language ArabicMMLU tasks.
+* `ammlu_other`: evaluates other ArabicMMLU tasks.
+
+#### Tasks
+
+* `ammlu`: evaluates all ArabicMMLU tasks.

--- a/lm_eval/tasks/ammlu/README.md
+++ b/lm_eval/tasks/ammlu/README.md
@@ -9,6 +9,8 @@ Abstract: https://arxiv.org/abs/2402.12840
 The focus of language model evaluation has
 transitioned towards reasoning and knowledge intensive tasks, driven by advancements in pretraining large models. While state-of-the-art models are partially trained on large Arabic texts, evaluating their performance in Arabic remains challenging due to the limited availability of relevant datasets. To bridge this gap, we present ArabicMMLU, the first multi-task language understanding benchmark for Arabic language, sourced from school exams across diverse educational levels in different countries spanning North Africa, the Levant, and the Gulf regions. Our data comprises 40 tasks and 14,575 multiple-choice questions in Modern Standard Arabic (MSA), and is carefully constructed by collaborating with native speakers in the region. Our comprehensive evaluations of 35 models reveal substantial room for improvement, particularly among the best open-source models. Notably, BLOOMZ, mT0, LLama2, and Falcon struggle to achieve a score of 50%, while even the top-performing Arabic centric model only achieves a score of 62.3%.
 
+The authors of the paper conducted studies by varying the language of the initial prompt and answer keys between English and Arabic. However, they set English initial prompts and answer keys as the standard, which is the version implemented in this task.
+
 Homepage: https://github.com/mbzuai-nlp/ArabicMMLU
 
 

--- a/lm_eval/tasks/ammlu/_default_template_yaml
+++ b/lm_eval/tasks/ammlu/_default_template_yaml
@@ -1,0 +1,13 @@
+dataset_path: yazeed7/ArabicMMLU
+test_split: test
+fewshot_split: dev
+fewshot_config:
+  sampler: first_n
+output_type: multiple_choice
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: !function utils.doc_to_choice
+doc_to_target: "Answer Key"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/ammlu/_generate_configs.py
+++ b/lm_eval/tasks/ammlu/_generate_configs.py
@@ -1,0 +1,116 @@
+"""
+Take in a YAML, and output all "other" splits with this YAML
+"""
+import argparse
+import logging
+import os
+
+import yaml
+from tqdm import tqdm
+
+
+eval_logger = logging.getLogger("lm-eval")
+
+
+SUBJECTS = {
+    "Driving Test": "other",
+    "High Geography": "social_science",
+    "High History": "humanities",
+    "Islamic Studies": "humanities",
+    "Univ Accounting": "social_science",
+    "Primary General Knowledge": "other",
+    "Univ Political Science": "social_science",
+    "Primary Math": "stem",
+    "Middle General Knowledge": "other",
+    "High Biology": "stem",
+    "Primary Natural Science": "stem",
+    "High Economics": "social_science",
+    "Middle Natural Science": "stem",
+    "Middle Geography": "social_science",
+    "Primary Social Science": "social_science",
+    "Middle Computer Science": "stem",
+    "Middle Islamic Studies": "humanities",
+    "Primary Computer Science": "stem",
+    "High Physics": "stem",
+    "Middle Social Science": "social_science",
+    "Middle Civics": "social_science",
+    "High Computer Science": "stem",
+    "General Knowledge": "other",
+    "High Civics": "social_science",
+    "Prof Law": "humanities",
+    "High Islamic Studies": "humanities",
+    "Primary Arabic Language": "language",
+    "High Arabic Language": "language",
+    "Arabic Language (Grammar)": "language",
+    "Primary History": "humanities",
+    "Middle History": "humanities",
+    "Univ Economics": "social_science",
+    "Arabic Language (General)": "language",
+    "Univ Computer Science": "stem",
+    "Primary Islamic Studies": "humanities",
+    "Primary Geography": "social_science",
+    "High Philosophy": "humanities",
+    "Middle Arabic Language": "language",
+    "Middle Economics": "social_science",
+    "Univ Management": "other",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base_yaml_path", default="_default_template_yaml")
+    parser.add_argument("--save_prefix_path", default="ammlu")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # get filename of base_yaml so we can `"include": ` it in our "other" YAMLs.
+    base_yaml_name = os.path.split(args.base_yaml_path)[-1]
+    with open(args.base_yaml_path, encoding="utf-8") as f:
+        base_yaml = yaml.full_load(f)
+
+    ALL_CATEGORIES = []
+    for subject, category in tqdm(SUBJECTS.items()):
+        if category not in ALL_CATEGORIES:
+            ALL_CATEGORIES.append(category)
+
+        
+        # description = f"The following are multiple choice questions (with answers) about {' '.join(subject.split('_'))}.\n\n"
+
+        yaml_dict = {
+            "include": base_yaml_name,
+            "group": f"ammlu_{category}",
+            "group_alias": category.replace("_", " "),
+            "task": f"ammlu_{subject.lower().replace(' ', '_')}",
+            "task_alias": subject,
+            "dataset_name": subject,
+            # "description": description,
+        }
+
+        file_save_path = args.save_prefix_path + f"_{subject.lower().replace(' ', '_').replace('(', '').replace(')', '')}.yaml"
+        eval_logger.info(f"Saving yaml for subset {subject} to {file_save_path}")
+        with open(file_save_path, "w", encoding="utf-8") as yaml_file:
+            yaml.dump(
+                yaml_dict,
+                yaml_file,
+                allow_unicode=True,
+                default_style='"',
+            )
+
+    ammlu_subcategories = [f"ammlu_{category}" for category in ALL_CATEGORIES]
+
+    file_save_path = args.save_prefix_path + ".yaml"
+
+    eval_logger.info(f"Saving benchmark config to {file_save_path}")
+    with open(file_save_path, "w", encoding="utf-8") as yaml_file:
+        yaml.dump(
+            {
+                "group": "ammlu",
+                "task": ammlu_subcategories,
+            },
+            yaml_file,
+            indent=4,
+            default_flow_style=False,
+        )

--- a/lm_eval/tasks/ammlu/ammlu.yaml
+++ b/lm_eval/tasks/ammlu/ammlu.yaml
@@ -1,0 +1,7 @@
+group: ammlu
+task:
+- ammlu_other
+- ammlu_social_science
+- ammlu_humanities
+- ammlu_stem
+- ammlu_language

--- a/lm_eval/tasks/ammlu/ammlu_arabic_language_general.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_arabic_language_general.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Arabic Language (General)"
+"group": "ammlu_language"
+"group_alias": "language"
+"include": "_default_template_yaml"
+"task": "ammlu_arabic_language_(general)"
+"task_alias": "Arabic Language (General)"

--- a/lm_eval/tasks/ammlu/ammlu_arabic_language_grammar.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_arabic_language_grammar.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Arabic Language (Grammar)"
+"group": "ammlu_language"
+"group_alias": "language"
+"include": "_default_template_yaml"
+"task": "ammlu_arabic_language_(grammar)"
+"task_alias": "Arabic Language (Grammar)"

--- a/lm_eval/tasks/ammlu/ammlu_driving_test.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_driving_test.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Driving Test"
+"group": "ammlu_other"
+"group_alias": "other"
+"include": "_default_template_yaml"
+"task": "ammlu_driving_test"
+"task_alias": "Driving Test"

--- a/lm_eval/tasks/ammlu/ammlu_general_knowledge.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_general_knowledge.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "General Knowledge"
+"group": "ammlu_other"
+"group_alias": "other"
+"include": "_default_template_yaml"
+"task": "ammlu_general_knowledge"
+"task_alias": "General Knowledge"

--- a/lm_eval/tasks/ammlu/ammlu_high_arabic_language.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_arabic_language.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Arabic Language"
+"group": "ammlu_language"
+"group_alias": "language"
+"include": "_default_template_yaml"
+"task": "ammlu_high_arabic_language"
+"task_alias": "High Arabic Language"

--- a/lm_eval/tasks/ammlu/ammlu_high_biology.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_biology.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Biology"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_high_biology"
+"task_alias": "High Biology"

--- a/lm_eval/tasks/ammlu/ammlu_high_civics.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_civics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Civics"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_high_civics"
+"task_alias": "High Civics"

--- a/lm_eval/tasks/ammlu/ammlu_high_computer_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_computer_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Computer Science"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_high_computer_science"
+"task_alias": "High Computer Science"

--- a/lm_eval/tasks/ammlu/ammlu_high_economics.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_economics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Economics"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_high_economics"
+"task_alias": "High Economics"

--- a/lm_eval/tasks/ammlu/ammlu_high_geography.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_geography.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Geography"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_high_geography"
+"task_alias": "High Geography"

--- a/lm_eval/tasks/ammlu/ammlu_high_history.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_history.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High History"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_high_history"
+"task_alias": "High History"

--- a/lm_eval/tasks/ammlu/ammlu_high_islamic_studies.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_islamic_studies.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Islamic Studies"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_high_islamic_studies"
+"task_alias": "High Islamic Studies"

--- a/lm_eval/tasks/ammlu/ammlu_high_philosophy.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_philosophy.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Philosophy"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_high_philosophy"
+"task_alias": "High Philosophy"

--- a/lm_eval/tasks/ammlu/ammlu_high_physics.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_high_physics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "High Physics"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_high_physics"
+"task_alias": "High Physics"

--- a/lm_eval/tasks/ammlu/ammlu_islamic_studies.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_islamic_studies.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Islamic Studies"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_islamic_studies"
+"task_alias": "Islamic Studies"

--- a/lm_eval/tasks/ammlu/ammlu_middle_arabic_language.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_arabic_language.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Arabic Language"
+"group": "ammlu_language"
+"group_alias": "language"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_arabic_language"
+"task_alias": "Middle Arabic Language"

--- a/lm_eval/tasks/ammlu/ammlu_middle_civics.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_civics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Civics"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_civics"
+"task_alias": "Middle Civics"

--- a/lm_eval/tasks/ammlu/ammlu_middle_computer_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_computer_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Computer Science"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_computer_science"
+"task_alias": "Middle Computer Science"

--- a/lm_eval/tasks/ammlu/ammlu_middle_economics.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_economics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Economics"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_economics"
+"task_alias": "Middle Economics"

--- a/lm_eval/tasks/ammlu/ammlu_middle_general_knowledge.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_general_knowledge.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle General Knowledge"
+"group": "ammlu_other"
+"group_alias": "other"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_general_knowledge"
+"task_alias": "Middle General Knowledge"

--- a/lm_eval/tasks/ammlu/ammlu_middle_geography.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_geography.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Geography"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_geography"
+"task_alias": "Middle Geography"

--- a/lm_eval/tasks/ammlu/ammlu_middle_history.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_history.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle History"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_history"
+"task_alias": "Middle History"

--- a/lm_eval/tasks/ammlu/ammlu_middle_islamic_studies.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_islamic_studies.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Islamic Studies"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_islamic_studies"
+"task_alias": "Middle Islamic Studies"

--- a/lm_eval/tasks/ammlu/ammlu_middle_natural_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_natural_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Natural Science"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_natural_science"
+"task_alias": "Middle Natural Science"

--- a/lm_eval/tasks/ammlu/ammlu_middle_social_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_middle_social_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Middle Social Science"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_middle_social_science"
+"task_alias": "Middle Social Science"

--- a/lm_eval/tasks/ammlu/ammlu_primary_arabic_language.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_arabic_language.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary Arabic Language"
+"group": "ammlu_language"
+"group_alias": "language"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_arabic_language"
+"task_alias": "Primary Arabic Language"

--- a/lm_eval/tasks/ammlu/ammlu_primary_computer_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_computer_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary Computer Science"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_computer_science"
+"task_alias": "Primary Computer Science"

--- a/lm_eval/tasks/ammlu/ammlu_primary_general_knowledge.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_general_knowledge.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary General Knowledge"
+"group": "ammlu_other"
+"group_alias": "other"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_general_knowledge"
+"task_alias": "Primary General Knowledge"

--- a/lm_eval/tasks/ammlu/ammlu_primary_geography.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_geography.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary Geography"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_geography"
+"task_alias": "Primary Geography"

--- a/lm_eval/tasks/ammlu/ammlu_primary_history.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_history.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary History"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_history"
+"task_alias": "Primary History"

--- a/lm_eval/tasks/ammlu/ammlu_primary_islamic_studies.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_islamic_studies.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary Islamic Studies"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_islamic_studies"
+"task_alias": "Primary Islamic Studies"

--- a/lm_eval/tasks/ammlu/ammlu_primary_math.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_math.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary Math"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_math"
+"task_alias": "Primary Math"

--- a/lm_eval/tasks/ammlu/ammlu_primary_natural_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_natural_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary Natural Science"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_natural_science"
+"task_alias": "Primary Natural Science"

--- a/lm_eval/tasks/ammlu/ammlu_primary_social_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_primary_social_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Primary Social Science"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_primary_social_science"
+"task_alias": "Primary Social Science"

--- a/lm_eval/tasks/ammlu/ammlu_prof_law.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_prof_law.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Prof Law"
+"group": "ammlu_humanities"
+"group_alias": "humanities"
+"include": "_default_template_yaml"
+"task": "ammlu_prof_law"
+"task_alias": "Prof Law"

--- a/lm_eval/tasks/ammlu/ammlu_univ_accounting.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_univ_accounting.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Univ Accounting"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_univ_accounting"
+"task_alias": "Univ Accounting"

--- a/lm_eval/tasks/ammlu/ammlu_univ_computer_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_univ_computer_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Univ Computer Science"
+"group": "ammlu_stem"
+"group_alias": "stem"
+"include": "_default_template_yaml"
+"task": "ammlu_univ_computer_science"
+"task_alias": "Univ Computer Science"

--- a/lm_eval/tasks/ammlu/ammlu_univ_economics.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_univ_economics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Univ Economics"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_univ_economics"
+"task_alias": "Univ Economics"

--- a/lm_eval/tasks/ammlu/ammlu_univ_management.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_univ_management.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Univ Management"
+"group": "ammlu_other"
+"group_alias": "other"
+"include": "_default_template_yaml"
+"task": "ammlu_univ_management"
+"task_alias": "Univ Management"

--- a/lm_eval/tasks/ammlu/ammlu_univ_political_science.yaml
+++ b/lm_eval/tasks/ammlu/ammlu_univ_political_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "Univ Political Science"
+"group": "ammlu_social_science"
+"group_alias": "social science"
+"include": "_default_template_yaml"
+"task": "ammlu_univ_political_science"
+"task_alias": "Univ Political Science"

--- a/lm_eval/tasks/ammlu/utils.py
+++ b/lm_eval/tasks/ammlu/utils.py
@@ -1,0 +1,38 @@
+PROMPT = 'This is a {}. Select the correct answer!\n\nQuestion: {}\n{}\n\nAnswer:'
+
+level_en = {
+        'Primary': 'primary school',
+        'Middle': 'middle school',
+        'High': 'high school',
+        'Univ': 'university',
+        'Prof': 'professional',
+}
+
+alpa = ['A.', 'B.', 'C.', 'D.', 'E.']
+
+
+def doc_to_text(doc):
+    """
+    Refactoring `prepare_data_en` to fit with the lm harness framework.
+    https://github.com/mbzuai-nlp/ArabicMMLU/blob/main/util_prompt.py
+    """
+
+    level = "" if not doc['Level'] else " for " + level_en[doc['Level']]
+    country = "" if not doc['Country'] else " in " + doc['Country']
+    main_meta_data = f"{doc['Subject']} question{level}{country}"
+
+    question = doc['Question'] if doc['Context']=="" else f"{doc['Context']}\n\n{doc['Question']}"
+
+    options = []
+    for i, opt in enumerate(['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5']):
+        if not doc[opt]:
+            break
+        options.append(f"{alpa[i]} {doc[opt]}")
+
+    doc_text = PROMPT.format(main_meta_data, question, '\n'.join(options))
+    
+    return doc_text
+
+
+def doc_to_choice(doc):
+    return [alpa[i][0] for i in range(5) if doc[f'Option {i+1}']]


### PR DESCRIPTION
Following up on the issues found in the translated Arabic MMLU #1596 that resulted in its subsequent removal #1948, I'm adding a localized Arabic MMLU in the same style of `cmmlu` and `kmmlu` previously implemented in LM Harness. This localized version contains original Arabic questions that cover 40 subjects, with a total of 14.5k questions. I followed the details outlined by the original authors in their [paper](https://arxiv.org/abs/2402.12840) and [evaluation repository](https://github.com/mbzuai-nlp/ArabicMMLU) to create this new task.

To test my implementation, I tested `FreedomIntelligence/AceGPT-13B-chat` with the following command:
```
accelerate launch -m lm_eval --model hf \
    --model_args pretrained=FreedomIntelligence/AceGPT-13B-chat \
    --tasks ammlu \
    --batch_size auto
```
Which resulted in:
```
|     Groups      |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|-----------------|-------|------|-----:|------|---|-----:|---|-----:|
|ammlu            |N/A    |none  |     0|acc   |↑  |0.5252|±  |0.0041|
```
Which is pretty close when we compare it to the 52.6 score reported in Table 4 in the original paper.