### PR TITLE
Use `shell=False` in `subprocess` Function Calls

### DIFF
--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -37,7 +37,7 @@ def get_nc_count() -> Union[int, None]:
     """Returns the number of neuron cores on the current instance."""
     try:
         cmd = "neuron-ls --json-output"
-        result = subprocess.run(cmd, shell=True, capture_output=True)
+        result = subprocess.run(cmd, shell=False, capture_output=True)
         print(f"inferring nc_count from `neuron-ls` {result.stdout}")
         json_output = json.loads(result.stdout)
         count = sum([x["nc_count"] for x in json_output])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "dill",
     "word2number",
     "more_itertools",
+    "security==1.3.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/clean_training_data/compress_and_package.py
+++ b/scripts/clean_training_data/compress_and_package.py
@@ -8,6 +8,7 @@ import subprocess
 from tqdm import tqdm
 from tqdm_multiprocess import TqdmMultiProcessPool
 from tqdm_multiprocess.logger import setup_logger_tqdm
+from security import safe_command
 
 
 logger = logging.getLogger(__name__)
@@ -18,7 +19,7 @@ def process_task(
 ):
     command = f"zstd {bucket_file_path}"
     logger.info(command)
-    subprocess.call(command, shell=False)
+    safe_command.run(subprocess.call, command, shell=False)
 
     compressed_file = bucket_file_path + ".zst"
     if output_directory:

--- a/scripts/clean_training_data/compress_and_package.py
+++ b/scripts/clean_training_data/compress_and_package.py
@@ -18,7 +18,7 @@ def process_task(
 ):
     command = f"zstd {bucket_file_path}"
     logger.info(command)
-    subprocess.call(command, shell=True)
+    subprocess.call(command, shell=False)
 
     compressed_file = bucket_file_path + ".zst"
     if output_directory:

--- a/scripts/clean_training_data/sort_13_gram_buckets.py
+++ b/scripts/clean_training_data/sort_13_gram_buckets.py
@@ -37,7 +37,7 @@ def sort_13_gram_buckets(working_directory):
         sorted_file_path = bucket_file_path + ".sorted"
         command = f"sort {bucket_file_path} > {sorted_file_path}"
         logger.info(command)
-        subprocess.call(command, shell=True)
+        subprocess.call(command, shell=False)
 
         if terminate:
             return

--- a/scripts/clean_training_data/sort_13_gram_buckets.py
+++ b/scripts/clean_training_data/sort_13_gram_buckets.py
@@ -18,6 +18,7 @@ from signal import SIGINT
 
 from tqdm import tqdm
 from tqdm_multiprocess.logger import setup_logger_tqdm
+from security import safe_command
 
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ def sort_13_gram_buckets(working_directory):
         sorted_file_path = bucket_file_path + ".sorted"
         command = f"sort {bucket_file_path} > {sorted_file_path}"
         logger.info(command)
-        subprocess.call(command, shell=False)
+        safe_command.run(subprocess.call, command, shell=False)
 
         if terminate:
             return


### PR DESCRIPTION
This codemod sets the `shell` keyword argument to `False` in `subprocess` module function calls that have set it to `True`.

Setting `shell=True` will execute the provided command through the system shell which can lead to shell injection vulnerabilities. In the worst case this can give an attacker the ability to run arbitrary commands on your system. In most cases using `shell=False` is sufficient and leads to much safer code.

The changes from this codemod look like this:

```diff
 import subprocess
- subprocess.run("echo 'hi'", shell=True)
+ subprocess.run("echo 'hi'", shell=False)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/library/subprocess.html#security-considerations](https://docs.python.org/3/library/subprocess.html#security-considerations)
  * [https://en.wikipedia.org/wiki/Code_injection#Shell_injection](https://en.wikipedia.org/wiki/Code_injection#Shell_injection)
  * [https://stackoverflow.com/a/3172488](https://stackoverflow.com/a/3172488)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:python/subprocess-shell-false](https://docs.pixee.ai/codemods/python/pixee_python_subprocess-shell-false) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Feleutherai_lm-evaluation-harness%7C259fd911ec53559f788e8aabf03e310552fd5152)


<!--{"type":"DRIP","codemod":"pixee:python/subprocess-shell-false"}-->