### PR TITLE
add kwargs passing into filters

### DIFF
--- a/lm_eval/api/filter.py
+++ b/lm_eval/api/filter.py
@@ -20,7 +20,9 @@ class Filter(ABC):
         """
 
     @abstractmethod
-    def apply(self, resps: Union[List, Iterable], docs: List[dict]) -> Iterable:
+    def apply(
+        self, resps: Union[List, Iterable], docs: List[dict], **kwargs
+    ) -> Iterable:
         """
         Defines the operation to perform on a list of the `inst.resps` properties of `Instance` objects.
         Should return the list of (filtered) response lists *in the same order as they were input*, e.g.
@@ -42,13 +44,13 @@ class FilterEnsemble:
     name: str
     filters: List[Callable[[], Filter]]
 
-    def apply(self, instances: List[Instance]) -> None:
+    def apply(self, instances: List[Instance], **kwargs) -> None:
         resps, docs = zip(*((inst.resps, inst.doc) for inst in instances))
         resps, docs = list(resps), list(docs)
 
         for f in self.filters:
             # apply filters in sequence
-            resps = f().apply(resps, docs)
+            resps = f().apply(resps, docs, **kwargs)
 
         # add the end results after filtering to filtered_requests of their respective source instances.
         # has key `self.name`: each FilterEnsemble applied in a given run should use a different name.

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -622,11 +622,11 @@ class Task(abc.ABC):
         example = self.doc_to_text(doc)
         return description + labeled_examples + example
 
-    def apply_filters(self) -> Optional[List[Instance]]:
+    def apply_filters(self, **kwargs) -> Optional[List[Instance]]:
         """Iterates over FilterEnsembles and applies them to instances"""
         if hasattr(self, "_filters"):
             for f in self._filters:
-                f.apply(self._instances)
+                f.apply(self._instances, **kwargs)
         else:
             eval_logger.warning("No filter defined, passing through instances")
             return self._instances
@@ -1233,11 +1233,11 @@ class ConfigurableTask(Task):
                 else:
                     return labeled_examples + str(example) + prefix
 
-    def apply_filters(self) -> Optional[List[Instance]]:
+    def apply_filters(self, **kwargs) -> Optional[List[Instance]]:
         """Iterates over FilterEnsembles and applies them to instances"""
         if hasattr(self, "_filters"):
             for f in self._filters:
-                f.apply(self._instances)
+                f.apply(self._instances, **kwargs)
         else:
             eval_logger.warning("No filter defined, passing through instances")
             return self._instances

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -350,6 +350,7 @@ def simple_evaluate(
         fewshot_as_multiturn=fewshot_as_multiturn,
         verbosity=verbosity,
         confirm_run_unsafe_code=confirm_run_unsafe_code,
+        predict_only=predict_only,
     )
     if verbosity is not None:
         setup_logging(verbosity=verbosity)
@@ -413,6 +414,7 @@ def evaluate(
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
     confirm_run_unsafe_code: bool = False,
+    predict_only: bool = False,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -447,6 +449,8 @@ def evaluate(
         Verbosity level for logging
     :param confirm_run_unsafe_code: bool
         Whether to confirm running tasks marked as unsafe.
+    :param predict_only: bool
+        If true only model outputs will be generated and returned. Metrics will not be evaluated
     :return
         Dictionary of results
     """
@@ -582,7 +586,7 @@ def evaluate(
     # TODO: del model here, maybe (idea: allow user to specify device of e.g. reward model separately)
     for task_output, limit in zip(eval_tasks, limits):
         task = task_output.task
-        task.apply_filters()
+        task.apply_filters(predict_only=predict_only)
 
         ### Collect values of metrics on all datapoints ###
         # # unpack results and sort back in order and return control to Task

--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -30,7 +30,9 @@ class RegexFilter(Filter):
         self.group_select = group_select
         self.fallback = fallback
 
-    def apply(self, resps: list[list[str]], docs: list[dict]) -> list[list[str]]:
+    def apply(
+        self, resps: list[list[str]], docs: list[dict], **kwargs
+    ) -> list[list[str]]:
         # here, we assume we have a list, in which each element is
         # a list of model responses for some particular input/target pair.
         # so we process each of these (same input/target response sets)
@@ -78,7 +80,7 @@ class POSFilter(Filter):
         self.group_select = group_select
         self.fallback = fallback
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def extract_tagged_tokens(text):
             # Extract tagged tokens list from text input using regex
             tokens = re.findall(r"\('([^']*)', '([^']*)'\)", text)
@@ -107,7 +109,9 @@ class POSFilter(Filter):
 class WhitespaceFilter(Filter):
     """Filters out leading whitespace from responses."""
 
-    def apply(self, resps: list[list[str]], docs: list[dict]) -> list[list[str]]:
+    def apply(
+        self, resps: list[list[str]], docs: list[dict], **kwargs
+    ) -> list[list[str]]:
         def filter_set(inst):
             filtered_resp = []
             for resp in inst:
@@ -152,7 +156,9 @@ class MultiChoiceRegexFilter(RegexFilter):
         self.ignore_punctuation = ignore_punctuation
         self.regexes_to_ignore = regexes_to_ignore
 
-    def apply(self, resps: list[list[str]], docs: list[dict]) -> list[list[str]]:
+    def apply(
+        self, resps: list[list[str]], docs: list[dict], **kwargs
+    ) -> list[list[str]]:
         # here, we assume we have a list, in which each element is
         # a list of model responses for some particular input/target pair.
         # so we process each of these (same input/target response sets)

--- a/lm_eval/filters/selection.py
+++ b/lm_eval/filters/selection.py
@@ -16,7 +16,7 @@ class TakeFirstFilter(Filter):
         Can define custom behavior here, if an individual instantiation of a Filter class should have state.
         """
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         """
         Assuming each entry of `resps` is a list of model responses, we discard all but the first response.
         """
@@ -30,7 +30,7 @@ class TakeKFilter(Filter):
 
         super().__init__(**kwargs)
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         # need resp to be subscriptable to check below
         resps = list(resps)
         # check we have at least k responses per doc, else we can't take the first k
@@ -47,7 +47,7 @@ class MajorityVoteFilter(Filter):
         Can define custom behavior here, if an individual instantiation of a Filter class should have state.
         """
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         """
         Each entry of `resps` is a list of model responses.
         We select the response that occurs most frequently in each entry of `resps`.

--- a/lm_eval/filters/transformation.py
+++ b/lm_eval/filters/transformation.py
@@ -9,7 +9,7 @@ class LowercaseFilter(Filter):
     def __init__(self) -> None:
         pass
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def filter_set(inst):
             return [resp.lower() for resp in inst]
 
@@ -21,7 +21,7 @@ class UppercaseFilter(Filter):
     def __init__(self) -> None:
         pass
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def filter_set(inst):
             return [resp.upper() for resp in inst]
 
@@ -51,7 +51,7 @@ class MapFilter(Filter):
         self.mapping_dict = mapping_dict
         self.default_value = default_value
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def filter_set(inst):
             return [self.mapping_dict.get(resp, self.default_value) for resp in inst]
 
@@ -63,7 +63,7 @@ class SPANFilter(Filter):
     def __init__(self) -> None:
         pass
 
-    def apply(self, resps, docs):
+    def apply(self, resps, docs, **kwargs):
         def format_ner_text(text):
             label_dict = {
                 "person": "PER",


### PR DESCRIPTION
some filters may include running llm-as-a-judge or some reward model. if user passes `--predict_only`, there is no need in applying such filters, so they need to be able to get the `predict_only` value to determine the behavior

this PR allows filters to get kwargs as input and directly passes predict_only as a kwarg. all default filters are changed to handle kwargs