### PR TITLE
Mathvista

### DIFF
--- a/lm_eval/tasks/ai2d/ai2d.yaml
+++ b/lm_eval/tasks/ai2d/ai2d.yaml
@@ -1,0 +1,16 @@
+task: ai2d
+dataset_path: lmms-lab/ai2d
+output_type: multiple_choice
+test_split: test
+doc_to_text: "<image> Question: {{question}}\nAnswer:"
+doc_to_target: "answer"
+doc_to_choice: "{{options}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mathvista/mathvista.yaml
+++ b/lm_eval/tasks/mathvista/mathvista.yaml
@@ -1,0 +1,18 @@
+dataset_path: AI4Math/MathVista
+task: mathvista_mcq
+test_split: testmini
+output_type: "greedy_until"
+process_docs: !function utils.process_docs
+doc_to_image: !function utils.doc_to_image
+doc_to_text: "<image> {{query}}"
+#doc_to_choice: '{{ ["A", "B", "C", "D", "E", "F"][:choices.length] }}'
+doc_to_target: answer
+process_results: !function utils.process_results
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/mathvista/mathvista.yaml
+++ b/lm_eval/tasks/mathvista/mathvista.yaml
@@ -3,7 +3,8 @@ task: mathvista
 test_split: testmini
 output_type: "generate_until"
 #process_docs: !function utils.process_docs
-doc_to_image: decoded_image
+doc_to_image:
+  - decoded_image
 doc_to_text: "<image> {{query}}"
 #doc_to_choice: '{{ ["A", "B", "C", "D", "E", "F"][:choices.length] }}'
 doc_to_target: answer

--- a/lm_eval/tasks/mathvista/mathvista.yaml
+++ b/lm_eval/tasks/mathvista/mathvista.yaml
@@ -1,13 +1,19 @@
 dataset_path: AI4Math/MathVista
-task: mathvista_mcq
+task: mathvista
 test_split: testmini
-output_type: "greedy_until"
-process_docs: !function utils.process_docs
-doc_to_image: !function utils.doc_to_image
+output_type: "generate_until"
+#process_docs: !function utils.process_docs
+doc_to_image: decoded_image
 doc_to_text: "<image> {{query}}"
 #doc_to_choice: '{{ ["A", "B", "C", "D", "E", "F"][:choices.length] }}'
 doc_to_target: answer
 process_results: !function utils.process_results
+generation_kwargs:
+  until:
+    - "<|endoftext|>"
+  temperature: 0.0
+  do_sample: false
+  max_gen_toks: 64
 metric_list:
   - metric: acc
     aggregation: mean

--- a/lm_eval/tasks/mathvista/utils.py
+++ b/lm_eval/tasks/mathvista/utils.py
@@ -1,0 +1,124 @@
+import re
+
+from Levenshtein import distance
+
+
+# taken from https://github.com/lupantech/MathVista/blob/main/evaluation/calculate_score.py
+def get_most_similar(prediction: str, choices: list):
+    """
+    Use the Levenshtein distance (or edit distance) to determine which of the choices is most similar to the given prediction
+    """
+    distances = [distance(prediction, choice) for choice in choices]
+    ind = distances.index(min(distances))
+    return choices[ind]
+    # return min(choices, key=lambda choice: distance(prediction, choice))
+
+
+def normalize_extracted_answer(
+    extraction,
+    choices: list,
+    question_type: str,
+    answer_type: str,
+    precision,
+    ignore_empty_extractions=False,
+):
+    """
+    Normalize the extracted answer to match the answer type
+    """
+    if question_type == "multi_choice":
+        # make sure the extraction is a string
+        if isinstance(extraction, str):
+            extraction = extraction.strip()
+        else:
+            try:
+                extraction = str(extraction)
+            except Exception:
+                extraction = ""
+
+        # if the extraction is empty, return None
+        if ignore_empty_extractions and not extraction:
+            return None
+
+        # extract "A" from "(A) text"
+        letter = re.findall(r"\(([a-zA-Z])\)", extraction)
+        if len(letter) > 0:
+            extraction = letter[0].upper()
+
+        sequential_characters = [chr(ord("A") + i) for i in range(len(choices))]
+
+        # if model output a character, use it as index of available choices
+        if extraction in sequential_characters:
+            option_index = sequential_characters.index(extraction)
+            normalized_extraction = choices[option_index]
+        else:
+            # select the most similar option
+            normalized_extraction = get_most_similar(extraction, choices)
+        assert normalized_extraction in choices
+
+    elif answer_type == "integer":
+        try:
+            normalized_extraction = str(int(float(extraction)))
+        except Exception:
+            normalized_extraction = None
+
+    elif answer_type == "float":
+        try:
+            normalized_extraction = str(round(float(extraction), precision))
+        except Exception:
+            normalized_extraction = None
+
+    elif answer_type == "list":
+        try:
+            normalized_extraction = str(extraction)
+        except Exception:
+            normalized_extraction = None
+
+    return normalized_extraction
+
+
+def safe_equal(prediction, answer):
+    """
+    Check if the prediction is equal to the answer, even if they are of different types
+    """
+    try:
+        if prediction == answer:
+            return True
+        return False
+    except Exception:
+        return False
+
+
+def get_acc_with_contion(res_pd, key, value):
+    if key == "skills":
+        total_pd = res_pd[res_pd[key].apply(lambda x: value in x)]
+    else:
+        total_pd = res_pd[res_pd[key] == value]
+
+    correct_pd = total_pd[total_pd["true_false"] == True]  # noqa: E712
+    acc = len(correct_pd) / len(total_pd)
+
+    return len(correct_pd), len(total_pd), acc
+
+
+# adapted from https://github.com/lupantech/MathVista/blob/main/evaluation/extract_answer.py
+def process_results(doc, results):
+    response = results[0]
+    choices = doc["choices"]
+    question_type = doc["question_type"]
+    answer_type = doc["answer_type"]
+    precision = doc["precision"]  # noqa: F841
+    extraction = doc["extraction"]  # noqa: F841
+    if question_type == "multi_choice" and response in choices:
+        return {"acc": 1.0}
+    if answer_type == "integer":
+        try:
+            extraction = int(response)
+            return str(extraction)
+        except Exception:
+            pass
+    if answer_type == "float":
+        try:
+            extraction = str(float(response))
+            return extraction
+        except Exception:
+            pass

--- a/lm_eval/tasks/mathvista/utils.py
+++ b/lm_eval/tasks/mathvista/utils.py
@@ -101,6 +101,12 @@ def extract_answer(response: str, problem: dict) -> str:
     if response == "":
         return ""
 
+    ### This is not in the original code:
+    extract = re.findall(r"[tT]he answer is (\d+)", response)
+    if extract:
+        return str(extract[0])
+    ###
+
     if question_type == "multi_choice" and response in choices:
         return response
 

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -499,3 +499,40 @@ def weighted_f1_score(items):
     preds = unzipped_list[1]
     fscore = f1_score(golds, preds, average="weighted")
     return fscore
+
+
+def add_padding_if_needed(
+    images: List["PIL.Image.Image"],  # noqa: F821
+    min_width: int = 50,
+    min_height: int = 50,
+    color=(255, 255, 255),
+) -> List["PIL.Image.Image"]:  # noqa: F821
+    """Adds (default white) padding to images to make them at least min_width and min_height"""
+    from PIL import ImageOps
+
+    res = []
+    for image in images:
+        width, height = image.size
+
+        if width >= min_width and height >= min_height:
+            return image
+        image = image.convert("RGB")
+        new_width = max(width, min_width)
+        new_height = max(height, min_height)
+
+        delta_width = new_width - width
+        delta_height = new_height - height
+
+        padding_left = delta_width // 2
+        padding_right = delta_width - padding_left
+        padding_top = delta_height // 2
+        padding_bottom = delta_height - padding_top
+        res.append(
+            ImageOps.expand(
+                image,
+                (padding_left, padding_top, padding_right, padding_bottom),
+                fill=color,
+            )
+        )
+
+    return res


### PR DESCRIPTION
added mathvisata. Couple of issues:
1. The Qwen processor errors out if an image_dimension < 28 (defaults to `do_resize=True` and that fn requires a min). Added a padding function to handle the exception.
2. The mathvista evaluation code falls back to extracting the answer through GPT if the regex code fails. Not sure how we want to handle that.

currently scoring (0.624(ours) vs 0.632) for `llava-hf/llava-onevision-qwen2-7b-ov-hf`. For `llava-hf/llava-onevision-qwen2-7b-ov-hf` it's ~.30 vs ~0.58.