### PR TITLE
Free space allocated for LM in the memory after evaluation finishes

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -358,11 +358,15 @@ def simple_evaluate(
         add_env_info(results)  # additional environment info to results
         add_tokenizer_info(results, lm)  # additional info about tokenizer
         
-        del lm
+        if not isinstance(model, lm_eval.api.model.LM): 
+            del lm
+        
         return results
     else:
         
-        del lm
+        if not isinstance(model, lm_eval.api.model.LM):
+            del lm
+        
         return None
 
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -357,8 +357,12 @@ def simple_evaluate(
         results["date"] = start_date
         add_env_info(results)  # additional environment info to results
         add_tokenizer_info(results, lm)  # additional info about tokenizer
+        
+        del lm
         return results
     else:
+        
+        del lm
         return None
 
 


### PR DESCRIPTION
Deletes **lm** object after simple_evaluate function finishes

Then, memory space can be easily freed as following: 
1. Free cache using Pytorch or TensorFlow (Depending on the model):
  - `tf.keras.backend.clear_session()` **for TensorFlow**
  - `torch.cuda.empty_cache()` **for Pytorch**

2. Garbage Collector 
  - **import gc**
  - `gc.collect()`

Important when multiple models are tested sequentially.