### PR TITLE
[leaderboard] math - sync with repo

### DIFF
--- a/lm_eval/tasks/leaderboard/math/_template_yaml
+++ b/lm_eval/tasks/leaderboard/math/_template_yaml
@@ -16,9 +16,12 @@ metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
+  - metric: exact_match_original
+    aggregation: mean
+    higher_is_better: true
 num_fewshot: 4
 metadata:
-  version: 2.0
+  version: 3.0
 dataset_kwargs:
   trust_remote_code: true
 fewshot_config:

--- a/lm_eval/tasks/leaderboard/math/utils.py
+++ b/lm_eval/tasks/leaderboard/math/utils.py
@@ -13,8 +13,8 @@ try:
     from sympy.parsing.latex import parse_latex
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "`math-verify` is required for generating translation task prompt templates. \
-please install math-verify via pip install lm-eval[math] or pip install -e .[math]",
+        "`math-verify`, `sympy>=1.12`, and antlr4-python3-runtime==4.11 is required for generating translation task prompt templates. \
+please install via pip install lm-eval[math] or pip install -e .[math]",
     )
 
 

--- a/lm_eval/tasks/leaderboard/math/utils.py
+++ b/lm_eval/tasks/leaderboard/math/utils.py
@@ -1,21 +1,16 @@
-import logging
-import re
-import signal
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import datasets
 
 
-eval_logger = logging.getLogger(__name__)
-
 try:
-    import sympy
-    from sympy.parsing.latex import parse_latex
+    from math_verify import LatexExtractionConfig, parse, verify
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "`sympy` is required for generating translation task prompt templates. \
-please install sympy via pip install lm-eval[math] or pip install -e .[math]",
+        "`math-verify` is required for generating translation task prompt templates. \
+please install math-verify via pip install lm-eval[math] or pip install -e .[math]",
     )
+
 
 INVALID_ANSWER = "[invalidanswer]"
 
@@ -31,9 +26,7 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
         out_doc = {
             "problem": doc["problem"],
             "solution": doc["solution"],
-            "answer": normalize_final_answer(
-                remove_boxed(last_boxed_only_string(doc["solution"]))
-            ),
+            "answer": remove_boxed(last_boxed_only_string(doc["solution"])),
         }
         if getattr(doc, "few_shot", None) is not None:
             out_doc["few_shot"] = True
@@ -73,32 +66,27 @@ def list_fewshot_samples() -> list[dict]:
 
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     candidates = results[0]
-
-    unnormalized_answer = get_unnormalized_answer(candidates)
-    answer = normalize_final_answer(unnormalized_answer)
-
-    if answer == INVALID_ANSWER:
-        return {"exact_match": 0}
-
-    if answer.strip() == doc["answer"].strip() or is_equiv(answer, doc["answer"]):
+    parsed_candidate = parse(candidates)
+    parsed_answer = parse(doc["solution"], extraction_config=[LatexExtractionConfig()])
+    if verify(parsed_answer, parsed_candidate):
         retval = 1
     else:
         retval = 0
 
-    results = {
+    output = {
         "exact_match": retval,
     }
-    return results
+    return output
 
 
-def last_boxed_only_string(string: str) -> Optional[str]:
+def last_boxed_only_string(string: str) -> str:
     idx = string.rfind("\\boxed")
     if "\\boxed " in string:
         return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
     if idx < 0:
         idx = string.rfind("\\fbox")
         if idx < 0:
-            return None
+            return INVALID_ANSWER
 
     i = idx
     right_brace_idx = None
@@ -114,7 +102,7 @@ def last_boxed_only_string(string: str) -> Optional[str]:
         i += 1
 
     if right_brace_idx is None:
-        retval = None
+        retval = INVALID_ANSWER
     else:
         retval = string[idx : right_brace_idx + 1]
 
@@ -135,171 +123,3 @@ def remove_boxed(s: str) -> str:
         return s[len(left) : -1]
     except AssertionError:
         return INVALID_ANSWER
-
-
-class timeout:
-    def __init__(self, seconds=1, error_message="Timeout"):
-        self.seconds = seconds
-        self.error_message = error_message
-
-    def handle_timeout(self, signum, frame):
-        raise TimeoutError(self.error_message)
-
-    def __enter__(self):
-        signal.signal(signal.SIGALRM, self.handle_timeout)
-        signal.alarm(self.seconds)
-
-    def __exit__(self, type, value, traceback):
-        signal.alarm(0)
-
-
-def is_equiv(x1: str, x2: str) -> bool:
-    """
-    x1 and x2 are normalized latex string
-    """
-    try:
-        with timeout(seconds=1):
-            try:
-                parsed_x1 = parse_latex(x1)
-                parsed_x2 = parse_latex(x2)
-            except (
-                sympy.parsing.latex.errors.LaTeXParsingError,
-                sympy.SympifyError,
-                TypeError,
-            ):
-                eval_logger.debug(f"couldn't parse one of {x1} or {x2}")
-                return False
-
-            try:
-                diff = parsed_x1 - parsed_x2
-            except TypeError:
-                eval_logger.debug(f"couldn't subtract {x1} and {x2}")
-                return False
-
-            try:
-                if sympy.simplify(diff) == 0:
-                    return True
-                else:
-                    return False
-            except ValueError:
-                eval_logger.debug(
-                    f"Had some trouble simplifying when comparing {x1} and {x2}"
-                )
-    except TimeoutError:
-        eval_logger.debug(f"Timed out comparing {x1} and {x2}")
-        return False
-    except ImportError as e:
-        eval_logger.error(e)
-        raise
-    except Exception as e:
-        eval_logger.debug(f"Failed comparing {x1} and {x2} with {e}")
-        return False
-
-
-def get_unnormalized_answer(text: str) -> str:
-    end_seq = "I hope it is correct."
-    text += end_seq
-    match = re.search(
-        r"Final Answer: The final answer is(.*?). I hope it is correct.",
-        text,
-    )
-    if match:
-        return match.group(1).strip()
-    else:
-        return INVALID_ANSWER
-
-
-SUBSTITUTIONS = [
-    ("an ", ""),
-    ("a ", ""),
-    (".$", "$"),
-    ("\\$", ""),
-    (r"\ ", ""),
-    (" ", ""),
-    ("mbox", "text"),
-    (",\\text{and}", ","),
-    ("\\text{and}", ","),
-    ("\\text{m}", "\\text{}"),
-]
-REMOVED_EXPRESSIONS = [
-    "square",
-    "ways",
-    "integers",
-    "dollars",
-    "mph",
-    "inches",
-    "ft",
-    "hours",
-    "km",
-    "units",
-    "\\ldots",
-    "sue",
-    "points",
-    "feet",
-    "minutes",
-    "digits",
-    "cents",
-    "degrees",
-    "cm",
-    "gm",
-    "pounds",
-    "meters",
-    "meals",
-    "edges",
-    "students",
-    "childrentickets",
-    "multiples",
-    "\\text{s}",
-    "\\text{.}",
-    "\\text{\ns}",
-    "\\text{}^2",
-    "\\text{}^3",
-    "\\text{\n}",
-    "\\text{}",
-    r"\mathrm{th}",
-    r"^\circ",
-    r"^{\circ}",
-    r"\;",
-    r",\!",
-    "{,}",
-    '"',
-    "\\dots",
-]
-
-
-def normalize_final_answer(final_answer: str) -> str:
-    """
-    Normalize a final answer to a quantitative reasoning question.
-
-    Copied character for character from appendix D of Lewkowycz et al. (2022)
-    """
-    final_answer = final_answer.split("=")[-1]
-
-    for before, after in SUBSTITUTIONS:
-        final_answer = final_answer.replace(before, after)
-    for expr in REMOVED_EXPRESSIONS:
-        final_answer = final_answer.replace(expr, "")
-
-    # Extract answer that is in LaTeX math, is bold,
-    # is surrounded by a box, etc.
-    final_answer = re.sub(r"(.*?)(\$)(.*?)(\$)(.*)", "$\\3$", final_answer)
-    final_answer = re.sub(r"(\\text\{)(.*?)(\})", "\\2", final_answer)
-    final_answer = re.sub(r"(\\textbf\{)(.*?)(\})", "\\2", final_answer)
-    final_answer = re.sub(r"(\\overline\{)(.*?)(\})", "\\2", final_answer)
-    final_answer = re.sub(r"(\\boxed\{)(.*)(\})", "\\2", final_answer)
-
-    # Normalize shorthand TeX:
-    #  \fracab -> \frac{a}{b}
-    #  \frac{abc}{bef} -> \frac{abc}{bef}
-    #  \fracabc -> \frac{a}{b}c
-    #  \sqrta -> \sqrt{a}
-    #  \sqrtab -> sqrt{a}b
-    final_answer = re.sub(r"(frac)([^{])(.)", "frac{\\2}{\\3}", final_answer)
-    final_answer = re.sub(r"(sqrt)([^{])", "sqrt{\\2}", final_answer)
-    final_answer = final_answer.replace("$", "")
-
-    # Normalize 100,000 -> 100000
-    if final_answer.replace(",", "").isdigit():
-        final_answer = final_answer.replace(",", "")
-
-    return final_answer

--- a/lm_eval/tasks/leaderboard/math/utils.py
+++ b/lm_eval/tasks/leaderboard/math/utils.py
@@ -79,9 +79,14 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     else:
         retval = 0
 
+    try:
+        original = process_result_v1(doc, candidates)
+    except:  # noqa: E722
+        original = 0
+
     output = {
         "exact_match": retval,
-        "exact_match_original": process_result_v1(doc, candidates),
+        "exact_match_original": original,
     }
     return output
 
@@ -90,11 +95,10 @@ def process_result_v1(doc: dict, candidates: str) -> int:
     # using the orginal answer extraction method
     unnormalized_answer = get_unnormalized_answer(candidates)
     answer = normalize_final_answer(unnormalized_answer)
+    normalized_gold = normalize_final_answer(doc["answer"])
     if answer == INVALID_ANSWER:
         return 0
-    if answer.strip() == doc["answer"].strip() or is_equiv(
-        answer, normalize_final_answer(doc["answer"])
-    ):
+    if answer.strip() == normalized_gold.strip() or is_equiv(answer, normalized_gold):
         retval = 1
     else:
         retval = 0

--- a/lm_eval/tasks/leaderboard/math/utils.py
+++ b/lm_eval/tasks/leaderboard/math/utils.py
@@ -1,10 +1,16 @@
+import logging
 from typing import Dict, List
 
 import datasets
 
 
 try:
+    import re
+    import signal
+
+    import sympy
     from math_verify import LatexExtractionConfig, parse, verify
+    from sympy.parsing.latex import parse_latex
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
         "`math-verify` is required for generating translation task prompt templates. \
@@ -75,8 +81,24 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
 
     output = {
         "exact_match": retval,
+        "exact_match_original": process_result_v1(doc, candidates),
     }
     return output
+
+
+def process_result_v1(doc: dict, candidates: str) -> int:
+    # using the orginal answer extraction method
+    unnormalized_answer = get_unnormalized_answer(candidates)
+    answer = normalize_final_answer(unnormalized_answer)
+    if answer == INVALID_ANSWER:
+        return 0
+    if answer.strip() == doc["answer"].strip() or is_equiv(
+        answer, normalize_final_answer(doc["answer"])
+    ):
+        retval = 1
+    else:
+        retval = 0
+    return retval
 
 
 def last_boxed_only_string(string: str) -> str:
@@ -123,3 +145,172 @@ def remove_boxed(s: str) -> str:
         return s[len(left) : -1]
     except AssertionError:
         return INVALID_ANSWER
+
+
+class timeout:
+    def __init__(self, seconds=1, error_message="Timeout"):
+        self.seconds = seconds
+        self.error_message = error_message
+
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.handle_timeout)
+        signal.alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        signal.alarm(0)
+
+
+def is_equiv(x1: str, x2: str) -> bool:
+    """
+    x1 and x2 are normalized latex string
+    """
+    eval_logger = logging.getLogger(__name__)
+    try:
+        with timeout(seconds=1):
+            try:
+                parsed_x1 = parse_latex(x1)
+                parsed_x2 = parse_latex(x2)
+            except (
+                sympy.parsing.latex.errors.LaTeXParsingError,
+                sympy.SympifyError,
+                TypeError,
+            ):
+                eval_logger.debug(f"couldn't parse one of {x1} or {x2}")
+                return False
+
+            try:
+                diff = parsed_x1 - parsed_x2
+            except TypeError:
+                eval_logger.debug(f"couldn't subtract {x1} and {x2}")
+                return False
+
+            try:
+                if sympy.simplify(diff) == 0:
+                    return True
+                else:
+                    return False
+            except ValueError:
+                eval_logger.debug(
+                    f"Had some trouble simplifying when comparing {x1} and {x2}"
+                )
+    except TimeoutError:
+        eval_logger.debug(f"Timed out comparing {x1} and {x2}")
+        return False
+    except ImportError as e:
+        eval_logger.error(e)
+        raise
+    except Exception as e:
+        eval_logger.debug(f"Failed comparing {x1} and {x2} with {e}")
+        return False
+
+
+def get_unnormalized_answer(text: str) -> str:
+    end_seq = "I hope it is correct."
+    text += end_seq
+    match = re.search(
+        r"Final Answer: The final answer is(.*?). I hope it is correct.",
+        text,
+    )
+    if match:
+        return match.group(1).strip()
+    else:
+        return INVALID_ANSWER
+
+
+SUBSTITUTIONS = [
+    ("an ", ""),
+    ("a ", ""),
+    (".$", "$"),
+    ("\\$", ""),
+    (r"\ ", ""),
+    (" ", ""),
+    ("mbox", "text"),
+    (",\\text{and}", ","),
+    ("\\text{and}", ","),
+    ("\\text{m}", "\\text{}"),
+]
+REMOVED_EXPRESSIONS = [
+    "square",
+    "ways",
+    "integers",
+    "dollars",
+    "mph",
+    "inches",
+    "ft",
+    "hours",
+    "km",
+    "units",
+    "\\ldots",
+    "sue",
+    "points",
+    "feet",
+    "minutes",
+    "digits",
+    "cents",
+    "degrees",
+    "cm",
+    "gm",
+    "pounds",
+    "meters",
+    "meals",
+    "edges",
+    "students",
+    "childrentickets",
+    "multiples",
+    "\\text{s}",
+    "\\text{.}",
+    "\\text{\ns}",
+    "\\text{}^2",
+    "\\text{}^3",
+    "\\text{\n}",
+    "\\text{}",
+    r"\mathrm{th}",
+    r"^\circ",
+    r"^{\circ}",
+    r"\;",
+    r",\!",
+    "{,}",
+    '"',
+    "\\dots",
+]
+
+
+def normalize_final_answer(final_answer: str) -> str:
+    """
+    Normalize a final answer to a quantitative reasoning question.
+
+    Copied character for character from appendix D of Lewkowycz et al. (2022)
+    """
+    final_answer = final_answer.split("=")[-1]
+
+    for before, after in SUBSTITUTIONS:
+        final_answer = final_answer.replace(before, after)
+    for expr in REMOVED_EXPRESSIONS:
+        final_answer = final_answer.replace(expr, "")
+
+    # Extract answer that is in LaTeX math, is bold,
+    # is surrounded by a box, etc.
+    final_answer = re.sub(r"(.*?)(\$)(.*?)(\$)(.*)", "$\\3$", final_answer)
+    final_answer = re.sub(r"(\\text\{)(.*?)(\})", "\\2", final_answer)
+    final_answer = re.sub(r"(\\textbf\{)(.*?)(\})", "\\2", final_answer)
+    final_answer = re.sub(r"(\\overline\{)(.*?)(\})", "\\2", final_answer)
+    final_answer = re.sub(r"(\\boxed\{)(.*)(\})", "\\2", final_answer)
+
+    # Normalize shorthand TeX:
+    #  \fracab -> \frac{a}{b}
+    #  \frac{abc}{bef} -> \frac{abc}{bef}
+    #  \fracabc -> \frac{a}{b}c
+    #  \sqrta -> \sqrt{a}
+    #  \sqrtab -> sqrt{a}b
+    final_answer = re.sub(r"(frac)([^{])(.)", "frac{\\2}{\\3}", final_answer)
+    final_answer = re.sub(r"(sqrt)([^{])", "sqrt{\\2}", final_answer)
+    final_answer = final_answer.replace("$", "")
+
+    # Normalize 100,000 -> 100000
+    if final_answer.replace(",", "").isdigit():
+        final_answer = final_answer.replace(",", "")
+
+    return final_answer


### PR DESCRIPTION
copied the official implementation from https://github.com/huggingface/lm-evaluation-harness/blob/main/lm_eval/tasks/leaderboard/math/utils.py, where they use `math_verify` for answer extraction.