### PR TITLE
Update citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,11 +496,11 @@ Extras dependencies can be installed via `pip install -e ".[NAME]"`
 @misc{eval-harness,
   author       = {Gao, Leo and Tow, Jonathan and Abbasi, Baber and Biderman, Stella and Black, Sid and DiPofi, Anthony and Foster, Charles and Golding, Laurence and Hsu, Jeffrey and Le Noac'h, Alain and Li, Haonan and McDonell, Kyle and Muennighoff, Niklas and Ociepa, Chris and Phang, Jason and Reynolds, Laria and Schoelkopf, Hailey and Skowron, Aviya and Sutawika, Lintang and Tang, Eric and Thite, Anish and Wang, Ben and Wang, Kevin and Zou, Andy},
   title        = {A framework for few-shot language model evaluation},
-  month        = 07,
+  month        = 10,
   year         = 2024,
   publisher    = {Zenodo},
-  version      = {v0.4.3},
-  doi          = {10.5281/zenodo.12608602},
-  url          = {https://zenodo.org/records/12608602}
+  version      = {v0.4.5},
+  doi          = {10.5281/zenodo.13905736},
+  url          = {https://zenodo.org/records/13905736}
 }
 ```


### PR DESCRIPTION
Update the citation in the README to the latest release.

I saw that the citation at the bottom of the README differs from CITATIONS.bib, both of which differ from the current release version. I'm just wondering if you want citations to be by minor or patch versions. Minor would be easier with the current manual citation updates. You could also update the citation (in the README and CITATIONS.bib) as part of the publish workflow, for either minor or patch versions.