### PR TITLE
Fix bug when running `watsonx_llm` models

### DIFF
--- a/lm_eval/models/ibm_watsonx_ai.py
+++ b/lm_eval/models/ibm_watsonx_ai.py
@@ -148,14 +148,14 @@ class WatsonxLLM(LM):
         # Get watsonx env config values
         watsonx_credentials = get_watsonx_credentials(
             env_name=args.get("env_name", None),
-            config_path=args.get("config_path", None)
+            config_path=args.get("config_path", None),
         )
 
         return cls(
             watsonx_credentials=watsonx_credentials,
             model_id=model_id,
             generate_params=generate_params,
-            batch_size=batch_size
+            batch_size=batch_size,
         )
 
     def __init__(
@@ -279,7 +279,7 @@ class WatsonxLLM(LM):
             range(0, len(requests), self._batch_size),
             desc=f"Running generate_until function with batch size {self._batch_size}",
         ):
-            batch = requests[i:i+self._batch_size]
+            batch = requests[i : i + self._batch_size]
             try:
                 responses = self.model.generate_text(batch, self.generate_params)
 
@@ -323,7 +323,7 @@ class WatsonxLLM(LM):
             range(0, len(requests), self._batch_size),
             desc=f"Running loglikelihood function with batch size {self._batch_size}",
         ):
-            batch = requests[i:i+self._batch_size]
+            batch = requests[i : i + self._batch_size]
             try:
                 tokenized_contexts = [
                     self.model.tokenize(prompt=context, return_tokens=True)["result"][
@@ -390,7 +390,7 @@ class WatsonxLLM(LM):
             range(0, len(requests), self._batch_size),
             desc=f"Running loglikelihood_rolling function with batch size {self._batch_size}",
         ):
-            batch = requests[i:i+self._batch_size]
+            batch = requests[i : i + self._batch_size]
 
             try:
                 responses = self.model.generate_text(


### PR DESCRIPTION
When invoking a watsonx_llm eval directly, a `TypeError` occurs at [this line](https://github.com/EleutherAI/lm-evaluation-harness/blob/bf2abb4172b5249e5e1ea01b01268f2cd27b255c/lm_eval/models/ibm_watsonx_ai.py#L138) where the function is expecting a str, but a dict is [passed](https://github.com/EleutherAI/lm-evaluation-harness/blob/bf2abb4172b5249e5e1ea01b01268f2cd27b255c/lm_eval/evaluator.py#L204) instead. 

This PR fixes that error by assuming the arguments to `create_from_arg_string` match those of the parent method, but allowing for the existence of a string as well. I'm not sure what the scenario looks like in which this value is a string, which is why I would appreciate review from @Medokins to confirm as I know that the PR #2397 delivering support for watsonx works for his purposes.