### PR TITLE
Use global filter alias

### DIFF
--- a/lm_eval/tasks/bbh/cot_zeroshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/date_understanding.yaml
@@ -7,7 +7,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/disambiguation_qa.yaml
@@ -7,7 +7,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/geometric_shapes.yaml
@@ -7,7 +7,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/hyperbaton.yaml
@@ -7,7 +7,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_five_objects.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_seven_objects.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_three_objects.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/movie_recommendation.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/penguins_in_a_table.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/reasoning_about_colored_objects.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/ruin_names.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/salient_translation_error_detection.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/snarks.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/temporal_sequences.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_five_objects.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_seven_objects.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_three_objects.yaml
@@ -6,7 +6,7 @@
 filter_list:
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: -1
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/date_understanding.yaml
@@ -10,7 +10,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/disambiguation_qa.yaml
@@ -10,7 +10,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/geometric_shapes.yaml
@@ -10,7 +10,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/hyperbaton.yaml
@@ -10,7 +10,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_five_objects.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_seven_objects.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_three_objects.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/movie_recommendation.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/penguins_in_a_table.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/reasoning_about_colored_objects.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/ruin_names.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/salient_translation_error_detection.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/snarks.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/temporal_sequences.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_five_objects.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_seven_objects.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_three_objects.yaml
@@ -9,7 +9,7 @@ filter_list:
       - function: "take_first"
   - name: "flexible-extract"
     filter:
-      - function: !function utils.MultiChoiceRegexFilter
+      - function: "multi_choice_regex"
         group_select: 0
         ignore_case: true
         ignore_punctuation: true


### PR DESCRIPTION
Use the filter registered alias instead of the class name. Per https://github.com/EleutherAI/lm-evaluation-harness/pull/2461, the registered filter name (`"multi_choice_regex"`) can be substituted for `!function utils.MultiChoiceRegexFilter`, just wondering if we can do this for consistency.