### PR TITLE
Fix the import source for eval_logger

### DIFF
--- a/lm_eval/tasks/leaderboard/math/utils.py
+++ b/lm_eval/tasks/leaderboard/math/utils.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 import datasets
 
-from lm_eval.utils import eval_logger
+from lm_eval.evaluator import eval_logger
 
 
 try:

--- a/lm_eval/tasks/leaderboard/math/utils.py
+++ b/lm_eval/tasks/leaderboard/math/utils.py
@@ -1,11 +1,12 @@
+import logging
 import re
 import signal
 from typing import Dict, List, Optional
 
 import datasets
 
-from lm_eval.evaluator import eval_logger
 
+eval_logger = logging.getLogger(__name__)
 
 try:
     import sympy

--- a/lm_eval/tasks/minerva_math/utils.py
+++ b/lm_eval/tasks/minerva_math/utils.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import signal
 from importlib.metadata import version
@@ -5,7 +6,8 @@ from typing import Dict, List, Optional
 
 import datasets
 
-from lm_eval.utils import eval_logger
+
+eval_logger = logging.getLogger(__name__)
 
 
 try:


### PR DESCRIPTION
Fixes the import source in `utils.py` inside the math task in the leaderboard task group, which was using the wrong source for importing `eval_logger`
