### PR TITLE
Minor features

### DIFF
--- a/lm_eval/api/filter.py
+++ b/lm_eval/api/filter.py
@@ -20,7 +20,9 @@ class Filter(ABC):
         """
 
     @abstractmethod
-    def apply(self, resps: Union[List, Iterable], docs: List[dict]) -> Iterable:
+    def apply(
+        self, resps: Union[List, Iterable], docs: List[dict], **kwargs
+    ) -> Iterable:
         """
         Defines the operation to perform on a list of the `inst.resps` properties of `Instance` objects.
         Should return the list of (filtered) response lists *in the same order as they were input*, e.g.
@@ -42,13 +44,13 @@ class FilterEnsemble:
     name: str
     filters: List[Callable[[], Filter]]
 
-    def apply(self, instances: List[Instance]) -> None:
+    def apply(self, instances: List[Instance], **kwargs) -> None:
         resps, docs = zip(*((inst.resps, inst.doc) for inst in instances))
         resps, docs = list(resps), list(docs)
 
         for f in self.filters:
             # apply filters in sequence
-            resps = f().apply(resps, docs)
+            resps = f().apply(resps, docs, **kwargs)
 
         # add the end results after filtering to filtered_requests of their respective source instances.
         # has key `self.name`: each FilterEnsemble applied in a given run should use a different name.

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -60,6 +60,30 @@ def f1_score(items):
     return np.max(fscore)
 
 
+@register_aggregation("f1_macro")
+def f1_macro_score(items):
+    from sklearn.metrics import f1_score
+
+    unzipped_list = list(zip(*items))
+    golds = unzipped_list[0]
+    preds = unzipped_list[1]
+    fscore = f1_score(golds, preds, average="macro")
+
+    return np.max(fscore)
+
+
+@register_aggregation("f1_micro")
+def f1_micro_score(items):
+    from sklearn.metrics import f1_score
+
+    unzipped_list = list(zip(*items))
+    golds = unzipped_list[0]
+    preds = unzipped_list[1]
+    fscore = f1_score(golds, preds, average="micro")
+
+    return np.max(fscore)
+
+
 @register_aggregation("matthews_corrcoef")
 def matthews_corrcoef(items):
     from sklearn.metrics import matthews_corrcoef
@@ -316,6 +340,26 @@ def mcc_fn(items):  # This is a passthrough function
     aggregation="f1",
 )
 def f1_fn(items):  # This is a passthrough function
+    return items
+
+
+@register_metric(
+    metric="f1_macro",
+    higher_is_better=True,
+    output_type="multiple_choice",
+    aggregation="f1_macro",
+)
+def f1_macro_fn(items):  # This is a passthrough function
+    return items
+
+
+@register_metric(
+    metric="f1_micro",
+    higher_is_better=True,
+    output_type="multiple_choice",
+    aggregation="f1_micro",
+)
+def f1_micro_fn(items):  # This is a passthrough function
     return items
 
 

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -612,11 +612,11 @@ class Task(abc.ABC):
         example = self.doc_to_text(doc)
         return description + labeled_examples + example
 
-    def apply_filters(self) -> Optional[List[Instance]]:
+    def apply_filters(self, **kwargs) -> Optional[List[Instance]]:
         """Iterates over FilterEnsembles and applies them to instances"""
         if hasattr(self, "_filters"):
             for f in self._filters:
-                f.apply(self._instances)
+                f.apply(self._instances, **kwargs)
         else:
             eval_logger.warning("No filter defined, passing through instances")
             return self._instances
@@ -1131,11 +1131,11 @@ class ConfigurableTask(Task):
                 else:
                     return labeled_examples + str(example)
 
-    def apply_filters(self):
+    def apply_filters(self, **kwargs):
         """Iterates over FilterEnsembles and applies them to instances"""
         if hasattr(self, "_filters"):
             for f in self._filters:
-                f.apply(self._instances)
+                f.apply(self._instances, **kwargs)
         else:
             eval_logger.warning("No filter defined, passing through instances")
             return self._instances

--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -25,7 +25,7 @@ class RegexFilter(Filter):
         self.group_select = group_select
         self.fallback = fallback
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         # here, we assume we have a list, in which each element is
         # a list of model responses for some particular input/target pair.
         # so we process each of these (same input/target response sets)
@@ -58,7 +58,7 @@ class WhitespaceFilter(Filter):
     def __init__(self) -> None:
         pass
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def filter_set(inst):
             filtered_resp = []
             for resp in inst:
@@ -103,7 +103,7 @@ class MultiChoiceRegexFilter(RegexFilter):
         self.ignore_punctuation = ignore_punctuation
         self.regexes_to_ignore = regexes_to_ignore
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         # here, we assume we have a list, in which each element is
         # a list of model responses for some particular input/target pair.
         # so we process each of these (same input/target response sets)

--- a/lm_eval/filters/selection.py
+++ b/lm_eval/filters/selection.py
@@ -16,7 +16,7 @@ class TakeFirstFilter(Filter):
         Can define custom behavior here, if an individual instantiation of a Filter class should have state.
         """
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         """
         Assuming each entry of `resps` is a list of model responses, we discard all but the first response.
         """
@@ -30,7 +30,7 @@ class TakeKFilter(Filter):
 
         super().__init__(**kwargs)
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         # need resp to be subscriptable to check below
         resps = list(resps)
         # check we have at least k responses per doc, else we can't take the first k
@@ -47,7 +47,7 @@ class MajorityVoteFilter(Filter):
         Can define custom behavior here, if an individual instantiation of a Filter class should have state.
         """
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         """
         Each entry of `resps` is a list of model responses.
         We select the response that occurs most frequently in each entry of `resps`.

--- a/lm_eval/filters/transformation.py
+++ b/lm_eval/filters/transformation.py
@@ -7,7 +7,7 @@ class LowercaseFilter(Filter):
     def __init__(self) -> None:
         pass
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def filter_set(inst):
             return [resp.lower() for resp in inst]
 
@@ -19,7 +19,7 @@ class UppercaseFilter(Filter):
     def __init__(self) -> None:
         pass
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def filter_set(inst):
             return [resp.upper() for resp in inst]
 
@@ -49,7 +49,7 @@ class MapFilter(Filter):
         self.mapping_dict = mapping_dict
         self.default_value = default_value
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def filter_set(inst):
             return [self.mapping_dict.get(resp, self.default_value) for resp in inst]
 


### PR DESCRIPTION
Features:
- disable `fewshot_as_multiturn` when `apply_chat_template` is not passed or `num_fewshots=0`. Why failing the run? For zero-shot setup multiturn==simple chat template, so no error at all. If chat_template is not enabled, then throw warning and disable multiturn (as long as it is not available without chat_template)
- pass predict_only into filters apply method. Why? The filters are designed to be used even with additional ML models (reward, for example). Then if one runs lm-eval with `predict_only` this may mean that the filter is not to be used. No user may customize filters to use `predict_only` info to manage filters behaviour
- add `filter_device` param from cli. There was a TODO about it. If I use another LLM as a filter, I may need to pass device that DIFFERS from one used to run the "main" LLM. Like llm-as-a-judge or LLMs to score the generations
- disable `ensure_ascii` for `apply_chat_template` method of TemplateAPI class. Now cyrillic symbols are stored in a valid form
- add f1_macro and f1_micro metrics (aggregations in fact) to register to handle multi-class classification tasks
- new param into model_args for APIs - timeout. When running vLLM server and using lm-eval in OpenAI API mode to make requests into this server, timeout may be increased (like to run Llama-3.1-405B, for me I had lots of connection errors, that have been solved by increasing the timeout param)