### PR TITLE
Typos: Fix 'loglikelihood' misspellings in api_models.py

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -58,7 +58,7 @@ class TemplateAPI(TemplateLM):
         pretrained: str = None,  # `model` takes precedence over `pretrained` when passed.
         base_url: str = None,
         tokenizer: Optional[str] = None,
-        # Logliklehood tasks require a tokenizer to calculate context lengths,
+        # Loglikelihood tasks require a tokenizer to calculate context lengths,
         # however the requests can be sent as a string if the API doesn't support token inputs.
         # use tokenized_requests=False
         tokenizer_backend: Optional[
@@ -196,7 +196,7 @@ class TemplateAPI(TemplateLM):
         if not self.tokenized_requests:
             # if messages are tokenized:
             if isinstance(messages[0][0], int):
-                # assuming decoding is lossless. However, this is only for logliklehood requests
+                # assuming decoding is lossless. However, this is only for loglikelihood requests
                 # as we need to compute the context length. For generations, we don't need to tokenize.
                 messages = self.decode_batch(messages)
             if self._batch_size <= 1:
@@ -415,7 +415,7 @@ class TemplateAPI(TemplateLM):
             )
             return None
 
-    def batch_logliklehood_requests(
+    def batch_loglikelihood_requests(
         self, chunks: Iterable[List[LogLikelihoodInputs]]
     ) -> Tuple[List[List[int]], List[int], List[Tuple[str, str]]]:
         inputs = []
@@ -500,7 +500,7 @@ class TemplateAPI(TemplateLM):
         if self._concurrent <= 1:
             pbar = tqdm(desc="Requesting API", total=len(requests))
             for chunk in chunked:
-                inputs, ctxlens, cache_keys = self.batch_logliklehood_requests([chunk])
+                inputs, ctxlens, cache_keys = self.batch_loglikelihood_requests([chunk])
 
                 outputs = retry(
                     stop=stop_after_attempt(self.max_retries),
@@ -524,7 +524,7 @@ class TemplateAPI(TemplateLM):
                             )
                         pbar.update(1)
         else:
-            inputs, ctxlens, cache_keys = self.batch_logliklehood_requests(chunked)
+            inputs, ctxlens, cache_keys = self.batch_loglikelihood_requests(chunked)
             res = itertools.chain.from_iterable(
                 asyncio.run(
                     self.get_batched_requests(


### PR DESCRIPTION
This is a quick typo fix for `api_models.py`, changing "logliklehood" to "loglikelihood". 

This is the only file that contains these misspellings or references to the misspelled function names, so correcting the typo should not cause any issues with the rest of the codebase.