### PR TITLE
Added regex filter for bbh fewshot

### DIFF
--- a/lm_eval/tasks/bbh/fewshot/_fewshot_template_yaml
+++ b/lm_eval/tasks/bbh/fewshot/_fewshot_template_yaml
@@ -15,6 +15,20 @@ generation_kwargs:
     - "\n\n"
   do_sample: false
   temperature: 0.0
+filter_list:
+  - name: remove_whitespace
+    filter:
+      # Filter everything after the first break line
+      - function: "regex"
+        regex_pattern: "^(.*?)(?=\\n|$)"
+      - function: remove_whitespace
+      # function to ignore right white spaces or line breaks
+      - function: "regex"
+        regex_pattern: "^(.*?)\\s*$"
+      # If there are things  between brackets, match those
+      - function: "regex"
+        regex_pattern: "\\([^()]*\\)|[^()]*"
+      - function: take_first
 num_fewshot: 3
 metadata:
   version: 2.0


### PR DESCRIPTION
Similar to https://github.com/EleutherAI/lm-evaluation-harness/pull/2013

The `fewshot` modality filtering is too strict resulting in zero accuracy on many models. This PR adds a filter to recover cases like:
- `Correct answer is (B)` -> `(B)`
- ` (B)` -> `(B)`
- `(B)\n` -> `(B)`