### PR TITLE
add support for "adapter_id@adapter_revision" for peft

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -637,8 +637,7 @@ class HFLM(TemplateLM):
 
             # check if peft contains peft revision according to "adapter_id@revision" format (f.e. used in [TGI endpoints](https://huggingface.co/docs/text-generation-inference/main/en/conceptual/lora#specifying-lora-models))
             if "@" in peft:
-                peft = peft.split("@")[0]
-                peft_revision = peft.split("@")[1]
+                peft, peft_revision = peft.split("@", 1)
                 self._model = PeftModel.from_pretrained(
                     self._model, peft, revision=peft_revision
                 )    

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -634,9 +634,18 @@ class HFLM(TemplateLM):
                     f"Model config indicates vocab_size='{self._model.config.vocab_size}', but found tokenizer with vocab size '{len(self.tokenizer)}'. Resizing model embedding layer..."
                 )
                 self._model.resize_token_embeddings(len(self.tokenizer))
-            self._model = PeftModel.from_pretrained(
-                self._model, peft, revision=revision
-            )
+
+            # check if peft contains peft revision according to "adapter_id@revision" format (f.e. used in TGI endpoints)
+            if "@" in peft:
+                peft = peft.split("@")[0]
+                peft_revision = peft.split("@")[1]
+                self._model = PeftModel.from_pretrained(
+                    self._model, peft, revision=peft_revision
+                )    
+            else:
+                self._model = PeftModel.from_pretrained(
+                    self._model, peft, revision=revision
+                )
         elif delta:
             if autogptq:
                 eval_logger.warning(

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -635,7 +635,7 @@ class HFLM(TemplateLM):
                 )
                 self._model.resize_token_embeddings(len(self.tokenizer))
 
-            # check if peft contains peft revision according to "adapter_id@revision" format (f.e. used in TGI endpoints)
+            # check if peft contains peft revision according to "adapter_id@revision" format (f.e. used in [TGI endpoints](https://huggingface.co/docs/text-generation-inference/main/en/conceptual/lora#specifying-lora-models))
             if "@" in peft:
                 peft = peft.split("@")[0]
                 peft_revision = peft.split("@")[1]


### PR DESCRIPTION
Add support for convention used with  [TGI](https://huggingface.co/docs/text-generation-inference/main/en/conceptual/lora#specifying-lora-models) where you can specify revision of the PEFT adapter in the form of `adapter_id@adapter_revision`