### PR TITLE
Fallback to super implementation in `fewshot_context` for Unitxt tasks

### DIFF
--- a/lm_eval/tasks/unitxt/task.py
+++ b/lm_eval/tasks/unitxt/task.py
@@ -105,7 +105,7 @@ class Unitxt(ConfigurableTask):
         return False
 
     def doc_to_target(self, doc):
-        doc["target"]
+        return doc["target"]
 
     def get_arguments(self, doc, ctx):
         return (ctx, {"until": ["\n"]})
@@ -120,8 +120,7 @@ class Unitxt(ConfigurableTask):
         chat_template: Optional[Callable] = None,
         gen_prefix: Optional[str] = None,
     ) -> str:
-        source = self.doc_to_text(doc)
-        if isinstance(source, list):
+        if isinstance(self.doc_to_text(doc), list):
             if apply_chat_template:
                 formated_source = chat_template(self.doc_to_text(doc))
                 return formated_source
@@ -130,7 +129,15 @@ class Unitxt(ConfigurableTask):
                     "Got chat template format from Unitxt, but apply_chat_template is false. Add '--apply_chat_template' to command line."
                 )
         else:
-            return source
+            return super().fewshot_context(
+                doc=doc,
+                num_fewshot=num_fewshot,
+                system_instruction=system_instruction,
+                apply_chat_template=apply_chat_template,
+                fewshot_as_multiturn=fewshot_as_multiturn,
+                chat_template=chat_template,
+                gen_prefix=gen_prefix,
+            )
 
     def construct_requests(self, doc, ctx, **kwargs):
         """Uses RequestFactory to construct Requests and returns an iterable of


### PR DESCRIPTION
Fixes a bug discussed in the comments of #2986

Local chat completions w/ built-in Unitxt tasks were previously failing due to a mismatch of the expected format of the chat template. Some Unitxt tasks (recipes) provide a list of chat messages in the prepared dataset `doc["source"]` field, but others don't. This PR defaults to calling the `ConfigurableTask` implementation of `fewshot_context` in the latter case, which is the more common case for the tasks that come built-in to `lm-evaluation-harness` right now