### PR TITLE
Wandb step handling bugfix and feature

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -58,7 +58,7 @@ This mode supports a number of command-line arguments, the details of which can 
 
 * `--seed`: Set seed for python's random, numpy and torch.  Accepts a comma-separated list of 3 values for python's random, numpy, and torch seeds, respectively, or a single integer to set the same seed for all three.  The values are either an integer or 'None' to not set the seed. Default is `0,1234,1234` (for backward compatibility).  E.g. `--seed 0,None,8` sets `random.seed(0)` and `torch.manual_seed(8)`. Here numpy's seed is not set since the second value is `None`.  E.g, `--seed 42` sets all three seeds to 42.
 
-* `--wandb_args`:  Tracks logging to Weights and Biases for evaluation runs and includes args passed to `wandb.init`, such as `project` and `job_type`. Full list [here](https://docs.wandb.ai/ref/python/init). e.g., ```--wandb_args project=test-project,name=test-run```
+* `--wandb_args`:  Tracks logging to Weights and Biases for evaluation runs and includes args passed to `wandb.init`, such as `project` and `job_type`. Full list [here](https://docs.wandb.ai/ref/python/init). e.g., ```--wandb_args project=test-project,name=test-run```. Also allows for the passing of the step to log things at (passed to `wandb.run.log`), e.g., `--wandb_args step=123`.
 
 * `--hf_hub_log_args` : Logs evaluation results to Hugging Face Hub. Accepts a string with the arguments separated by commas. Available arguments:
     * `hub_results_org` - organization name on Hugging Face Hub, e.g., `EleutherAI`. If not provided, the results will be pushed to the owner of the Hugging Face token,

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -104,7 +104,7 @@ def simple_parse_args_string(args_string):
         return {}
     arg_list = [arg for arg in args_string.split(",") if arg]
     args_dict = {
-        k: handle_arg_string(v) for k, v in [arg.split("=") for arg in arg_list]
+        kv[0]: handle_arg_string("=".join(kv[1:])) for kv in [arg.split("=") for arg in arg_list]
     }
     return args_dict
 

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -104,7 +104,8 @@ def simple_parse_args_string(args_string):
         return {}
     arg_list = [arg for arg in args_string.split(",") if arg]
     args_dict = {
-        kv[0]: handle_arg_string("=".join(kv[1:])) for kv in [arg.split("=") for arg in arg_list]
+        kv[0]: handle_arg_string("=".join(kv[1:]))
+        for kv in [arg.split("=") for arg in arg_list]
     }
     return args_dict
 


### PR DESCRIPTION
This PR contains:
1. a bugfix to the parsing of args that allows for the passing of the `resume_from` argument whose value may contain `=`, which under the current implementation gets oversplit resulting in an error.
2. For projects without rewinding, where the above is not an option, allow for the explicit passing of the `step` during `wandb.run.log` instead, defaulting to None, but if set through the same `wandb_args` list allowing the editing of reports (to not have to add more logic around that, I think the behavior of having the report be based on the latest run is quite reasonable anyway) and passing the split-off value that way.

Please let me know what you think about these changes, if edits are needed, or if the process works somewhat differently here :)