### PR TITLE
fix mmlu (generative) metric aggregation

### DIFF
--- a/lm_eval/tasks/mmlu/generative/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/generative/_mmlu.yaml
@@ -7,27 +7,32 @@ task:
     aggregate_metric_list:
       - metric: exact_match
         weight_by_size: true
+        filter_list: get_response
   - group: other
     task:
       - mmlu_other_generative
     aggregate_metric_list:
       - metric: exact_match
         weight_by_size: true
+        filter_list: get_response
   - group: social sciences
     task:
       - mmlu_social_sciences_generative
     aggregate_metric_list:
       - metric: exact_match
         weight_by_size: true
+        filter_list: get_response
   - group: humanities
     task:
       - mmlu_humanities_generative
     aggregate_metric_list:
       - metric: exact_match
         weight_by_size: true
+        filter_list: get_response
 aggregate_metric_list:
   - aggregation: mean
     metric: exact_match
     weight_by_size: true
+    filter_list: get_response
 metadata:
   version: 3


### PR DESCRIPTION
This PR fixes a metric aggregation problem after the #2503 (ref: #2245) by adding the new filter introduced in #2503.

Before the fix:
```
|Groups|Version|Filter|n-shot|Metric|   |Value|   |Stderr|
|------|-------|------|------|------|---|-----|---|------|

```

After the fix:
```
|      Groups      |Version|   Filter   |n-shot|  Metric   |   |Value |   |Stderr|
|------------------|-------|------------|------|-----------|---|-----:|---|-----:|
|mmlu (generative) |      3|get_response|      |exact_match|↑  |0.5351|±  |0.0439|
| - humanities     |    N/A|get_response|      |exact_match|↑  |0.5769|±  |0.1018|
| - other          |    N/A|get_response|      |exact_match|↑  |0.5000|±  |0.0860|
| - social sciences|    N/A|get_response|      |exact_match|↑  |0.5417|±  |0.0932|
| - stem           |    N/A|get_response|      |exact_match|↑  |0.5263|±  |0.0744|

```
