### PR TITLE
Super little tiny fix doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,6 @@ Extras dependencies can be installed via `pip install -e ".[NAME]"`
 | hf_transfer     | For speeding up HF Hub file downloads        |
 | ifeval          | For running the IFEval task                  |
 | ibm_watsonx_ai  | For using IBM watsonx.ai model apis          |
-
 | neuronx         | For running on AWS inf2 instances            |
 | mamba           | For loading Mamba SSM models                 |
 | math            | For running math task answer checking        |


### PR DESCRIPTION
Hi thanks for the lib! When reading README, it seems that a tiny little doc needs to be fixed:

![image](https://github.com/user-attachments/assets/a0097a97-e264-4820-bcfa-fe15575644fe)
