### PR TITLE
Fix printout tests (N/A expected for stderrs)

### DIFF
--- a/tests/testdata/ai2_arc_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
+++ b/tests/testdata/ai2_arc_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
@@ -1,6 +1,6 @@
 |    Tasks    |Version|Filter|n-shot| Metric |   |Value|   |Stderr|
-|-------------|------:|------|-----:|--------|---|----:|---|-----:|
-|arc_challenge|      1|none  |     0|acc     |↑  |  0.0|±  |0.0000|
-|             |       |none  |     0|acc_norm|↑  |  0.0|±  |0.0000|
-|arc_easy     |      1|none  |     0|acc     |↑  |  0.3|±  |0.1528|
-|             |       |none  |     0|acc_norm|↑  |  0.1|±  |0.1000|
+|-------------|------:|------|-----:|--------|---|----:|---|------|
+|arc_challenge|      1|none  |     0|acc     |↑  |  0.0|±  |   N/A|
+|             |       |none  |     0|acc_norm|↑  |  0.0|±  |   N/A|
+|arc_easy     |      1|none  |     0|acc     |↑  |  0.3|±  |   N/A|
+|             |       |none  |     0|acc_norm|↑  |  0.1|±  |   N/A|

--- a/tests/testdata/lambada_openai_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
+++ b/tests/testdata/lambada_openai_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
@@ -1,4 +1,4 @@
-|    Tasks     |Version|Filter|n-shot|  Metric  |   | Value  |   | Stderr  |
-|--------------|------:|------|-----:|----------|---|-------:|---|--------:|
-|lambada_openai|      1|none  |     0|acc       |↑  |  0.1000|±  |   0.1000|
-|              |       |none  |     0|perplexity|↓  |605.3866|±  |1636.6987|
+|    Tasks     |Version|Filter|n-shot|  Metric  |   | Value  |   |Stderr|
+|--------------|------:|------|-----:|----------|---|-------:|---|------|
+|lambada_openai|      1|none  |     0|acc       |↑  |  0.1000|±  |   N/A|
+|              |       |none  |     0|perplexity|↓  |605.3866|±  |   N/A|

--- a/tests/testdata/mmlu_stem_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
+++ b/tests/testdata/mmlu_stem_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
@@ -1,22 +1,22 @@
 |             Tasks             |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
-|-------------------------------|------:|------|-----:|------|---|-----:|---|-----:|
-|stem                           |      1|none  |      |acc   |↑  |0.2474|±  |0.0315|
-| - abstract_algebra            |      0|none  |     0|acc   |↑  |0.2000|±  |0.1333|
-| - anatomy                     |      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
-| - astronomy                   |      0|none  |     0|acc   |↑  |0.1000|±  |0.1000|
-| - college_biology             |      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
-| - college_chemistry           |      0|none  |     0|acc   |↑  |0.1000|±  |0.1000|
-| - college_computer_science    |      0|none  |     0|acc   |↑  |0.2000|±  |0.1333|
-| - college_mathematics         |      0|none  |     0|acc   |↑  |0.2000|±  |0.1333|
-| - college_physics             |      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
-| - computer_security           |      0|none  |     0|acc   |↑  |0.5000|±  |0.1667|
-| - conceptual_physics          |      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
-| - electrical_engineering      |      0|none  |     0|acc   |↑  |0.4000|±  |0.1633|
-| - elementary_mathematics      |      0|none  |     0|acc   |↑  |0.0000|±  |0.0000|
-| - high_school_biology         |      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
-| - high_school_chemistry       |      0|none  |     0|acc   |↑  |0.4000|±  |0.1633|
-| - high_school_computer_science|      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
-| - high_school_mathematics     |      0|none  |     0|acc   |↑  |0.2000|±  |0.1333|
-| - high_school_physics         |      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
-| - high_school_statistics      |      0|none  |     0|acc   |↑  |0.0000|±  |0.0000|
-| - machine_learning            |      0|none  |     0|acc   |↑  |0.3000|±  |0.1528|
+|-------------------------------|------:|------|-----:|------|---|-----:|---|------|
+|stem                           |      1|none  |      |acc   |↑  |0.2474|±  |   N/A|
+| - abstract_algebra            |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - anatomy                     |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - astronomy                   |      0|none  |     0|acc   |↑  |0.1000|±  |   N/A|
+| - college_biology             |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - college_chemistry           |      0|none  |     0|acc   |↑  |0.1000|±  |   N/A|
+| - college_computer_science    |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - college_mathematics         |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - college_physics             |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - computer_security           |      0|none  |     0|acc   |↑  |0.5000|±  |   N/A|
+| - conceptual_physics          |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - electrical_engineering      |      0|none  |     0|acc   |↑  |0.4000|±  |   N/A|
+| - elementary_mathematics      |      0|none  |     0|acc   |↑  |0.0000|±  |   N/A|
+| - high_school_biology         |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - high_school_chemistry       |      0|none  |     0|acc   |↑  |0.4000|±  |   N/A|
+| - high_school_computer_science|      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - high_school_mathematics     |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - high_school_physics         |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - high_school_statistics      |      0|none  |     0|acc   |↑  |0.0000|±  |   N/A|
+| - machine_learning            |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|


### PR DESCRIPTION
this fixes a mistake I made when updating our table-printing tests in #1749 . Namely, I added files in `tests/testdata` which reflected changes to our printing, but didn't take into account the fact that we run these tests with `bootstrap_iters=0` (and thus Stderrs in the tables should be `N/A`). 


This fixes the expected test output by making those stderrs N/A.