### PR TITLE
fix cache

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -246,9 +246,10 @@ class CachingLM:
         # add hook to lm
         lm.set_cache_hook(self.get_cache_hook())
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str):
         lm_attr = getattr(self.lm, attr)
-        if not callable(lm_attr):
+        if attr not in ["loglikelihood", "loglikelihood_rolling", "generate_until"]:
+            eval_logger.debug(f"Passing through attribute '{attr}' to underlying LM")
             return lm_attr
 
         def fn(requests):


### PR DESCRIPTION
Updated the __getattr__ method to explicitly handle certain attributes and not all callables. Was buggy after the introduction of `apply_chat_template()`

edit: the test failure is due to the CI caching error