### PR TITLE
Update vllm requirement to latest stable version 0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ sparseml = ["sparseml-nightly[llm]>=1.8.0.20240404"]
 sparsify = ["sparsify"]
 testing = ["pytest", "pytest-cov", "pytest-xdist"]
 vllm = ["vllm>=0.8.3"]
+torchao = ["torchao>=0.10.0"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sentencepiece = ["sentencepiece>=0.1.98"]
 sparseml = ["sparseml-nightly[llm]>=1.8.0.20240404"]
 sparsify = ["sparsify"]
 testing = ["pytest", "pytest-cov", "pytest-xdist"]
-vllm = ["vllm>=0.4.2"]
+vllm = ["vllm>=0.8.3"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ sparsify = ["sparsify"]
 testing = ["pytest", "pytest-cov", "pytest-xdist"]
 vllm = ["vllm>=0.8.3"]
 torchao = ["torchao>=0.10.0"]
+tenacity = ["tenacity>=9.1.2"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
 all = [


### PR DESCRIPTION
lm-evaluation-harness/lm_eval/models/vllm_causallms.py
```
import copy
import logging
from importlib.metadata import version
from importlib.util import find_spec
from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union

from more_itertools import distribute
from packaging.version import parse as parse_version
from tqdm import tqdm

from lm_eval.api.instance import Instance
from lm_eval.api.model import TemplateLM
from lm_eval.api.registry import register_model
from lm_eval.models.utils import (
    Collator,
    configure_pad_token,
    handle_stop_sequences,
    undistribute,
)
from lm_eval.utils import (
    get_rolling_token_windows,
    make_disjoint_window,
)


try:
    import ray
    from vllm import LLM, SamplingParams
    from vllm.lora.request import LoRARequest
    from vllm.transformers_utils.tokenizer import get_tokenizer
    from vllm.entrypoints.chat_utils import resolve_hf_chat_template
```
Line 33 depends on the vllm library resolve_hf_chat_template, which is only available in vllm0.8.3 and above！