### PR TITLE
improvement: Use yaml.CLoader to load yaml files when available.

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -10,6 +10,7 @@ import os
 import re
 from dataclasses import asdict, is_dataclass
 from itertools import islice
+from pathlib import Path
 from typing import Any, Callable, Generator, List, Tuple
 
 import numpy as np
@@ -428,17 +429,22 @@ def ignore_constructor(loader, node):
     return node
 
 
-def import_function(loader, node):
+def import_function(loader: yaml.Loader, node, yaml_path: Path):
     function_name = loader.construct_scalar(node)
-    yaml_path = os.path.dirname(loader.name)
 
     *module_name, function_name = function_name.split(".")
     if isinstance(module_name, list):
         module_name = ".".join(module_name)
-    module_path = os.path.normpath(os.path.join(yaml_path, "{}.py".format(module_name)))
+    module_path = yaml_path.parent / f"{module_name}.py"
 
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path.as_posix())
+
+    if spec is None:
+        raise ImportError(f"Could not import module {module_name} from {module_path}.")
     module = importlib.util.module_from_spec(spec)
+
+    if spec.loader is None:
+        raise ImportError(f"Module loader is None, {module_name} from {module_path}.")
     spec.loader.exec_module(module)
 
     function = getattr(module, function_name)
@@ -449,13 +455,17 @@ def load_yaml_config(yaml_path=None, yaml_config=None, yaml_dir=None, mode="full
     if mode == "simple":
         constructor_fn = ignore_constructor
     elif mode == "full":
-        constructor_fn = import_function
+        if yaml_path is None:
+            raise ValueError("yaml_path must be provided if mode is 'full'.")
+        # Attach yaml_path to the import function so that it can be used later
+        constructor_fn = functools.partial(import_function, yaml_path=Path(yaml_path))
 
+    loader = yaml.CLoader if yaml.__with_libyaml__ else yaml.FullLoader
     # Add the import_function constructor to the YAML loader
-    yaml.add_constructor("!function", constructor_fn)
+    yaml.add_constructor("!function", constructor_fn, Loader=loader)
     if yaml_config is None:
         with open(yaml_path, "rb") as file:
-            yaml_config = yaml.full_load(file)
+            yaml_config = yaml.load(file, Loader=loader)
 
     if yaml_dir is None:
         yaml_dir = os.path.dirname(yaml_path)


### PR DESCRIPTION
Hi @baberabb, this PR contains a speedup for the TaskManager `__init__` which is quite slow atm - it's quite annoying to wait 15+ seconds for an `lm_eval --task list`.

# Description

I briefly looked into it, turns out the longest time is spend parsing (read + graph construction) the (currently) `6625` yaml files under `tasks`. I suggest here a couple changes to switch from `yaml.FullLoader` to `yaml.CLoader` which as far as I can tell works the same - the only particular thing `lm_eval` needs are the custom constructors and those can be added to a `CLoader` as well. The one difference is that `CLoader` does not have a `.name` attribute (which points to the yaml file in the FullLoader) so I had to change the `import_function` accordingly by passing the `yaml_path` through.

# Runtimes

Comparison before and after the change

## Listing tasks [local]

Before (in `main`):

```bash
$ time lm_eval --task list
real    0m20.034s
user    0m19.182s
sys     0m2.114s
```

in this branch:

```bash
$ time lm_eval --task list
real    0m6.361s
user    0m6.984s
sys     0m1.514s
```

## Running Tests [local]

I haven't looked too much into it but I would expect a `TaskManager` is initialized more than once in testing. 

Before:
```bash
$ time python -m pytest --showlocals -s -vv -n=auto --ignore=tests/models/test_neuralmagic.py --ignore=tests/models/
============================================================================= 89 passed, 4 skipped, 41 warnings in 185.87s (0:03:05) =============================================================================
real    3m6.054s
user    16m29.785s
sys     1m24.957s
```

```bash
$ time python -m pytest --showlocals -s -vv -n=auto --ignore=tests/models/test_neuralmagic.py --ignore=tests/models/test_openvino.py
============================================================================= 89 passed, 4 skipped, 41 warnings in 116.94s (0:01:56) =============================================================================
real    1m57.136s
user    5m52.046s
sys     1m28.895s
```

## Running Tests, Github Actions

Decent speedup ->

Before:

[Random py3.9 job](https://github.com/EleutherAI/lm-evaluation-harness/actions/runs/13676912126/job/38239356496): `7m 57s`

Now:

[this PRs py3.9 job](https://github.com/EleutherAI/lm-evaluation-harness/actions/runs/13737129440/job/38422166960?pr=2777): `4m 20s`