### PR TITLE
batch_size may be str if 'auto' is specified

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -50,7 +50,7 @@ def simple_evaluate(
     model_args: Optional[Union[str, dict]] = None,
     tasks: Optional[List[Union[str, dict, object]]] = None,
     num_fewshot: Optional[int] = None,
-    batch_size: Optional[int] = None,
+    batch_size: Optional[Union[int, str]] = None,
     max_batch_size: Optional[int] = None,
     device: Optional[str] = None,
     use_cache: Optional[str] = None,


### PR DESCRIPTION
Minor: `batch_size` may be `str` if its value is 'auto', this adds that detail to help with type checking.