### PR TITLE
Fix formatting issues in XNLI tasks in Basque, Catalan, Galician and Spanish

### DIFF
--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -10,29 +10,39 @@ from lm_eval.utils import general_detokenize
 def lowercase_first_letter(text):
     return text[0].lower() + text[1:]
 
+def uppercase_first_letter(text):
+    return text[0].upper() + text[1:]
 
 def process_doc_nli(dataset):
+
+    def filter_fn(doc):
+        # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
+        # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
+        if any([punct in sent for punct in ["!", "?", "¿"] for sent in [doc["premise"], doc["hypothesis"]]]):
+            return False
+
+        return True
+
     def process_fn(doc):
         # Detokenize(remove extra whitespaces)
         doc["premise"] = general_detokenize(doc["premise"]).strip()
         doc["hypothesis"] = general_detokenize(doc["hypothesis"]).strip()
-        # Remove last punctuation mark in the premise
-        doc["premise"] = (
-            doc["premise"][:-1]
-            if doc["premise"].endswith((".", ",", "!", "?"))
-            else doc["premise"]
-        )
+
+        # Remove periods from the end of the premise
+        doc["premise"] = doc["premise"].rstrip(".")
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
-        # Ensure that the hypothesis ends with a dot
-        doc["hypothesis"] = (
-            (doc["hypothesis"] + ".")
-            if not doc["hypothesis"].endswith(".")
-            else doc["hypothesis"]
-        )
+
+        # Uppercase the first letter in the premise
+        doc["premise"] = uppercase_first_letter(doc["premise"])
+
+        # Ensure that the hypothesis ends with a single period
+        doc["hypothesis"] = doc["hypothesis"].rstrip(".") + "."
+
         return doc
 
-    return dataset.map(process_fn)
+    return dataset.filter(filter_fn).map(process_fn)
 
 
 def process_results_coqcat(doc, results):

--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -18,7 +18,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["!", "?", "¿"] for sent in [doc["premise"], doc["hypothesis"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/catalan_bench/utils.py
+++ b/lm_eval/tasks/catalan_bench/utils.py
@@ -18,7 +18,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/galician_bench/utils.py
+++ b/lm_eval/tasks/galician_bench/utils.py
@@ -147,7 +147,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in sentence1 or sentence2.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["sentence1"], doc["sentence2"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["sentence1"], doc["sentence2"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/spanish_bench/utils.py
+++ b/lm_eval/tasks/spanish_bench/utils.py
@@ -10,29 +10,39 @@ from lm_eval.utils import general_detokenize
 def lowercase_first_letter(text):
     return text[0].lower() + text[1:]
 
+def uppercase_first_letter(text):
+    return text[0].upper() + text[1:]
 
 def process_doc_nli(dataset):
+
+    def filter_fn(doc):
+        # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
+        # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
+            return False
+
+        return True
+
     def process_fn(doc):
         # Detokenize(remove extra whitespaces)
         doc["premise"] = general_detokenize(doc["premise"]).strip()
         doc["hypothesis"] = general_detokenize(doc["hypothesis"]).strip()
-        # Remove last punctuation mark in the premise
-        doc["premise"] = (
-            doc["premise"][:-1]
-            if doc["premise"].endswith((".", ",", "!", "?"))
-            else doc["premise"]
-        )
+
+        # Remove periods from the end of the premise
+        doc["premise"] = doc["premise"].rstrip(".")
+
         # Lowercase the first letter in the hypothesis
         doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
-        # Ensure that the hypothesis ends with a dot
-        doc["hypothesis"] = (
-            (doc["hypothesis"] + ".")
-            if not doc["hypothesis"].endswith(".")
-            else doc["hypothesis"]
-        )
+
+        # Uppercase the first letter in the premise
+        doc["premise"] = uppercase_first_letter(doc["premise"])
+
+        # Ensure that the hypothesis ends with a single period
+        doc["hypothesis"] = doc["hypothesis"].rstrip(".") + "."
+
         return doc
 
-    return dataset.map(process_fn)
+    return dataset.filter(filter_fn).map(process_fn)
 
 
 def process_xlsum(dataset):

--- a/lm_eval/tasks/spanish_bench/utils.py
+++ b/lm_eval/tasks/spanish_bench/utils.py
@@ -18,7 +18,7 @@ def process_doc_nli(dataset):
     def filter_fn(doc):
         # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
         # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
-        if any([punct in sent for punct in ["¡", "!", "?", "¿", "..."] for sent in [doc["premise"], doc["hypothesis"]]]):
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):
             return False
 
         return True

--- a/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
@@ -4,7 +4,7 @@ dataset_path: xnli
 dataset_name: es
 output_type: multiple_choice
 doc_to_choice: '{{[premise+", ¿correcto? Sí, "+hypothesis,premise+", ¿correcto? Así
-  que, "+hypothesis,premise+", ¿correcto? No, "+hypothesis]}}'
+  que "+hypothesis,premise+", ¿correcto? No, "+hypothesis]}}'
 doc_to_text: ''
 target_delimiter: ''
 process_docs: !function utils.process_doc_nli

--- a/lm_eval/tasks/xnli_eu/utils.py
+++ b/lm_eval/tasks/xnli_eu/utils.py
@@ -1,0 +1,38 @@
+from lm_eval.utils import general_detokenize
+
+def lowercase_first_letter(text):
+    return text[0].lower() + text[1:]
+
+def uppercase_first_letter(text):
+    return text[0].upper() + text[1:]
+
+def process_doc_nli(dataset):
+
+    def filter_fn(doc):
+        # There shouldn't be any final punctuation marks (except periods) in the premise or the hypothesis.
+        # They're supposed to be one single sentence in order to be concatenated properly in the prompt.
+        if any([punct in sent for punct in ["¡", "!", "?", "¿", "...", ":", ";"] for sent in [doc["premise"], doc["hypothesis"]]]):
+            return False
+
+        return True
+
+    def process_fn(doc):
+        # Detokenize(remove extra whitespaces)
+        doc["premise"] = general_detokenize(doc["premise"]).strip()
+        doc["hypothesis"] = general_detokenize(doc["hypothesis"]).strip()
+
+        # Remove periods from the end of the premise
+        doc["premise"] = doc["premise"].rstrip(".")
+
+        # Lowercase the first letter in the hypothesis
+        doc["hypothesis"] = lowercase_first_letter(doc["hypothesis"])
+
+        # Uppercase the first letter in the premise
+        doc["premise"] = uppercase_first_letter(doc["premise"])
+
+        # Ensure that the hypothesis ends with a single period
+        doc["hypothesis"] = doc["hypothesis"].rstrip(".") + "."
+
+        return doc
+
+    return dataset.filter(filter_fn).map(process_fn)

--- a/lm_eval/tasks/xnli_eu/xnli_common_yaml
+++ b/lm_eval/tasks/xnli_eu/xnli_common_yaml
@@ -4,6 +4,7 @@ dataset_name: null
 output_type: multiple_choice
 training_split: train
 validation_split: validation
+process_docs: !function utils.process_doc_nli
 doc_to_text: null
 doc_to_target: label
 doc_to_choice: null


### PR DESCRIPTION
This PR corrects a number of formatting issues that we have identified with the construction of prompts for the following XNLI tasks: `xnli_eu`, `xnli_ca`, `xnli_gl` and `xnli_es_spanish_bench`.

TO-DO

- The XNLI datasets contain several documents that are not fit to be concatenated into the prompt style of these tasks, where they will be in the middle of a sentence like `{premise}, ¿correcto?` or `No, {hypothesis}`. It does not make any sense to put anything in these spaces that is not a single, affirmative sentence; there are instances that contain questions, sentences with "..." in the middle and sentences with exclamation points, which led to grammatically-incorrect (and ininteligible) prompts. We include some examples below. The solution we proposed is to **filter out** these documents before preprocessing. We add a filter function that removes instances where the `premise` or the `hypothesis` contains punctuation in the middle.
- We remove the comma after "Así que" in `xnli_es`, because it is grammatically incorrect in Spanish.
- We fix the pre-processing functions to ensure that: (1) all sentences start with an uppercase letter; (2) all hypotheses (which are concatenated into the middle of a full sentence) start with a lowercase letter; (3) all sentences end with a single period.

**Examples of misformatted prompts**

`xnli_es_spanish_bench`:
- `... jirones de nubes blancas esparcidas por todo un claro cielo azul, ¿correcto? Así que, el sol está detrás de una nube esponjosa con forma de un conejito.`
- `Ese fue..., ese fue un día bastante aterrador, ¿correcto? No, fue un día relajante.`
- `¿Qué te gusta más, las matemáticas o las ciencias, ¿correcto? Sí, ¿Prefiere las matemáticas o las ciencias?.`

`xnli_gl`:
- `Por exemplo, un presidente do programa preparou a man algúns comentarios introdutorios laudatorios sobre un.., verdadeiro? Si, un presidente do programa preparou algunhas observacións introdutorias.`
- `si, escóitoo, verdadeiro? Ademais, creo que o oio.`
- `Debería cambiar a Linux, verdadeiro? Si, deberías cambiar o teu sistema operativo a Linux?.`

`xnli_ca`:
- `bé per què no comences perquè has tingut més temps per pensar-hi si no t'importa, correcte? Sí, per què no ho fas tu primer?.`
- `Aquest home va néixer a Alemanya, és ric, ben educat, ha viatjat.., correcte? No, aquest home va néixer a Arkansas i era pobre, no tenia educació i no va viatjar mai.`
- `... però la segona vegada que té lloc la trobada es veu atrapat al mig entre dos amics, correcte? No, només té una trobada, en què participa un amic seu.`

`xnli_eu`:
- ` Ez, neskak egia perfektuarekin erantzun zuen., ezta? Bai, Zintzoa zen, eta ezetz esan zuen.`
- `139 \"Eta, hala ere, absolbitua izan daitekeela diozu?\", ezta? Gainera, Banpiroen jaunekin lan egiteko epaiketan dago.`