### PR TITLE
max_length not used

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1304,8 +1304,10 @@ class HFLM(TemplateLM):
             context_enc = context_enc.to(self.device)
             attn_masks = attn_masks.to(self.device)
 
-            if "max_length" not in kwargs:
+            if self.max_length is None:
                 kwargs["max_length"] = context_enc.shape[1] + max_gen_toks
+            else:
+                kwargs["max_length"] = self.max_length
 
             # perform batched generation
             cont = self._model_generate(


### PR DESCRIPTION
Using `max_length=...` in --model_args somehow is not used. This is suppose to fix that.