### PR TITLE
Update Lightning import

### DIFF
--- a/lm_eval/models/nemo_lm.py
+++ b/lm_eval/models/nemo_lm.py
@@ -191,7 +191,7 @@ class NeMoLM(LM):
                 generate,
             )
             from nemo.collections.nlp.parts.nlp_overrides import NLPDDPStrategy
-            from pytorch_lightning.trainer.trainer import Trainer
+            from lightning.pytorch.trainer.trainer import Trainer
 
             self.generate = generate
         except ModuleNotFoundError as exception:

--- a/lm_eval/models/nemo_lm.py
+++ b/lm_eval/models/nemo_lm.py
@@ -187,11 +187,11 @@ class NeMoLM(LM):
         **kwargs,
     ):
         try:
+            from lightning.pytorch.trainer.trainer import Trainer
             from nemo.collections.nlp.modules.common.text_generation_utils import (
                 generate,
             )
             from nemo.collections.nlp.parts.nlp_overrides import NLPDDPStrategy
-            from lightning.pytorch.trainer.trainer import Trainer
 
             self.generate = generate
         except ModuleNotFoundError as exception:

--- a/lm_eval/models/optimum_lm.py
+++ b/lm_eval/models/optimum_lm.py
@@ -71,9 +71,11 @@ class OptimumLM(HFLM):
         else:
             model_kwargs["ov_config"] = {}
         model_kwargs["ov_config"].setdefault("CACHE_DIR", "")
-        if 'pipeline_parallel' in model_kwargs:
-            if model_kwargs['pipeline_parallel']:
-                model_kwargs["ov_config"]["MODEL_DISTRIBUTION_POLICY"] = "PIPELINE_PARALLEL"
+        if "pipeline_parallel" in model_kwargs:
+            if model_kwargs["pipeline_parallel"]:
+                model_kwargs["ov_config"]["MODEL_DISTRIBUTION_POLICY"] = (
+                    "PIPELINE_PARALLEL"
+                )
         model_file = Path(pretrained) / "openvino_model.xml"
         if model_file.exists():
             export = False


### PR DESCRIPTION
NeMo recently updated imports of `pytorch_lightning` to `lightning` (see [1](https://github.com/NVIDIA/NeMo/pull/11252), [2](https://github.com/NVIDIA/NeMo/pull/11306) for context). 
We have seen errors when mixing imports from these two packages, so to avoid any potential problems using eval harness for evaluating NeMo models, I'm suggesting we make the same change here. 