### PR TITLE
Update IFEval dataset to official one

### DIFF
--- a/lm_eval/tasks/ifeval/ifeval.yaml
+++ b/lm_eval/tasks/ifeval/ifeval.yaml
@@ -1,5 +1,5 @@
 task: ifeval
-dataset_path: wis-k/instruction-following-eval
+dataset_path: google/IFEval
 dataset_name: null
 output_type: generate_until
 test_split: train

--- a/lm_eval/tasks/ifeval/ifeval.yaml
+++ b/lm_eval/tasks/ifeval/ifeval.yaml
@@ -26,4 +26,4 @@ metric_list:
     aggregation: !function utils.agg_inst_level_acc
     higher_is_better: true
 metadata:
-  version: 2.0
+  version: 3.0


### PR DESCRIPTION
This PR updates the IFEval dataset to the one hosted under the Google org: https://huggingface.co/datasets/google/IFEval

Note the main change is an updated prompt from this commit in the GitHub repo: https://github.com/google-research/google-research/commit/26d8ccdab6fec61b5c83ad6327ea8bda9e580288