### PR TITLE
Solution for CSAT-QA tasks evaluation

### DIFF
--- a/lm_eval/tasks/csatqa/_default_csatqa_yaml
+++ b/lm_eval/tasks/csatqa/_default_csatqa_yaml
@@ -1,4 +1,4 @@
-dataset_path: EleutherAI/csatqa
+dataset_path: HAERAE-HUB/csatqa
 test_split: test
 output_type: multiple_choice
 process_docs: !function utils.process_docs


### PR DESCRIPTION
Hello! Thank you for your great repo..!
Here, I suggested a solution for `CSAT-QA` tasks.

CSAT-QA has 6 tasks:  `csatqa_gr`, `csatqa_li`, `csatqa_rch`, `csatqa_rcs`, `csatqa_rcss`, and `csata_wr`.
But, the tasks have an error: `dataset 'EleutherAI/csatqa' doesn't exist on the hub or cannot be accessed.`.

So, I changed the `dataset_path` in the yaml file and this works fine.

Thank you!
