### PR TITLE
add Basque translation of PIQA (piqa_eu) to BasqueBench

### DIFF
--- a/lm_eval/tasks/basque_bench/README.md
+++ b/lm_eval/tasks/basque_bench/README.md
@@ -8,6 +8,7 @@ The new evaluation datasets included in BasqueBench are:
 | Task          | Category       | Homepage  |
 |:-------------:|:-----:|:-----:|
 | MGSM_eu | Math | https://huggingface.co/datasets/HiTZ/MGSM-eu |
+| PIQA_eu | Question Answering | https://huggingface.co/datasets/HiTZ/PIQA-eu |
 | WNLI_eu | Natural Language Inference | https://huggingface.co/datasets/HiTZ/wnli-eu |
 | XCOPA_eu | Commonsense Reasoning | https://huggingface.co/datasets/HiTZ/XCOPA-eu |
 
@@ -63,6 +64,7 @@ The following tasks evaluate tasks on BasqueBench dataset using various scoring 
   - `flores_pt-eu`
   - `mgsm_direct_eu`
   - `mgsm_native_cot_eu`
+  - `piqa_eu`
   - `qnlieu`
   - `wnli_eu`
   - `xcopa_eu`

--- a/lm_eval/tasks/basque_bench/basque_bench.yaml
+++ b/lm_eval/tasks/basque_bench/basque_bench.yaml
@@ -14,5 +14,6 @@ task:
     - xcopa_eu
     - mgsm_direct_eu
     - mgsm_native_cot_eu
+    - piqa_eu
 metadata:
   version: 1.0

--- a/lm_eval/tasks/basque_bench/piqa_eu.yaml
+++ b/lm_eval/tasks/basque_bench/piqa_eu.yaml
@@ -1,0 +1,21 @@
+task: piqa_eu
+dataset_path: HiTZ/PIQA-eu
+dataset_name: null
+output_type: multiple_choice
+training_split: null
+validation_split: validation
+test_split: null
+doc_to_text: "Galdera: {{goal}}\nErantzuna:"
+doc_to_target: label
+doc_to_choice: "{{[sol1, sol2]}}"
+should_decontaminate: true
+doc_to_decontamination_query: goal
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0


### PR DESCRIPTION
This PR adds a new task to BasqueBench: a human translation of PIQA to Basque (piq_eu). The PR includes:
- the new piqa_eu task configuration yaml 
- update of BasqueBench group yaml to include this task
- update of BasqueBench readme to reflect the new task

I am one of the co-authors of BasqueBench. @zxcvuser (original committer of BasqueBench) is aware and agrees with of this addition.
