### PR TITLE
Added softmax_dtype argument to HFLM to coerce log_softmax computations

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -92,6 +92,7 @@ class HFLM(TemplateLM):
         autogptq: Optional[Union[bool, str]] = False,
         gptqmodel: Optional[bool] = False,
         gguf_file: Optional[str] = None,
+        softmax_dtype: Optional[Union[str, torch.dtype]] = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -234,6 +235,7 @@ class HFLM(TemplateLM):
         self.batch_schedule = 1
         self.batch_sizes = {}
         self.max_batch_size = max_batch_size
+        self.softmax_dtype = get_dtype(softmax_dtype) if softmax_dtype is not None else None
 
         if str(batch_size).startswith("auto"):
             batch_size = batch_size.split(":")
@@ -768,7 +770,7 @@ class HFLM(TemplateLM):
                     (batch_size, max_length), device=self.device
                 ).long()
             for _ in range(5):
-                out = F.log_softmax(self._model_call(test_batch, **call_kwargs), dim=-1)  # noqa: F841
+                out = F.log_softmax(self._model_call(test_batch, **call_kwargs), dim=-1, dtype=self.softmax_dtype)  # noqa: F841
 
             return batch_size
 
@@ -1200,7 +1202,7 @@ class HFLM(TemplateLM):
                 }
 
             multi_logits = F.log_softmax(
-                self._model_call(batched_inps, **call_kwargs), dim=-1
+                self._model_call(batched_inps, **call_kwargs), dim=-1, dtype=self.softmax_dtype
             )  # [batch, padding_length (inp or cont), vocab]
 
             for (request_str, ctx_tokens, _), logits, inplen, cont_toks in zip(

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -74,6 +74,7 @@ class HFLM(TemplateLM):
         max_length: Optional[int] = None,
         device: Optional[str] = "cuda",
         dtype: Optional[Union[str, torch.dtype]] = "auto",
+        softmax_dtype: Optional[Union[str, torch.dtype]] = None,
         batch_size: Optional[Union[int, str]] = 1,
         max_batch_size: Optional[int] = 64,
         trust_remote_code: Optional[bool] = False,
@@ -92,7 +93,6 @@ class HFLM(TemplateLM):
         autogptq: Optional[Union[bool, str]] = False,
         gptqmodel: Optional[bool] = False,
         gguf_file: Optional[str] = None,
-        softmax_dtype: Optional[Union[str, torch.dtype]] = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -235,7 +235,9 @@ class HFLM(TemplateLM):
         self.batch_schedule = 1
         self.batch_sizes = {}
         self.max_batch_size = max_batch_size
-        self.softmax_dtype = get_dtype(softmax_dtype) if softmax_dtype is not None else None
+        self.softmax_dtype = (
+            get_dtype(softmax_dtype) if softmax_dtype is not None else None
+        )
 
         if str(batch_size).startswith("auto"):
             batch_size = batch_size.split(":")
@@ -770,7 +772,11 @@ class HFLM(TemplateLM):
                     (batch_size, max_length), device=self.device
                 ).long()
             for _ in range(5):
-                out = F.log_softmax(self._model_call(test_batch, **call_kwargs), dim=-1, dtype=self.softmax_dtype)  # noqa: F841
+                _ = F.log_softmax(
+                    self._model_call(test_batch, **call_kwargs),
+                    dim=-1,
+                    dtype=self.softmax_dtype,
+                )
 
             return batch_size
 
@@ -1202,7 +1208,9 @@ class HFLM(TemplateLM):
                 }
 
             multi_logits = F.log_softmax(
-                self._model_call(batched_inps, **call_kwargs), dim=-1, dtype=self.softmax_dtype
+                self._model_call(batched_inps, **call_kwargs),
+                dim=-1,
+                dtype=self.softmax_dtype,
             )  # [batch, padding_length (inp or cont), vocab]
 
             for (request_str, ctx_tokens, _), logits, inplen, cont_toks in zip(

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -772,7 +772,7 @@ class HFLM(TemplateLM):
                     (batch_size, max_length), device=self.device
                 ).long()
             for _ in range(5):
-                F.log_softmax(
+                out = F.log_softmax(  # noqa: F841
                     self._model_call(test_batch, **call_kwargs),
                     dim=-1,
                     dtype=self.softmax_dtype,

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -772,7 +772,7 @@ class HFLM(TemplateLM):
                     (batch_size, max_length), device=self.device
                 ).long()
             for _ in range(5):
-                _ = F.log_softmax(
+                F.log_softmax(
                     self._model_call(test_batch, **call_kwargs),
                     dim=-1,
                     dtype=self.softmax_dtype,


### PR DESCRIPTION
This PR adds a new `softmax_dtype: Optional[Union[str, torch.dtype]]` parameter to `HFLM`.

When provided (either as, e.g., `"float32"` or `torch.float32`), all internal calls to `F.log_softmax` will be cast to that dtype, independent of the model’s native output dtype.  
- **Scope**: only impacts `loglikelihood` and `rolling_loglikelihood` computations, and automatic batch size detection.  
- **Unaffected**: sampling via `generate_until` remains at the model’s default precision.  
- **Default**: `None` -> original behavior (no casting).

The addition of this feature can be useful when evaluating half precision or quantized models as it can improve stability when computing log likelihoods, particularly in cases where the un-normalised logits have a large range and for models with extremely large vocabularies.

**Usage**
> **Python API**  
> ```py
> lm = HFLM(model_name, softmax_dtype="float32")   # or torch.float32
> ```  
> **CLI**  
> ```bash
> lm_eval --model hf \
>     --model_args pretrained=model_name,dtype="float16",softmax_dtype="float32"
> ```  
Although any `torch.dtype` is accepted, in practice `"float32"` is the most effective for numeric stability.

**Docs**
No documentation has been added as the `HFLM` class does not have specific documentation, and the argument name and typing is self explanatory.