### PR TITLE
Extend support for chat template in vLLM

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -134,7 +134,7 @@ class VLLM(TemplateLM):
                 "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
             )
 
-        self.chat_template = resolve_hf_chat_template(
+        self.hf_chat_template = resolve_hf_chat_template(
             tokenizer=self.tokenizer, 
             chat_template=None, 
             tools=None,
@@ -203,7 +203,7 @@ class VLLM(TemplateLM):
             tokenize=False,
             add_generation_prompt=add_generation_prompt,
             continue_final_message=not add_generation_prompt,
-            chat_template=self.chat_template,
+            chat_template=self.hf_chat_template,
         )
 
         return chat_templated

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -28,6 +28,7 @@ try:
     from vllm import LLM, SamplingParams
     from vllm.lora.request import LoRARequest
     from vllm.transformers_utils.tokenizer import get_tokenizer
+    from vllm.entrypoints.chat_utils import resolve_hf_chat_template
 except ModuleNotFoundError:
     pass
 
@@ -133,6 +134,13 @@ class VLLM(TemplateLM):
                 "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
             )
 
+        self.chat_template = resolve_hf_chat_template(
+            tokenizer=self.tokenizer, 
+            chat_template=None, 
+            tools=None,
+            trust_remote_code=trust_remote_code,
+        )
+
         self.custom_prefix_token_id = prefix_token_id
         if prefix_token_id is not None:
             eval_logger.info(
@@ -195,6 +203,7 @@ class VLLM(TemplateLM):
             tokenize=False,
             add_generation_prompt=add_generation_prompt,
             continue_final_message=not add_generation_prompt,
+            chat_template=self.chat_template,
         )
 
         return chat_templated


### PR DESCRIPTION
Some HF models, especially multi-modal models, started defining the chat template outside of `tokenizer_config.json` (e.g., `chat_template.json`). In the current state, lm_eval fails to apply the chat template in these cases when using the vLLM model.

vLLM already has logic to deal with this. This PR updates the vLLM model definition to leverage this logic when applying the chat template.