### PR TITLE
add Mbpp instruct

### DIFF
--- a/lm_eval/tasks/mbpp/mbpp_instruct.yaml
+++ b/lm_eval/tasks/mbpp/mbpp_instruct.yaml
@@ -1,0 +1,25 @@
+task: mbpp_instruct
+dataset_path: google-research-datasets/mbpp
+dataset_name: full
+unsafe_code: true
+output_type: generate_until
+test_split: test
+doc_to_text: "You are an expert Python programmer, and here is your task:\n{{text}}\nYour code should pass these tests:\n{{test_list[0]}}\n{{test_list[1]}}\n{{test_list[2]}}"
+doc_to_target: "{% if is_fewshot is defined %}{{code}}\n```{% else %}{{test_list[0]}}\n{{test_list[1]}}\n{{test_list[2]}}{% endif %}"
+gen_prefix: "\n```python\n"
+target_delimiter: ""
+metric_list:
+  - metric: !function utils.pass_at_1
+    aggregation: mean
+    higher_is_better: true
+generation_kwargs:
+  max_gen_toks: 256
+  until:
+    - "[DONE]"
+  do_sample: false
+num_fewshot: 3
+fewshot_config:
+  sampler: first_n
+  samples: !function utils.list_fewshot_samples
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mbpp/mbpp_instruct.yaml
+++ b/lm_eval/tasks/mbpp/mbpp_instruct.yaml
@@ -12,6 +12,11 @@ metric_list:
   - metric: !function utils.pass_at_1
     aggregation: mean
     higher_is_better: true
+filter_list:
+  - name: "extract_code"
+    filter:
+      - function: "custom"
+        filter_fn: !function utils.build_predictions
 generation_kwargs:
   max_gen_toks: 256
   until: []

--- a/lm_eval/tasks/mbpp/mbpp_instruct.yaml
+++ b/lm_eval/tasks/mbpp/mbpp_instruct.yaml
@@ -14,8 +14,7 @@ metric_list:
     higher_is_better: true
 generation_kwargs:
   max_gen_toks: 256
-  until:
-    - "[DONE]"
+  until: []
   do_sample: false
 num_fewshot: 3
 fewshot_config:

--- a/lm_eval/tasks/mbpp/mbpp_plus_instruct.yaml
+++ b/lm_eval/tasks/mbpp/mbpp_plus_instruct.yaml
@@ -1,0 +1,8 @@
+include: mbpp_instruct.yaml
+task: mbpp_plus
+dataset_path: evalplus/mbppplus
+dataset_name: null
+doc_to_text: "{{prompt if prompt is defined else text}} Your code should satisfy the following assertion:\n{{test_list[0]}}"
+doc_to_target: "{{test_list[0]}}"
+gen_prefix: "Here is a solution to this programming problem:\n```python\n"
+num_fewshot: 0

--- a/lm_eval/tasks/mbpp/mbpp_plus_instruct.yaml
+++ b/lm_eval/tasks/mbpp/mbpp_plus_instruct.yaml
@@ -6,3 +6,7 @@ doc_to_text: "{{prompt if prompt is defined else text}} Your code should satisfy
 doc_to_target: "{{test_list[0]}}"
 gen_prefix: "Here is a solution to this programming problem:\n```python\n"
 num_fewshot: 0
+generation_kwargs:
+  max_gen_toks: 1024
+  until: []
+  do_sample: false

--- a/lm_eval/tasks/mbpp/mbpp_plus_instruct.yaml
+++ b/lm_eval/tasks/mbpp/mbpp_plus_instruct.yaml
@@ -1,5 +1,5 @@
 include: mbpp_instruct.yaml
-task: mbpp_plus
+task: mbpp_plus_instruct
 dataset_path: evalplus/mbppplus
 dataset_name: null
 doc_to_text: "{{prompt if prompt is defined else text}} Your code should satisfy the following assertion:\n{{test_list[0]}}"

--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -1,3 +1,5 @@
+import re
+
 import evaluate as hf_evaluate
 
 
@@ -18,6 +20,23 @@ def pass_at_1(references, predictions):
         predictions=[predictions],
         k=[1],
     )[0]["pass@1"]
+
+
+def extract_code_blocks(text: str) -> str:
+    # Pattern to match ```...``` blocks
+    pattern = r"```(?:\w+)?\n?(.*?)\n?```"
+    matches = re.findall(pattern, text, re.DOTALL)
+    if not matches:
+        text = r"```" + text
+        matches = re.findall(pattern, text, re.DOTALL)
+    if not matches:
+        return ""
+    else:
+        return matches[0]
+
+
+def build_predictions(resps: list[list[str]], docs: list[dict]) -> list[list[str]]:
+    return [[extract_code_blocks(r) for r in resp] for resp in resps]
 
 
 def list_fewshot_samples():

--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -17,7 +17,7 @@ except Exception as e:
 def pass_at_1(references, predictions):
     return pass_at_k.compute(
         references=references,
-        predictions=[predictions],
+        predictions=predictions,
         k=[1],
     )[0]["pass@1"]
 

--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -25,10 +25,12 @@ def pass_at_1(references: list[str], predictions: list[list[str]]) -> float:
 def extract_code_blocks(text: str) -> str:
     # Pattern to match ```...``` blocks
     pattern = r"```(?:\w+)?\n?(.*?)\n?```"
-    matches = re.findall(pattern, text, re.DOTALL)
+    # + ``` as we add the opening "```python" to the gen_prefix
+    matches = re.findall(pattern, r"```" + text, re.DOTALL)
+    # if no matches, try to match ```...``` blocks (after removing the language)
     if not matches:
-        text = r"```" + text
-        matches = re.findall(pattern, text, re.DOTALL)
+        text_without_lang = re.sub(r"```python", "```", text)
+        matches = re.findall(pattern, text_without_lang, re.DOTALL)
     if not matches:
         return ""
     else:

--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -25,7 +25,7 @@ def pass_at_1(references: list[str], predictions: list[list[str]]) -> float:
 def extract_code_blocks(text: str) -> str:
     # Pattern to match ```...``` blocks
     pattern = r"```(?:\w+)?\n?(.*?)\n?```"
-    # + ``` as we add the opening "```python" to the gen_prefix
+    # (+ ```) as we add the opening "```python" to the gen_prefix
     matches = re.findall(pattern, r"```" + text, re.DOTALL)
     # if no matches, try to match ```...``` blocks (after removing the language)
     if not matches:

--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -14,7 +14,7 @@ except Exception as e:
     raise e
 
 
-def pass_at_1(references, predictions):
+def pass_at_1(references: list[str], predictions: list[list[str]]) -> float:
     return pass_at_k.compute(
         references=references,
         predictions=predictions,


### PR DESCRIPTION
Added MBPP variants, `mbpp_instruct` and `mbpp_plus_instruct` for instruct models, based on llama [evals](https://huggingface.co/datasets/meta-llama/Llama-3.1-8B-Instruct-evals/viewer/Llama-3.1-8B-Instruct-evals__mbpp_plus__details?row=1&sql=SELECT+AVG%28is_correct%3A%3AINTEGER%29+AS+average_accuracy%0AFROM+llama_31_8b_instruct_evals__mbpp_plus__details%3B).

```
vllm (pretrained=meta-llama/Llama-3.1-8B-Instruct,max_length=8096), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|      Tasks       |Version|   Filter   |n-shot| Metric  |   |Value |   |Stderr|
|------------------|------:|------------|-----:|---------|---|-----:|---|-----:|
|mbpp_instruct     |      1|extract_code|     3|pass_at_1|↑  |0.6120|±  |0.0218|
|mbpp_plus_instruct|      1|extract_code|     0|pass_at_1|↑  |0.7619|±  |0.0219|
```
vs
`0.608` for mbpp; and
`0.727513` for mbpp plus

for `meta-llama/Llama-3.1-8B-Instruct` from link above

closes #2990