### PR TITLE
initialize tokenizer with `add_bos_token`

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -184,6 +184,7 @@ class HFLM(TemplateLM):
             trust_remote_code=trust_remote_code,
             use_fast_tokenizer=use_fast_tokenizer,
             gguf_file=gguf_file,
+            add_bos_token=add_bos_token,
         )
 
         # if we passed `pretrained` as a string, initialize our model now
@@ -688,6 +689,7 @@ class HFLM(TemplateLM):
         trust_remote_code: Optional[bool] = False,
         use_fast_tokenizer: Optional[bool] = True,
         gguf_file: Optional[str] = None,
+        add_bos_token: Optional[bool] = False,
     ) -> None:
         """
         Helper method during initialization.
@@ -705,6 +707,9 @@ class HFLM(TemplateLM):
             kwargs["gguf_file"] = gguf_file
         else:
             kwargs["use_fast"] = use_fast_tokenizer
+
+        if add_bos_token:
+            kwargs["add_bos_token"] = True
 
         if tokenizer:
             if isinstance(tokenizer, str):

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -123,6 +123,7 @@ class VLLM(TemplateLM):
             tokenizer_mode=tokenizer_mode,
             trust_remote_code=trust_remote_code,
             revision=tokenizer_revision,
+            add_bos_token=add_bos_token,
         )
         self.tokenizer = configure_pad_token(self.tokenizer)
         self.add_bos_token = add_bos_token


### PR DESCRIPTION
Some tokenizers do not add the `bos` token using `add_special_tokens=True` unless initialized with `add_bos_token=True`

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("EleutherAI/pythia-14m")
tokenizer.encode("hello", add_special_tokens=True)
# [25521]

tokenizer = AutoTokenizer.from_pretrained("EleutherAI/pythia-14m", add_bos_token=True)
tokenizer.encode("hello", add_special_tokens=True)
# [0, 25521]

# llama 3.2 tokenizer works either way
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B")
tokenizer.encode("hello", add_special_tokens=True)
# [128000, 15339]
```