### PR TITLE
mmlu pro generation_kwargs until Q: -> Question:

### DIFF
--- a/lm_eval/tasks/longbench/utils.py
+++ b/lm_eval/tasks/longbench/utils.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 from metrics import (
-    classification_score,
+    # classification_score,
     code_sim_score,
     count_score,
     qa_f1_score,
@@ -29,10 +29,10 @@ dataset2metric = {
     "qmsum": rouge_score,
     "multi_news": rouge_score,
     "vcsum": rouge_zh_score,
-    "trec": classification_score,
+    # "trec": classification_score,
     "triviaqa": qa_f1_score,
     "samsum": rouge_score,
-    "lsht": classification_score,
+    # "lsht": classification_score,
     "passage_retrieval_en": retrieval_score,
     "passage_count": count_score,
     "passage_retrieval_zh": retrieval_zh_score,

--- a/lm_eval/tasks/mmlu_pro/README.md
+++ b/lm_eval/tasks/mmlu_pro/README.md
@@ -64,3 +64,5 @@ If other tasks on this dataset are already supported:
   * Added one newline to task description(s) as per [reference implementation](https://github.com/TIGER-AI-Lab/MMLU-Pro/blob/47b9891aacb8bd7cda29d5c5ba17b9434dd333bc/evaluate_from_local.py#L93)
 * (tasks, group) 2025-03-20 -- (version 2.0 --> version 2.1)
   * Changed default max_length from 2048 to 8192 and max_gen_toks from 256 to 2048.
+* (tasks, group) 2025-05-20 -- (version 2.1 --> version 3)
+  * changed stop sequence from "Q:" to "Question:" PR #2945

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -17,9 +17,7 @@ filter_list:
       - function: "take_first"
 generation_kwargs:
   until:
-    - "</s>"
     - "Question:"
-    - "<|im_end|>"
   max_gen_toks: 2048
   do_sample: false
   temperature: 0.0

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -18,7 +18,7 @@ filter_list:
 generation_kwargs:
   until:
     - "</s>"
-    - "Q:"
+    - "Question:"
     - "<|im_end|>"
   max_gen_toks: 2048
   do_sample: false


### PR DESCRIPTION
MMLU-Pro prompt uses "Question:" instead of "Q". So the stop string should be "Question:" instead of "Q".

Example prompt:
```
The following are multiple choice questions (with answers) about biology. Think step by step and then finish your answer with "the answer is (X)" where X is the correct letter choice.
Question:
Which of the following represents an accurate statement concerning arthropods?
Options:
A. They possess an exoskeleton composed primarily of peptidoglycan.
B. They possess an open circulatory system with a dorsal heart.
C. They are members of a biologically unsuccessful phylum incapable of exploiting diverse habitats and nutrition sources.
D. They lack paired, jointed appendages.
E. N/A
F. N/A
G. N/A
H. N/A
I. N/A
J. N/A
Answer: Let's think step by step.
```