### PR TITLE
Increase default max_gen_toks to 2048 and max_length to 8192 for MMLU Pro tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ lm_eval/caching/.cache
 # don't track files created by wandb
 wandb
 examples/wandb
-lehenv/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ lm_eval/caching/.cache
 # don't track files created by wandb
 wandb
 examples/wandb
+lehenv/

--- a/lm_eval/tasks/mmlu_pro/README.md
+++ b/lm_eval/tasks/mmlu_pro/README.md
@@ -63,4 +63,4 @@ If other tasks on this dataset are already supported:
 * (tasks, group) 2024-09-23 -- (version 1 --> version 2)
   * Added one newline to task description(s) as per [reference implementation](https://github.com/TIGER-AI-Lab/MMLU-Pro/blob/47b9891aacb8bd7cda29d5c5ba17b9434dd333bc/evaluate_from_local.py#L93)
 * (tasks, group) 2025-03-20 -- (version 2.0 --> version 2.1)
-  * Changed default max_length from 2048 to 8192 and max_gen_toks from 256 to 2048. 
+  * Changed default max_length from 2048 to 8192 and max_gen_toks from 256 to 2048.

--- a/lm_eval/tasks/mmlu_pro/README.md
+++ b/lm_eval/tasks/mmlu_pro/README.md
@@ -62,3 +62,5 @@ If other tasks on this dataset are already supported:
 
 * (tasks, group) 2024-09-23 -- (version 1 --> version 2)
   * Added one newline to task description(s) as per [reference implementation](https://github.com/TIGER-AI-Lab/MMLU-Pro/blob/47b9891aacb8bd7cda29d5c5ba17b9434dd333bc/evaluate_from_local.py#L93)
+* (tasks, group) 2025-03-20 -- (version 2.0 --> version 2.1)
+  * Changed default max_length from 2048 to 8192 and max_gen_toks from 256 to 2048. 

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -20,7 +20,6 @@ generation_kwargs:
     - "</s>"
     - "Q:"
     - "<|im_end|>"
-  max_length: 8192
   max_gen_toks: 2048
   do_sample: false
   temperature: 0.0

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -20,6 +20,8 @@ generation_kwargs:
     - "</s>"
     - "Q:"
     - "<|im_end|>"
+  max_length: 8192
+  max_gen_toks: 2048
   do_sample: false
   temperature: 0.0
 num_fewshot: 5
@@ -30,4 +32,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 2.1


### PR DESCRIPTION
## Changes
- Updated the default `max_gen_toks` to 2048 in the configuration file.
- Updated the default `max_length` to 8192 in the configuration file.
- Incremented the version number to 2.1
- Added an entry to the changelog.

Closes #2798
