### PR TITLE
keep new line for task description

### DIFF
--- a/lm_eval/tasks/aclue/_aclue.yaml
+++ b/lm_eval/tasks/aclue/_aclue.yaml
@@ -23,4 +23,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/aclue/_default_template_yaml
+++ b/lm_eval/tasks/aclue/_default_template_yaml
@@ -15,4 +15,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/aexams/_aexams.yaml
+++ b/lm_eval/tasks/aexams/_aexams.yaml
@@ -13,4 +13,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/aexams/_default_template_yaml
+++ b/lm_eval/tasks/aexams/_default_template_yaml
@@ -15,4 +15,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/bbh/cot_fewshot/_bbh.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/_bbh.yaml
@@ -33,4 +33,4 @@ aggregate_metric_list:
     weight_by_size: true
     filter_list: get-answer
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/bbh/cot_fewshot/_bbh_cot_fewshot.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/_bbh_cot_fewshot.yaml
@@ -33,4 +33,4 @@ aggregate_metric_list:
     weight_by_size: true
     filter_list: get-answer
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/bbh/cot_fewshot/_cot_fewshot_template_yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/_cot_fewshot_template_yaml
@@ -24,4 +24,4 @@ filter_list:
       - function: "take_first"
 num_fewshot: 3
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/bbh/cot_zeroshot/_bbh_cot_zeroshot.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/_bbh_cot_zeroshot.yaml
@@ -33,4 +33,4 @@ aggregate_metric_list:
     weight_by_size: true
     filter_list: flexible-extract
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/bbh/cot_zeroshot/_cot_zeroshot_template_yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/_cot_zeroshot_template_yaml
@@ -23,4 +23,4 @@ generation_kwargs:
   temperature: 0.0
 num_fewshot: 0
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/bbh/fewshot/_bbh_fewshot.yaml
+++ b/lm_eval/tasks/bbh/fewshot/_bbh_fewshot.yaml
@@ -32,4 +32,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: true
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/bbh/fewshot/_fewshot_template_yaml
+++ b/lm_eval/tasks/bbh/fewshot/_fewshot_template_yaml
@@ -17,4 +17,4 @@ generation_kwargs:
   temperature: 0.0
 num_fewshot: 3
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/bbh/zeroshot/_bbh_zeroshot.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/_bbh_zeroshot.yaml
@@ -33,4 +33,4 @@ aggregate_metric_list:
     weight_by_size: true
     filter_list: flexible-extract
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/bbh/zeroshot/_zeroshot_template_yaml
+++ b/lm_eval/tasks/bbh/zeroshot/_zeroshot_template_yaml
@@ -23,4 +23,4 @@ generation_kwargs:
   temperature: 0.0
 num_fewshot: 0
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/ceval/_ceval-valid.yaml
+++ b/lm_eval/tasks/ceval/_ceval-valid.yaml
@@ -7,7 +7,7 @@ aggregate_metric_list:
   weight_by_size: true
 group: ceval-valid
 metadata:
-  version: 1.0
+  version: 2.0
 task:
   - ceval-valid_computer_network
   - ceval-valid_operating_system

--- a/lm_eval/tasks/ceval/_default_ceval_yaml
+++ b/lm_eval/tasks/ceval/_default_ceval_yaml
@@ -15,4 +15,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/cmmlu/_cmmlu.yaml
+++ b/lm_eval/tasks/cmmlu/_cmmlu.yaml
@@ -75,4 +75,4 @@ aggregate_metric_list:
     metric: acc_norm
     weight_by_size: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/cmmlu/_default_template_yaml
+++ b/lm_eval/tasks/cmmlu/_default_template_yaml
@@ -15,4 +15,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
@@ -35,4 +35,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
@@ -36,4 +36,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
@@ -18,4 +18,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/leaderboard/bbh_mc/_fewshot_template_yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/_fewshot_template_yaml
@@ -13,4 +13,4 @@ num_fewshot: 3
 fewshot_config:
   sampler: first_n
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/leaderboard/bbh_mc/boolean_expressions.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/boolean_expressions.yaml
@@ -1,7 +1,5 @@
 dataset_name: boolean_expressions
-description: 'Evaluate the result of a random Boolean expression.
-
-        '
+description: 'Evaluate the result of a random Boolean expression.'
 doc_to_choice: ["False", "True"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/causal_judgement.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/causal_judgement.yaml
@@ -1,7 +1,5 @@
 dataset_name: causal_judgement
-description: 'Answer questions about causal attribution.
-
-        '
+description: 'Answer questions about causal attribution.'
 doc_to_choice: ["Yes", "No"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/date_understanding.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/date_understanding.yaml
@@ -1,7 +1,5 @@
 dataset_name: date_understanding
-description: 'Infer the date from context.
-
-        '
+description: 'Infer the date from context.'
 doc_to_choice: ["(A)", "(B)", "(C)", "(D)", "(E)", "(F)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/disambiguation_qa.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/disambiguation_qa.yaml
@@ -1,7 +1,5 @@
 dataset_name: disambiguation_qa
-description: 'Clarify the meaning of sentences with ambiguous pronouns.
-
-        '
+description: 'Clarify the meaning of sentences with ambiguous pronouns.'
 doc_to_choice: ["(A)", "(B)", "(C)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/formal_fallacies.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/formal_fallacies.yaml
@@ -1,7 +1,5 @@
 dataset_name: formal_fallacies
-description: 'Distinguish deductively valid arguments from formal fallacies.
-
-        '
+description: 'Distinguish deductively valid arguments from formal fallacies.'
 doc_to_choice: ["valid", "invalid"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/geometric_shapes.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/geometric_shapes.yaml
@@ -1,7 +1,5 @@
 dataset_name: geometric_shapes
-description: 'Name geometric shapes from their SVG paths.
-
-        '
+description: 'Name geometric shapes from their SVG paths.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)","(F)","(G)","(H)","(I)","(J)","(K)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/hyperbaton.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/hyperbaton.yaml
@@ -1,7 +1,5 @@
 dataset_name: hyperbaton
-description: 'Order adjectives correctly in English sentences.
-
-        '
+description: 'Order adjectives correctly in English sentences.'
 doc_to_choice: ["(A)", "(B)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/logical_deduction_five_objects.yaml
@@ -1,8 +1,6 @@
 dataset_name: logical_deduction_five_objects
 description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-        '
+  of objects.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/logical_deduction_seven_objects.yaml
@@ -1,8 +1,6 @@
 dataset_name: logical_deduction_seven_objects
 description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-  '
+  of objects.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)","(F)","(G)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/logical_deduction_three_objects.yaml
@@ -1,8 +1,6 @@
 dataset_name: logical_deduction_three_objects
 description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-        '
+  of objects.'
 doc_to_choice: ["(A)","(B)","(C)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/movie_recommendation.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/movie_recommendation.yaml
@@ -1,7 +1,5 @@
 dataset_name: movie_recommendation
-description: 'Recommend movies similar to the given list of movies.
-
-        '
+description: 'Recommend movies similar to the given list of movies.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)","(F)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/navigate.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/navigate.yaml
@@ -1,8 +1,6 @@
 dataset_name: navigate
 description: 'Given a series of navigation instructions, determine whether one would
-  end up back at the starting point.
-
-        '
+  end up back at the starting point.'
 doc_to_choice: ["Yes","No"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/object_counting.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/object_counting.yaml
@@ -1,8 +1,6 @@
 dataset_name: object_counting
 description: 'Questions that involve enumerating objects and asking the model to count
-  them.
-
-        '
+  them.'
 doc_to_choice: ["0","1","2","3","4","5","6","7","8","9","10", "11", "12", "13", "14", "15", "16", "17", "18"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/penguins_in_a_table.yaml
@@ -1,7 +1,5 @@
 dataset_name: penguins_in_a_table
-description: 'Answer questions about a table of penguins and their attributes.
-
-        '
+description: 'Answer questions about a table of penguins and their attributes.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/reasoning_about_colored_objects.yaml
@@ -1,7 +1,5 @@
 dataset_name: reasoning_about_colored_objects
-description: 'Answer extremely simple questions about the colors of objects on a surface.
-
-        '
+description: 'Answer extremely simple questions about the colors of objects on a surface.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)","(F)","(G)","(H)","(I)","(J)","(K)","(L)","(M)","(N)","(O)","(P)","(Q)","(R)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/ruin_names.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/ruin_names.yaml
@@ -1,8 +1,6 @@
 dataset_name: ruin_names
 description: 'Select the humorous edit that ''ruins'' the input movie or musical artist
-  name.
-
-        '
+  name.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)","(F)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/salient_translation_error_detection.yaml
@@ -1,8 +1,6 @@
 dataset_name: salient_translation_error_detection
 description: 'Detect the type of error in an English translation of a German source
-  sentence.
-
-        '
+  sentence.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)","(F)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/snarks.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/snarks.yaml
@@ -5,10 +5,7 @@ description: 'Determine which of two sentences is sarcastic.
   According to Cambridge University Dictionary, sarcasm is "the use of remarks that
   clearly mean the opposite of what they say, made in order to hurt someone''s feelings
   or to criticize something in a humorous way." Sarcastic sentences often contain
-  satirical or ironic utterances, hyperboles, ambivalent or witty remarks.
-
-
-  '
+  satirical or ironic utterances, hyperboles, ambivalent or witty remarks.'
 doc_to_choice: ["(A)","(B)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/sports_understanding.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/sports_understanding.yaml
@@ -1,8 +1,6 @@
 dataset_name: sports_understanding
 description: 'Determine whether an artificially constructed sentence relating to sports
-  is plausible or not.
-
-        '
+  is plausible or not.'
 doc_to_choice: ["yes","no"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/temporal_sequences.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/temporal_sequences.yaml
@@ -1,8 +1,6 @@
 dataset_name: temporal_sequences
 description: 'Task description: Answer questions about which times certain events
-  could have occurred.
-
-        '
+  could have occurred.'
 doc_to_choice: ["(A)","(B)","(C)","(D)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/tracking_shuffled_objects_five_objects.yaml
@@ -1,8 +1,6 @@
 dataset_name: tracking_shuffled_objects_five_objects
 description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-        '
+  given their initial positions and a description of a sequence of swaps.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/tracking_shuffled_objects_seven_objects.yaml
@@ -1,8 +1,6 @@
 dataset_name: tracking_shuffled_objects_seven_objects
 description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-        '
+  given their initial positions and a description of a sequence of swaps.'
 doc_to_choice: ["(A)","(B)","(C)","(D)","(E)","(F)","(G)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/tracking_shuffled_objects_three_objects.yaml
@@ -1,8 +1,6 @@
 dataset_name: tracking_shuffled_objects_three_objects
 description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-        '
+  given their initial positions and a description of a sequence of swaps.'
 doc_to_choice: ["(A)","(B)","(C)"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/leaderboard/bbh_mc/web_of_lies.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/web_of_lies.yaml
@@ -1,7 +1,5 @@
 dataset_name: web_of_lies
-description: 'Evaluate a random boolean function expressed as a word problem.
-
-        '
+description: 'Evaluate a random boolean function expressed as a word problem.'
 doc_to_choice: ["Yes","No"]
 fewshot_config:
   sampler: first_n

--- a/lm_eval/tasks/med_concepts_qa/_default_template_yaml
+++ b/lm_eval/tasks/med_concepts_qa/_default_template_yaml
@@ -13,3 +13,5 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mmlu/continuation/_continuation_template_yaml
+++ b/lm_eval/tasks/mmlu/continuation/_continuation_template_yaml
@@ -8,6 +8,6 @@ doc_to_text: "Question: {{question.strip()}}\nAnswer:"
 doc_to_choice: "{{choices}}"
 doc_to_target: "{{answer}}"
 metadata:
-  version: 0.0
+  version: 1.0
 dataset_kwargs:
   trust_remote_code: true

--- a/lm_eval/tasks/mmlu/continuation/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/continuation/_mmlu.yaml
@@ -29,4 +29,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/default/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/default/_default_template_yaml
@@ -12,6 +12,6 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 1.0
 dataset_kwargs:
   trust_remote_code: true

--- a/lm_eval/tasks/mmlu/default/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/default/_mmlu.yaml
@@ -8,4 +8,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/default/_mmlu_humanities.yaml
+++ b/lm_eval/tasks/mmlu/default/_mmlu_humanities.yaml
@@ -6,4 +6,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/default/_mmlu_other.yaml
+++ b/lm_eval/tasks/mmlu/default/_mmlu_other.yaml
@@ -6,4 +6,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/default/_mmlu_social_sciences.yaml
+++ b/lm_eval/tasks/mmlu/default/_mmlu_social_sciences.yaml
@@ -6,4 +6,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/default/_mmlu_stem.yaml
+++ b/lm_eval/tasks/mmlu/default/_mmlu_stem.yaml
@@ -6,4 +6,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu.yaml
@@ -29,4 +29,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu_flan_cot_fewshot_template_yaml
@@ -26,6 +26,6 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 2.0
 dataset_kwargs:
   trust_remote_code: true

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu.yaml
@@ -29,4 +29,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu_flan_cot_zeroshot_template_yaml
@@ -33,6 +33,6 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 2.0
+  version: 3.0
 dataset_kwargs:
   trust_remote_code: true

--- a/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu.yaml
@@ -29,4 +29,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_n_shot/generative/_mmlu_flan_generative_template_yaml
@@ -29,6 +29,6 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 2.0
+  version: 3.0
 dataset_kwargs:
   trust_remote_code: true

--- a/lm_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu.yaml
@@ -29,4 +29,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu_flan_loglikelihood_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_n_shot/loglikelihood/_mmlu_flan_loglikelihood_template_yaml
@@ -12,6 +12,6 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.0
 dataset_kwargs:
   trust_remote_code: true

--- a/lm_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/generative/_default_template_yaml
@@ -15,6 +15,6 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.0
 dataset_kwargs:
   trust_remote_code: true

--- a/lm_eval/tasks/mmlu/generative/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/generative/_mmlu.yaml
@@ -29,4 +29,4 @@ aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlusr/answer_only/_answer_only.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/_answer_only.yaml
@@ -9,7 +9,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_ao_other
     group_alias: Other (Answer Only)
     task:
@@ -18,7 +18,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_ao_social_sciences
     group_alias: Social Sciences (Answer Only)
     task:
@@ -27,7 +27,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_ao_humanities
     group_alias: Humanities (Answer Only)
     task:
@@ -36,9 +36,9 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
 aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlusr/answer_only/_mmlusr_a_yml
+++ b/lm_eval/tasks/mmlusr/answer_only/_mmlusr_a_yml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/mmlusr/question_and_answer/_mmlusr_qna_yml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/_mmlusr_qna_yml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/mmlusr/question_and_answer/_question_and_answer.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/_question_and_answer.yaml
@@ -9,7 +9,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_qa_other
     group_alias: Other (Question & Answer)
     task:
@@ -18,7 +18,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_qa_social_sciences
     group_alias: Social Sciences (Question & Answer)
     task:
@@ -27,7 +27,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_qa_humanities
     group_alias: Humanities (Question & Answer)
     task:
@@ -36,9 +36,9 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
 aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/mmlusr/question_only/_mmlusr_q_yml
+++ b/lm_eval/tasks/mmlusr/question_only/_mmlusr_q_yml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 1.0

--- a/lm_eval/tasks/mmlusr/question_only/_question_only.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/_question_only.yaml
@@ -9,7 +9,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_qo_other
     group_alias: Other (Question Only)
     task:
@@ -18,7 +18,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_qo_social_sciences
     group_alias: Social Sciences (Question Only)
     task:
@@ -27,7 +27,7 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
   - group: mmlusr_qo_humanities
     group_alias: Humanities (Question Only)
     task:
@@ -36,9 +36,9 @@ task:
       - metric: acc
         weight_by_size: True
     metadata:
-      version: 1
+      version: 2
 aggregate_metric_list:
   - metric: acc
     weight_by_size: True
 metadata:
-  version: 1
+  version: 2

--- a/lm_eval/tasks/nq_open/nq_open.yaml
+++ b/lm_eval/tasks/nq_open/nq_open.yaml
@@ -29,4 +29,4 @@ metric_list:
     regexes_to_ignore:
     - "\\b(?:The |the |An |A |The |a |an )"
 metadata:
-  version: 3.0
+  version: 4.0

--- a/lm_eval/tasks/tmmluplus/default/_default_template_yaml
+++ b/lm_eval/tasks/tmmluplus/default/_default_template_yaml
@@ -16,4 +16,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.1
+  version: 1.0

--- a/lm_eval/tasks/wmdp/_default_template_yaml
+++ b/lm_eval/tasks/wmdp/_default_template_yaml
@@ -12,4 +12,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0
+  version: 1

--- a/lm_eval/tasks/wmdp/_wmdp.yaml
+++ b/lm_eval/tasks/wmdp/_wmdp.yaml
@@ -8,4 +8,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: True
 metadata:
-  version: 0
+  version: 1

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -471,7 +471,7 @@ def regex_replace(string, pattern, repl, count: int = 0):
     return re.sub(pattern, repl, string, count=count)
 
 
-env = Environment(loader=BaseLoader, undefined=StrictUndefined)
+env = Environment(loader=BaseLoader, undefined=StrictUndefined, keep_trailing_newline=True)
 env.filters["regex_replace"] = regex_replace
 
 

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -471,7 +471,9 @@ def regex_replace(string, pattern, repl, count: int = 0):
     return re.sub(pattern, repl, string, count=count)
 
 
-env = Environment(loader=BaseLoader, undefined=StrictUndefined, keep_trailing_newline=True)
+env = Environment(
+    loader=BaseLoader, undefined=StrictUndefined, keep_trailing_newline=True
+)
 env.filters["regex_replace"] = regex_replace
 
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,119 @@
+import random
+from typing import List
+
+import numpy as np
+import pytest
+
+from lm_eval import tasks
+from lm_eval.tasks import TaskManager
+from lm_eval.utils import join_iters
+
+
+MMLU_ANATOMY_ZERO_SHOT = """The following are multiple choice questions (with answers) about anatomy.
+
+A lesion causing compression of the facial nerve at the stylomastoid foramen will cause ipsilateral
+A. paralysis of the facial muscles.
+B. paralysis of the facial muscles and loss of taste.
+C. paralysis of the facial muscles, loss of taste and lacrimation.
+D. paralysis of the facial muscles, loss of taste, lacrimation and decreased salivation.
+Answer:"""
+
+MMLU_ANATOMY_FIVE_SHOT = """The following are multiple choice questions (with answers) about anatomy.
+
+What is the embryological origin of the hyoid bone?
+A. The first pharyngeal arch
+B. The first and second pharyngeal arches
+C. The second pharyngeal arch
+D. The second and third pharyngeal arches
+Answer: D
+
+Which of these branches of the trigeminal nerve contain somatic motor processes?
+A. The supraorbital nerve
+B. The infraorbital nerve
+C. The mental nerve
+D. None of the above
+Answer: D
+
+The pleura
+A. have no sensory innervation.
+B. are separated by a 2 mm space.
+C. extend into the neck.
+D. are composed of respiratory epithelium.
+Answer: C
+
+In Angle's Class II Div 2 occlusion there is
+A. excess overbite of the upper lateral incisors.
+B. negative overjet of the upper central incisors.
+C. excess overjet of the upper lateral incisors.
+D. excess overjet of the upper central incisors.
+Answer: C
+
+Which of the following is the body cavity that contains the pituitary gland?
+A. Abdominal
+B. Cranial
+C. Pleural
+D. Spinal
+Answer: B
+
+A lesion causing compression of the facial nerve at the stylomastoid foramen will cause ipsilateral
+A. paralysis of the facial muscles.
+B. paralysis of the facial muscles and loss of taste.
+C. paralysis of the facial muscles, loss of taste and lacrimation.
+D. paralysis of the facial muscles, loss of taste, lacrimation and decreased salivation.
+Answer:"""
+
+
+@pytest.mark.parametrize(
+    "task_names,sets,num_fewshot,seed,num_examples,expected_prompt",
+    [
+        (["mmlu_anatomy"], "test", 0, 42, 1, MMLU_ANATOMY_ZERO_SHOT),
+        (["mmlu_anatomy"], "test", 5, 42, 1, MMLU_ANATOMY_FIVE_SHOT),
+    ],
+)
+def test_mmlu_prompt_rendering(
+    task_names: List[str],
+    sets: str,
+    num_fewshot: int,
+    seed: int,
+    num_examples: int,
+    expected_prompt: str,
+):
+    np.random.seed(seed)
+
+    task_manager = TaskManager()
+    task_dict = tasks.get_task_dict(task_names, task_manager)
+
+    for task_name, task in task_dict.items():
+        if isinstance(task, tuple):
+            _, task = task
+
+        rnd = random.Random()
+        rnd.seed(seed)
+
+        iters = []
+
+        for set in sets.split(","):
+            docs = None
+            if set == "train" and task.has_training_docs():
+                docs = task.training_docs()
+            if set == "val" and task.has_validation_docs():
+                docs = task.validation_docs()
+            if set == "test" and task.has_test_docs():
+                docs = task.test_docs()
+            if docs is not None:
+                iters.append(docs)
+
+        if len(iters) == 0:
+            raise ValueError
+
+        docs = join_iters(iters)
+
+        for i, doc in (
+            zip(range(num_examples), docs) if num_examples > 0 else enumerate(docs)
+        ):
+            ctx = task.fewshot_context(
+                doc=doc,
+                num_fewshot=num_fewshot,
+            )
+
+            assert ctx == expected_prompt

--- a/tests/testdata/mmlu_stem_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
+++ b/tests/testdata/mmlu_stem_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
@@ -1,6 +1,6 @@
 |             Tasks             |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
 |-------------------------------|------:|------|-----:|------|---|-----:|---|------|
-|stem                           |      1|none  |      |acc   |↑  |0.2474|±  |   N/A|
+|stem                           |      2|none  |      |acc   |↑  |0.2474|±  |   N/A|
 | - abstract_algebra            |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
 | - anatomy                     |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
 | - astronomy                   |      0|none  |     0|acc   |↑  |0.1000|±  |   N/A|

--- a/tests/testdata/mmlu_stem_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
+++ b/tests/testdata/mmlu_stem_10_hf_pretrained-EleutherAI-pythia-14m-dtype-float32-device-cpu.txt
@@ -1,22 +1,22 @@
 |             Tasks             |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
 |-------------------------------|------:|------|-----:|------|---|-----:|---|------|
 |stem                           |      2|none  |      |acc   |↑  |0.2474|±  |   N/A|
-| - abstract_algebra            |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
-| - anatomy                     |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
-| - astronomy                   |      0|none  |     0|acc   |↑  |0.1000|±  |   N/A|
-| - college_biology             |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
-| - college_chemistry           |      0|none  |     0|acc   |↑  |0.1000|±  |   N/A|
-| - college_computer_science    |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
-| - college_mathematics         |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
-| - college_physics             |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
-| - computer_security           |      0|none  |     0|acc   |↑  |0.5000|±  |   N/A|
-| - conceptual_physics          |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
-| - electrical_engineering      |      0|none  |     0|acc   |↑  |0.4000|±  |   N/A|
-| - elementary_mathematics      |      0|none  |     0|acc   |↑  |0.0000|±  |   N/A|
-| - high_school_biology         |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
-| - high_school_chemistry       |      0|none  |     0|acc   |↑  |0.4000|±  |   N/A|
-| - high_school_computer_science|      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
-| - high_school_mathematics     |      0|none  |     0|acc   |↑  |0.2000|±  |   N/A|
-| - high_school_physics         |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
-| - high_school_statistics      |      0|none  |     0|acc   |↑  |0.0000|±  |   N/A|
-| - machine_learning            |      0|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - abstract_algebra            |      1|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - anatomy                     |      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - astronomy                   |      1|none  |     0|acc   |↑  |0.1000|±  |   N/A|
+| - college_biology             |      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - college_chemistry           |      1|none  |     0|acc   |↑  |0.1000|±  |   N/A|
+| - college_computer_science    |      1|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - college_mathematics         |      1|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - college_physics             |      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - computer_security           |      1|none  |     0|acc   |↑  |0.5000|±  |   N/A|
+| - conceptual_physics          |      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - electrical_engineering      |      1|none  |     0|acc   |↑  |0.4000|±  |   N/A|
+| - elementary_mathematics      |      1|none  |     0|acc   |↑  |0.0000|±  |   N/A|
+| - high_school_biology         |      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - high_school_chemistry       |      1|none  |     0|acc   |↑  |0.4000|±  |   N/A|
+| - high_school_computer_science|      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - high_school_mathematics     |      1|none  |     0|acc   |↑  |0.2000|±  |   N/A|
+| - high_school_physics         |      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|
+| - high_school_statistics      |      1|none  |     0|acc   |↑  |0.0000|±  |   N/A|
+| - machine_learning            |      1|none  |     0|acc   |↑  |0.3000|±  |   N/A|


### PR DESCRIPTION
related: https://github.com/EleutherAI/lm-evaluation-harness/issues/1817

I found out that `apply_template` to description removes line break since jinja2.
For example, in `mmlu_anatomy` task, yaml file is as below.

```yaml
"dataset_name": "anatomy"
"description": "The following are multiple choice questions (with answers) about anatomy.\n\
  \n"
```

**AS-IS**
```
!!@@##@@!! -- Example 0
The following are multiple choice questions (with answers) about anatomy.
A lesion causing compression of the facial nerve at the stylomastoid foramen will cause ipsilateral
A. paralysis of the facial muscles.
B. paralysis of the facial muscles and loss of taste.
C. paralysis of the facial muscles, loss of taste and lacrimation.
D. paralysis of the facial muscles, loss of taste, lacrimation and decreased salivation.
Answer:
```

**TO-BE**
```
The following are multiple choice questions (with answers) about anatomy.

A lesion causing compression of the facial nerve at the stylomastoid foramen will cause ipsilateral
A. paralysis of the facial muscles.
B. paralysis of the facial muscles and loss of taste.
C. paralysis of the facial muscles, loss of taste and lacrimation.
D. paralysis of the facial muscles, loss of taste, lacrimation and decreased salivation.
Answer:
```

I'm not sure it is the best solution, but I think it's the quickest fix for the current situation (https://jinja.palletsprojects.com/en/3.0.x/api/#high-level-api)