### PR TITLE
Fix import error for eval_logger in score utils

### DIFF
--- a/lm_eval/tasks/aclue/_generate_configs.py
+++ b/lm_eval/tasks/aclue/_generate_configs.py
@@ -9,6 +9,7 @@ import os
 import yaml
 from tqdm import tqdm
 
+
 eval_logger = logging.getLogger(__name__)
 
 

--- a/lm_eval/tasks/aclue/_generate_configs.py
+++ b/lm_eval/tasks/aclue/_generate_configs.py
@@ -3,12 +3,13 @@ Take in a YAML, and output all other splits with this YAML
 """
 
 import argparse
+import logging
 import os
 
 import yaml
 from tqdm import tqdm
 
-from lm_eval.utils import eval_logger
+eval_logger = logging.getLogger(__name__)
 
 
 SUBJECTS = {

--- a/lm_eval/tasks/ceval/_generate_configs.py
+++ b/lm_eval/tasks/ceval/_generate_configs.py
@@ -9,6 +9,7 @@ import os
 import yaml
 from tqdm import tqdm
 
+
 eval_logger = logging.getLogger(__name__)
 
 

--- a/lm_eval/tasks/ceval/_generate_configs.py
+++ b/lm_eval/tasks/ceval/_generate_configs.py
@@ -3,12 +3,13 @@ Take in a YAML, and output all other splits with this YAML
 """
 
 import argparse
+import logging
 import os
 
 import yaml
 from tqdm import tqdm
 
-from lm_eval.utils import eval_logger
+eval_logger = logging.getLogger(__name__)
 
 
 SUBJECTS = {

--- a/lm_eval/tasks/cmmlu/_generate_configs.py
+++ b/lm_eval/tasks/cmmlu/_generate_configs.py
@@ -9,6 +9,7 @@ import os
 import yaml
 from tqdm import tqdm
 
+
 eval_logger = logging.getLogger(__name__)
 
 

--- a/lm_eval/tasks/cmmlu/_generate_configs.py
+++ b/lm_eval/tasks/cmmlu/_generate_configs.py
@@ -3,12 +3,13 @@ Take in a YAML, and output all other splits with this YAML
 """
 
 import argparse
+import logging
 import os
 
 import yaml
 from tqdm import tqdm
 
-from lm_eval.utils import eval_logger
+eval_logger = logging.getLogger(__name__)
 
 
 SUBJECTS = {

--- a/lm_eval/tasks/csatqa/_generate_configs.py
+++ b/lm_eval/tasks/csatqa/_generate_configs.py
@@ -9,6 +9,7 @@ import os
 import yaml
 from tqdm import tqdm
 
+
 eval_logger = logging.getLogger(__name__)
 
 

--- a/lm_eval/tasks/csatqa/_generate_configs.py
+++ b/lm_eval/tasks/csatqa/_generate_configs.py
@@ -3,12 +3,13 @@ Take in a YAML, and output all other splits with this YAML
 """
 
 import argparse
+import logging
 import os
 
 import yaml
 from tqdm import tqdm
 
-from lm_eval.logger import eval_logger
+eval_logger = logging.getLogger(__name__)
 
 
 SUBSETS = ["WR", "GR", "RCS", "RCSS", "RCH", "LI"]

--- a/lm_eval/tasks/realtoxicityprompts/metric.py
+++ b/lm_eval/tasks/realtoxicityprompts/metric.py
@@ -5,6 +5,7 @@ import os
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+
 eval_logger = logging.getLogger(__name__)
 
 

--- a/lm_eval/tasks/realtoxicityprompts/metric.py
+++ b/lm_eval/tasks/realtoxicityprompts/metric.py
@@ -1,10 +1,11 @@
 import json
+import logging
 import os
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from lm_eval.utils import eval_logger
+eval_logger = logging.getLogger(__name__)
 
 
 def toxicity_perspective_api(

--- a/lm_eval/tasks/score/agi_eval/utils_agieval.py
+++ b/lm_eval/tasks/score/agi_eval/utils_agieval.py
@@ -24,6 +24,7 @@ from datasets import Dataset
 from lm_eval.tasks.score import utils
 from lm_eval.tasks.score.utils import prompt_consistency_rate, robustness_doc_to_text
 
+
 eval_logger = logging.getLogger(__name__)
 
 TEMPLATE_FILE_PATH = os.path.join(os.path.dirname(__file__), "prompt_templates.json")

--- a/lm_eval/tasks/score/agi_eval/utils_agieval.py
+++ b/lm_eval/tasks/score/agi_eval/utils_agieval.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import re
 from functools import partial
@@ -22,8 +23,8 @@ from datasets import Dataset
 
 from lm_eval.tasks.score import utils
 from lm_eval.tasks.score.utils import prompt_consistency_rate, robustness_doc_to_text
-from lm_eval.utils import eval_logger
 
+eval_logger = logging.getLogger(__name__)
 
 TEMPLATE_FILE_PATH = os.path.join(os.path.dirname(__file__), "prompt_templates.json")
 

--- a/lm_eval/tasks/score/math/utils_math.py
+++ b/lm_eval/tasks/score/math/utils_math.py
@@ -30,6 +30,7 @@ from lm_eval.tasks.score.math.math_grader import (
 )
 from lm_eval.tasks.score.utils import robustness_doc_to_text
 
+
 eval_logger = logging.getLogger(__name__)
 
 TEMPLATE_FILE_PATH = os.path.join(os.path.dirname(__file__), "prompt_templates.json")

--- a/lm_eval/tasks/score/math/utils_math.py
+++ b/lm_eval/tasks/score/math/utils_math.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import logging
 import os
 from functools import partial
 from itertools import combinations
@@ -28,8 +29,8 @@ from lm_eval.tasks.score.math.math_grader import (
     normalize_answer_string,
 )
 from lm_eval.tasks.score.utils import robustness_doc_to_text
-from lm_eval.utils import eval_logger
 
+eval_logger = logging.getLogger(__name__)
 
 TEMPLATE_FILE_PATH = os.path.join(os.path.dirname(__file__), "prompt_templates.json")
 

--- a/lm_eval/tasks/score/mmlu_pro/utils_mmlu_pro.py
+++ b/lm_eval/tasks/score/mmlu_pro/utils_mmlu_pro.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import logging
 from functools import partial
 from typing import Any, Dict, List
 
@@ -20,8 +21,8 @@ import numpy as np
 
 from lm_eval.tasks.score import utils
 from lm_eval.tasks.score.utils import prompt_consistency_rate, robustness_doc_to_text
-from lm_eval.utils import eval_logger
 
+eval_logger = logging.getLogger(__name__)
 
 TEMPLATE_FILE_PATH = os.path.join(os.path.dirname(__file__), "prompt_templates.json")
 

--- a/lm_eval/tasks/score/mmlu_pro/utils_mmlu_pro.py
+++ b/lm_eval/tasks/score/mmlu_pro/utils_mmlu_pro.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
+import os
 from functools import partial
 from typing import Any, Dict, List
 
@@ -21,6 +21,7 @@ import numpy as np
 
 from lm_eval.tasks.score import utils
 from lm_eval.tasks.score.utils import prompt_consistency_rate, robustness_doc_to_text
+
 
 eval_logger = logging.getLogger(__name__)
 

--- a/lm_eval/tasks/score/utils.py
+++ b/lm_eval/tasks/score/utils.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List
 import numpy as np
 from datasets import Dataset
 
+
 eval_logger = logging.getLogger(__name__)
 
 

--- a/lm_eval/tasks/score/utils.py
+++ b/lm_eval/tasks/score/utils.py
@@ -14,6 +14,7 @@
 
 import copy
 import json
+import logging
 import re
 import string
 import sys
@@ -24,7 +25,7 @@ from typing import Any, Dict, List
 import numpy as np
 from datasets import Dataset
 
-from lm_eval.utils import eval_logger
+eval_logger = logging.getLogger(__name__)
 
 
 NUMERALS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]


### PR DESCRIPTION
## 🛠 Description of the Issue

Some tasks (e.g., `score` and others under `lm_eval/tasks/`) attempt to import `eval_logger` using:

```python
from lm_eval.utils import eval_logger
```

or:

```python
from lm_eval.loggers import eval_logger
```

However, `eval_logger` is no longer defined in those modules, resulting in the following runtime error:

```
ImportError: cannot import name 'eval_logger' from 'lm_eval.utils'
```

This prevents tasks from running correctly, including `score_robustness_agieval` and potentially others relying on similar logging mechanisms.

## ✅ Fix

To resolve the issue across all affected tasks, the following replacement was made:

```python
import logging
eval_logger = logging.getLogger("lm_eval.score")
```

This change restores proper logger usage by leveraging Python's standard logging infrastructure and avoids relying on deprecated or non-existent imports.

The fix has been applied consistently across all tasks that were impacted by this issue.