### PR TITLE
[change] group -> tag on afrimgsm, afrimmlu, afrixnli dataset

### DIFF
--- a/lm_eval/tasks/afrimgsm/direct/direct_yaml
+++ b/lm_eval/tasks/afrimgsm/direct/direct_yaml
@@ -1,7 +1,7 @@
 # This file will be included in the generated language-specific task configs.
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
-group:
+tag:
     - afrimgsm
     - afrimgsm_direct
 dataset_path: masakhane/afrimgsm

--- a/lm_eval/tasks/afrimgsm/en_cot/cot_yaml
+++ b/lm_eval/tasks/afrimgsm/en_cot/cot_yaml
@@ -1,6 +1,6 @@
 # This file will be included in the generated language-specific task configs.
 # It doesn't have a yaml file extension as it is not meant to be imported directly by the harness.
-group:
+tag:
     - afrimgsm
     - afrimgsm_en_cot
 dataset_path: masakhane/afrimgsm

--- a/lm_eval/tasks/afrimgsm/translate/translate_direct_yaml
+++ b/lm_eval/tasks/afrimgsm/translate/translate_direct_yaml
@@ -1,7 +1,7 @@
 # This file will be included in the generated language-specific task configs.
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
-group:
+tag:
     - afrimgsm
     - afrimgsm_translate
 dataset_path: masakhane/afrimgsm-translate-test

--- a/lm_eval/tasks/afrimmlu/direct/afrimmlu_common_yaml
+++ b/lm_eval/tasks/afrimmlu/direct/afrimmlu_common_yaml
@@ -1,4 +1,4 @@
-group:
+tag:
   - afrimmlu
   - afrimmlu_direct
 task: null

--- a/lm_eval/tasks/afrimmlu/translate/afrimmlu_common_translate_yaml
+++ b/lm_eval/tasks/afrimmlu/translate/afrimmlu_common_translate_yaml
@@ -1,4 +1,4 @@
-group:
+tag:
   - afrimmlu_translate
 task: null
 dataset_path: masakhane/afrimmlu-translate-test

--- a/lm_eval/tasks/afrixnli/anli prompt/en-direct/afrixnli_en_direct_yaml
+++ b/lm_eval/tasks/afrixnli/anli prompt/en-direct/afrixnli_en_direct_yaml
@@ -1,4 +1,4 @@
-group:
+tag:
     - afrixnli
     - afrixnli_en_direct
 dataset_path: masakhane/afrixnli

--- a/lm_eval/tasks/afrixnli/anli prompt/native-direct/afrixnli_native_direct_yaml
+++ b/lm_eval/tasks/afrixnli/anli prompt/native-direct/afrixnli_native_direct_yaml
@@ -1,4 +1,4 @@
-group:
+tag:
     - afrixnli
     - afrixnli_native_direct
 dataset_path: masakhane/afrixnli

--- a/lm_eval/tasks/afrixnli/anli prompt/translate/afrixnli_translate_yaml
+++ b/lm_eval/tasks/afrixnli/anli prompt/translate/afrixnli_translate_yaml
@@ -1,4 +1,4 @@
-group:
+tag:
     - afrixnli
     - afrixnli_translate
 dataset_path: masakhane/afrixnli-translate-test

--- a/lm_eval/tasks/afrixnli/lai prompt/direct/afrixnli_manual_direct_yaml
+++ b/lm_eval/tasks/afrixnli/lai prompt/direct/afrixnli_manual_direct_yaml
@@ -1,4 +1,4 @@
-group:
+tag:
     - afrixnli
     - afrixnli_manual_direct
 dataset_path: masakhane/afrixnli

--- a/lm_eval/tasks/afrixnli/lai prompt/translate/afrixnli_manual_translate_yaml
+++ b/lm_eval/tasks/afrixnli/lai prompt/translate/afrixnli_manual_translate_yaml
@@ -1,4 +1,4 @@
-group:
+tag:
     - afrixnli
     - afrixnli_manual_direct
 dataset_path: masakhane/afrixnli-translate-test


### PR DESCRIPTION
To fix a type error `TypeError: TaskConfig.__init__() got an unexpected keyword argument 'group'`, I changed config `group` to `tag`.