### PR TITLE
Pin unitxt to most recent minor version to avoid test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ Repository = "https://github.com/EleutherAI/lm-evaluation-harness"
 api = ["requests", "aiohttp", "tenacity", "tqdm", "tiktoken"]
 audiolm_qwen = ["librosa", "soundfile"]
 deepsparse = ["deepsparse-nightly[llm]>=1.8.0.20240404"]
-dev = ["pytest", "pytest-cov", "pytest-xdist", "pre-commit", "mypy", "unitxt", "requests", "aiohttp", "tenacity", "tqdm", "tiktoken", "sentencepiece"]
+dev = ["pytest", "pytest-cov", "pytest-xdist", "pre-commit", "mypy", "unitxt==1.22.0", "requests", "aiohttp", "tenacity", "tqdm", "tiktoken", "sentencepiece"]
 gptq = ["auto-gptq[triton]>=0.6.0"]
 gptqmodel = ["gptqmodel>=1.0.9"]
 hf_transfer = ["hf_transfer"]


### PR DESCRIPTION
Opened #2969 and noticed that a recent change in unitxt is breaking task tests. This is a hotfix for that issue that pins it to the most recent minor version. Unitxt is a pretty fast-moving project as far as releases go, and while this solution may not be the best long-term, I think it's reasonable for now. I can discuss with the unitxt team for a better long-term solution but wanted to get a quick fix out before more PRs come in.