### PR TITLE
Gracefully skip BigBench tasks with no data & guard final aggregation

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -691,10 +691,13 @@ def evaluate(
         ) = consolidate_results(eval_tasks)
 
         ### Calculate group metrics ###
+        # default to no group-table if there are no results
+        show_group_table = False
         if bool(results):
             results, versions, show_group_table, *_ = consolidate_group_results(
                 results, versions, task_dict
             )
+
 
         results_agg, group_agg = prepare_print_tasks(task_dict, results)
         subtask_list = get_subtask_list(task_dict)
@@ -724,28 +727,28 @@ def evaluate(
                 higher_is_better[group] = _higher_is_better
 
         results_dict = {
-            "results": dict(results_agg.items()),
-            **(
-                {"groups": dict(group_agg.items())}
-                if (bool(group_agg) & show_group_table)
-                else {}
-            ),
-            "group_subtasks": dict(reversed(subtask_list.items())),
-            "configs": dict(sorted(configs.items())),
-            "versions": dict(sorted(versions.items())),
-            "n-shot": dict(sorted(num_fewshot.items())),
-            "higher_is_better": dict(sorted(higher_is_better.items())),
-            "n-samples": {
-                task_output.task_name: {
-                    "original": len(task_output.task.eval_docs),
-                    "effective": min(
-                        limit if limit else len(task_output.task.eval_docs),
-                        len(task_output.task.eval_docs),
-                    ),
-                }
-                for task_output, limit in zip(eval_tasks, limits)
-            },
-        }
+          "results": dict(results_agg.items()),
+          **(
+              {"groups": dict(group_agg.items())}
+              if bool(group_agg) and show_group_table
+              else {}
+          ),
+          "group_subtasks": dict(reversed(subtask_list.items())),
+          "configs": dict(sorted(configs.items())),
+          "versions": dict(sorted(versions.items())),
+          "n-shot": dict(sorted(num_fewshot.items())),
+          "higher_is_better": dict(sorted(higher_is_better.items())),
+          "n-samples": {
+              task_output.task_name: {
+                  "original": len(task_output.task.eval_docs),
+                  "effective": min(
+                      limit if limit else len(task_output.task.eval_docs),
+                      len(task_output.task.eval_docs),
+                  ),
+              }
+              for task_output, limit in zip(eval_tasks, limits)
+          },
+      }
         if log_samples:
             results_dict["samples"] = dict(samples)
 


### PR DESCRIPTION
**Description**:
Running the harness on BigBench stalls (or crashes) once it reaches bigbench_simple_arithmetic_multiple_targets_json_generate_until because that task’s configured split (“train”) doesn’t exist, causing:

- A ValueError: Instruction "train" corresponds to no data! in datasets.load_dataset().

- An unguarded “Test One Doc” block in ConfigurableTask.__init__ that blindly indexes eval_docs[0].

- Later, an UnboundLocalError in evaluate() when referencing show_group_table if all tasks have zero examples.

This PR makes the harness robust to missing-split/empty tasks by:

- Catching missing-split errors in ConfigurableTask.download() and substituting an empty DatasetDict({"default": …}).

- Wrapping the “one‐doc” sanity checks in ConfigurableTask.__init__ inside if self.eval_docs: (with an else fallback for minimal attribute initialization).

- Filtering out zero-example tasks at the top of evaluate(), so they never build requests or invoke the LM.

- Initializing show_group_table=False before the group-aggregation step and switching from bitwise & to logical and when inserting the "groups" entry in results_dict.

These changes resolve the crash and prevent any lag or endless stalling when the harness reaches that BigBench task, or other tasks that experience similar issues.