### PR TITLE
Fix `loglikelihood_rolling` caching ( #1821 )

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -284,7 +284,7 @@ class CachingLM:
                 f"Cached requests: {len(requests) - len(remaining_reqs)}, Requests remaining: {len(remaining_reqs)}"
             )
             if remaining_reqs:
-            # actually run the LM on the requests that do not have cached results
+                # actually run the LM on the requests that do not have cached results
                 rem_res = getattr(self.lm, attr)(remaining_reqs)
             else:
                 rem_res = []

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -283,8 +283,11 @@ class CachingLM:
             eval_logger.info(
                 f"Cached requests: {len(requests) - len(remaining_reqs)}, Requests remaining: {len(remaining_reqs)}"
             )
+            if remaining_reqs:
             # actually run the LM on the requests that do not have cached results
-            rem_res = getattr(self.lm, attr)(remaining_reqs)
+                rem_res = getattr(self.lm, attr)(remaining_reqs)
+            else:
+                rem_res = []
 
             # stick the new ones back into the list and also cache any of the new ones
             resptr = 0

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -510,7 +510,7 @@ class TemplateAPI(TemplateLM):
                 ):
                     if answer_ is not None:
                         res.append(answer_)
-                        # partial caching
+                        # cache requests that aren't from a loglikelihood_rolling request
                         if cache_key is not None:
                             self.cache_hook.add_partial(
                                 "loglikelihood", cache_key, answer_
@@ -638,4 +638,7 @@ class TemplateAPI(TemplateLM):
 
             string_nll = sum(string_nll)
             loglikelihoods.append(string_nll)
+
+            # cache this loglikelihood_rolling request
+            self.cache_hook.add_partial("loglikelihood_rolling", (string,), string_nll)
         return loglikelihoods

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -154,6 +154,7 @@ class HFLM(TemplateLM):
                     else torch.device(device)
                 )
 
+            revision = str(revision)  # cast to string if not already one
             # TODO: update this to be less of a hack once subfolder is fixed in HF
             revision = revision + ("/" + subfolder if subfolder is not None else "")
 
@@ -333,10 +334,9 @@ class HFLM(TemplateLM):
                     del max_memory_all_gpus["cpu"]
                 if not hasattr(self, "accelerator"):
                     max_memory_per_gpu_map = {
-                        k: v
-                        for k, v in max_memory_all_gpus.items()
+                        k: v for k, v in max_memory_all_gpus.items()
                     }
-                else: 
+                else:
                     # use only 1 / num_processes of the GPUs if we are running under accelerate launch
                     max_memory_per_gpu_map = {
                         k: v

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -932,6 +932,9 @@ class HFLM(TemplateLM):
             string_nll = sum(string_nll)
             loglikelihoods.append(string_nll)
 
+            # cache this loglikelihood_rolling request
+            self.cache_hook.add_partial("loglikelihood_rolling", (string,), string_nll)
+
         return loglikelihoods
 
     def _batch_scheduler(self, pos, n_reordered_requests):
@@ -1160,11 +1163,13 @@ class HFLM(TemplateLM):
 
                     res.append(answer)
 
-                    if request_str is None:
-                        # special case: loglikelihood_rolling inputs condition on None.
-                        # cache this as empty string instead of NoneType
-                        request_str = ""
-                    self.cache_hook.add_partial("loglikelihood", request_str, answer)
+                    if request_str is not None:
+                        # special case: loglikelihood_rolling produces a number of loglikelihood requests
+                        # all with cache key None. instead do add_partial on the per-example level
+                        # in the loglikelihood_rolling() function for those.
+                        self.cache_hook.add_partial(
+                            "loglikelihood", request_str, answer
+                        )
                     pbar.update(1)
 
         pbar.close()

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1160,6 +1160,10 @@ class HFLM(TemplateLM):
 
                     res.append(answer)
 
+                    if request_str is None:
+                        # special case: loglikelihood_rolling inputs condition on None.
+                        # cache this as empty string instead of NoneType
+                        request_str = ""
                     self.cache_hook.add_partial("loglikelihood", request_str, answer)
                     pbar.update(1)
 

--- a/lm_eval/models/nemo_lm.py
+++ b/lm_eval/models/nemo_lm.py
@@ -467,8 +467,11 @@ class NeMoLM(LM):
                     is_greedy = is_greedy.all()
                 answer = (logprob, is_greedy)
 
-                if cache_key is not None:
-                    self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                if cache_key is None:
+                    # special case: loglikelihood_rolling inputs condition on None.
+                    # cache this as empty string instead of NoneType
+                    cache_key = ""
+                self.cache_hook.add_partial("loglikelihood", cache_key, answer)
 
                 res.append(answer)
                 pbar.update(1)

--- a/lm_eval/models/neuralmagic.py
+++ b/lm_eval/models/neuralmagic.py
@@ -320,8 +320,11 @@ class DeepSparseLM(LM):
 
                 res.append(answer)
 
-                if cache_key is not None:
-                    self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                if cache_key is None:
+                    # special case: loglikelihood_rolling inputs condition on None.
+                    # cache this as empty string instead of NoneType
+                    cache_key = ""
+                self.cache_hook.add_partial("loglikelihood", cache_key, answer)
 
         return re_ord.get_original(res)
 

--- a/lm_eval/models/neuralmagic.py
+++ b/lm_eval/models/neuralmagic.py
@@ -320,11 +320,11 @@ class DeepSparseLM(LM):
 
                 res.append(answer)
 
-                if cache_key is None:
-                    # special case: loglikelihood_rolling inputs condition on None.
-                    # cache this as empty string instead of NoneType
-                    cache_key = ""
-                self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                if cache_key is not None:
+                    # special case: loglikelihood_rolling produces a number of loglikelihood requests
+                    # all with cache key None. instead do add_partial on the per-example level
+                    # in the loglikelihood_rolling() function for those.
+                    self.cache_hook.add_partial("loglikelihood", cache_key, answer)
 
         return re_ord.get_original(res)
 

--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -231,6 +231,7 @@ class NEURON_HF(TemplateLM):
             " For inf2.48xlarge, set it to `24`."
         )
 
+        revision = str(revision)  # cast to string if not already one
         # TODO: update this to be less of a hack once subfolder is fixed in HF
         revision = revision + ("/" + subfolder if subfolder is not None else "")
 

--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -620,6 +620,10 @@ class NEURON_HF(TemplateLM):
 
                 res.append(answer)
 
+                if cache_key is None:
+                    # special case: loglikelihood_rolling inputs condition on None.
+                    # cache this as empty string instead of NoneType
+                    cache_key = ""
                 self.cache_hook.add_partial("loglikelihood", cache_key, answer)
 
         return re_ord.get_original(res)

--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -502,7 +502,8 @@ class NEURON_HF(TemplateLM):
 
             string_nll = sum(string_nll)
             loglikelihoods.append(string_nll)
-
+            # cache this loglikelihood_rolling request
+            self.cache_hook.add_partial("loglikelihood_rolling", (string,), string_nll)
         return loglikelihoods
 
     def _loglikelihood_tokens(
@@ -620,11 +621,11 @@ class NEURON_HF(TemplateLM):
 
                 res.append(answer)
 
-                if cache_key is None:
-                    # special case: loglikelihood_rolling inputs condition on None.
-                    # cache this as empty string instead of NoneType
-                    cache_key = ""
-                self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                if cache_key is not None:
+                    # special case: loglikelihood_rolling produces a number of loglikelihood requests
+                    # all with cache key None. instead do add_partial on the per-example level
+                    # in the loglikelihood_rolling() function for those.
+                    self.cache_hook.add_partial("loglikelihood", cache_key, answer)
 
         return re_ord.get_original(res)
 

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -453,9 +453,11 @@ class VLLM(TemplateLM):
 
                 res.append(answer)
 
-                # partial caching
-                if cache_key is not None:
-                    self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                if cache_key is None:
+                    # special case: loglikelihood_rolling inputs condition on None.
+                    # cache this as empty string instead of NoneType
+                    cache_key = ""
+                self.cache_hook.add_partial("loglikelihood", cache_key, answer)
                 pbar.update(1)
         pbar.close()
         return re_ord.get_original(res)


### PR DESCRIPTION
This PR should fix the caching of `None`-input requests, which was preventing PPL tasks like `wikitext` from working. 

cc @baberabb since you wrote the `# partial caching` comment in vllm just to clarify that there was not a reason, beyond circumventing the NoneType error, to avoid caching such requests?
I think this can also be applied to api_models.py , unless you see a compelling reason why not.