### PR TITLE
fix typo bug for minerva_math

### DIFF
--- a/lm_eval/tasks/minerva_math/minerva_math_algebra.yaml
+++ b/lm_eval/tasks/minerva_math/minerva_math_algebra.yaml
@@ -1,4 +1,4 @@
-group:
+tag:
   - math_word_problems
 task: minerva_math_algebra
 dataset_path: EleutherAI/hendrycks_math


### PR DESCRIPTION
I discovered this bug while comparing the code between `hendrycks_math` and `minerva_math`. The issue prevents the evaluation process from running properly in the latter. This fix addresses the discrepancy to ensure successful evaluation for `minerva_math`.