### PR TITLE
Fix TypeError in samplers.py by converting int to str

### DIFF
--- a/lm_eval/api/samplers.py
+++ b/lm_eval/api/samplers.py
@@ -55,7 +55,7 @@ class ContextSampler:
             labeled_examples += (
                 str(doc_target[0])
                 if isinstance(doc_target, list)
-                else doc_target
+                else str(doc_target)
                 if self.config.doc_to_choice is None or isinstance(doc_target, str)
                 else str(self.doc_to_choice(doc)[doc_target])
             )


### PR DESCRIPTION
This PR addresses a TypeError that occurs when running the super-glue-t5-prompt task. The error message is as follows:

```
2024-07-08:00:27:18,051 INFO     [task.py:411] Building contexts for super_glue-wsc-t5-prompt on rank 0...
  0%|                                                                        | 0/104 [00:00<?, ?it/s]
TypeError: can only concatenate str (not "int") to str
```

I modified samplers.py on line 55 to ensure that all parts being concatenated are strings.