### PR TITLE
Fix naming error; 'include: _paloma_template' -> 'include: paloma.yaml'

### DIFF
--- a/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
+++ b/lm_eval/tasks/paloma/paloma_dolma_100_programing_languages.yaml
@@ -1,4 +1,4 @@
-include: _paloma_template
+include: paloma.yaml
 task: paloma_dolma_100_programing_languages
 task_alias: 100 PLs
 dataset_name: dolma_100_programing_languages


### PR DESCRIPTION
When installing lm-eval-harness from source after the inclusion of the paloma benchmark, I run into errors:

```bash
lm_eval --model hf  \
        --model_args pretrained="gpt2" \
        --tasks tinyHellaswag \
        --batch_size 4
/home/lucas/anaconda3/envs/lmHarness/lib/python3.11/site-packages/torch/cuda/__init__.py:619: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
2024-06-19:15:14:51,854 INFO     [__main__.py:272] Verbosity set to INFO
Traceback (most recent call last):
  File "/home/lucas/anaconda3/envs/lmHarness/bin/lm_eval", line 8, in <module>
    sys.exit(cli_evaluate())
             ^^^^^^^^^^^^^^
  File "/home/lucas/git_repos/lm-evaluation-harness/lm_eval/__main__.py", line 304, in cli_evaluate
    task_manager = TaskManager(args.verbosity, include_path=args.include_path)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucas/git_repos/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 28, in __init__
    self._task_index = self.initialize_tasks(
                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucas/git_repos/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 61, in initialize_tasks
    tasks = self._get_task_and_group(task_dir)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucas/git_repos/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 325, in _get_task_and_group
    config = utils.load_yaml_config(yaml_path, mode="simple")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucas/git_repos/lm-evaluation-harness/lm_eval/utils.py", line 460, in load_yaml_config
    raise ex
  File "/home/lucas/git_repos/lm-evaluation-harness/lm_eval/utils.py", line 456, in load_yaml_config
    included_yaml_config = load_yaml_config(yaml_path=path, mode=mode)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucas/git_repos/lm-evaluation-harness/lm_eval/utils.py", line 430, in load_yaml_config
    with open(yaml_path, "rb") as file:
         ^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/lucas/git_repos/lm-evaluation-harness/lm_eval/tasks/paloma/_paloma_template'
```

This is because of a naming issue in one of the configs (`paloma_dolma_100_programing_languages.yaml`).
I changed the name of the template file, to what I found in the other configs (@zafstojano should confirm that this is correct).

  