### PR TITLE
Add kmmlu multiple-choice(accuracy) task #2848

### DIFF
--- a/lm_eval/tasks/kmmlu/README.md
+++ b/lm_eval/tasks/kmmlu/README.md
@@ -32,6 +32,7 @@ Homepage: https://huggingface.co/datasets/HAERAE-HUB/KMMLU
 #### Tasks
 
 The following tasks evaluate subjects in the KMMLU dataset
+- `kmmlu_{subject_english}`
 - `kmmlu_direct_{subject_english}`
 
 The following tasks evaluate subjects in the KMMLU-Hard dataset

--- a/lm_eval/tasks/kmmlu/default/_default_kmmlu_yaml
+++ b/lm_eval/tasks/kmmlu/default/_default_kmmlu_yaml
@@ -1,0 +1,13 @@
+dataset_path: HAERAE-HUB/KMMLU
+output_type: multiple_choice
+test_split: test
+fewshot_split: dev
+doc_to_text: "{{question.strip()}}\nA. {{A}}\nB. {{B}}\nC. {{C}}\nD. {{D}}\n정답："
+doc_to_choice: ["A", "B", "C", "D"]
+doc_to_target: "{{answer-1}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/kmmlu/default/_kmmlu_applied_science.yaml
+++ b/lm_eval/tasks/kmmlu/default/_kmmlu_applied_science.yaml
@@ -1,0 +1,8 @@
+group: kmmlu_applied_science
+task:
+  - kmmlu_applied_science_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: True
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/kmmlu/default/_kmmlu_default.yaml
+++ b/lm_eval/tasks/kmmlu/default/_kmmlu_default.yaml
@@ -1,0 +1,11 @@
+group: kmmlu
+task:
+  - kmmlu_stem
+  - kmmlu_other
+  - kmmlu_applied_science
+  - kmmlu_humss
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: True
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/kmmlu/default/_kmmlu_humss.yaml
+++ b/lm_eval/tasks/kmmlu/default/_kmmlu_humss.yaml
@@ -1,0 +1,8 @@
+group: kmmlu_humss
+task:
+  - kmmlu_humss_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: True
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/kmmlu/default/_kmmlu_other.yaml
+++ b/lm_eval/tasks/kmmlu/default/_kmmlu_other.yaml
@@ -1,0 +1,8 @@
+group: kmmlu_other
+task:
+  - kmmlu_other_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: True
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/kmmlu/default/_kmmlu_stem.yaml
+++ b/lm_eval/tasks/kmmlu/default/_kmmlu_stem.yaml
@@ -1,0 +1,8 @@
+group: kmmlu_stem
+task:
+  - kmmlu_stem_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: True
+metadata:
+  version: 2.0

--- a/lm_eval/tasks/kmmlu/default/kmmlu_accounting.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_accounting.yaml
@@ -1,0 +1,4 @@
+dataset_name: Accounting
+include: _default_kmmlu_yaml
+task: kmmlu_accounting
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_agricultural_sciences.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_agricultural_sciences.yaml
@@ -1,0 +1,4 @@
+dataset_name: Agricultural-Sciences
+include: _default_kmmlu_yaml
+task: kmmlu_agricultural_sciences
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_aviation_engineering_and_maintenance.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_aviation_engineering_and_maintenance.yaml
@@ -1,0 +1,4 @@
+dataset_name: Aviation-Engineering-and-Maintenance
+include: _default_kmmlu_yaml
+task: kmmlu_aviation_engineering_and_maintenance
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_biology.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_biology.yaml
@@ -1,0 +1,4 @@
+dataset_name: Biology
+include: _default_kmmlu_yaml
+task: kmmlu_biology
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_chemical_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_chemical_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Chemical-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_chemical_engineering
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_chemistry.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_chemistry.yaml
@@ -1,0 +1,4 @@
+dataset_name: Chemistry
+include: _default_kmmlu_yaml
+task: kmmlu_chemistry
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_civil_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_civil_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Civil-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_civil_engineering
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_computer_science.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_computer_science.yaml
@@ -1,0 +1,4 @@
+dataset_name: Computer-Science
+include: _default_kmmlu_yaml
+task: kmmlu_computer_science
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_construction.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_construction.yaml
@@ -1,0 +1,4 @@
+dataset_name: Construction
+include: _default_kmmlu_yaml
+task: kmmlu_construction
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_criminal_law.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_criminal_law.yaml
@@ -1,0 +1,4 @@
+dataset_name: Criminal-Law
+include: _default_kmmlu_yaml
+task: kmmlu_criminal_law
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_ecology.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_ecology.yaml
@@ -1,0 +1,4 @@
+dataset_name: Ecology
+include: _default_kmmlu_yaml
+task: kmmlu_ecology
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_economics.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_economics.yaml
@@ -1,0 +1,4 @@
+dataset_name: Economics
+include: _default_kmmlu_yaml
+task: kmmlu_economics
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_education.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_education.yaml
@@ -1,0 +1,4 @@
+dataset_name: Education
+include: _default_kmmlu_yaml
+task: kmmlu_education
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_electrical_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_electrical_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Electrical-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_electrical_engineering
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_electronics_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_electronics_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Electronics-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_electronics_engineering
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_energy_management.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_energy_management.yaml
@@ -1,0 +1,4 @@
+dataset_name: Energy-Management
+include: _default_kmmlu_yaml
+task: kmmlu_energy_management
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_environmental_science.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_environmental_science.yaml
@@ -1,0 +1,4 @@
+dataset_name: Environmental-Science
+include: _default_kmmlu_yaml
+task: kmmlu_environmental_science
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_fashion.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_fashion.yaml
@@ -1,0 +1,4 @@
+dataset_name: Fashion
+include: _default_kmmlu_yaml
+task: kmmlu_fashion
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_food_processing.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_food_processing.yaml
@@ -1,0 +1,4 @@
+dataset_name: Food-Processing
+include: _default_kmmlu_yaml
+task: kmmlu_food_processing
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_gas_technology_and_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_gas_technology_and_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Gas-Technology-and-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_gas_technology_and_engineering
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_geomatics.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_geomatics.yaml
@@ -1,0 +1,4 @@
+dataset_name: Geomatics
+include: _default_kmmlu_yaml
+task: kmmlu_geomatics
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_health.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_health.yaml
@@ -1,0 +1,4 @@
+dataset_name: Health
+include: _default_kmmlu_yaml
+task: kmmlu_health
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_industrial_engineer.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_industrial_engineer.yaml
@@ -1,0 +1,4 @@
+dataset_name: Industrial-Engineer
+include: _default_kmmlu_yaml
+task: kmmlu_industrial_engineer
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_information_technology.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_information_technology.yaml
@@ -1,0 +1,4 @@
+dataset_name: Information-Technology
+include: _default_kmmlu_yaml
+task: kmmlu_information_technology
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_interior_architecture_and_design.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_interior_architecture_and_design.yaml
@@ -1,0 +1,4 @@
+dataset_name: Interior-Architecture-and-Design
+include: _default_kmmlu_yaml
+task: kmmlu_interior_architecture_and_design
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_korean_history.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_korean_history.yaml
@@ -1,0 +1,4 @@
+dataset_name: Korean-History
+include: _default_kmmlu_yaml
+task: kmmlu_korean_history
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_law.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_law.yaml
@@ -1,0 +1,4 @@
+dataset_name: Law
+include: _default_kmmlu_yaml
+task: kmmlu_law
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_machine_design_and_manufacturing.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_machine_design_and_manufacturing.yaml
@@ -1,0 +1,4 @@
+dataset_name: Machine-Design-and-Manufacturing
+include: _default_kmmlu_yaml
+task: kmmlu_machine_design_and_manufacturing
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_management.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_management.yaml
@@ -1,0 +1,4 @@
+dataset_name: Management
+include: _default_kmmlu_yaml
+task: kmmlu_management
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_maritime_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_maritime_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Maritime-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_maritime_engineering
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_marketing.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_marketing.yaml
@@ -1,0 +1,4 @@
+dataset_name: Marketing
+include: _default_kmmlu_yaml
+task: kmmlu_marketing
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_materials_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_materials_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Materials-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_materials_engineering
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_math.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_math.yaml
@@ -1,0 +1,4 @@
+dataset_name: Math
+include: _default_kmmlu_yaml
+task: kmmlu_math
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_mechanical_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_mechanical_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Mechanical-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_mechanical_engineering
+tag: kmmlu_stem_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_nondestructive_testing.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_nondestructive_testing.yaml
@@ -1,0 +1,4 @@
+dataset_name: Nondestructive-Testing
+include: _default_kmmlu_yaml
+task: kmmlu_nondestructive_testing
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_patent.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_patent.yaml
@@ -1,0 +1,4 @@
+dataset_name: Patent
+include: _default_kmmlu_yaml
+task: kmmlu_patent
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_political_science_and_sociology.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_political_science_and_sociology.yaml
@@ -1,0 +1,4 @@
+dataset_name: Political-Science-and-Sociology
+include: _default_kmmlu_yaml
+task: kmmlu_political_science_and_sociology
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_psychology.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_psychology.yaml
@@ -1,0 +1,4 @@
+dataset_name: Psychology
+include: _default_kmmlu_yaml
+task: kmmlu_psychology
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_public_safety.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_public_safety.yaml
@@ -1,0 +1,4 @@
+dataset_name: Public-Safety
+include: _default_kmmlu_yaml
+task: kmmlu_public_safety
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_railway_and_automotive_engineering.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_railway_and_automotive_engineering.yaml
@@ -1,0 +1,4 @@
+dataset_name: Railway-and-Automotive-Engineering
+include: _default_kmmlu_yaml
+task: kmmlu_railway_and_automotive_engineering
+tag: kmmlu_applied_science_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_real_estate.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_real_estate.yaml
@@ -1,0 +1,4 @@
+dataset_name: Real-Estate
+include: _default_kmmlu_yaml
+task: kmmlu_real_estate
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_refrigerating_machinery.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_refrigerating_machinery.yaml
@@ -1,0 +1,4 @@
+dataset_name: Refrigerating-Machinery
+include: _default_kmmlu_yaml
+task: kmmlu_refrigerating_machinery
+tag: kmmlu_other_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_social_welfare.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_social_welfare.yaml
@@ -1,0 +1,4 @@
+dataset_name: Social-Welfare
+include: _default_kmmlu_yaml
+task: kmmlu_social_welfare
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_taxation.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_taxation.yaml
@@ -1,0 +1,4 @@
+dataset_name: Taxation
+include: _default_kmmlu_yaml
+task: kmmlu_taxation
+tag: kmmlu_humss_tasks

--- a/lm_eval/tasks/kmmlu/default/kmmlu_telecommunications_and_wireless_technology.yaml
+++ b/lm_eval/tasks/kmmlu/default/kmmlu_telecommunications_and_wireless_technology.yaml
@@ -1,0 +1,4 @@
+dataset_name: Telecommunications-and-Wireless-Technology
+include: _default_kmmlu_yaml
+task: kmmlu_telecommunications_and_wireless_technology
+tag: kmmlu_applied_science_tasks


### PR DESCRIPTION
### Description

Restores the standard multiple-choice (acc metric) kmmlu task, addressing issue #2848.

The task was previously missing, despite being listed in the README and widely used (e.g., [arXiv:2412.04862](https://www.google.com/url?sa=E&q=https%3A%2F%2Farxiv.org%2Fabs%2F2412.04862)).

Brings kmmlu in line with kmmlu-hard which has both multiple-choice and generative versions.

Adds kmmlu.yaml using the HAERAE-HUB/KMMLU dataset.

Tested locally.

#### #2848 