### PR TITLE
add dolomite-engine support for lm-eval-harness

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -36,6 +36,13 @@ from lm_eval.models.utils import (
     stop_sequences_criteria,
 )
 
+try:
+    # import for using dolomite_engine models in lm-eval directly
+    # https://github.com/ibm-granite/dolomite-engine
+    import dolomite_engine.hf_models
+except:
+    pass
+
 
 eval_logger = utils.eval_logger
 


### PR DESCRIPTION
Dolomite Engine is the repository used by IBM's genAI team for pretraining and finetuning LLMs.
We would highly appreciate if we can natively add support in lm-eval-harness for evaluating models trained with this repo.

All it requires is the import statement.