### PR TITLE
Fix haerae task groups

### DIFF
--- a/lm_eval/tasks/haerae/_haerae.yaml
+++ b/lm_eval/tasks/haerae/_haerae.yaml
@@ -1,10 +1,10 @@
 group: haerae
 task:
-  - haerae_gk
-  - haerae_hi
-  - haerae_lw
-  - haerae_rw
-  - haerae_sn
+  - haerae_general_knowledge
+  - haerae_history
+  - haerae_loan_word
+  - haerae_rare_word
+  - haerae_standard_nomenclature
 aggregate_metric_list:
   - metric: acc
     aggregation: mean

--- a/lm_eval/tasks/haerae/haerae_gk.yaml
+++ b/lm_eval/tasks/haerae/haerae_gk.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "general_knowledge"
-"include": "_default_haerae_yaml"
-"task": "haerae_general_knowledge"
+dataset_name: general_knowledge
+include: _default_haerae_yaml
+task: haerae_general_knowledge

--- a/lm_eval/tasks/haerae/haerae_hi.yaml
+++ b/lm_eval/tasks/haerae/haerae_hi.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "history"
-"include": "_default_haerae_yaml"
-"task": "haerae_history"
+dataset_name: history
+include: _default_haerae_yaml
+task: haerae_history

--- a/lm_eval/tasks/haerae/haerae_lw.yaml
+++ b/lm_eval/tasks/haerae/haerae_lw.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "loan_words"
-"include": "_default_haerae_yaml"
-"task": "haerae_loan_word"
+dataset_name: loan_words
+include: _default_haerae_yaml
+task: haerae_loan_word

--- a/lm_eval/tasks/haerae/haerae_rw.yaml
+++ b/lm_eval/tasks/haerae/haerae_rw.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "rare_words"
-"include": "_default_haerae_yaml"
-"task": "haerae_rare_word"
+dataset_name: rare_words
+include: _default_haerae_yaml
+task: haerae_rare_word

--- a/lm_eval/tasks/haerae/haerae_sn.yaml
+++ b/lm_eval/tasks/haerae/haerae_sn.yaml
@@ -1,3 +1,3 @@
-"dataset_name": "standard_nomenclature"
-"include": "_default_haerae_yaml"
-"task": "haerae_standard_nomenclature"
+dataset_name: standard_nomenclature
+include: _default_haerae_yaml
+task: haerae_standard_nomenclature


### PR DESCRIPTION
After group agg update, haerae tasks got error like below since tasks in group yaml do not match with each subtasks.

```
  File "/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 232, in _get_tasklist
    return self.task_index[name]["task"]
  File "/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 312, in _load_individual_task_or_group
    subtask_list = self._get_tasklist(name_or_config)
  File "/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 394, in _load_individual_task_or_group
    group_name: dict(collections.ChainMap(*map(fn, reversed(subtask_list))))
  File "/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 410, in load_task_or_group
    collections.ChainMap(*map(self._load_individual_task_or_group, task_list))
  File "/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 616, in get_task_dict
    task_name_from_string_dict = task_manager.load_task_or_group(
  File "/lm-evaluation-harness/lm_eval/evaluator.py", line 227, in simple_evaluate
    task_dict = get_task_dict(tasks, task_manager)
  File "/mnt/naplm/users/jungwhan/lm-evaluation-harness/lm_eval/utils.py", line 397, in _wrapper
    return fn(*args, **kwargs)
  File "/lm-evaluation-harness/lm_eval/__main__.py", line 382, in cli_evaluate
    results = evaluator.simple_evaluate(
  File "/lm-evaluation-harness/lm_eval/__main__.py", line 461, in <module>
    cli_evaluate()
KeyError: 'haerae_sn'
```