### PR TITLE
[HF] fix quantization config

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -597,7 +597,7 @@ class HFLM(TemplateLM):
                 torch_dtype=get_dtype(dtype),
                 trust_remote_code=trust_remote_code,
                 gguf_file=gguf_file,
-                quantization_config=quantization_config,
+                # quantization_config=quantization_config,
                 **model_kwargs,
             )
         else:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -189,13 +189,10 @@ class HFLM(TemplateLM):
             add_bos_token=add_bos_token,
         )
 
-        if quantization_config := getattr(self.config, "quantization_config", None):
+        if (
+            quantization_config := getattr(self.config, "quantization_config", None)
+        ) is not None and isinstance(quantization_config, dict):
             from transformers.quantizers import AutoQuantizationConfig
-
-            if quantization_config is not None and not isinstance(
-                quantization_config, dict
-            ):
-                quantization_config = quantization_config.to_dict()
 
             quantization_config = AutoQuantizationConfig.from_dict(quantization_config)
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -192,6 +192,11 @@ class HFLM(TemplateLM):
         if quantization_config := getattr(self.config, "quantization_config", None):
             from transformers.quantizers import AutoQuantizationConfig
 
+            if quantization_config is not None and not isinstance(
+                quantization_config, dict
+            ):
+                quantization_config = quantization_config.to_dict()
+
             quantization_config = AutoQuantizationConfig.from_dict(quantization_config)
 
         # if we passed `pretrained` as a string, initialize our model now


### PR DESCRIPTION
continuing from from #3029 to close #3026.

`transformers/quantizers/auto.py` expects the `quantization_config` to be the appropriate Config object rather than a dict. This converts the it now using `AutoQuantizationConfig.from_dict()` before passing it to the model initialization 

@shanhx2000: If you could help test this, would be really helpful.

cc: @jerryzh168, would appreciate a review to make sure this still works with #2842!