### PR TITLE
[Add Dataset Update] KBL 2025

### DIFF
--- a/lm_eval/tasks/kbl/bar_exam/civil/kbl_bar_exam_em_civil_2025.yaml
+++ b/lm_eval/tasks/kbl/bar_exam/civil/kbl_bar_exam_em_civil_2025.yaml
@@ -1,0 +1,3 @@
+task: kbl_bar_exam_em_civil_2025
+dataset_name: bar_exam_civil_2025
+include: _base_em_yaml


### PR DESCRIPTION
This PR adds support for the 2025 Korean Bar Exam multiple-choice questions to the [`kbl` dataset](https://aclanthology.org/2024.findings-emnlp.319/) within the `lm-evaluation-harness`.

In light of the recent update to the [KBL dataset reflecting the 2025 exam](https://huggingface.co/datasets/lbox/kbl/discussions/4#682aae8a4a6fe170fac8d781), this contribution ensures that the latest version is incorporated into the evaluation framework. This will allow for continued benchmarking of language models on up-to-date legal domain tasks.