### PR TITLE
Try fixing issue 3026

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -597,7 +597,7 @@ class HFLM(TemplateLM):
                 torch_dtype=get_dtype(dtype),
                 trust_remote_code=trust_remote_code,
                 gguf_file=gguf_file,
-                quantization_config=quantization_config,
+                # quantization_config=quantization_config,
                 **model_kwargs,
             )
         else:


### PR DESCRIPTION
Try fixing issue 3026 which is caused by the quantization_config argument introduced in Commit 758c5ed. 
The argument is in Dict type, but for a GPTQ quantized model, it has a conflict with the huggingface interface which expects QuantizationConfigMixin type. 
Current solution is removing quantization_config argument in HFLM._create_model() of lm_eval/models/huggingface.py.
Require further modification to restore the functionality provided by the previous commit.
