### PR TITLE
Fix Datasets `--trust_remote_code`

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -354,7 +354,17 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
 
     # Respect user's value passed in via CLI, otherwise default to True and add to comma-separated model args
     if args.trust_remote_code:
-        os.environ["HF_DATASETS_TRUST_REMOTE_CODE"] = str(args.trust_remote_code)
+        eval_logger.info(
+            "Passed `--trust_remote_code`, setting environment variable `HF_DATASETS_TRUST_REMOTE_CODE=true`"
+        )
+        os.environ["HF_DATASETS_TRUST_REMOTE_CODE"] = "YES"
+        # HACK: import datasets and override its HF_DATASETS_TRUST_REMOTE_CODE value internally,
+        # because it's already been determined based on the prior env var before launching our
+        # script--`datasets` gets imported by lm_eval internally before these lines can update the env.
+        import datasets
+
+        datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = True
+
         args.model_args = (
             args.model_args
             + f",trust_remote_code={os.environ['HF_DATASETS_TRUST_REMOTE_CODE']}"

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -357,7 +357,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         eval_logger.info(
             "Passed `--trust_remote_code`, setting environment variable `HF_DATASETS_TRUST_REMOTE_CODE=true`"
         )
-        os.environ["HF_DATASETS_TRUST_REMOTE_CODE"] = "YES"
         # HACK: import datasets and override its HF_DATASETS_TRUST_REMOTE_CODE value internally,
         # because it's already been determined based on the prior env var before launching our
         # script--`datasets` gets imported by lm_eval internally before these lines can update the env.
@@ -365,10 +364,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
 
         datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = True
 
-        args.model_args = (
-            args.model_args
-            + f",trust_remote_code={os.environ['HF_DATASETS_TRUST_REMOTE_CODE']}"
-        )
+        args.model_args = args.model_args + ",trust_remote_code=True"
 
     eval_logger.info(f"Selected Tasks: {task_names}")
 


### PR DESCRIPTION
closes #1932 .

Basically, `datasets.config.HF_DATASETS_TRUST_REMOTE_CODE` is set using the preexisting environment variable value before these lines run: https://github.com/EleutherAI/lm-evaluation-harness/blob/78a54e1448ccb8c05ab3e83c110e0386316206a2/lm_eval/__main__.py#L356-L361

and so although we set the environment variable `"HF_DATASETS_TRUST_REMOTE_CODE"`, it's not seen by `datasets`, and so `--trust_remote_code` isn't respected.

This PR accesses and overwrites `datasets.config.HF_DATASETS_TRUST_REMOTE_CODE` directly.

cc @lhoestq just wanted to confirm whether this sort of direct access and setting of `datasets.config` attributes is an acceptable interaction with the library!