### PR TITLE
Warn when splitting sequences

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -16,7 +16,9 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 import numpy as np
 import yaml
 from jinja2 import BaseLoader, Environment, StrictUndefined
+import logging
 
+logger = logging.getLogger(__name__)
 
 SPACING = " " * 47
 
@@ -265,6 +267,9 @@ def get_rolling_token_windows(
     # +1 offset, going from input->preds
     pred_len = max_seq_len - context_len + 1
     predicted = 0
+
+    if len(token_list) > max_seq_len:
+        logger.warning(f"Processing a sequence of length {len(token_list)}, larger than max_length={max_seq_len}. The sequence will be split and processed in subsequences of at most {max_seq_len + 1} tokens, potentially impacting evaluation metrics.")
 
     # Special handling for first window: predict all tokens
     first_seq_len = min(max_seq_len, len(token_list))


### PR DESCRIPTION
As per title.

Unless set by the user, `TemplateAPI` hard-codes `max_length=2048`

https://github.com/EleutherAI/lm-evaluation-harness/blob/e4a7b69fe0fc6cb430e12cf15c4109bf28185124/lm_eval/models/api_models.py#L74

contrarily to e.g. `HFLM`:

https://github.com/EleutherAI/lm-evaluation-harness/blob/e4a7b69fe0fc6cb430e12cf15c4109bf28185124/lm_eval/models/huggingface.py#L419-L431

This lead to inconsistent eval metrics when comparing transformers/vllm backends, due to silent sequence splitting by lm-evaluation-harness.

Some warnings in `batch_loglikelihood_requests` are never hit, because the sequences are split beforehand.

https://github.com/EleutherAI/lm-evaluation-harness/blob/e4a7b69fe0fc6cb430e12cf15c4109bf28185124/lm_eval/models/api_models.py#L455-L458