### PR TITLE
Revert missing utf-8 encoding for logged sample files (#2027)

### DIFF
--- a/lm_eval/loggers/evaluation_tracker.py
+++ b/lm_eval/loggers/evaluation_tracker.py
@@ -288,7 +288,7 @@ class EvaluationTracker:
                         + "\n"
                     )
 
-                    with open(file_results_samples, "a") as f:
+                    with open(file_results_samples, "a", encoding="utf-8") as f:
                         f.write(sample_dump)
 
                 if self.api and self.push_samples_to_hub:


### PR DESCRIPTION
closes #2027

when switching to `EvaluationTracker` an `open(..., encoding="utf-8")` was mistakenly dropped, causing issues for tasks where sample content might not be ascii. This PR fixes that. Tested to resolve the issue on BoolQ reported in #2027 .