### PR TITLE
fix: type error while checking context length

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -486,7 +486,7 @@ class VLLM(TemplateLM):
             inputs = []
             ctxlens = []
             for cache_key, context_enc, continuation_enc in chunk:
-                if full_length := (context_enc + continuation_enc) >= self.max_length:
+                if full_length := len(context_enc + continuation_enc) >= self.max_length:
                     eval_logger.warning(
                         f"Context length {full_length} exceeds max length ({self.max_length}). Truncating context."
                     )


### PR DESCRIPTION
## summary
During testing with vLLM, I encountered a TypeError due to comparing a list with an integer.

## error log
```
context_enc:  [3497, 1733, 617, 5259, 236789, 236751, 2148, 2918, 668, 691, 8101, 28383, 496, 13288, 236764, 532, 506, 227862, 119405, 81994, 580, 506, 1813, 236793, 532, 1299, 668, 691, 9378, 1343, 506, 13254, 236764, 1343, 40357, 1976, 4073, 236764, 1298, 506, 227862, 691, 18367, 528, 506, 6114, 529, 506, 28682, 529, 506, 1494, 7613, 236751, 236793, 532, 1299, 668, 691, 9378, 1343, 506, 14958, 236764, 837, 236764, 1651, 711, 11716, 14649, 236764, 2036, 8008, 914, 3825, 528, 5931, 236793, 532, 1299, 236764, 7046, 39964, 531, 914, 27311, 236764, 668, 691, 26407, 236764, 532, 506, 227862, 2112, 720, 524, 1063, 657, 1515, 699, 506, 11474, 25652, 11595, 236793, 1492, 668, 691, 528, 506, 13254, 3622, 919, 236793, 532, 1299, 668, 691, 580, 496, 4284, 1343, 6877, 6426, 236764, 532, 668, 113832, 524, 496, 130813, 1646, 16630, 684, 1156, 68663, 236764, 1646, 14208, 684, 496, 3875, 528, 496, 2604, 5808, 1015, 6976, 236764, 573, 506, 45699, 668, 2506, 529, 1116, 236764, 506, 1595, 603, 2993, 154709, 691, 9710, 528, 914, 4083, 6249, 236793, 532, 2264, 2918, 532, 668, 691, 528, 496, 99710, 159636, 236764, 532, 668, 1451, 6899, 506, 149195, 529, 1813, 618, 625, 195766, 532, 10661, 1061, 1595, 1131, 496, 1944, 115752, 236761, 108, 2209, 3721, 2264, 2918, 236764, 840, 668, 691, 2036, 528, 506]
continuation_enc:  [159636]
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/lm_eval/__main__.py", line 530, in <module>
    cli_evaluate()
  File "/lm_eval/__main__.py", line 449, in cli_evaluate
    results = evaluator.simple_evaluate(
  File "/lm_eval/utils.py", line 439, in _wrapper
    return fn(*args, **kwargs)
  File "/lm_eval/evaluator.py", line 338, in simple_evaluate
    results = evaluate(
  File "/lm_eval/utils.py", line 439, in _wrapper
    return fn(*args, **kwargs)
  File "/lm_eval/evaluator.py", line 570, in evaluate
    resps = getattr(lm, reqtype)(cloned_reqs)
  File "/lm_eval/api/model.py", line 382, in loglikelihood
    return self._loglikelihood_tokens(new_reqs, disable_tqdm=disable_tqdm)
  File "/lm_eval/models/vllm_causallms.py", line 500, in _loglikelihood_tokens
    if full_length := (context_enc + continuation_enc) >= self.max_length:

```