### PR TITLE
Fixed a bug that in MMLU-Pro utils.py that throw index error if one choice was removed

### DIFF
--- a/lm_eval/tasks/mmlu_pro/utils.py
+++ b/lm_eval/tasks/mmlu_pro/utils.py
@@ -1,25 +1,6 @@
 from functools import partial
 
-
-choices = [
-    "A",
-    "B",
-    "C",
-    "D",
-    "E",
-    "F",
-    "G",
-    "H",
-    "I",
-    "J",
-    "K",
-    "L",
-    "M",
-    "N",
-    "O",
-    "P",
-]
-
+choices = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
 
 def format_cot_example(example, including_answer=True):
     prompt = "Question:\n"
@@ -27,8 +8,12 @@ def format_cot_example(example, including_answer=True):
     options = example["options"]
     prompt += question + "\n"
     prompt += "Options:\n"
+
     for i, opt in enumerate(options):
+        if i >= len(choices):
+            break
         prompt += "{}. {}\n".format(choices[i], opt)
+
     if including_answer:
         cot_content = example["cot_content"].replace(
             "A: Let's think step by step.", "Answer: Let's think step by step."
@@ -36,16 +21,14 @@ def format_cot_example(example, including_answer=True):
         prompt += cot_content + "\n\n"
     else:
         prompt += "Answer: Let's think step by step."
+    
     return prompt
-
 
 doc_to_text = partial(format_cot_example, including_answer=False)
 fewshot_to_text = partial(format_cot_example, including_answer=True)
 
-
 def process_docs(dataset, subject):
     return dataset.filter(lambda x: x["category"] == subject)
-
 
 process_biology = partial(process_docs, subject="biology")
 process_business = partial(process_docs, subject="business")


### PR DESCRIPTION
I had recently been experimenting with eval datasets and found in MMLU-Pro, if I removed a choice despite the `utils.py` code being concrete written for edge cases where a choice can be removed, it was still throwing an index-error. It didn't make sense. I had talked with `baber` and he had mentioned to work with a debugger and fix it. But, I was able to fix it and adding this modification.

Now the code works both with default 10 choices and modified number of choices (only for cases where choices are removed)