### PR TITLE
model args as json_path

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -313,6 +313,9 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         # we allow for args to be passed externally, else we parse them ourselves
         parser = setup_parser()
         args = parse_eval_args(parser)
+        if args.model_args.endswith("json"):
+            with open(args.model_args, 'r') as f:  
+                args.model_args = json.load(f)  
 
     if args.wandb_args:
         wandb_args_dict = simple_parse_args_string(args.wandb_args)


### PR DESCRIPTION
model_args is sometimes very complex(like multi depth json)..

may model_args support json path it would be good.

```json
{
    "pretrained" : "microsoft/Phi-4-multimodal-instruct",
    "dtype" : "auto",
    "trust_remote_code" : true,
    "gpu_memory_utilization" : 0.9,
    "max_model_len" : 131072,
    "enable_lora" : true,
    "max_lora_rank" : 320,
    "limit_mm_per_prompt" : {
        "audio" : 3,
        "image" : 3
    },
    "max_loras": 2,
    "tensor_parallel_size" : 2,
    "lora_modules" : {
        "speech":"/home/ubuntu/.cache/huggingface/hub/models--microsoft--Phi-4-multimodal-instruct/snapshots/0af439b3adb8c23fda473c4f86001dbf9a226021/speech-lora",
        "vision": "/home/ubuntu/.cache/huggingface/hub/models--microsoft--Phi-4-multimodal-instruct/snapshots/0af439b3adb8c23fda473c4f86001dbf9a226021/vision-lora"
    }
}
```