### PR TITLE
Tarjma bench

### DIFF
--- a/lm_eval/tasks/darija_bench/darija_translation/terjama_bench_utils.py
+++ b/lm_eval/tasks/darija_bench/darija_translation/terjama_bench_utils.py
@@ -1,0 +1,15 @@
+
+def input_prompt_en_ary(dataset):
+    prompt=f"English phrase: {dataset['English']} \nTranslate to Moroccan Arabic Darija (in Arabic script only):"
+    return prompt
+
+def target_output_en_ary(dataset):
+    return dataset["Darija"]
+
+def input_prompt_ary_en(dataset):
+    prompt=f"Moroccan Arabic Darija phrase: {dataset['Darija']} \nTranslate to English:"
+    return prompt
+
+def target_output_ary_en(dataset):
+    return dataset["English"]
+

--- a/lm_eval/tasks/darija_bench/darija_translation/terjamabench_ary-en.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/terjamabench_ary-en.yaml
@@ -1,0 +1,10 @@
+dataset_name: default
+dataset_path: atlasia/TerjamaBench
+doc_to_target: !function terjma_bench_utils.target_output_ary_en
+doc_to_text: !function terjma_bench_utils.input_prompt_ary_en
+tag:
+- translation
+- terjamabench
+task: terjamabench-ary-en
+include:
+  - terjmabench_common_yaml

--- a/lm_eval/tasks/darija_bench/darija_translation/terjamabench_ary-en.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/terjamabench_ary-en.yaml
@@ -1,10 +1,10 @@
 dataset_name: default
 dataset_path: atlasia/TerjamaBench
-doc_to_target: !function terjma_bench_utils.target_output_ary_en
-doc_to_text: !function terjma_bench_utils.input_prompt_ary_en
+doc_to_target: !function terjama_bench_utils.target_output_ary_en
+doc_to_text: !function terjama_bench_utils.input_prompt_ary_en
 tag:
 - translation
 - terjamabench
 task: terjamabench-ary-en
 include:
-  - terjmabench_common_yaml
+  - terjamabench_common_yaml

--- a/lm_eval/tasks/darija_bench/darija_translation/terjamabench_common_yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/terjamabench_common_yaml
@@ -1,0 +1,23 @@
+output_type: generate_until
+training_split: null
+validation_split: null
+fewshot_split: null
+test_split: test
+metric_list:
+  - metric: bleu
+  - metric: ter
+  - metric: chrf
+generation_kwargs:
+  until:
+    - "\n"
+    - "<end_of_turn>"
+    - "<eos>"
+    - "</s>"
+    - "<|end_of_text|>"
+    - "<|eot_id|>"
+    - "<|endoftext|>"
+  do_sample: false
+  temperature: 0.0
+repeats: 1
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/darija_bench/darija_translation/terjamabench_en-ary.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/terjamabench_en-ary.yaml
@@ -1,0 +1,10 @@
+dataset_name: default
+dataset_path: atlasia/TerjamaBench
+doc_to_target: !function terjma_bench_utils.target_output_en_ary
+doc_to_text: !function terjma_bench_utils.input_prompt_en_ary
+tag:
+- translation
+- terjamabench
+task: terjamabench-en-ary
+include:
+  - terjmabench_common_yaml

--- a/lm_eval/tasks/darija_bench/darija_translation/terjamabench_en-ary.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/terjamabench_en-ary.yaml
@@ -7,4 +7,4 @@ tag:
 - terjamabench
 task: terjamabench-en-ary
 include:
-  - terjama_bench_common_yaml
+  - terjamabench_common_yaml

--- a/lm_eval/tasks/darija_bench/darija_translation/terjamabench_en-ary.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/terjamabench_en-ary.yaml
@@ -1,10 +1,10 @@
 dataset_name: default
 dataset_path: atlasia/TerjamaBench
-doc_to_target: !function terjma_bench_utils.target_output_en_ary
-doc_to_text: !function terjma_bench_utils.input_prompt_en_ary
+doc_to_target: !function terjama_bench_utils.target_output_en_ary
+doc_to_text: !function terjama_bench_utils.input_prompt_en_ary
 tag:
 - translation
 - terjamabench
 task: terjamabench-en-ary
 include:
-  - terjmabench_common_yaml
+  - terjama_bench_common_yaml


### PR DESCRIPTION
# TerjamaBench: English-Moroccan Arabic Darija Translation Benchmark

## Overview
This PR introduces TerjamaBench, a benchmark for evaluating machine translation models on English-Moroccan Arabic (Darija) translation tasks. The benchmark supports bidirectional translation:
- English to Moroccan Arabic (Darija)
- Moroccan Arabic (Darija) to English

## Implementation Details
- Created YAML configuration files for both translation directions:
  - `terjamabench_en-ary.yaml`: English to Darija translation
  - `terjamabench_ary-en.yaml`: Darija to English translation
  - `terjamabench_common_yaml`: Shared configuration settings

- Implemented utility functions in `terjama_bench_utils.py` for:
  - Input prompt formatting
  - Target output extraction
  - Bidirectional translation handling

## Evaluation Metrics
The benchmark uses standard machine translation metrics:
- BLEU
- TER (Translation Edit Rate)
- chrF

## Configuration
- Uses the `atlasia/TerjamaBench` dataset
- Implements proper generation settings with appropriate stop tokens
- Configured for test split evaluation
- Temperature set to 0.0 for deterministic outputs

## Testing
✅ Verified with MBZUAI-Paris/Atlas-Chat-2B LLM on CPU/GPU.
