### PR TITLE
change ensure_ascii to False for JsonChatStr

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -265,7 +265,7 @@ class TemplateAPI(TemplateLM):
             )
         else:
             # bit of a hack. We'll load back before sending to the API
-            return JsonChatStr(json.dumps(chat_history))
+            return JsonChatStr(json.dumps(chat_history, ensure_ascii=False))
 
     @cached_property
     def eot_token_id(self) -> Optional[int]:


### PR DESCRIPTION
make it possible to store in logs cyrillic symbols

right now they are encoded the wrong way so that in "samples_*.jsonl" files user will see special symbols instead of the real ones due to forcing ascii