### PR TITLE
Update vLLM compatibility

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -31,7 +31,7 @@ from lm_eval.utils import (
 
 try:
     import ray
-    from vllm import LLM, SamplingParams
+    from vllm import LLM, SamplingParams, TokensPrompt
     from vllm.lora.request import LoRARequest
     from vllm.transformers_utils.tokenizer import get_tokenizer
     from vllm.utils import get_open_port
@@ -77,7 +77,7 @@ def _vllm_mp_worker(
     try:
         llm = LLM(**model_args)
         res = llm.generate(
-            prompt_token_ids=requests,
+            [TokensPrompt(prompt_token_ids=request) for request in requests],
             sampling_params=sampling_params,
             lora_request=lora_request,
         )
@@ -219,13 +219,6 @@ class VLLM(TemplateLM):
                 kwargs_resolve_hf_chat_template["model_config"] = (
                     self.model.llm_engine.model_config
                 )
-
-            # https://github.com/vllm-project/vllm/pull/18259
-            if (
-                "trsut_remote_code"
-                in inspect.signature(resolve_hf_chat_template).parameters
-            ):
-                kwargs_resolve_hf_chat_template["trsut_remote_code"] = trust_remote_code
             else:
                 kwargs_resolve_hf_chat_template["trust_remote_code"] = trust_remote_code
 


### PR DESCRIPTION
- vLLM v0.9.0 has been released with the bugfix vllm-project/vllm#18259, so the workaround in #2992 is no longer needed.
- Update `llm.generate` call to work with vllm-project/vllm#18800

cc @fxmarty-amd @baberabb 