### PR TITLE
Replace missing `lighteval/MATH-Hard` dataset with `DigitalLearningGmbH/MATH-lighteval`

### DIFF
--- a/lm_eval/tasks/leaderboard/math/_template_yaml
+++ b/lm_eval/tasks/leaderboard/math/_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: lighteval/MATH-Hard
+dataset_path: DigitalLearningGmbH/MATH-lighteval
 process_docs: !function utils.process_docs
 output_type: generate_until
 training_split: train


### PR DESCRIPTION
As mentioned in #2618, the Hugging Face dataset repo for `lighteval/MATH-hard` has been removed and is no longer available: <https://huggingface.co/datasets/lighteval/MATH-Hard>. As a result, this breaks the Open LLM Leaderboard v2 task.

The `DigitalLearningGmbH/MATH-lighteval` dataset is a drop-in replacement: <https://huggingface.co/datasets/DigitalLearningGmbH/MATH-lighteval>. It also appears that other repos are now using this replacement: <https://github.com/stanfordnlp/dspy/issues/3358>.

This PR replaces the missing dataset with this drop-in replacement to fix the broken task.