### PR TITLE
Update unitxt task.py to bring in line with recent repo changes

### DIFF
--- a/lm_eval/tasks/unitxt/task.py
+++ b/lm_eval/tasks/unitxt/task.py
@@ -109,6 +109,7 @@ class Unitxt(ConfigurableTask):
         apply_chat_template: bool = False,
         fewshot_as_multiturn: bool = False,
         chat_template: Optional[Callable] = None,
+        gen_prefix: Optional[str] = None,
     ) -> str:
         source = self.doc_to_text(doc)
         if isinstance(source, list):
@@ -134,6 +135,7 @@ class Unitxt(ConfigurableTask):
             part of the document for `doc`.
         """
         kwargs.pop("apply_chat_template", False)  # Not used by unitxt
+        kwargs.pop("chat_template", False)  # Not used by unitxt
         return [
             Instance(
                 request_type="generate_until",


### PR DESCRIPTION
A few recent PRs have broken unitxt tasks, specifically:

- Pop `chat_template` kwarg in `construct_requests`
  - Re: #2576 (and related fix #2668)
- Add `gen_prefix` positional arg 
  - Introduced in #2615 and name changed in #2630

For the latter, it may be worth switching to a kwarg-based implementation for `fewshot_context` since the positional version will be deprecated in the future. Happy to add that to this PR or a different one

cc: @yoavkatz 