### PR TITLE
Gemma-2 also needs default `add_bos_token=True`

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -256,9 +256,8 @@ class HFLM(TemplateLM):
         # select (or create) a pad token to use
         self.tokenizer = configure_pad_token(self.tokenizer, model_config=self.config)
 
-        # TODO: override this for Gemma
         self.add_bos_token = add_bos_token
-        if getattr(self.config, "model_type", None) == "gemma":
+        if getattr(self.config, "model_type", None) in ["gemma", "gemma2"]:
             self.add_bos_token = True
             eval_logger.info(
                 f"Model type is '{self.config.model_type}', a BOS token will be used as Gemma underperforms without it."

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -125,7 +125,7 @@ class VLLM(TemplateLM):
         if "gemma" in pretrained.lower():
             self.add_bos_token = True
             eval_logger.info(
-                "Found 'gemma' in model name, a BOS token will be used as Gemma underperforms without it."
+                "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
             )
 
         self.custom_prefix_token_id = prefix_token_id


### PR DESCRIPTION
as with #1465 , we've found that Gemma models underperform when not provided with a BOS token. 

There is a flag (`--model_args add_bos_token=True`) to pass a BOS token, but this PR makes it so that the default value for Gemma-2 models (as with Gemma-1 models) is for `add_bos_token` to default to True to avoid this being a sharp edge.

prior to this change:

```
hf (pretrained=google/gemma-2-9b), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|    Tasks     |Version|Filter|n-shot|  Metric  |   |  Value  |   | Stderr |
|--------------|------:|------|-----:|----------|---|--------:|---|-------:|
|lambada_openai|      1|none  |     0|acc       |↑  |   0.2663|±  |  0.0062|
|              |       |none  |     0|perplexity|↓  |2645.4121|±  |240.9389|
|piqa          |      1|none  |     0|acc       |↑  |   0.5495|±  |  0.0116|
|              |       |none  |     0|acc_norm  |↑  |   0.5517|±  |  0.0116|
```

after passing `add_bos_token=True` (this PR makes the latter the default):

```
hf (pretrained=google/gemma-2-9b,add_bos_token=True), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|    Tasks     |Version|Filter|n-shot|  Metric  |   |Value |   |Stderr|
|--------------|------:|------|-----:|----------|---|-----:|---|-----:|
|lambada_openai|      1|none  |     0|acc       |↑  |0.7518|±  |0.0060|
|              |       |none  |     0|perplexity|↓  |2.9163|±  |0.0526|
|piqa          |      1|none  |     0|acc       |↑  |0.7514|±  |0.0101|
|              |       |none  |     0|acc_norm  |↑  |0.7557|±  |0.0100|

```