### PR TITLE
Update `trust_remote_code` for Hellaswag

### DIFF
--- a/lm_eval/tasks/hellaswag/hellaswag.yaml
+++ b/lm_eval/tasks/hellaswag/hellaswag.yaml
@@ -20,3 +20,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true


### PR DESCRIPTION
as requested by @ScottHoang , although for other tasks we'll probably mostly want to just have people incentivized to use `--trust_remote_code`