### PR TITLE
Add multiple chat template

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -48,6 +48,12 @@ This mode supports a number of command-line arguments, the details of which can 
 
 - `--apply_chat_template` : If this flag is on, a chat template will be applied to the prompt. This flag can also be specified with a string to choose from available multiple model templates if they exist. For Hugging Face models, the chat template is taken from the tokenizer. For other models, chat templating is not currently implemented. Providing –-apply_chat_template without an argument will apply the available template, or if the model does not have one, it will use the default template. To apply a specific template from the available list of templates, provide the template name as an argument (e.g., --apply_chat_template template_name).
 
+- `--apply_chat_template` : This flag specifies whether to apply a chat template to the prompt. It can be used in the following ways:
+	- `--apply_chat_template` : When used without an argument, applies the only available chat template to the prompt. For Hugging Face models, if no dedicated chat template exists, the default chat template is applied.
+	- `--apply_chat_template template_name` : If the model has multiple chat templates, applies the specified template to the prompt.
+
+    For Hugging Face models, the default chat template can be found in the Transformers Tokenizer's [`default_chat_template`](https://github.com/huggingface/transformers/blob/fc35907f95459d7a6c5281dfadd680b6f7b620e3/src/transformers/tokenization_utils_base.py#L1912) property.
+
 - `--fewshot_as_multiturn` : If this flag is on, the Fewshot examples are treated as a multi-turn conversation. Questions are provided as user content and answers are provided as assistant responses. Requires `--num_fewshot` to be set to be greater than 0, and `--apply_chat_template` to be on.
 
 - `--predict_only`: Generates the model outputs without computing metrics. Use with `--log_samples` to retrieve decoded results.

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -47,10 +47,10 @@ This mode supports a number of command-line arguments, the details of which can 
 - `--system_instruction`: Specifies a system instruction string to prepend to the prompt.
 
 - `--apply_chat_template` : This flag specifies whether to apply a chat template to the prompt. It can be used in the following ways:
-	- `--apply_chat_template` : When used without an argument, applies the only available chat template to the prompt. For Hugging Face models, if no dedicated chat template exists, the default chat template is applied.
-	- `--apply_chat_template template_name` : If the model has multiple chat templates, applies the specified template to the prompt.
+	- `--apply_chat_template` : When used without an argument, applies the only available chat template to the prompt. For Hugging Face models, if no dedicated chat template exists, the default chat template will be applied.
+	- `--apply_chat_template template_name` : If the model has multiple chat templates, apply the specified template to the prompt.
 
-    For Hugging Face models, the default chat template can be found in the Transformers Tokenizer's [`default_chat_template`](https://github.com/huggingface/transformers/blob/fc35907f95459d7a6c5281dfadd680b6f7b620e3/src/transformers/tokenization_utils_base.py#L1912) property.
+    For Hugging Face models, the default chat template can be found in the [`default_chat_template`](https://github.com/huggingface/transformers/blob/fc35907f95459d7a6c5281dfadd680b6f7b620e3/src/transformers/tokenization_utils_base.py#L1912) property of the Transformers Tokenizer.
 
 - `--fewshot_as_multiturn` : If this flag is on, the Fewshot examples are treated as a multi-turn conversation. Questions are provided as user content and answers are provided as assistant responses. Requires `--num_fewshot` to be set to be greater than 0, and `--apply_chat_template` to be on.
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -46,7 +46,7 @@ This mode supports a number of command-line arguments, the details of which can 
 
 - `--system_instruction`: Specifies a system instruction string to prepend to the prompt.
 
-- `--apply_chat_template` : If this flag is on, a chat template will be applied to the prompt. For Hugging Face models, the chat template is taken from the tokenizer, if the tokenizer does not have a chat template, a default one will be applied. For other models, chat templating is not currently implemented.
+- `--apply_chat_template` : If this flag is on, a chat template will be applied to the prompt. This flag can also be specified with a string to choose from available multiple model templates if they exist. For Hugging Face models, the chat template is taken from the tokenizer. For other models, chat templating is not currently implemented. Providing --apply_chat_template without an argument will apply the default chat template to the prompt. To apply a specific template from the available list of templates, provide the template name as an argument (e.g., --apply_chat_template template_name).
 
 - `--fewshot_as_multiturn` : If this flag is on, the Fewshot examples are treated as a multi-turn conversation. Questions are provided as user content and answers are provided as assistant responses. Requires `--num_fewshot` to be set to be greater than 0, and `--apply_chat_template` to be on.
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -46,8 +46,6 @@ This mode supports a number of command-line arguments, the details of which can 
 
 - `--system_instruction`: Specifies a system instruction string to prepend to the prompt.
 
-- `--apply_chat_template` : If this flag is on, a chat template will be applied to the prompt. This flag can also be specified with a string to choose from available multiple model templates if they exist. For Hugging Face models, the chat template is taken from the tokenizer. For other models, chat templating is not currently implemented. Providing –-apply_chat_template without an argument will apply the available template, or if the model does not have one, it will use the default template. To apply a specific template from the available list of templates, provide the template name as an argument (e.g., --apply_chat_template template_name).
-
 - `--apply_chat_template` : This flag specifies whether to apply a chat template to the prompt. It can be used in the following ways:
 	- `--apply_chat_template` : When used without an argument, applies the only available chat template to the prompt. For Hugging Face models, if no dedicated chat template exists, the default chat template is applied.
 	- `--apply_chat_template template_name` : If the model has multiple chat templates, applies the specified template to the prompt.

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -46,7 +46,7 @@ This mode supports a number of command-line arguments, the details of which can 
 
 - `--system_instruction`: Specifies a system instruction string to prepend to the prompt.
 
-- `--apply_chat_template` : If this flag is on, a chat template will be applied to the prompt. This flag can also be specified with a string to choose from available multiple model templates if they exist. For Hugging Face models, the chat template is taken from the tokenizer. For other models, chat templating is not currently implemented. Providing --apply_chat_template without an argument will apply the default chat template to the prompt. To apply a specific template from the available list of templates, provide the template name as an argument (e.g., --apply_chat_template template_name).
+- `--apply_chat_template` : If this flag is on, a chat template will be applied to the prompt. This flag can also be specified with a string to choose from available multiple model templates if they exist. For Hugging Face models, the chat template is taken from the tokenizer. For other models, chat templating is not currently implemented. Providing –-apply_chat_template without an argument will apply the available template, or if the model does not have one, it will use the default template. To apply a specific template from the available list of templates, provide the template name as an argument (e.g., --apply_chat_template template_name).
 
 - `--fewshot_as_multiturn` : If this flag is on, the Fewshot examples are treated as a multi-turn conversation. Questions are provided as user content and answers are provided as assistant responses. Requires `--num_fewshot` to be set to be greater than 0, and `--apply_chat_template` to be on.
 

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -118,18 +118,45 @@ class MyCustomLM(LM):
     #...
     @property
     def tokenizer_name(self) -> str:
-        # should return a string denoting the name of the model's tokenizer and/or the accompanying chat template.
+        """
+        Return the name of the model's tokenizer and/or the accompanying chat template.
+        The returned string is used to cache requests.
 
-    def chat_template(self, chat_template: Optional[bool | str] = True) -> str:
-        # takes as input a boolean or string to choose between different chat templates if the model has multiple.
-        # for the reference check docstring of the method in HFLM.
-        # should return a chat template formatting string that is used to build prompt from a user/assistant chat history.
-        # this will be saved in the evaluation results for reproducibility.
+        Returns:
+            str: The name of the model's tokenizer and/or chat template.
+        """
+
+    def chat_template(self, chat_template: Optional[Union[bool, str]] = True) -> str:
+        """
+        Get the appropriate chat template for the model based on the chat_template argument.
+
+        This method returns the chat template string to build the prompt from a chat history.
+        The chat template is saved in the evaluation results for reproducibility.
+        Boolean arguments should be used with models that have only one chat template,
+        while string arguments are used with models that have multiple chat templates.
+        For the reference implementation, see HFLM.
+
+        Args:
+            chat_template (Optional[Union[bool, str]]): Specifies whether to apply a chat template:
+                - True: Apply the default chat template.
+                - False: Do not apply any chat template.
+                - str: Apply the specified chat template by name.
+
+        Returns:
+            str: The selected chat template in Jinja format.
+        """
 
     def apply_chat_template(self, chat_history: List[Dict[str, str]]) -> str:
-        # responsible for taking as input a chat history that would be fed into the model, and
-        # rendering it as a string that can be then tokenized and input into the model.
-    #...
+        """
+        Process a chat history to create a string that can be tokenized and input into the model.
+
+        Args:
+            chat_history (List[Dict[str, str]]): A list of dictionaries representing the chat history,
+                where each dictionary has "role" and "content" keys.
+
+        Returns:
+            str: A string representing the chat history that can be tokenized and fed into the model.
+        """
 ```
 
 - `apply_chat_template`

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -126,7 +126,7 @@ class MyCustomLM(LM):
             str: The name of the model's tokenizer and/or chat template.
         """
 
-    def chat_template(self, chat_template: Optional[Union[bool, str]] = True) -> str:
+    def chat_template(self, chat_template: Optional[Union[bool, str]] = False) -> str:
         """
         Get the appropriate chat template for the model based on the chat_template argument.
 
@@ -134,12 +134,12 @@ class MyCustomLM(LM):
         The chat template is saved in the evaluation results for reproducibility.
         Boolean arguments should be used with models that have only one chat template,
         while string arguments are used with models that have multiple chat templates.
-        For the reference implementation, see HFLM.
+        For the reference implementation, see HFLM class in lm_eval.models.huggingface.
 
         Args:
             chat_template (Optional[Union[bool, str]]): Specifies whether to apply a chat template:
-                - If True: Apply the default chat template.
                 - If False: Do not apply any chat template.
+                - If True: Apply the default chat template.
                 - If str: Apply the specified chat template by name.
 
         Returns:

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -126,7 +126,7 @@ class MyCustomLM(LM):
             str: The name of the model's tokenizer and/or chat template.
         """
 
-    def chat_template(self, chat_template: Optional[Union[bool, str]] = False) -> str:
+    def chat_template(self, chat_template: Union[bool, str] = False) -> str:
         """
         Get the appropriate chat template for the model based on the `chat_template` argument.
 
@@ -137,7 +137,7 @@ class MyCustomLM(LM):
         For the reference implementation, see HFLM class in `lm_eval.models.huggingface`.
 
         Args:
-            chat_template (Optional[Union[bool, str]]): Specifies whether to apply a chat template:
+            chat_template (Union[bool, str]): Specifies whether to apply a chat template:
                 - If False: Do not apply any chat template.
                 - If True: Apply the default chat template.
                 - If str: Apply the specified chat template by name.

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -138,9 +138,9 @@ class MyCustomLM(LM):
 
         Args:
             chat_template (Optional[Union[bool, str]]): Specifies whether to apply a chat template:
-                - True: Apply the default chat template.
-                - False: Do not apply any chat template.
-                - str: Apply the specified chat template by name.
+                - If True: Apply the default chat template.
+                - If False: Do not apply any chat template.
+                - If str: Apply the specified chat template by name.
 
         Returns:
             str: The selected chat template in Jinja format.

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -128,13 +128,13 @@ class MyCustomLM(LM):
 
     def chat_template(self, chat_template: Optional[Union[bool, str]] = False) -> str:
         """
-        Get the appropriate chat template for the model based on the chat_template argument.
+        Get the appropriate chat template for the model based on the `chat_template` argument.
 
         This method returns the chat template string to build the prompt from a chat history.
         The chat template is saved in the evaluation results for reproducibility.
         Boolean arguments should be used with models that have only one chat template,
         while string arguments are used with models that have multiple chat templates.
-        For the reference implementation, see HFLM class in lm_eval.models.huggingface.
+        For the reference implementation, see HFLM class in `lm_eval.models.huggingface`.
 
         Args:
             chat_template (Optional[Union[bool, str]]): Specifies whether to apply a chat template:

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -120,8 +120,9 @@ class MyCustomLM(LM):
     def tokenizer_name(self) -> str:
         # should return a string denoting the name of the model's tokenizer and/or the accompanying chat template.
 
-    @property
-    def chat_template(self) -> str:
+    def chat_template(self, chat_template: Optional[bool | str] = True) -> str:
+        # takes as input a boolean or string to choose between different chat templates if the model has multiple.
+        # for the reference check docstring of the method in HFLM.
         # should return a chat template formatting string that is used to build prompt from a user/assistant chat history.
         # this will be saved in the evaluation results for reproducibility.
 

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -176,7 +176,7 @@ def setup_parser() -> argparse.ArgumentParser:
         default=False,
         help=(
             "If True, apply chat template to the prompt. "
-            "Providing --apply_chat_template without an argument will apply the default chat template to the prompt. "
+            "Providing `--apply_chat_template` without an argument will apply the default chat template to the prompt. "
             "To apply a specific template from the available list of templates, provide the template name as an argument. "
             "E.g. `--apply_chat_template template_name`"
         ),

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -174,7 +174,12 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs="?",
         const=True,
         default=False,
-        help="If True, apply chat template to the prompt. If argument is provided, specific chat template will be applied.",
+        help=(
+            "If True, apply chat template to the prompt. "
+            "Providing --apply_chat_template without an argument will apply the default chat template to the prompt. "
+            "To apply a specific template from the available list of templates, provide the template name as an argument."
+            "E.g. `--apply_chat_template template_name`"
+        ),
     )
     parser.add_argument(
         "--fewshot_as_multiturn",

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -177,7 +177,7 @@ def setup_parser() -> argparse.ArgumentParser:
         help=(
             "If True, apply chat template to the prompt. "
             "Providing --apply_chat_template without an argument will apply the default chat template to the prompt. "
-            "To apply a specific template from the available list of templates, provide the template name as an argument."
+            "To apply a specific template from the available list of templates, provide the template name as an argument. "
             "E.g. `--apply_chat_template template_name`"
         ),
     )
@@ -296,7 +296,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
 
     if args.fewshot_as_multiturn and args.apply_chat_template is False:
         raise ValueError(
-            "If fewshot_as_multiturn is set, apply_chat_template must be set to True."
+            "When fewshot_as_multiturn is enabled, apply_chat_template must be set to True or specify a template name."
         )
 
     if (

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -296,7 +296,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
 
     if args.fewshot_as_multiturn and args.apply_chat_template is False:
         raise ValueError(
-            "When fewshot_as_multiturn is enabled, apply_chat_template must be set to True or specify a template name."
+            "When `fewshot_as_multiturn` is selected, `apply_chat_template` must be set (either to `True` or to the chosen template name)."
         )
 
     if (

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -170,9 +170,11 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--apply_chat_template",
-        action="store_true",
+        type=str,
+        nargs="?",
+        const=True,
         default=False,
-        help="If True, applies the chat template to the prompt",
+        help="If True, apply chat template to the prompt. If argument is provided, specific chat template will be applied.",
     )
     parser.add_argument(
         "--fewshot_as_multiturn",

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -64,7 +64,7 @@ def simple_evaluate(
     log_samples: bool = True,
     evaluation_tracker: Optional[EvaluationTracker] = None,
     system_instruction: Optional[str] = None,
-    apply_chat_template: Optional[Union[bool, str]] = False,
+    apply_chat_template: Union[bool, str] = False,
     fewshot_as_multiturn: bool = False,
     gen_kwargs: Optional[str] = None,
     task_manager: Optional[TaskManager] = None,
@@ -112,7 +112,7 @@ def simple_evaluate(
         If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis
     :param system_instruction: str
         System instruction to be applied to the prompt
-    :param apply_chat_template: Optional[Union[bool, str]]
+    :param apply_chat_template: Union[bool, str]
         Specifies whether to apply a chat template to the prompt.
         - If set to True, the default chat template is applied.
         - If set to a string, applies the specified chat template by name.
@@ -365,7 +365,7 @@ def evaluate(
     write_out: bool = False,
     log_samples: bool = True,
     system_instruction: Optional[str] = None,
-    apply_chat_template: Optional[Union[bool, str]] = False,
+    apply_chat_template: Union[bool, str] = False,
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
 ):
@@ -385,7 +385,7 @@ def evaluate(
         If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis
     :param system_instruction: str
         System instruction to be applied to the prompt
-    :param apply_chat_template: Optional[Union[bool, str]]
+    :param apply_chat_template: Union[bool, str]
         Specifies whether to apply a chat template to the prompt.
         - If set to True, the default chat template is applied.
         - If set to a string, applies the specified chat template by name.

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -182,10 +182,6 @@ def simple_evaluate(
             model_args = ""
 
         if isinstance(model_args, dict):
-            # testing if True or a string
-            if apply_chat_template is not None and apply_chat_template:
-                model_args["chat_template_definition"] = apply_chat_template
-
             eval_logger.info(
                 f"Initializing {model} model, with arguments: {model_args}"
             )
@@ -199,10 +195,6 @@ def simple_evaluate(
             )
 
         else:
-            # testing if True or a string
-            if apply_chat_template is not None and apply_chat_template:
-                model_args += f",chat_template_definition={str(apply_chat_template)}"
-
             eval_logger.info(
                 f"Initializing {model} model, with arguments: {simple_parse_args_string(model_args)}"
             )
@@ -300,7 +292,9 @@ def simple_evaluate(
             model_source=model,
             model_args=model_args,
             system_instruction=system_instruction,
-            chat_template=lm.chat_template if apply_chat_template else None,
+            chat_template=lm.chat_template(apply_chat_template)
+            if apply_chat_template
+            else None,
             fewshot_as_multiturn=fewshot_as_multiturn,
         )
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -179,11 +179,10 @@ def simple_evaluate(
             model_args = ""
 
         if isinstance(model_args, dict):
-            if apply_chat_template is not None and apply_chat_template is not False:
-                if apply_chat_template is True:
-                    model_args["chat_template_definition"] = True
-                else:
-                    model_args["chat_template_definition"] = apply_chat_template
+            if (
+                apply_chat_template is not None and apply_chat_template
+            ):  # testing if True or a string
+                model_args["chat_template_definition"] = apply_chat_template
 
             eval_logger.info(
                 f"Initializing {model} model, with arguments: {model_args}"
@@ -198,11 +197,10 @@ def simple_evaluate(
             )
 
         else:
-            if apply_chat_template is not None and apply_chat_template is not False:
-                if apply_chat_template is True:
-                    model_args += ",chat_template_definition=True"
-                else:
-                    model_args += f",chat_template_definition={apply_chat_template}"
+            if (
+                apply_chat_template is not None and apply_chat_template
+            ):  # testing if True or a string
+                model_args += f",chat_template_definition={str(apply_chat_template)}"
 
             eval_logger.info(
                 f"Initializing {model} model, with arguments: {simple_parse_args_string(model_args)}"

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -292,9 +292,7 @@ def simple_evaluate(
             model_source=model,
             model_args=model_args,
             system_instruction=system_instruction,
-            chat_template=lm.chat_template(apply_chat_template)
-            if apply_chat_template
-            else None,
+            chat_template=lm.chat_template(apply_chat_template),
             fewshot_as_multiturn=fewshot_as_multiturn,
         )
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -179,9 +179,8 @@ def simple_evaluate(
             model_args = ""
 
         if isinstance(model_args, dict):
-            if (
-                apply_chat_template is not None and apply_chat_template
-            ):  # testing if True or a string
+            # testing if True or a string
+            if apply_chat_template is not None and apply_chat_template:
                 model_args["chat_template_definition"] = apply_chat_template
 
             eval_logger.info(
@@ -197,9 +196,8 @@ def simple_evaluate(
             )
 
         else:
-            if (
-                apply_chat_template is not None and apply_chat_template
-            ):  # testing if True or a string
+            # testing if True or a string
+            if apply_chat_template is not None and apply_chat_template:
                 model_args += f",chat_template_definition={str(apply_chat_template)}"
 
             eval_logger.info(

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -64,7 +64,7 @@ def simple_evaluate(
     log_samples: bool = True,
     evaluation_tracker: Optional[EvaluationTracker] = None,
     system_instruction: Optional[str] = None,
-    apply_chat_template: Optional[bool | str] = None,
+    apply_chat_template: Optional[bool | str] = False,
     fewshot_as_multiturn: bool = False,
     gen_kwargs: Optional[str] = None,
     task_manager: Optional[TaskManager] = None,
@@ -113,7 +113,10 @@ def simple_evaluate(
     :param system_instruction: str
         System instruction to be applied to the prompt
     :param apply_chat_template: Optional[bool|str]
-        If True, apply chat template to the prompt. If a chat template name is provided, respective chat template will be applied.
+        Specifies whether to apply a chat template to the prompt.
+        - If set to True, the default chat template is applied.
+        - If set to a string, applies the specified chat template by name.
+        Defaults to False (no chat template applied).
     :param fewshot_as_multiturn: bool
         Whether to provide the fewshot examples as a multiturn conversation or a single user turn.
     :param gen_kwargs: str
@@ -391,7 +394,10 @@ def evaluate(
     :param system_instruction: str
         System instruction to be applied to the prompt
     :param apply_chat_template: Optional[bool|str]
-        If True, apply chat template to the prompt. If a chat template name is provided, respective chat template will be applied.
+        Specifies whether to apply a chat template to the prompt.
+        - If set to True, the default chat template is applied.
+        - If set to a string, applies the specified chat template by name.
+        Defaults to False (no chat template applied).
     :param fewshot_as_multiturn: bool
         Whether to provide the fewshot examples as a multiturn conversation or a single user turn.
     :return

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -64,7 +64,7 @@ def simple_evaluate(
     log_samples: bool = True,
     evaluation_tracker: Optional[EvaluationTracker] = None,
     system_instruction: Optional[str] = None,
-    apply_chat_template: Optional[bool | str] = False,
+    apply_chat_template: Optional[Union[bool, str]] = False,
     fewshot_as_multiturn: bool = False,
     gen_kwargs: Optional[str] = None,
     task_manager: Optional[TaskManager] = None,
@@ -112,7 +112,7 @@ def simple_evaluate(
         If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis
     :param system_instruction: str
         System instruction to be applied to the prompt
-    :param apply_chat_template: Optional[bool|str]
+    :param apply_chat_template: Optional[Union[bool, str]]
         Specifies whether to apply a chat template to the prompt.
         - If set to True, the default chat template is applied.
         - If set to a string, applies the specified chat template by name.
@@ -365,7 +365,7 @@ def evaluate(
     write_out: bool = False,
     log_samples: bool = True,
     system_instruction: Optional[str] = None,
-    apply_chat_template: Optional[bool | str] = False,
+    apply_chat_template: Optional[Union[bool, str]] = False,
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
 ):
@@ -385,7 +385,7 @@ def evaluate(
         If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis
     :param system_instruction: str
         System instruction to be applied to the prompt
-    :param apply_chat_template: Optional[bool|str]
+    :param apply_chat_template: Optional[Union[bool, str]]
         Specifies whether to apply a chat template to the prompt.
         - If set to True, the default chat template is applied.
         - If set to a string, applies the specified chat template by name.

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -64,7 +64,7 @@ def simple_evaluate(
     log_samples: bool = True,
     evaluation_tracker: Optional[EvaluationTracker] = None,
     system_instruction: Optional[str] = None,
-    apply_chat_template: bool = False,
+    apply_chat_template: Optional[bool | str] = None,
     fewshot_as_multiturn: bool = False,
     gen_kwargs: Optional[str] = None,
     task_manager: Optional[TaskManager] = None,
@@ -112,8 +112,8 @@ def simple_evaluate(
         If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis
     :param system_instruction: str
         System instruction to be applied to the prompt
-    :param apply_chat_template: bool
-        If True, apply chat template to the prompt
+    :param apply_chat_template: Optional[bool|str]
+        If True, apply chat template to the prompt. If a chat template name is provided, respective chat template will be applied.
     :param fewshot_as_multiturn: bool
         Whether to provide the fewshot examples as a multiturn conversation or a single user turn.
     :param gen_kwargs: str
@@ -179,6 +179,12 @@ def simple_evaluate(
             model_args = ""
 
         if isinstance(model_args, dict):
+            if apply_chat_template is not None and apply_chat_template is not False:
+                if apply_chat_template is True:
+                    model_args["chat_template_definition"] = True
+                else:
+                    model_args["chat_template_definition"] = apply_chat_template
+
             eval_logger.info(
                 f"Initializing {model} model, with arguments: {model_args}"
             )
@@ -192,6 +198,12 @@ def simple_evaluate(
             )
 
         else:
+            if apply_chat_template is not None and apply_chat_template is not False:
+                if apply_chat_template is True:
+                    model_args += ",chat_template_definition=True"
+                else:
+                    model_args += f",chat_template_definition={apply_chat_template}"
+
             eval_logger.info(
                 f"Initializing {model} model, with arguments: {simple_parse_args_string(model_args)}"
             )
@@ -362,7 +374,7 @@ def evaluate(
     write_out: bool = False,
     log_samples: bool = True,
     system_instruction: Optional[str] = None,
-    apply_chat_template: bool = False,
+    apply_chat_template: Optional[bool | str] = False,
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
 ):
@@ -382,8 +394,8 @@ def evaluate(
         If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis
     :param system_instruction: str
         System instruction to be applied to the prompt
-    :param apply_chat_template: bool
-        If True, apply chat template to the prompt
+    :param apply_chat_template: Optional[bool|str]
+        If True, apply chat template to the prompt. If a chat template name is provided, respective chat template will be applied.
     :param fewshot_as_multiturn: bool
         Whether to provide the fewshot examples as a multiturn conversation or a single user turn.
     :return
@@ -416,7 +428,7 @@ def evaluate(
             cache_requests=cache_requests,
             rewrite_requests_cache=rewrite_requests_cache,
             system_instruction=system_instruction,
-            apply_chat_template=apply_chat_template,
+            apply_chat_template=bool(apply_chat_template),
             fewshot_as_multiturn=fewshot_as_multiturn,
             chat_template=getattr(lm, "apply_chat_template")
             if apply_chat_template

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -402,7 +402,7 @@ class HFLM(TemplateLM):
     def tokenizer_name(self) -> str:
         return self.tokenizer.name_or_path.replace("/", "__")
 
-    def chat_template(self, chat_template: Optional[bool | str] = True) -> str:
+    def chat_template(self, chat_template: Optional[bool | str] = False) -> str:
         """
         Get the appropriate chat template for the model based on configuration and input.
         This method determines, and returns the correct chat template, ensuring reproducibility.
@@ -422,18 +422,20 @@ class HFLM(TemplateLM):
 
         Args:
             chat_template (Optional[Union[bool, str]]): Specifies the chat template to use.
-                - If True (default), use the default template.
-                - If False or None, no template is applied (handled externally).
-                - If a string, use the template with the matching name.
+                - If False or None, no template is applied.
+                - If True, the default or only available template is used.
+                - If a string, the template with the matching name is used.
 
         Returns:
             str: The selected chat template.
         """
         # This method should not be called if the chat_template argument is None or False
-        if chat_template is False or chat_template is None:
-            raise ValueError(
-                "Chat template method should not be called with chat_template=None or chat_template=False."
+        if not chat_template:
+            eval_logger.warning(
+                "model.chat_template was called with the chat_template set to False or None. "
+                "Therefore no chat template will be applied. Make sure this is an intended behavior."
             )
+            return None
         # Handle the case where chat_template is a boolean (True)
         if isinstance(chat_template, bool):
             chat_template = None

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -412,6 +412,9 @@ class HFLM(TemplateLM):
 
         The logic for determining the correct chat template is adapted from the Transformers library,
         it reflects how it is handled in the `apply_chat_template` method in the Tokenizer class.
+        The original code can be found at:
+        https://github.com/huggingface/transformers/blob/fc35907f95459d7a6c5281dfadd680b6f7b620e3/src/transformers/tokenization_utils_base.py#L1687
+
         This method ensures that the right template is chosen based on the following:
 
         1. If the model's tokenizer has a dictionary of multiple templates:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -402,7 +402,9 @@ class HFLM(TemplateLM):
     def tokenizer_name(self) -> str:
         return self.tokenizer.name_or_path.replace("/", "__")
 
-    def chat_template(self, chat_template: Optional[Union[bool, str]] = False) -> str:
+    def chat_template(
+        self, chat_template: Optional[Union[bool, str]] = False
+    ) -> Optional[str]:
         """
         Get the appropriate chat template for the model based on configuration and input.
         This method determines, and returns the correct chat template, ensuring reproducibility.
@@ -427,16 +429,16 @@ class HFLM(TemplateLM):
                 - If a string, the template with the matching name is used.
 
         Returns:
-            str: The selected chat template.
+            Optional[str]: The selected chat template, or None if no template is applied.
         """
-        # This method should not be called if the chat_template argument is None or False
-        if not chat_template:
+        if chat_template is False or chat_template is None:
             eval_logger.warning(
                 "model.chat_template was called with the chat_template set to False or None. "
                 "Therefore no chat template will be applied. Make sure this is an intended behavior."
             )
             return None
-        # Handle the case where chat_template is a boolean (True)
+
+        # Convert boolean chat_template to None to ensure compatibility with the adapted logic
         if isinstance(chat_template, bool):
             chat_template = None
         using_default_template = False
@@ -469,7 +471,7 @@ class HFLM(TemplateLM):
                         f"template names are {sorted(template.keys())}."
                     )
 
-        # These are the cases when the model has a single template or no template
+        # Cases when the model has a single template or no template
         else:
             # priority: `chat_template` argument > `tokenizer.chat_template` > `tokenizer.default_chat_template
             if isinstance(chat_template, str):

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -431,7 +431,7 @@ class HFLM(TemplateLM):
         """
         if chat_template is False or chat_template is None:
             eval_logger.warning(
-                f"The model's `.chat_template` method was called with argument {chat_template}. No chat template will be applied. Please ensure this is the intended behavior."
+                "model.chat_template was called with the chat_template set to False or None. "
                 "Therefore no chat template will be applied. Make sure this is an intended behavior."
             )
             return None
@@ -449,7 +449,7 @@ class HFLM(TemplateLM):
 
             if chat_template is not None:
                 if chat_template in template:
-                    chat_template = template[chat_template]
+                    selected_template = template[chat_template]
                     if using_default_dict:
                         using_default_template = True
                 else:
@@ -460,12 +460,12 @@ class HFLM(TemplateLM):
             else:
                 # If user didn't pass a chat template, use the default template from the dict
                 if "default" in template:
-                    chat_template = template["default"]
+                    selected_template = template["default"]
                     using_default_template = True
                 else:
                     raise ValueError(
-                        "This model has multiple chat templates with no default specified! Please pass "
-                        "the name of the template you wish to use manually either through the CLI or to `lm_eval.evaluate()` or `lm_eval.simple_evaluate()`. Available "
+                        "This model has multiple chat templates with no default specified! Please either pass a chat "
+                        "template or the name of the template you wish to use to the `chat_template` argument. Available "
                         f"template names are {sorted(template.keys())}."
                     )
 
@@ -478,9 +478,9 @@ class HFLM(TemplateLM):
                     "Using the tokenizer's chat template or the default template instead."
                 )
             if self.tokenizer.chat_template is not None:
-                chat_template = self.tokenizer.chat_template
+                selected_template = self.tokenizer.chat_template
             else:
-                chat_template = self.tokenizer.default_chat_template
+                selected_template = self.tokenizer.default_chat_template
                 using_default_template = True
 
         if using_default_template:
@@ -492,7 +492,7 @@ class HFLM(TemplateLM):
                 "then to ensure that this model continues working without issues."
             )
 
-        return chat_template
+        return selected_template
 
     def _get_backend(
         self,

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -402,9 +402,7 @@ class HFLM(TemplateLM):
     def tokenizer_name(self) -> str:
         return self.tokenizer.name_or_path.replace("/", "__")
 
-    def chat_template(
-        self, chat_template: Optional[Union[bool, str]] = False
-    ) -> Optional[str]:
+    def chat_template(self, chat_template: Union[bool, str] = False) -> Optional[str]:
         """
         Get the appropriate chat template for the model based on configuration and input.
         This method determines, and returns the correct chat template, ensuring reproducibility.
@@ -423,7 +421,7 @@ class HFLM(TemplateLM):
             b. Fall back to the default chat template if no tokenizer chat template exists.
 
         Args:
-            chat_template (Optional[Union[bool, str]]): Specifies the chat template to use.
+            chat_template (Union[bool, str]): Specifies the chat template to use.
                 - If False or None, no template is applied.
                 - If True, the default or only available template is used.
                 - If a string, the template with the matching name is used.

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -416,8 +416,8 @@ class HFLM(TemplateLM):
         This method ensures that the right template is chosen based on the following:
         1. If the model's tokenizer has multiple templates:
             a. Use the specified template if it exists in the dictionary.
-            b. Use the default template if no specific template is provided.
-            c. Raise an error if no default template exists and no specific template is specified.
+            b. Use the default template from the list of templates if no specific template is provided.
+            c. Raise an error if no default template exists and no specific template is provided.
         2. If the model's tokenizer has a single template or no template:
             a. Use the tokenizer's chat template if available.
             b. Fall back to the default chat template if no tokenizer chat template exists.

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -402,7 +402,7 @@ class HFLM(TemplateLM):
     def tokenizer_name(self) -> str:
         return self.tokenizer.name_or_path.replace("/", "__")
 
-    def chat_template(self, chat_template: Optional[bool | str] = False) -> str:
+    def chat_template(self, chat_template: Optional[Union[bool, str]] = False) -> str:
         """
         Get the appropriate chat template for the model based on configuration and input.
         This method determines, and returns the correct chat template, ensuring reproducibility.

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -431,7 +431,7 @@ class HFLM(TemplateLM):
         """
         if chat_template is False or chat_template is None:
             eval_logger.warning(
-                "model.chat_template was called with the chat_template set to False or None. "
+                f"The model's `.chat_template` method was called with argument {chat_template}. No chat template will be applied. Please ensure this is the intended behavior."
                 "Therefore no chat template will be applied. Make sure this is an intended behavior."
             )
             return None
@@ -464,8 +464,8 @@ class HFLM(TemplateLM):
                     using_default_template = True
                 else:
                     raise ValueError(
-                        "This model has multiple chat templates with no default specified! Please either pass a chat "
-                        "template or the name of the template you wish to use to the `chat_template` argument. Available "
+                        "This model has multiple chat templates with no default specified! Please pass "
+                        "the name of the template you wish to use manually either through the CLI or to `lm_eval.evaluate()` or `lm_eval.simple_evaluate()`. Available "
                         f"template names are {sorted(template.keys())}."
                     )
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -466,7 +466,7 @@ class HFLM(TemplateLM):
                     using_default_template = True
 
         # This is the case when model chat template is not specified
-        elif chat_template is not None and chat_template is not False:
+        elif chat_template is not None and chat_template:
             # These are the cases when the model has a single template
             # priority: `chat_template` argument > `tokenizer.chat_template` > `tokenizer.default_chat_template
             if isinstance(self.tokenizer.chat_template, str):

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -102,7 +102,6 @@ class HFLM(TemplateLM):
         use_fast_tokenizer: Optional[bool] = True,
         add_bos_token: Optional[bool] = False,
         prefix_token_id: Optional[int] = None,
-        chat_template_definition: Optional[bool | str] = None,
         # arguments used for splitting a model across GPUs naively.
         # only used if `parallelize=True`.
         parallelize: Optional[bool] = False,
@@ -272,7 +271,6 @@ class HFLM(TemplateLM):
         self.batch_schedule = 1
         self.batch_sizes = {}
         self.max_batch_size = max_batch_size
-        self.chat_template_definition = chat_template_definition
 
         if str(batch_size).startswith("auto"):
             batch_size = batch_size.split(":")
@@ -404,36 +402,41 @@ class HFLM(TemplateLM):
     def tokenizer_name(self) -> str:
         return self.tokenizer.name_or_path.replace("/", "__")
 
-    @property
-    def chat_template(self) -> str:
+    def chat_template(self, chat_template: Optional[bool | str] = True) -> str:
         """
-        Returns the appropriate chat template for the model,
-        ensuring reproducibility by explicitly saving which template was used.
+        Get the appropriate chat template for the model based on configuration and input.
+        This method determines, and returns the correct chat template, ensuring reproducibility.
 
-        The logic for determining the correct chat template is adapted from the Transformers library,
-        it reflects how it is handled in the `apply_chat_template` method in the Tokenizer class.
-        The original code can be found at:
+        The template selection logic is adapted from the Transformers library's `apply_chat_template`
+        method in the Tokenizer class. The original implementation can be found at:
         https://github.com/huggingface/transformers/blob/fc35907f95459d7a6c5281dfadd680b6f7b620e3/src/transformers/tokenization_utils_base.py#L1687
 
         This method ensures that the right template is chosen based on the following:
-
-        1. If the model's tokenizer has a dictionary of multiple templates:
-            - If a template name is specified and exists in the dictionary, use that template.
-            - If no template name is specified, use the default template from the dictionary.
-            - Raise an error if no default template is found and no specific template is specified.
-
+        1. If the model's tokenizer has multiple templates:
+            a. Use the specified template if it exists in the dictionary.
+            b. Use the default template if no specific template is provided.
+            c. Raise an error if no default template exists and no specific template is specified.
         2. If the model's tokenizer has a single template or no template:
-            - Use the tokenizer's chat template if available.
-            - If no tokenizer chat template is available, use the default chat template.
+            a. Use the tokenizer's chat template if available.
+            b. Fall back to the default chat template if no tokenizer chat template exists.
+
+        Args:
+            chat_template (Optional[Union[bool, str]]): Specifies the chat template to use.
+                - If True (default), use the default template.
+                - If False or None, no template is applied (handled externally).
+                - If a string, use the template with the matching name.
 
         Returns:
-            str: The chat template to be used for the model.
+            str: The selected chat template.
         """
-        # This method won't be called if the self.chat_template_definition is False or None
-        if isinstance(self.chat_template_definition, bool):
+        # This method should not be called if the chat_template argument is None or False
+        if chat_template is False or chat_template is None:
+            raise ValueError(
+                "Chat template method should not be called with chat_template=None or chat_template=False."
+            )
+        # Handle the case where chat_template is a boolean (True)
+        if isinstance(chat_template, bool):
             chat_template = None
-        else:
-            chat_template = self.chat_template_definition
         using_default_template = False
 
         # First, handle the cases when the model has a dict of multiple templates

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -416,7 +416,7 @@ class HFLM(TemplateLM):
         This method ensures that the right template is chosen based on the following:
         1. If the model's tokenizer has multiple templates:
             a. Use the specified template if it exists in the dictionary.
-            b. Use the default template from the list of templates if no specific template is provided.
+            b. Use the default template from the list if no specific template is provided.
             c. Raise an error if no default template exists and no specific template is provided.
         2. If the model's tokenizer has a single template or no template:
             a. Use the tokenizer's chat template if available.

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -418,8 +418,8 @@ class HFLM(TemplateLM):
         This method ensures that the right template is chosen based on the following:
 
         1. If the model's tokenizer has a dictionary of multiple templates:
-            - If a chat template is specified and exists in the dictionary, use that template.
-            - If no template is specified, use the default template from the dictionary.
+            - If a template name is specified and exists in the dictionary, use that template.
+            - If no template name is specified, use the default template from the dictionary.
             - Raise an error if no default template is found and no specific template is specified.
 
         2. If the model's tokenizer has a single template or no template:
@@ -437,41 +437,39 @@ class HFLM(TemplateLM):
         using_default_template = False
 
         # First, handle the cases when the model has a dict of multiple templates
-        if isinstance(self.tokenizer.chat_template, dict) or (
-            self.tokenizer.chat_template is None
-            and isinstance(self.tokenizer.default_chat_template, dict)
-        ):
-            if self.tokenizer.chat_template is not None:
-                template_dict = self.tokenizer.chat_template
-                using_default_dict = False
+        template = self.tokenizer.chat_template or self.tokenizer.default_chat_template
+
+        if isinstance(template, dict):
+            using_default_dict = self.tokenizer.chat_template is None
+
+            if chat_template is not None:
+                if chat_template in template:
+                    chat_template = template[chat_template]
+                    if using_default_dict:
+                        using_default_template = True
+                else:
+                    raise ValueError(
+                        f"The specified chat template '{chat_template}' is not available. "
+                        f"Available template names are {sorted(template.keys())}."
+                    )
             else:
-                template_dict = self.tokenizer.default_chat_template
-                using_default_dict = True
-            if chat_template is not None and chat_template in template_dict:
-                # The user can pass the name of a template to the chat template argument instead of an entire template
-                chat_template = template_dict[chat_template]
-                if using_default_dict:
-                    using_default_template = True
-            elif chat_template is None:
                 # If user didn't pass a chat template, use the default template from the dict
-                if "default" in template_dict:
-                    chat_template = template_dict["default"]
+                if "default" in template:
+                    chat_template = template["default"]
+                    using_default_template = True
                 else:
                     raise ValueError(
                         "This model has multiple chat templates with no default specified! Please either pass a chat "
                         "template or the name of the template you wish to use to the `chat_template` argument. Available "
-                        f"template names are {sorted(template_dict.keys())}."
+                        f"template names are {sorted(template.keys())}."
                     )
-                if using_default_dict:
-                    using_default_template = True
 
-        # This is the case when model chat template is not specified
-        elif chat_template is not None and chat_template:
-            # These are the cases when the model has a single template
+        # These are the cases when the model has a single template or no template
+        else:
             # priority: `chat_template` argument > `tokenizer.chat_template` > `tokenizer.default_chat_template
-            if isinstance(self.tokenizer.chat_template, str):
+            if isinstance(chat_template, str):
                 eval_logger.warning(
-                    "Specified chat template is a string, but the tokenizer chat template is not a dictionary. "
+                    "Chat template name provided, but the tokenizer's chat template is not a dictionary. "
                     "Using the tokenizer's chat template or the default template instead."
                 )
             if self.tokenizer.chat_template is not None:


### PR DESCRIPTION
This PR adds support for models with multiple chat templates, such as [Cohere Command R+](https://huggingface.co/CohereForAI/c4ai-command-r-plus/blob/eebd6029879e9d11fa6b40a0d4c5e88708940003/tokenizer_config.json#L304-L316), addressing issue https://github.com/EleutherAI/lm-evaluation-harness/issues/1962.

The command line API has been updated to reuse an existing flag to specify the template name, while preserving backward compatibility:

```bash
--apply_chat_template {template_name}
```

@haileyschoelkopf Let me know if anything needs updating! :)

cc @clefourrier @NathanHB