### PR TITLE
remove `group` from bigbench task configs

### DIFF
--- a/lm_eval/tasks/bigbench/README.md
+++ b/lm_eval/tasks/bigbench/README.md
@@ -30,6 +30,12 @@ Homepage: https://github.com/google/BIG-bench
 
 * `group_name`: `Short description`
 
+#### Tags
+
+* `bigbench_generate_until`
+* `bigbench_multiple_choice_a`
+* `bigbench_multiple_choice_b`
+
 #### Tasks
 
 * `task_name`: `1-sentence description of what this particular task does`

--- a/lm_eval/tasks/bigbench/generate_until_template_yaml
+++ b/lm_eval/tasks/bigbench/generate_until_template_yaml
@@ -1,3 +1,4 @@
+tag: bigbench_generate_until
 dataset_path: hails/bigbench
 output_type: generate_until
 dataset_kwargs:

--- a/lm_eval/tasks/bigbench/generate_until_template_yaml
+++ b/lm_eval/tasks/bigbench/generate_until_template_yaml
@@ -1,4 +1,3 @@
-group: bigbench_generate_until
 dataset_path: hails/bigbench
 output_type: generate_until
 dataset_kwargs:

--- a/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
@@ -1,4 +1,3 @@
-group: bigbench_multiple_choice
 dataset_path: hails/bigbench
 dataset_kwargs:
   # num_shots: 0 # TODO: num of shots for `bigbench` HF dataset should be controlled through this, not through the typical methods

--- a/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
@@ -1,3 +1,4 @@
+tag: bigbench_multiple_choice_a
 dataset_path: hails/bigbench
 dataset_kwargs:
   # num_shots: 0 # TODO: num of shots for `bigbench` HF dataset should be controlled through this, not through the typical methods

--- a/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
@@ -1,4 +1,3 @@
-group: bigbench_multiple_choice
 dataset_path: hails/bigbench
 dataset_kwargs:
   # num_shots: 0 # TODO: num of shots for `bigbench` HF dataset should be controlled through this, not through the typical methods

--- a/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
@@ -1,3 +1,4 @@
+tag: bigbench_multiple_choice_b
 dataset_path: hails/bigbench
 dataset_kwargs:
   # num_shots: 0 # TODO: num of shots for `bigbench` HF dataset should be controlled through this, not through the typical methods


### PR DESCRIPTION
After #2060 groups are created in separate configs.

closes #2661 