### PR TITLE
Configure the pad tokens for Qwen when using vLLM

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -113,11 +113,11 @@ class VLLM(TemplateLM):
             self.batch_size = "auto"
             eval_logger.info("Manual batching is not compatible with data parallelism.")
 
-            from transformers import AutoConfig
+        from transformers import AutoConfig
 
-            self._config = AutoConfig.from_pretrained(
-                pretrained, trust_remote_code=trust_remote_code, revision=revision
-            )
+        self._config = AutoConfig.from_pretrained(
+            pretrained, trust_remote_code=trust_remote_code, revision=revision
+        )
         self.tokenizer = get_tokenizer(
             tokenizer if tokenizer else pretrained,
             tokenizer_mode=tokenizer_mode,
@@ -125,7 +125,7 @@ class VLLM(TemplateLM):
             revision=tokenizer_revision,
             add_bos_token=add_bos_token,
         )
-        self.tokenizer = configure_pad_token(self.tokenizer)
+        self.tokenizer = configure_pad_token(self.tokenizer, model_config=self._config)
         self.add_bos_token = add_bos_token
         if "gemma" in pretrained.lower():
             self.add_bos_token = True


### PR DESCRIPTION
I use the following command to run the Qwen model with the vLLM inference engine.

```
VLLM_WORKER_MULTIPROC_METHOD=spawn lm_eval --model vllm --model_args pretrained=Qwen/Qwen-7B,trust_remote_code=True --device cuda --batch_size 64 --tasks ceval-valid_accountant,ceval-valid_advanced_mathematics,ceval-valid_art_studies,ceval-valid_basic_medicine
```

But it results in the following error:

```
Traceback (most recent call last):
  File "/home/tiger/.pyenv/versions/3.11.2/bin/lm_eval", line 8, in <module>
    sys.exit(cli_evaluate())
             ^^^^^^^^^^^^^^
  File "/opt/tiger/lm-evaluation-harness/lm_eval/__main__.py", line 389, in cli_evaluate
    results = evaluator.simple_evaluate(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/tiger/lm-evaluation-harness/lm_eval/utils.py", line 423, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/tiger/lm-evaluation-harness/lm_eval/evaluator.py", line 217, in simple_evaluate
    lm = lm_eval.api.registry.get_model(model).create_from_arg_string(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/tiger/lm-evaluation-harness/lm_eval/api/model.py", line 151, in create_from_arg_string
    return cls(**args, **args2)
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/tiger/lm-evaluation-harness/lm_eval/models/vllm_causallms.py", line 128, in __init__
    self.tokenizer = configure_pad_token(self.tokenizer)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/tiger/lm-evaluation-harness/lm_eval/models/utils.py", line 666, in configure_pad_token
    tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
  File "/home/tiger/.pyenv/versions/3.11.2/lib/python3.11/site-packages/transformers/tokenization_utils_base.py", line 1000, in add_special_tokens
    added_tokens = self.add_tokens(added_tokens, special_tokens=True)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tiger/.pyenv/versions/3.11.2/lib/python3.11/site-packages/transformers/tokenization_utils_base.py", line 1050, in add_tokens
    return self._add_tokens(new_tokens, special_tokens=special_tokens)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.cache/huggingface/modules/transformers_modules/Qwen/Qwen-7B/ef3c5c9c57b252f3149c1408daf4d649ec8b6c85/tokenization_qwen.py", line 165, in _add_tokens
    raise ValueError("Adding unknown special tokens is not supported")
ValueError: Adding unknown special tokens is not supported
```

The likely cause of this error is that the pad tokens for the Qwen model are not correctly configured.
This MR provides a potential solution. I would appreciate it if this MR could be reviewed and merged.
Thanks!