### PR TITLE
add debug log

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -838,6 +838,10 @@ class ConfigurableTask(Task):
                 filter_pipeline = build_filter_ensemble(filter_name, components)
                 self._filters.append(filter_pipeline)
         else:
+            # TODO: handle repeats in a more general way rather than just discarding
+            eval_logger.debug(
+                "No custom filters defined. Using default 'take_first' filter for handling repeats."
+            )
             self._filters = [build_filter_ensemble("none", [["take_first", None]])]
 
         if self.config.use_prompt is not None:


### PR DESCRIPTION
If any filter is not set, then the task defaults to `take_first`. Adding a debug log as was not sufficiently clear