### PR TITLE
Added selection filter: take_last

### DIFF
--- a/lm_eval/filters/selection.py
+++ b/lm_eval/filters/selection.py
@@ -23,6 +23,20 @@ class TakeFirstFilter(Filter):
         return map(lambda r: r[0], resps)
 
 
+@register_filter("take_last")
+class TakeLastFilter(Filter):
+    def __init__(self) -> None:
+        """
+        Can define custom behavior here, if an individual instantiation of a Filter class should have state.
+        """
+
+    def apply(self, resps, docs):
+        """
+        Assuming each entry of `resps` is a list of model responses, we discard all but the last response.
+        """
+        return map(lambda r: r[-1], resps)
+
+
 @register_filter("take_first_k")
 class TakeKFilter(Filter):
     def __init__(self, **kwargs) -> None:


### PR DESCRIPTION
Adds a `take_last` filter in `lm_eval/filters/selection.py`.
Its a simple PR, but i think it would be useful. there are many situations where an LLM might trigger the answer regex while its drafting its response, etc (reasoning models for example in the `<think>` tags), by grabbing the last instance of the answer pattern you can avoid these issues.

# Example
```yaml
filter_list:
  - name: extract_final_answer
    filter:
      - function: regex
        # Added re.IGNORECASE flag equivalent via (?i) - more robust than just ignore_case in metric
        regex_pattern: "(?i)Final Answer:\\s*([A-F])" # <-- Made regex case-insensitive
      - function: take_last
``` 

# Checklist
- [x] Implementation
- [x] Testing 

# Alternatives

Not a lot existing, `take_first_k` is bound relative to the top of the stack.

Perhaps a filter function could be made with more complex logic to combine `take_first` and `take_last` where the user specifies some params, more flexible, but less simple for the user. the `take_last` seems more simple to me. 

Just put this here to cover all bases.