### PR TITLE
Fix `longbench_trec_e` yaml formatting

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -486,7 +486,10 @@ class VLLM(TemplateLM):
             inputs = []
             ctxlens = []
             for cache_key, context_enc, continuation_enc in chunk:
-                if full_length := len(context_enc + continuation_enc) >= self.max_length:
+                if (
+                    full_length := len(context_enc + continuation_enc)
+                    >= self.max_length
+                ):
                     eval_logger.warning(
                         f"Context length {full_length} exceeds max length ({self.max_length}). Truncating context."
                     )

--- a/lm_eval/tasks/longbench/trec_e.yaml
+++ b/lm_eval/tasks/longbench/trec_e.yaml
@@ -7,13 +7,14 @@ test_split: test
 dataset_name: trec_e
 doc_to_text: 'Please determine the type of the question below. Here are some examples of questions.\n\n{{context}}\n{{input}}'
 doc_to_target: '{{answers[0]}}'
+process_results: !function metrics.classification_score
 generation_kwargs:
   max_gen_toks: 64
   temperature: 1
   do_sample: True
   until: ['\n']
 metric_list:
-  - metric: !function metrics.classification_score
+  - metric: "classification_score"
     aggregation: mean
     higher_is_better: True
 metadata:


### PR DESCRIPTION
Fixes #2976 

Brings `longbench_trec_e` changes in line with other longbench tasks that use the `classification_score` metric (`lsht`, `trec`) 

(Reference #2895)