### PR TITLE
fix the regex string in mmlu_pro template

### DIFF
--- a/lm_eval/api/samplers.py
+++ b/lm_eval/api/samplers.py
@@ -82,8 +82,9 @@ class ContextSampler:
                 if self.config.doc_to_choice is None or isinstance(doc_content, str)
                 else self.doc_to_choice(doc)[doc_content]
             )
-            labeled_examples += self.target_delimiter
+
             if doc_target != "":
+                labeled_examples += self.target_delimiter
                 labeled_examples += (
                     str(doc_target[0])
                     if isinstance(doc_target, list)

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -12,7 +12,7 @@ filter_list:
   - name: "custom-extract"
     filter:
       - function: "regex"
-        regex_pattern: r"answer is \(?([ABCDEFGHIJ])\)?"
+        regex_pattern: 'answer is \(?([ABCDEFGHIJ])\)?'
         # regex_pattern: r".*[aA]nswer:\s*([A-J])",
       - function: "take_first"
 generation_kwargs:


### PR DESCRIPTION
After this fixing for issue #2237 , I can get the score.

Command
```
lm_eval --model hf     --model_args pretrained=meta-llama/Meta-Llama-3.1-8B-Instruct --tasks mmlu_pro_biology --batch_size auto --gen_kwargs max_gen_toks=512,do_sample=true,temperature=0.6,max_length=2048 --limit 5 --num_fewshot 5 --output_path ~/trtllm/lm_eval/output_820 --write_out --log_samples --apply_chat_template

f (pretrained=meta-llama/Meta-Llama-3.1-8B-Instruct), gen_kwargs: (max_gen_toks=512,do_sample=true,temperature=0.6,max_length=2048), limit: 5.0, num_fewshot: 5, batch_size: auto
| Tasks |Version|    Filter    |n-shot|  Metric   |   |Value|   |Stderr|
|-------|------:|--------------|-----:|-----------|---|----:|---|-----:|
|biology|      0|custom-extract|     5|exact_match|↑  |  0.8|±  |   0.2|
```
