### PR TITLE
[add] multiple-choice-question versions of fld benchmark

### DIFF
--- a/lm_eval/tasks/fld/README.md
+++ b/lm_eval/tasks/fld/README.md
@@ -41,9 +41,14 @@ Homepage: https://github.com/hitachi-nlp/FLD
 This release is the simplified version of FLD where a model is required to predict only an answer.
 This setting is described by "answer accuracy" in the original paper.
 
+
 #### Tasks in Group `fld`
 * `fld_default` is a basic task based on [FLD.v2](https://huggingface.co/datasets/hitachi-nlp/FLD.v2/viewer/star)
 * `fld_star`: is a more challenging version based on [FLD.v2-star](https://huggingface.co/datasets/hitachi-nlp/FLD.v2/viewer/star)
+
+The output format is `generate_until`, which requires a model to generate, rather than choose, a label from the specific set: "PROVED", "DISPROVED", or "UNKNOWN".
+Therefor, if a model fails to follow this format, its answer is evaluated as incorrect.
+
 
 #### Tasks in Group `fld_logical_formula`
 Further, we have "logical formula" versions of the benchmarks, which evaluate LLMs' pure logical reasoning capabilities within the domain of logical formulas, rather than natural language:
@@ -51,15 +56,15 @@ Further, we have "logical formula" versions of the benchmarks, which evaluate LL
 * `fld_logical_formula_fld_star`
 
 
-### Checklist
+#### **(RECOMMENDED)** Tasks in Group `fld_mcq`
+* `fld_mcq_default`
+* `fld_mcq_star`
 
-For adding novel benchmarks/datasets to the library:
-* [x] Is the task an existing benchmark in the literature?
-  * [x] Have you referenced the original paper that introduced the task?
-  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+The multiple-choice question version of `fld` group.
+We recommend using this variant to avoid the issue of models generating answers in unexpected formats, as stated above.
 
 
-If other tasks on this dataset are already supported:
-* [ ] Is the "Main" variant of this task clearly denoted?
-* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
-* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?
+### **(RECOMMENDED)** Tasks in Group `fld_mcq_logical_formula`
+The multiple-choice question version of `fld_logical_formula` group.
+* `fld_mcq_logical_formula_default`
+* `fld_mcq_logical_formula_star`

--- a/lm_eval/tasks/fld/generation/_base.yaml
+++ b/lm_eval/tasks/fld/generation/_base.yaml
@@ -1,0 +1,17 @@
+dataset_path: hitachi-nlp/FLD.v2
+dataset_name: default
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_target: world_assump_label
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+filter_list:
+  - name: remove_whitespace
+    filter:
+      - function: remove_whitespace
+      - function: take_first
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/fld/generation/fld_default.yaml
+++ b/lm_eval/tasks/fld/generation/fld_default.yaml
@@ -1,0 +1,5 @@
+include: _base.yaml
+group:
+  - fld
+task: fld_default
+doc_to_text: "Based on the provided facts ($context$), either prove or disprove the hypothesis or state that it is unknown. {{prompt_serial}}"

--- a/lm_eval/tasks/fld/generation/fld_logical_formula_default.yaml
+++ b/lm_eval/tasks/fld/generation/fld_logical_formula_default.yaml
@@ -1,0 +1,5 @@
+include: _base.yaml
+group:
+  - fld_logical_formula
+task: fld_logical_formula_default
+doc_to_text: "Based on the provided facts ($context$), either prove or disprove the hypothesis or state that it is unknown. The facts and the hypothesis are written in logical formulas as follows: capital letters such as \"{A}\", \"{B}\", \"{AB}\" are predicates, small letters such as \"{a}\", \"{b}\", \"{ab}\" are constants, \"&\" is logical conjunction, \"v\" is logical disjunction, \"¬\" is negation, \"->\" is implication, \"(x)\" is \"for all x\", and \"(Ex)\" is \"for some x\". $hypothesis$ = {{hypothesis_formula}} ; $context$ = {{context_formula}} ; $proof$ = "

--- a/lm_eval/tasks/fld/generation/fld_logical_formula_star.yaml
+++ b/lm_eval/tasks/fld/generation/fld_logical_formula_star.yaml
@@ -1,0 +1,3 @@
+include: fld_logical_formula_default.yaml
+task: fld_logical_formula_star
+dataset_name: star

--- a/lm_eval/tasks/fld/generation/fld_star.yaml
+++ b/lm_eval/tasks/fld/generation/fld_star.yaml
@@ -1,0 +1,3 @@
+include: fld_default.yaml
+task: fld_star
+dataset_name: star

--- a/lm_eval/tasks/fld/multiple_choice_question/_base.yaml
+++ b/lm_eval/tasks/fld/multiple_choice_question/_base.yaml
@@ -1,0 +1,14 @@
+dataset_path: hitachi-nlp/FLD.v2
+dataset_name: default
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_target: world_assump_label
+doc_to_choice: ["PROVED", "DISPROVED", "UNKNOWN"]
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_default.yaml
+++ b/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_default.yaml
@@ -1,0 +1,5 @@
+include: _base.yaml
+group:
+  - fld_mcq
+task: fld_mcq_default
+doc_to_text: "Based on the provided facts ($context$), either prove or disprove the hypothesis or state that it is unknown. {{prompt_serial}}"

--- a/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_logical_formula_default.yaml
+++ b/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_logical_formula_default.yaml
@@ -1,0 +1,5 @@
+include: _base.yaml
+group:
+  - fld_mcq_logical_formula
+task: fld_mcq_logical_formula_default
+doc_to_text: "Based on the provided facts ($context$), either prove or disprove the hypothesis or state that it is unknown. The facts and the hypothesis are written in logical formulas as follows: capital letters such as \"{A}\", \"{B}\", \"{AB}\" are predicates, small letters such as \"{a}\", \"{b}\", \"{ab}\" are constants, \"&\" is logical conjunction, \"v\" is logical disjunction, \"¬\" is negation, \"->\" is implication, \"(x)\" is \"for all x\", and \"(Ex)\" is \"for some x\". $hypothesis$ = {{hypothesis_formula}} ; $context$ = {{context_formula}} ; $proof$ = "

--- a/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_logical_formula_star.yaml
+++ b/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_logical_formula_star.yaml
@@ -1,0 +1,3 @@
+include: fld_mcq_logical_formula_default.yaml
+task: fld_mcq_logical_formula_star
+dataset_name: star

--- a/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_star.yaml
+++ b/lm_eval/tasks/fld/multiple_choice_question/fld_mcq_star.yaml
@@ -1,0 +1,3 @@
+include: fld_mcq_default.yaml
+task: fld_mcq_star
+dataset_name: star


### PR DESCRIPTION
Hi,

Can we add multiple-choice-question versions of FLD benchmarks?
Currently, FLD benchmarks only support output_type=generate_until.
When models fail to follow the output format, i.e. labels from "PROVED", "DISPROVED" or "UNKNOWN", they are scored zero.

To add new versions, we have refactored fld yamls a bit, but the old versions remains to work as before.

Thanks!