### PR TITLE
squad v2: load metric with `evaluate`

### DIFF
--- a/lm_eval/tasks/squadv2/task.py
+++ b/lm_eval/tasks/squadv2/task.py
@@ -37,7 +37,9 @@ _CITATION = """
 
 
 def _squad_metric(predictions, references):
-    squad_metric = datasets.load_metric("squad_v2")
+    import evaluate
+
+    squad_metric = evaluate.load("squad_v2")
     return squad_metric.compute(predictions=predictions, references=references)
 
 


### PR DESCRIPTION
`datasets.load_metric()` has been depreciated in the newest `datasets`. Switched metric to `evaluate`

#closes #2348