### PR TITLE
Support override_generation_config in vLLM

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -2,7 +2,7 @@ import copy
 import logging
 from importlib.metadata import version
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union, Any
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
 import ast
 
 from more_itertools import distribute

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -98,7 +98,8 @@ class VLLM(TemplateLM):
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
-            "override_generation_config": ast.literal_eval(override_generation_config) if override_generation_config is not None else {},
+            "override_generation_config": ast.literal_eval(override_generation_config) \
+                if override_generation_config is not None else {},
         }
         self.model_args.update(kwargs)
         self.batch_size = (

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -2,7 +2,8 @@ import copy
 import logging
 from importlib.metadata import version
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union, Any
+import ast
 
 from more_itertools import distribute
 from packaging.version import parse as parse_version
@@ -65,6 +66,7 @@ class VLLM(TemplateLM):
         device: str = "cuda",
         data_parallel_size: int = 1,
         lora_local_path: str = None,
+        override_generation_config: str = '',
         **kwargs,
     ):
         super().__init__()
@@ -96,6 +98,7 @@ class VLLM(TemplateLM):
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
+            "override_generation_config": ast.literal_eval(override_generation_config),
         }
         self.model_args.update(kwargs)
         self.batch_size = (

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -66,7 +66,7 @@ class VLLM(TemplateLM):
         device: str = "cuda",
         data_parallel_size: int = 1,
         lora_local_path: str = None,
-        override_generation_config: str = '',
+        override_generation_config: Optional[str] = None,
         **kwargs,
     ):
         super().__init__()
@@ -98,7 +98,7 @@ class VLLM(TemplateLM):
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
-            "override_generation_config": ast.literal_eval(override_generation_config),
+            "override_generation_config": ast.literal_eval(override_generation_config) if override_generation_config is not None else {},
         }
         self.model_args.update(kwargs)
         self.batch_size = (


### PR DESCRIPTION
vllm supports `override_generation_config` https://github.com/vllm-project/vllm/blob/63375f0cdb0073e466d9012aad1192c445a5fa64/vllm/engine/arg_utils.py#L203 to allow users to override generation_config.json at server time.

however when directly passing `override_generation_config` like below
```
lm_eval.simple_evaluate(
    model="vllm",
    model_args={
        ...,
        "override_generation_config": {...}
    },
    batch_size="auto",
)
```

`override_generation_config` gets recognized as a string and caused issues like 
```
`ValueError: dictionary update sequence element #0 has length 1; 2 is required`
```

this PR issues ensure the type is corrected to be a dict.