### PR TITLE
use verify_certificate flag in batch api requests

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -411,6 +411,7 @@ class TemplateAPI(TemplateLM):
                 self.base_url,
                 json=payload,
                 headers=self.header,
+                ssl=self.verify_certificate,
             ) as response:
                 if not response.ok:
                     error_text = await response.text()


### PR DESCRIPTION
Currently, batch API requests rely on the `aiohttp` library, which does not utilize the `verify_certificate` flag, resulting in request failures despite explicitly setting `verify_certificate=False`. This pull request aims to ensure that the flag is passed correctly to `aiohttp` requests.