### PR TITLE
fix group args of mmlu and mmlu_pro

### DIFF
--- a/lm_eval/tasks/mmlu/generative/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/generative/_mmlu.yaml
@@ -26,7 +26,8 @@ task:
       - metric: acc
         weight_by_size: True
 aggregate_metric_list:
-  - metric: acc
+  - aggregation: mean
+    metric: exact_match
     weight_by_size: True
 metadata:
   version: 2

--- a/lm_eval/tasks/mmlu_pro/_mmlu_pro.yaml
+++ b/lm_eval/tasks/mmlu_pro/_mmlu_pro.yaml
@@ -1,0 +1,23 @@
+group: mmlu_pro
+task:
+  - mmlu_pro_biology
+  - mmlu_pro_business
+  - mmlu_pro_chemistry
+  - mmlu_pro_computer_science
+  - mmlu_pro_economics
+  - mmlu_pro_engineering
+  - mmlu_pro_health
+  - mmlu_pro_history
+  - mmlu_pro_law
+  - mmlu_pro_math
+  - mmlu_pro_other
+  - mmlu_pro_philosophy
+  - mmlu_pro_physics
+  - mmlu_pro_psychology
+aggregate_metric_list:
+  - aggregation: mean
+    metric: exact_match
+    weight_by_size: true
+    filter_list: custom-extract
+metadata:
+  version: 1.0


### PR DESCRIPTION
1. Fix the bug related to outputting information about group results for MMLU (generative).
When I run the 'mmlu_generative' dataset, the group score does not produce any output.
```
|Groups|Version|Filter|n-shot|Metric|   |Value|   |Stderr|
|------|-------|------|------|------|---|-----|---|------|
```
After fixing:
```
|     Groups      |Version|Filter|n-shot|  Metric   |   |Value|   |Stderr|
|-----------------|------:|------|------|-----------|---|----:|---|-----:|
|mmlu (generative)|      2|none  |      |exact_match|↑  |0.007|±  |0.0034|
```
2. Add the group configuration for the MMLU Pro dataset.
