### PR TITLE
Fix max_tokens handling in vllm_vlms.py

### DIFF
--- a/lm_eval/models/vllm_vlms.py
+++ b/lm_eval/models/vllm_vlms.py
@@ -271,7 +271,9 @@ class VLLM_VLM(VLLM):
                 left_truncate_len=max_ctx_len,
             )
 
-            cont = self._model_generate(inputs, stop=until, generate=True, max_tokens=max_gen_toks, **kwargs)
+            cont = self._model_generate(
+                inputs, stop=until, generate=True, max_tokens=max_gen_toks, **kwargs
+            )
 
             for output, context in zip(cont, contexts):
                 generated_text = output.outputs[0].text

--- a/lm_eval/models/vllm_vlms.py
+++ b/lm_eval/models/vllm_vlms.py
@@ -271,7 +271,7 @@ class VLLM_VLM(VLLM):
                 left_truncate_len=max_ctx_len,
             )
 
-            cont = self._model_generate(inputs, stop=until, generate=True, **kwargs)
+            cont = self._model_generate(inputs, stop=until, generate=True, max_tokens=max_gen_toks, **kwargs)
 
             for output, context in zip(cont, contexts):
                 generated_text = output.outputs[0].text


### PR DESCRIPTION
Currently max_tokens parameter is not set properly when using vllm_vlms.py script : 
https://github.com/EleutherAI/lm-evaluation-harness/blob/f724be699e8adf7ca8004ea0e519dfac83a06f18/lm_eval/models/vllm_vlms.py#L274
max_gen_toks is assigned at lines 261-264, but it's not passed to _model_generate, which indicates max_tokens to be None in vllm. This causes errors when launching multi step scheduling scenarios.

Comparing with vllm_causallms - the script asigns the parameter properly, so it does not cause any error in vllm:
https://github.com/EleutherAI/lm-evaluation-harness/blob/f724be699e8adf7ca8004ea0e519dfac83a06f18/lm_eval/models/vllm_causallms.py#L424