### PR TITLE
Add device arg to model_args passed to LLM object in VLLM model class

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -96,6 +96,7 @@ class VLLM(TemplateLM):
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
+            "device": device,
         }
         self.model_args.update(kwargs)
         self.batch_size = (

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -96,7 +96,7 @@ class VLLM(TemplateLM):
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
-            "device": device,
+            "device": str(device),
         }
         self.model_args.update(kwargs)
         self.batch_size = (


### PR DESCRIPTION
When using the VLLM model (in vllm_causalllms.py), the device arg was passed to the VLLM class, but never to the actual LLM object. 
For this reason, specifying a device from the interface had no effect and the LLM was always instantiated on cuda:0 as default.