### PR TITLE
Fix logging when resizing embedding layer in peft mode

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -688,10 +688,10 @@ class HFLM(TemplateLM):
                     raise AssertionError("load_in_4bit requires peft >= 0.4.0")
             if self._model.config.vocab_size != len(self.tokenizer):
                 # resize model for LoRAs with added tokens
-                self._model.resize_token_embeddings(len(self.tokenizer))
                 eval_logger.info(
                     f"Model config indicates vocab_size='{self._model.config.vocab_size}', but found tokenizer with vocab size '{len(self.tokenizer)}'. Resizing model embedding layer..."
                 )
+                self._model.resize_token_embeddings(len(self.tokenizer))
             self._model = PeftModel.from_pretrained(
                 self._model, peft, revision=revision
             )


### PR DESCRIPTION
The logging after a resize in peft mode happens with the *new* config, not the old one. So it will always log something like:

```
INFO:lm-eval:Model config indicates vocab_size='41510', but found tokenizer with vocab size '41510'. Resizing model embedding layer...
```

Even though the original `vocab_size` was 32000, for example.

This PR fixes this by moving the logging up so it uses the correct config.