### PR TITLE
Resolve the inconsistency between the description of output_path and the actual logic

### DIFF
--- a/lm_eval/loggers/evaluation_tracker.py
+++ b/lm_eval/loggers/evaluation_tracker.py
@@ -227,13 +227,18 @@ class EvaluationTracker:
                     default=handle_non_serializable,
                     ensure_ascii=False,
                 )
-
+                
                 path = Path(self.output_path if self.output_path else Path.cwd())
-                path = path.joinpath(self.general_config_tracker.model_name_sanitized)
-                path.mkdir(parents=True, exist_ok=True)
-
-                self.date_id = datetime.now().isoformat().replace(":", "-")
-                file_results_aggregated = path.joinpath(f"results_{self.date_id}.json")
+                
+                if path.suffix.lower() == ".json":
+                    file_results_aggregated = path
+                    file_results_aggregated.parent.mkdir(parents=True, exist_ok=True)
+                else:
+                    path = path.joinpath(self.general_config_tracker.model_name_sanitized)
+                    path.mkdir(parents=True, exist_ok=True)
+                    self.date_id = datetime.now().isoformat().replace(":", "-")
+                    file_results_aggregated = path.joinpath(f"results_{self.date_id}.json")
+                    
                 file_results_aggregated.open("w", encoding="utf-8").write(dumped)
 
                 if self.api and self.push_results_to_hub:


### PR DESCRIPTION
We noticed that the description of output_path claims to support inputting file path ( DIR/file.json )
https://github.com/EleutherAI/lm-evaluation-harness/blob/e4a7b69fe0fc6cb430e12cf15c4109bf28185124/lm_eval/__main__.py#L132-L139  

However, in the current logic, even if output_path is a file path, it is still treated as a long path prefix, preventing users from customizing the saved filename (instead of the default `result_self.date_id.json`).