### PR TITLE
Update Legacy OpenLLM leaderboard to use "train" split for ARC fewshot

### DIFF
--- a/lm_eval/tasks/benchmarks/README.md
+++ b/lm_eval/tasks/benchmarks/README.md
@@ -1,0 +1,2 @@
+### Changelog
+- 2025-Mar-17 OpenLLM v.2: Fixed few-shot split to correctly use train set for arc_challenge.

--- a/lm_eval/tasks/benchmarks/README.md
+++ b/lm_eval/tasks/benchmarks/README.md
@@ -1,2 +1,2 @@
 ### Changelog
-- 2025-Mar-17 OpenLLM v.2: Fixed few-shot split to correctly use train set for arc_challenge.
+- 2025-Mar-17 OpenLLM v2: Fixed few-shot split to correctly use train set for arc_challenge.

--- a/lm_eval/tasks/benchmarks/openllm.yaml
+++ b/lm_eval/tasks/benchmarks/openllm.yaml
@@ -2,7 +2,7 @@ group: openllm
 group_alias: Open LLM Leaderboard
 task:
   - task: arc_challenge
-    fewshot_split: validation
+    fewshot_split: train
     num_fewshot: 25
   - task: hellaswag
     fewshot_split: train

--- a/lm_eval/tasks/benchmarks/openllm.yaml
+++ b/lm_eval/tasks/benchmarks/openllm.yaml
@@ -16,3 +16,5 @@ task:
     num_fewshot: 5
   - task: gsm8k
     num_fewshot: 5
+metadata:
+  version: 2


### PR DESCRIPTION
The original Open LLM leaderboard can be replicated by calling the individual tasks from the CLI with the relevant fewshot number. The behaviour of the harness is to select the following order of splits for fewshot if a fewshot split is not present: `train -> validation -> test`. The original arc task class included train, validation and test splits but did NOT contain a fewshot split, meaning by default it would use the `train` split.

This PR changes the openllm.yaml config to use `train` rather than `validation` for ARC.