### PR TITLE
Updated wandb logger to use `new_printer()` instead of `get_printer(...)`

### DIFF
--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -15,10 +15,9 @@ logger = logging.getLogger(__name__)
 
 def get_wandb_printer() -> Literal["Printer"]:
     """Returns a wandb printer instance for pretty stdout."""
-    from wandb.sdk.lib.printer import get_printer
-    from wandb.sdk.wandb_settings import Settings
+    from wandb.sdk.lib.printer import new_printer
 
-    printer = get_printer(Settings()._jupyter)
+    printer = new_printer()
     return printer
 
 


### PR DESCRIPTION
Following issue #2483 this is a proposed quick-fix for the Weights and Biases logger to use the new `new_printer()` function instead of the now-removed `get_printer(...)` function in the `wandb` API.

I've briefly tested that a reproducer like the following works ok, but have not done any extensive testing otherwise:
```
lm_eval \
    --model hf \
    --model_args pretrained=meta-llama/Llama-3.2-1B,dtype="float" \
    --tasks arc_easy \
    --device cuda:0 \
    --wandb_args project=lm-eval-logger-repro
```

I hope this helps!

Thanks,
Alex