### PR TITLE
add image hashing and `LMEVAL_HASHMM` envar

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -300,6 +300,11 @@ def setup_parser() -> argparse.ArgumentParser:
         default=None,
         help="""JSON string metadata to pass to task configs, for example '{"max_seq_lengths":[4096,8192]}'. Will be merged with model_args. Can also be set in task config.""",
     )
+    parser.add_argument(
+        "--hash_images",
+        action="store_true",
+        help="Sets hash_images to True to convert images to hashes to reduce memory that is taken by jsonl file with samples (if log_samples=True)",
+    )
     return parser
 
 
@@ -473,6 +478,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         fewshot_random_seed=args.seed[3],
         confirm_run_unsafe_code=args.confirm_run_unsafe_code,
         metadata=metadata,
+        hash_images=args.hash_images,
         **request_caching_args,
     )
 

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -300,11 +300,6 @@ def setup_parser() -> argparse.ArgumentParser:
         default=None,
         help="""JSON string metadata to pass to task configs, for example '{"max_seq_lengths":[4096,8192]}'. Will be merged with model_args. Can also be set in task config.""",
     )
-    parser.add_argument(
-        "--hash_images",
-        action="store_true",
-        help="Sets hash_images to True to convert images to hashes to reduce memory that is taken by jsonl file with samples (if log_samples=True)",
-    )
     return parser
 
 
@@ -478,7 +473,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         fewshot_random_seed=args.seed[3],
         confirm_run_unsafe_code=args.confirm_run_unsafe_code,
         metadata=metadata,
-        hash_images=args.hash_images,
         **request_caching_args,
     )
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -78,7 +78,6 @@ def simple_evaluate(
     fewshot_random_seed: int = 1234,
     confirm_run_unsafe_code: bool = False,
     metadata: Optional[dict] = None,
-    hash_images: bool = False,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -29,6 +29,7 @@ from lm_eval.loggers.utils import add_env_info, add_tokenizer_info, get_git_comm
 from lm_eval.tasks import TaskManager, get_task_dict
 from lm_eval.utils import (
     handle_non_serializable,
+    hash_dict_images,
     hash_string,
     positional_deprecated,
     setup_logging,
@@ -76,6 +77,7 @@ def simple_evaluate(
     fewshot_random_seed: int = 1234,
     confirm_run_unsafe_code: bool = False,
     metadata: Optional[dict] = None,
+    hash_images: bool = False,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -140,7 +142,8 @@ def simple_evaluate(
         Random seed for fewshot sampler random generator. If set to None, the seed of generator will be set to None.
     :param metadata: dict
         Additional metadata to be added to the task manager. Will get passed to the download function of the task.
-
+    :param hash_images: bool
+        Whether to convert images to hashes to memory json takes to be stored.
     return
         Dictionary of results
     """
@@ -350,6 +353,7 @@ def simple_evaluate(
         fewshot_as_multiturn=fewshot_as_multiturn,
         verbosity=verbosity,
         confirm_run_unsafe_code=confirm_run_unsafe_code,
+        hash_images=hash_images,
     )
     if verbosity is not None:
         setup_logging(verbosity=verbosity)
@@ -413,6 +417,7 @@ def evaluate(
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
     confirm_run_unsafe_code: bool = False,
+    hash_images: bool = False,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -447,6 +452,8 @@ def evaluate(
         Verbosity level for logging
     :param confirm_run_unsafe_code: bool
         Whether to confirm running tasks marked as unsafe.
+    :param hash_images: bool
+        Whether to convert images to hashes to memory json takes to be stored.
     :return
         Dictionary of results
     """
@@ -747,6 +754,8 @@ def evaluate(
             },
         }
         if log_samples:
+            if hash_images:
+                samples = hash_dict_images(samples)
             results_dict["samples"] = dict(samples)
 
         return results_dict

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import logging
+import os
 import random
 import time
 from collections import defaultdict
@@ -142,8 +143,6 @@ def simple_evaluate(
         Random seed for fewshot sampler random generator. If set to None, the seed of generator will be set to None.
     :param metadata: dict
         Additional metadata to be added to the task manager. Will get passed to the download function of the task.
-    :param hash_images: bool
-        Whether to convert images to hashes to memory json takes to be stored.
     return
         Dictionary of results
     """
@@ -353,7 +352,6 @@ def simple_evaluate(
         fewshot_as_multiturn=fewshot_as_multiturn,
         verbosity=verbosity,
         confirm_run_unsafe_code=confirm_run_unsafe_code,
-        hash_images=hash_images,
     )
     if verbosity is not None:
         setup_logging(verbosity=verbosity)
@@ -417,7 +415,6 @@ def evaluate(
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
     confirm_run_unsafe_code: bool = False,
-    hash_images: bool = False,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -452,8 +449,6 @@ def evaluate(
         Verbosity level for logging
     :param confirm_run_unsafe_code: bool
         Whether to confirm running tasks marked as unsafe.
-    :param hash_images: bool
-        Whether to convert images to hashes to memory json takes to be stored.
     :return
         Dictionary of results
     """
@@ -754,8 +749,12 @@ def evaluate(
             },
         }
         if log_samples:
-            if hash_images:
-                samples = hash_dict_images(samples)
+            # default: hash images
+            samples = (
+                hash_dict_images(samples)
+                if os.environ.get("LMEVAL_HASHMM", "1") != "0"
+                else samples
+            )
             results_dict["samples"] = dict(samples)
 
         return results_dict

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -571,8 +571,6 @@ def hash_dict_images(data_dict):
 
     Parameters:
         data_dict (dict): The input dictionary with arbitrary nesting of dicts and lists.
-        convert_bytes_to_hash (callable): Function that takes bytes and returns a hash (e.g., str).
-        convert_pil_to_hash (callable): Function that takes a PIL.Image.Image and returns a hash.
 
     Returns:
         dict: A new dictionary with the same structure as `data_dict`, but with all

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -17,7 +17,6 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 import numpy as np
 import yaml
 from jinja2 import BaseLoader, Environment, StrictUndefined
-from PIL import Image
 
 
 SPACING = " " * 47
@@ -576,6 +575,7 @@ def hash_dict_images(data_dict):
         dict: A new dictionary with the same structure as `data_dict`, but with all
               bytes and PIL.Image.Image objects replaced by their hashes.
     """
+    from PIL import Image
 
     def _process_value(value):
         # Bytes -> hash

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 from dataclasses import asdict, is_dataclass
-from io import BytesIO
 from itertools import islice
 from pathlib import Path
 from typing import Any, Callable, Generator, List, Optional, Tuple
@@ -554,6 +553,8 @@ def weighted_f1_score(items):
 
 
 def convert_pil_to_hash(value):
+    from io import BytesIO
+
     img_bytes = BytesIO()
     value.save(img_bytes, format="PNG")
     return hashlib.sha256(str(img_bytes).encode()).hexdigest()


### PR DESCRIPTION
when evaluating multimodal models on multimodal datasets, the samples that are saved take to much space

pr allows passing flag that triggers the fuction that converts all images into sha256 hashes for those who do not need images in samples afterwards