### PR TITLE
Minor doc fix: leaderboard README.md missing mmlu-pro group and task

### DIFF
--- a/lm_eval/tasks/leaderboard/README.md
+++ b/lm_eval/tasks/leaderboard/README.md
@@ -264,6 +264,15 @@ progress in the field.
 }
 ```
 
+### Groups
+
+- `leaderboard_mmlu_pro`
+
+### Tasks
+
+- `leaderboard_mmlu_pro`
+
+
 ## Musr
 
 ### Paper


### PR DESCRIPTION
leaderboard README.md missing mmlu-pro group and task just like other leaderboard group and task name