### PR TITLE
Log tokenized request warning only once

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -598,6 +598,10 @@ class TemplateAPI(TemplateLM):
             n=self._batch_size if self._concurrent <= 1 else 0, batch_fn=None
         )
         if self._concurrent <= 1:
+            if not self.tokenized_requests:
+                eval_logger.info(
+                    "Tokenized requests are disabled. Context + generation length is not checked."
+                )
             pbar = tqdm(desc="Requesting API", total=len(requests))
             for chunk in chunked:
                 contexts, all_gen_kwargs, encodings_list = zip(*chunk)
@@ -615,10 +619,7 @@ class TemplateAPI(TemplateLM):
                         eval_logger.warning(
                             f"Some contexts exceeded (max length: ({self.max_length}) - max_gen_toks: ({max_gen_toks}). They were left truncated."
                         )
-                else:
-                    eval_logger.info(
-                        "Tokenized requests are disabled. Context + generation length is not checked."
-                    )
+
                 req = encodings_list if self.tokenized_requests else contexts
                 outputs = retry(
                     stop=stop_after_attempt(self.max_retries),

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -597,11 +597,11 @@ class TemplateAPI(TemplateLM):
         chunked = re_ord.get_batched(
             n=self._batch_size if self._concurrent <= 1 else 0, batch_fn=None
         )
+        if not self.tokenized_requests:
+            eval_logger.info(
+                "Tokenized requests are disabled. Context + generation length is not checked."
+            )
         if self._concurrent <= 1:
-            if not self.tokenized_requests:
-                eval_logger.info(
-                    "Tokenized requests are disabled. Context + generation length is not checked."
-                )
             pbar = tqdm(desc="Requesting API", total=len(requests))
             for chunk in chunked:
                 contexts, all_gen_kwargs, encodings_list = zip(*chunk)
@@ -665,10 +665,7 @@ class TemplateAPI(TemplateLM):
                         eval_logger.warning(
                             f"Some contexts exceeded (max length: ({self.max_length}) - max_gen_toks ({max_gen_toks}). They were left truncated."
                         )
-                else:
-                    eval_logger.info(
-                        "Tokenized requests are disabled. Context + generation length is not checked."
-                    )
+
                 req = encodings_list if self.tokenized_requests else contexts
                 results = itertools.chain.from_iterable(
                     asyncio.run(


### PR DESCRIPTION
## Description
Currently, when using a `local-chat-completions` model or a `local-completions` model with `tokenized_requests=False` for a `generate_until` task, the message "`Tokenized requests are disabled. Context + generation length is not checked.`" is printed for every single inference. This disrupts the tqdm progress bar and clutters the evaluation logs, e.g.:
```
Requesting API: 83%|████████▎ | 7048/8520 [4:02:27<47:39, 1.94s/it]
2025-05-20:18:48:54,665 INFO [lm_eval.models.api_models:619] Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 83%|████████▎ | 7049/8520 [4:02:28<44:09, 1.80s/it]
2025-05-20:18:48:56,136 INFO [lm_eval.models.api_models:619] Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 83%|████████▎ | 7050/8520 [4:02:31<48:45, 1.99s/it]
2025-05-20:18:48:58,565 INFO [lm_eval.models.api_models:619] Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 83%|████████▎ | 7051/8520 [4:02:32<43:40, 1.78s/it]
2025-05-20:18:48:59,869 INFO [lm_eval.models.api_models:619] Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 83%|████████▎ | 7052/8520 [4:02:33<39:18, 1.61s/it]
2025-05-20:18:49:01,061 INFO [lm_eval.models.api_models:619] Tokenized requests are disabled. Context + generation length is not checked.
```

This PR changes the logging behavior of this message to only appear for the very first inference chunk.


## Verification:
Running a `local-completions` evaluation with `tokenized_requests=False` on a `generate_until` task (e.g., `mmlu_astronomy_generative`) now produces:

```
2025-05-20:20:05:26 INFO     [evaluator:561] Running generate_until requests
2025-05-20:20:05:26 INFO     [models.api_models:602] Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  13%|███████████████████████████▉
```
The log message is produced before inferences begin, and the progress bar works as expected for subsequent inferences. 