### PR TITLE
Added metric aggregation for leaderboard tasks.

### DIFF
--- a/lm_eval/tasks/leaderboard/bbh_mc/_leaderboard_bbh.yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/_leaderboard_bbh.yaml
@@ -24,3 +24,7 @@ task:
   - leaderboard_bbh_tracking_shuffled_objects_seven_objects
   - leaderboard_bbh_tracking_shuffled_objects_three_objects
   - leaderboard_bbh_web_of_lies
+aggregate_metric_list:
+  - metric: acc_norm
+    aggregation: mean
+    weight_by_size: true 

--- a/lm_eval/tasks/leaderboard/gpqa/_leaderboard_gpqa.yaml
+++ b/lm_eval/tasks/leaderboard/gpqa/_leaderboard_gpqa.yaml
@@ -3,3 +3,7 @@ task:
   - leaderboard_gpqa_diamond
   - leaderboard_gpqa_extended
   - leaderboard_gpqa_main
+aggregate_metric_list:
+  - metric: acc_norm
+    aggregation: mean
+    weight_by_size: true 

--- a/lm_eval/tasks/leaderboard/math/_leaderboard_math.yaml
+++ b/lm_eval/tasks/leaderboard/math/_leaderboard_math.yaml
@@ -7,3 +7,7 @@ task:
   - leaderboard_math_num_theory_hard
   - leaderboard_math_prealgebra_hard
   - leaderboard_math_precalculus_hard
+aggregate_metric_list:
+  - metric: exact_match
+    aggregation: mean
+    weight_by_size: true 

--- a/lm_eval/tasks/leaderboard/musr/_musr.yaml
+++ b/lm_eval/tasks/leaderboard/musr/_musr.yaml
@@ -3,3 +3,7 @@ task:
   - leaderboard_musr_murder_mysteries
   - leaderboard_musr_object_placements
   - leaderboard_musr_team_allocation
+aggregate_metric_list:
+  - metric: acc_norm
+    aggregation: mean
+    weight_by_size: true 


### PR DESCRIPTION
In the original implementation of leaderboard tasks, the metrics for all tasks except IfEval are aggregated; I believe this was lost with the changes to the grouping feature.

As a reference, below is a snippet on how the scores are currently generated on the Open LLM Leaderboard

```json
{"leaderboard_bbh": {
            "acc_norm,none": 0.5039055719493144,
            "acc_norm_stderr,none": 0.006156228088732406,
            "alias": " - leaderboard_bbh"
        },
        "leaderboard_bbh_boolean_expressions": {
            "acc_norm,none": 0.824,
            "acc_norm_stderr,none": 0.02413349752545711,
            "alias": "  - leaderboard_bbh_boolean_expressions"
        },
        "leaderboard_bbh_causal_judgement": {
            "acc_norm,none": 0.6470588235294118,
            "acc_norm_stderr,none": 0.03504019983419236,
            "alias": "  - leaderboard_bbh_causal_judgement"
        }
    }  
 ```

^^ from: https://huggingface.co/datasets/open-llm-leaderboard/macadeliccc__Samantha-Qwen-2-7B-details

While the latest version of lm-eval, reports the following:

```json
{
 "leaderboard_bbh": {
      " ": " ",
      "alias": " - leaderboard_bbh"
    },
    "leaderboard_bbh_boolean_expressions": {
      "alias": "  - leaderboard_bbh_boolean_expressions",
      "acc_norm,none": 0.484,
      "acc_norm_stderr,none": 0.03166998503010742
    },
    "leaderboard_bbh_causal_judgement": {
      "alias": "  - leaderboard_bbh_causal_judgement",
      "acc_norm,none": 0.4919786096256685,
      "acc_norm_stderr,none": 0.03665706061581778
    }
    }
   ```

This PR adds back the metric aggregation across subtasks.