### PR TITLE
Fix: fix vllm issue with DP>1

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -216,9 +216,17 @@ class VLLM(TemplateLM):
             }
 
             if parse_version(version("vllm")) >= parse_version("0.9.0"):
-                kwargs_resolve_hf_chat_template["model_config"] = (
-                    self.model.llm_engine.model_config
-                )
+                if self.data_parallel_size <= 1:
+                    kwargs_resolve_hf_chat_template["model_config"] = (
+                        self.model.llm_engine.model_config
+                    )
+                else:
+                    from vllm.engine.arg_utils import EngineArgs
+
+                    engine_args = EngineArgs(**self.model_args)
+                    model_config = engine_args.create_model_config()
+
+                    kwargs_resolve_hf_chat_template["model_config"] = model_config
 
             # https://github.com/vllm-project/vllm/pull/18259
             if (


### PR DESCRIPTION
When using VLLM (nightly or recent) + DP>1: https://github.com/EleutherAI/lm-evaluation-harness/pull/3020 users face:

```
'VLLM' object has no attribute 'model'
```

This is because when initializing the model we need to properly infer `model_config` if DP>1

cc @baberabb 

