### PR TITLE
Remove unnecessary space prefix

### DIFF
--- a/lm_eval/tasks/leaderboard/bbh_mc/_fewshot_template_yaml
+++ b/lm_eval/tasks/leaderboard/bbh_mc/_fewshot_template_yaml
@@ -14,3 +14,4 @@ fewshot_config:
   sampler: first_n
 metadata:
   version: 1.0
+target_delimiter: ""

--- a/lm_eval/tasks/leaderboard/gpqa/_template_yaml
+++ b/lm_eval/tasks/leaderboard/gpqa/_template_yaml
@@ -17,3 +17,4 @@ metadata:
   version: 1.0
 fewshot_config:
   sampler: first_n
+target_delimiter: ""

--- a/lm_eval/tasks/leaderboard/mmlu_pro/mmlu_pro.yaml
+++ b/lm_eval/tasks/leaderboard/mmlu_pro/mmlu_pro.yaml
@@ -15,3 +15,4 @@ metric_list:
 num_fewshot: 5
 metadata:
   version: 0.1
+target_delimiter: ""

--- a/lm_eval/tasks/leaderboard/musr/_template_yaml
+++ b/lm_eval/tasks/leaderboard/musr/_template_yaml
@@ -9,3 +9,4 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+target_delimiter: ""


### PR DESCRIPTION
This PR fixes https://github.com/EleutherAI/lm-evaluation-harness/issues/2346

As described in the issue above, this "unexpected" space causes complete collapse for some evals (e.g. MMLU-Pro), and for others it blows up scores which makes the `--tasks=leaderboard` evaluation to produce very bad results compared to the ones available in https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard

With this fix, results of Leaderboard-v2 are fully reproducible and have matching hashes (`doc_hash`, `prompt_hash`, `target_hash`) against the log files of Leaderboard-v2, which are available at:
- https://huggingface.co/datasets/open-llm-leaderboard/meta-llama__Meta-Llama-3.1-8B-Instruct-details/tree/main/meta-llama__Meta-Llama-3.1-8-Instruct
-  https://huggingface.co/datasets/open-llm-leaderboard/meta-llama__Meta-Llama-3.1-70B-Instruct-details/tree/main/meta-llama__Meta-Llama-3.1-70B-Instruct
-  https://huggingface.co/datasets/open-llm-leaderboard/meta-llama__Meta-Llama-3.1-405B-Instruct-details/tree/main/meta-llama__Meta-Llama-3.1-405B-Instruct