### PR TITLE
Filters bugfix; add `metrics` and `filter` to logged sample

### DIFF
--- a/lm_eval/api/registry.py
+++ b/lm_eval/api/registry.py
@@ -188,8 +188,9 @@ def register_filter(name):
 def get_filter(filter_name: Union[str, Callable]) -> Callable:
     try:
         return FILTER_REGISTRY[filter_name]
-    except KeyError:
+    except KeyError as e:
         if callable(filter_name):
             return filter_name
         else:
             eval_logger.warning(f"filter `{filter_name}` is not registered!")
+            raise e

--- a/lm_eval/api/registry.py
+++ b/lm_eval/api/registry.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict
+from typing import Callable, Dict, Union
 
 import evaluate as hf_evaluate
 
@@ -185,8 +185,11 @@ def register_filter(name):
     return decorate
 
 
-def get_filter(filter_name: str) -> type:
+def get_filter(filter_name: Union[str, Callable]) -> Callable:
     try:
         return FILTER_REGISTRY[filter_name]
     except KeyError:
-        eval_logger.warning(f"filter `{filter_name}` is not registered!")
+        if callable(filter_name):
+            return filter_name
+        else:
+            eval_logger.warning(f"filter `{filter_name}` is not registered!")

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -553,6 +553,7 @@ def evaluate(
                             req.filtered_resps[filter_key] for req in requests
                         ],
                         "filter": filter_key,
+                        "metric": ",".join(metrics.keys()),
                         "doc_hash": hash_string(
                             json.dumps(
                                 requests[0].doc,

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -552,6 +552,7 @@ def evaluate(
                         "filtered_resps": [
                             req.filtered_resps[filter_key] for req in requests
                         ],
+                        "filter": filter_key,
                         "doc_hash": hash_string(
                             json.dumps(
                                 requests[0].doc,

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -553,7 +553,7 @@ def evaluate(
                             req.filtered_resps[filter_key] for req in requests
                         ],
                         "filter": filter_key,
-                        "metric": ",".join(metrics.keys()),
+                        "metrics": list(metrics.keys()),
                         "doc_hash": hash_string(
                             json.dumps(
                                 requests[0].doc,

--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -37,16 +37,18 @@ class RegexFilter(Filter):
                 if match:
                     match = match[self.group_select]
                     if isinstance(match, tuple):
-                        match = [m for m in match if m][0]
+                        match = [m for m in match if m]
+                        if match:
+                            match = match[0]
+                        else:
+                            match = self.fallback
                     match = match.strip()
                 else:
                     match = self.fallback
                 filtered.append(match)
             return filtered
 
-        # print(resps)
         filtered_resps = list(map(lambda x: filter_set(x), resps))
-        # print(filtered_resps)
 
         return filtered_resps
 


### PR DESCRIPTION
- Allow custom function filters
- `RegexFilter`: group select can be falsy

closes #2511

Also add `filter` and `metrics` fields to logged samples for identification. closes #2025