### PR TITLE
Fix `trust_remote_code`-related test failures

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -55,7 +55,6 @@ jobs:
         cache-dependency-path: pyproject.toml
     - name: Install dependencies
       run: |
-        export HF_DATASETS_TRUST_REMOTE_CODE=1
         python -m pip install --upgrade pip
         pip install -e '.[dev,anthropic,sentencepiece]' --extra-index-url https://download.pytorch.org/whl/cpu
 #         Install optional git dependencies

--- a/lm_eval/tasks/mmlu/continuation/_continuation_template_yaml
+++ b/lm_eval/tasks/mmlu/continuation/_continuation_template_yaml
@@ -9,3 +9,5 @@ doc_to_choice: "{{choices}}"
 doc_to_target: "{{answer}}"
 metadata:
   version: 0.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/mmlu/default/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/default/_default_template_yaml
@@ -13,3 +13,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 0.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
@@ -27,3 +27,5 @@ metric_list:
     ignore_punctuation: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
@@ -34,3 +34,5 @@ metric_list:
     ignore_punctuation: true
 metadata:
   version: 2.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
@@ -31,3 +31,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 2.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu_flan_loglikelihood_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu_flan_loglikelihood_template_yaml
@@ -13,3 +13,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/generative/_default_template_yaml
@@ -16,3 +16,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true


### PR DESCRIPTION
Our unit tests started failing because of the `trust_remote_code` defaults changing in HF datasets. We run using the `hails/mmlu_no_train` dataset which requires remote code exec in our tests, which is what's causing the failure.

This PR removes the need for `--trust_remote_code` when running MMLU, making our tests (hopefully) no longer fail for this reason.