### PR TITLE
Error Correction: Eliminate undefined parameter in function call

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -433,10 +433,6 @@ class Task(abc.ABC):
             fewshot_ctx = self.fewshot_context(
                 doc,
                 0 if self.config.num_fewshot is None else self.config.num_fewshot,
-                system_instruction,
-                apply_chat_template,
-                fewshot_as_multiturn,
-                lm,
             )
 
             # TODO: we should override self.config.repeats if doing greedy gen so users don't waste time+compute


### PR DESCRIPTION
The `fewshot_context()` function in this class does not have the parameters `system_instruction`, `apply_chat_template`, `fewshot_as_multiturn`, `lm`. To resolve the error `TypeError: fewshot_context() takes from 3 to 5 positional arguments but 7 were given`, I modified the input arguments. 
![image](https://github.com/EleutherAI/lm-evaluation-harness/assets/74179177/af438aa8-bb91-4563-a0c3-9a8a14faa4a6)
![image](https://github.com/EleutherAI/lm-evaluation-harness/assets/74179177/59a080ea-db22-4035-8941-34d803115633)
