### PR TITLE
Set defaults for BLiMP scores

### DIFF
--- a/lm_eval/tasks/blimp/_template_yaml
+++ b/lm_eval/tasks/blimp/_template_yaml
@@ -9,5 +9,7 @@ should_decontaminate: true
 doc_to_decontamination_query: "{{sentence_good}} {{sentence_bad}}"
 metric_list:
   - metric: acc
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 1.0


### PR DESCRIPTION
`aggregation` and `higher_is_better` are not set for BLiMP, so the default arguments are used. This pull request makes the arguments explicit.