### PR TITLE
Add verify_certificate argument to local-completion

### DIFF
--- a/docs/API_guide.md
+++ b/docs/API_guide.md
@@ -91,6 +91,10 @@ When initializing a `TemplateAPI` instance or a subclass, you can provide severa
   - Custom token ID to use as a prefix for inputs.
   - If not provided, uses the model's default BOS or EOS token (if `add_bos_token` is True).
 
+- `verify_certificate` (bool, optional):
+  - Whether to validate the certificate of the API endpoint (if HTTPS).
+  - Default is True.
+
 
 Example usage:
 

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -79,6 +79,7 @@ class TemplateAPI(TemplateLM):
         trust_remote_code: bool = False,
         revision: Optional[str] = "main",
         use_fast_tokenizer: bool = True,
+        verify_certificate: bool = True,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -120,6 +121,7 @@ class TemplateAPI(TemplateLM):
         self.custom_prefix_token_id = custom_prefix_token_id
         self.tokenized_requests = tokenized_requests
         self.max_retries = int(max_retries)
+        self.verify_certificate = verify_certificate
 
         eval_logger.info(f"Using tokenizer {self.tokenizer_backend}")
         if self.tokenizer_backend is None:
@@ -342,6 +344,7 @@ class TemplateAPI(TemplateLM):
                     **kwargs,
                 ),
                 headers=self.header,
+                verify=self.verify_certificate,
             )
             if not response.ok:
                 eval_logger.warning(


### PR DESCRIPTION
This PR adds a model_arg to local-completion that disables the certificate check done by `requests` which allows us to work with models behind self-signed HTTPS endpoints.

Closes #2436 