### PR TITLE
modify _template_yaml dataset path with exact replicate

### DIFF
--- a/lm_eval/tasks/leaderboard/math/_template_yaml
+++ b/lm_eval/tasks/leaderboard/math/_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lighteval/MATH-Hard
+dataset_path: DigitalLearningGmbH/MATH-lighteval
 process_docs: !function utils.process_docs
 output_type: generate_until
 training_split: train


### PR DESCRIPTION
> We have created a drop-in replacement for the original dataset here: [DigitalLearningGmbH/MATH-lighteval](https://huggingface.co/datasets/DigitalLearningGmbH/MATH-lighteval).
> 
> It contains appropriate builder configs s.t. it can be directly used with https://github.com/huggingface/lighteval/blob/main/examples/nanotron/custom_evaluation_tasks.py#L252 (you just need to adjust `hf_repo="lighteval/MATH"` to `hf_repo="DigitalLearningGmbH/MATH-lighteval"`. Hope this helps someone.

[Link](https://github.com/huggingface/lighteval/issues/494#issuecomment-2592158180)

Would be great to make this eval work again!