### PR TITLE
Fix Type Hints for vLLM CausalLM model

### DIFF
--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -29,7 +29,7 @@ class Instance:
         self.task_name, self.doc_id, self.repeats = self.metadata
 
     @property
-    def args(self):
+    def args(self) -> Tuple[str, ...]:
         """
         Returns (string,) where `string` is the string to calculate loglikelihood over
         """

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -246,15 +246,15 @@ class VLLM(TemplateLM):
     @overload
     def tok_encode(
         self,
-        string: List[str],
-        left_truncate_len: Optional[int],
-        add_special_tokens: bool,
+        string: Union[List[str], Tuple[str, ...]],
+        left_truncate_len: Optional[int] = ...,
+        add_special_tokens: bool = ...,
         truncation: bool = ...,
     ) -> List[List[int]]: ...
 
     def tok_encode(
         self,
-        string: Union[str, List[str]],
+        string: Union[str, List[str], Tuple[str, ...]],
         left_truncate_len: Optional[int] = None,
         add_special_tokens: bool = False,
         truncation: bool = False,
@@ -384,7 +384,7 @@ class VLLM(TemplateLM):
         # batch tokenize contexts
         context, all_gen_kwargs = zip(*(req.args for req in requests))
         context_encoding: List[List[int]] = self.tok_encode(
-            context, add_special_tokens=self.add_bos_token
+            list(context), add_special_tokens=self.add_bos_token
         )
         requests = [
             ((a, b), c) for a, b, c in zip(context, context_encoding, all_gen_kwargs)
@@ -473,7 +473,7 @@ class VLLM(TemplateLM):
         # reorder all group of results back to original unsorted form
         return re_ords.get_original(res)
 
-    def _loglikelihood_tokens(
+    def _loglikelihood_tokens(  # type: ignore[override]
         self,
         requests: List[Tuple[Tuple[str, str], List[int], List[int]]],
         disable_tqdm: bool = False,

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -260,7 +260,7 @@ class VLLM(TemplateLM):
         truncation: bool = False,
     ) -> Union[List[int], List[List[int]]]:
         if not add_special_tokens:
-            add_special_tokens = False or self.add_bos_token
+            add_special_tokens = self.add_bos_token or False
         encoding = self.tokenizer(
             string,
             add_special_tokens=add_special_tokens,

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -365,12 +365,14 @@ class VLLM(TemplateLM):
             )
 
             # discard is_greedy
-            string_nll = sum(x[0] for x in string_nll)
+            summed_loglikelihood = sum(x[0] for x in string_nll)
 
-            loglikelihoods.append(string_nll)
+            loglikelihoods.append(summed_loglikelihood)
 
             # cache this loglikelihood_rolling request
-            self.cache_hook.add_partial("loglikelihood_rolling", (string,), string_nll)
+            self.cache_hook.add_partial(
+                "loglikelihood_rolling", (string,), summed_loglikelihood
+            )
 
         return loglikelihoods
 


### PR DESCRIPTION
There are a handful of type hints that can be improved in the VLLM model class. This PR makes those changes.

This PR does not solve all of the type hinting issues in this file, as it would require updating type hints in other places.

In the process of fixing these type errors, I also made a handful of small refactors.