### PR TITLE
Fix revision parameter to vllm get_tokenizer

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -118,7 +118,7 @@ class VLLM(TemplateLM):
             tokenizer if tokenizer else pretrained,
             tokenizer_mode=tokenizer_mode,
             trust_remote_code=trust_remote_code,
-            tokenizer_revision=tokenizer_revision,
+            revision=tokenizer_revision,
         )
         self.tokenizer = configure_pad_token(self.tokenizer)
         self.add_bos_token = add_bos_token


### PR DESCRIPTION
This makes the code compatible with recent versions of vllm since this PR merged April 25: https://github.com/vllm-project/vllm/pull/4107  (currently the `tokenizer_revision` setting will just be ignored)

