### PR TITLE
Fix typos in docstrings in instructions.py

### DIFF
--- a/lm_eval/tasks/ifeval/instructions.py
+++ b/lm_eval/tasks/ifeval/instructions.py
@@ -740,7 +740,7 @@ class RephraseChecker(Instruction):
 
 
 class KeywordChecker(Instruction):
-    """Check the exisitence of certain keywords."""
+    """Check the existence of certain keywords."""
 
     def build_description(self, *, keywords=None):
         """Build the instruction description.
@@ -1161,7 +1161,7 @@ class RephraseParagraph(Instruction):
 
         Args:
           original_paragraph: A string presenting the original paragraph. The
-            rephrases response should have betweeb low-high words in common.
+            rephrases response should have between low-high words in common.
           low: An integer presenting the lower bound of similar words.
           high: An integer representing the upper bound of similar words.
 


### PR DESCRIPTION


Description:
This pull request corrects two minor typos in the docstrings of the lm_eval/tasks/ifeval/instructions.py file:
- Fixed the spelling of "existence" in the KeywordChecker class docstring.
- Corrected "betweeb" to "between" in the build_description function docstring.
