### PR TITLE
Fixed dummy model

### DIFF
--- a/lm_eval/models/dummy.py
+++ b/lm_eval/models/dummy.py
@@ -26,9 +26,9 @@ class DummyLM(LM):
     def generate_until(self, requests, disable_tqdm: bool = False):
         res = []
 
-        for ctx, _ in tqdm(requests, disable=disable_tqdm):
+        for request in tqdm(requests, disable=disable_tqdm):
             res.append("lol")
-            assert ctx.strip() != ""
+            assert request.arguments[0].strip() != ""
 
         return res
 


### PR DESCRIPTION
Currently running the dummy model gives the following error:

```
 File "/Users/amine.elhattami/workspace/lm-evaluation-harness/lm_eval/models/dummy.py", line 29, in generate_until
    for ctx, _ in tqdm(requests, disable=disable_tqdm):
        ^^^^^^
TypeError: cannot unpack non-iterable Instance object
```

The proposed fix in the PR is ported from the HF fork https://github.com/huggingface/lm-evaluation-harness/blob/d4631ea6e32537923430f9d20acdda5f67daa159/lm_eval/models/dummy.py#L26