### PR TITLE
support distributed executor backend - torchrun

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -556,7 +556,7 @@ def evaluate(
                 )
             elif distributed_executor_backend == "torchrun":
                 gathered_item = [torch.zeros_like(instances_rnk)] * lm.world_size
-                dist.all_gather(gathered_item, instances_rnk)
+                torch.distributed.all_gather(gathered_item, instances_rnk)
                 gathered_item = [x.item() for x in gathered_item]
             else:
                 raise ValueError(
@@ -598,7 +598,7 @@ def evaluate(
             if distributed_executor_backend == "accelerator":
                 lm.accelerator.wait_for_everyone()
             elif distributed_executor_backend == "torchrun":
-                dist.barrier()
+                torch.distributed.barrier()
             else:
                 raise ValueError(
                     f"distributed_executor_backend must be one of ['accelerator', 'torchrun'], but got {distributed_executor_backend}."

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -75,6 +75,7 @@ def simple_evaluate(
     torch_random_seed: int = 1234,
     fewshot_random_seed: int = 1234,
     confirm_run_unsafe_code: bool = False,
+    distributed_executor_backend: str = "accelerator",
     metadata: Optional[dict] = None,
 ):
     """Instantiate and evaluate a model on a list of tasks.
@@ -138,6 +139,8 @@ def simple_evaluate(
         Random seed for torch. If set to None, the seed will not be set.
     :param fewshot_random_seed: int
         Random seed for fewshot sampler random generator. If set to None, the seed of generator will be set to None.
+    :param distributed_executor_backend: str
+        The backend to use for distributed execution, `accelerator` or `torchrun`. Defaults to "accelerator" for the `accelerate` library.
     :param metadata: dict
         Additional metadata to be added to the task manager. Will get passed to the download function of the task.
 
@@ -189,6 +192,11 @@ def simple_evaluate(
     if len(tasks) == 0:
         raise ValueError(
             "No tasks specified, or no tasks found. Please verify the task names."
+        )
+
+    if distributed_executor_backend not in {"accelerator", "torchrun"}:
+        raise ValueError(
+            f"distributed_executor_backend must be one of ['accelerator', 'torchrun'], but got {distributed_executor_backend}."
         )
 
     if gen_kwargs is not None:
@@ -246,18 +254,14 @@ def simple_evaluate(
             use_cache
             # each rank receives a different cache db.
             # necessary to avoid multiple writes to cache at once
-            + "_rank"
-            + str(lm.rank)
-            + ".db",
+            + "_rank" + str(lm.rank) + ".db",
         )
 
     if task_manager is None:
         metadata = (
             simple_parse_args_string(model_args)
             if isinstance(model_args, str)
-            else model_args
-            if isinstance(model_args, dict)
-            else {}
+            else model_args if isinstance(model_args, dict) else {}
         ) | (metadata or {})
         task_manager = TaskManager(metadata=metadata)
 
@@ -329,9 +333,9 @@ def simple_evaluate(
             model_source=model,
             model_args=model_args,
             system_instruction=system_instruction,
-            chat_template=lm.chat_template(apply_chat_template)
-            if apply_chat_template
-            else None,
+            chat_template=(
+                lm.chat_template(apply_chat_template) if apply_chat_template else None
+            ),
             fewshot_as_multiturn=fewshot_as_multiturn,
         )
 
@@ -350,6 +354,7 @@ def simple_evaluate(
         fewshot_as_multiturn=fewshot_as_multiturn,
         verbosity=verbosity,
         confirm_run_unsafe_code=confirm_run_unsafe_code,
+        distributed_executor_backend=distributed_executor_backend,
     )
     if verbosity is not None:
         setup_logging(verbosity=verbosity)
@@ -413,6 +418,7 @@ def evaluate(
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
     confirm_run_unsafe_code: bool = False,
+    distributed_executor_backend: str = "accelerator",
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -447,6 +453,8 @@ def evaluate(
         Verbosity level for logging
     :param confirm_run_unsafe_code: bool
         Whether to confirm running tasks marked as unsafe.
+    :param distributed_executor_backend: str
+        The backend to use for distributed execution, `accelerator` or `torchrun`. Defaults to "accelerator" for the `accelerate` library.
     :return
         Dictionary of results
     """
@@ -510,9 +518,11 @@ def evaluate(
         limits.append(limit)
         task.build_all_requests(
             limit=limit,
-            samples=samples.get(task_output.task_name, None)
-            if samples is not None
-            else samples,
+            samples=(
+                samples.get(task_output.task_name, None)
+                if samples is not None
+                else samples
+            ),
             rank=lm.rank,
             world_size=lm.world_size,
             cache_requests=cache_requests,
@@ -520,12 +530,12 @@ def evaluate(
             system_instruction=system_instruction,
             apply_chat_template=bool(apply_chat_template),
             fewshot_as_multiturn=fewshot_as_multiturn,
-            chat_template=getattr(lm, "apply_chat_template")
-            if apply_chat_template
-            else None,
-            tokenizer_name=getattr(lm, "tokenizer_name", "")
-            if apply_chat_template
-            else "",
+            chat_template=(
+                getattr(lm, "apply_chat_template") if apply_chat_template else None
+            ),
+            tokenizer_name=(
+                getattr(lm, "tokenizer_name", "") if apply_chat_template else ""
+            ),
         )
         eval_logger.debug(
             f"Task: {task_output.task_name}; number of requests on this rank: {len(task.instances)}"
@@ -539,9 +549,20 @@ def evaluate(
 
         if lm.world_size > 1:
             instances_rnk = torch.tensor(len(task._instances), device=lm.device)
-            gathered_item = (
-                lm.accelerator.gather(instances_rnk).cpu().detach().numpy().tolist()
-            )
+
+            if distributed_executor_backend == "accelerator":
+                gathered_item = (
+                    lm.accelerator.gather(instances_rnk).cpu().detach().numpy().tolist()
+                )
+            elif distributed_executor_backend == "torchrun":
+                gathered_item = [torch.zeros_like(instances_rnk)] * lm.world_size
+                dist.all_gather(gathered_item, instances_rnk)
+                gathered_item = [x.item() for x in gathered_item]
+            else:
+                raise ValueError(
+                    f"distributed_executor_backend must be one of ['accelerator', 'torchrun'], but got {distributed_executor_backend}."
+                )
+
             # "multiple_choice" task types dispatch (several) "loglikelihood" request types
             reqtype = (
                 "loglikelihood"
@@ -574,7 +595,14 @@ def evaluate(
             req.resps.append(x)
 
         if lm.world_size > 1:
-            lm.accelerator.wait_for_everyone()
+            if distributed_executor_backend == "accelerator":
+                lm.accelerator.wait_for_everyone()
+            elif distributed_executor_backend == "torchrun":
+                dist.barrier()
+            else:
+                raise ValueError(
+                    f"distributed_executor_backend must be one of ['accelerator', 'torchrun'], but got {distributed_executor_backend}."
+                )
 
     RANK = lm.rank
     WORLD_SIZE = lm.world_size


### PR DESCRIPTION
This PR will add a param of `distributed_executor_backend: str = "accelerator"` to the functions of `simple_evaluate` and `evaluate` in `evaluator.py`.

This param will use `accelerator` in default that won't affect the previous usage.

If users want to call evaluation through API with the `torchrun` launcher, they can do

```python
results = simple_evaluate(
    model=EvalLmCls,
    tasks=[benchmark],
    num_fewshot=num_fewshot,
    task_manager=task_manager,
    batch_size=cfg.batch_size,
    distributed_executor_backend="torchrun",
)
```