### PR TITLE
fix storycloze datanames

### DIFF
--- a/lm_eval/tasks/storycloze/storycloze_2016.yaml
+++ b/lm_eval/tasks/storycloze/storycloze_2016.yaml
@@ -1,7 +1,7 @@
 tag: storycloze
 task: storycloze_2016
 dataset_path: story_cloze
-dataset_name: 2016
+dataset_name: "2016"
 output_type: multiple_choice
 validation_split: validation
 test_split: test

--- a/lm_eval/tasks/storycloze/storycloze_2018.yaml
+++ b/lm_eval/tasks/storycloze/storycloze_2018.yaml
@@ -1,7 +1,7 @@
 tag: storycloze
 task: storycloze_2018
 dataset_path: story_cloze
-dataset_name: 2018
+dataset_name: "2018"
 output_type: multiple_choice
 validation_split: validation
 test_split: test


### PR DESCRIPTION
The dataset_name fields in `lm_eval/tasks/storycloze/storycloze_2016.yaml` and `lm_eval/tasks/storycloze/storycloze_2016.yaml` are integers, which causes 
```
TypeError: argument of type 'int' is not iterable
```
FIX: convert them to strings.
