### PR TITLE
Custom request headers |  trust_remote_code param fix

### DIFF
--- a/docs/API_guide.md
+++ b/docs/API_guide.md
@@ -21,7 +21,7 @@ When subclassing `TemplateAPI`, you need to implement the following methods:
 1. `_create_payload`: Creates the JSON payload for API requests.
 2. `parse_logprobs`: Parses log probabilities from API responses.
 3. `parse_generations`: Parses generated text from API responses.
-4. `headers`: Returns the headers for the API request.
+4. `header`: Returns the headers for the API request.
 
 You may also need to override other methods or properties depending on your API's specific requirements.
 

--- a/docs/API_guide.md
+++ b/docs/API_guide.md
@@ -97,6 +97,10 @@ When initializing a `TemplateAPI` instance or a subclass, you can provide severa
   - Whether to validate the certificate of the API endpoint (if HTTPS).
   - Default is True.
 
+- `header` (dict, optional):
+  - Custom headers for API requests.
+  - If not provided, uses `{"Authorization": f"Bearer {self.api_key}"}` by default.
+
 Example usage:
 
 ```python

--- a/docs/API_guide.md
+++ b/docs/API_guide.md
@@ -21,7 +21,11 @@ When subclassing `TemplateAPI`, you need to implement the following methods:
 1. `_create_payload`: Creates the JSON payload for API requests.
 2. `parse_logprobs`: Parses log probabilities from API responses.
 3. `parse_generations`: Parses generated text from API responses.
+
+Optional Properties:
+
 4. `header`: Returns the headers for the API request.
+5. `api_key`: Returns the API key for authentication (if required).
 
 You may also need to override other methods or properties depending on your API's specific requirements.
 

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -435,7 +435,10 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
 
         datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = True
 
-        args.model_args = args.model_args + ",trust_remote_code=True"
+        if isinstance(args.model_args, dict):
+            args.model_args["trust_remote_code"] = True
+        else:
+            args.model_args = args.model_args + ",trust_remote_code=True"
     (
         eval_logger.info(f"Selected Tasks: {task_names}")
         if eval_logger.getEffectiveLevel() >= logging.INFO

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -296,7 +296,7 @@ class TemplateAPI(TemplateLM):
     @cached_property
     def header(self) -> dict:
         """Override this property to return the headers for the API request."""
-        return {"Authorization": f"Bearer {self.api_key}"}
+        return None
 
     @property
     def tokenizer_name(self) -> str:

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -135,6 +135,7 @@ class TemplateAPI(TemplateLM):
         eos_string: str = None,
         # timeout in seconds
         timeout: int = 300,
+        header: Optional[Dict[str, str]] = None,
         max_images: int = 1,
         **kwargs,
     ) -> None:
@@ -152,6 +153,7 @@ class TemplateAPI(TemplateLM):
         self.model = model or pretrained
         self.base_url = base_url
         self.tokenizer = tokenizer
+        self._header = header
         if not isinstance(batch_size, int) and "auto" in batch_size:
             eval_logger.warning(
                 "Automatic batch size is not supported for API models. Defaulting to batch size 1."
@@ -296,7 +298,7 @@ class TemplateAPI(TemplateLM):
     @cached_property
     def header(self) -> dict:
         """Override this property to return the headers for the API request."""
-        return None
+        return self._header or {"Authorization": f"Bearer {self.api_key}"}
 
     @property
     def tokenizer_name(self) -> str:

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -17,20 +17,12 @@ class LocalCompletionsAPI(TemplateAPI):
     def __init__(
         self,
         base_url: str = None,
-        headers: dict[str, str] = None,
         tokenizer_backend: str = "huggingface",
         **kwargs,
     ):
         super().__init__(
             base_url=base_url, tokenizer_backend=tokenizer_backend, **kwargs
         )
-        # Assign headers
-        self.headers = headers
-
-    @cached_property
-    def header(self) -> dict:
-        """Set API headers."""
-        return self.headers
 
     def _create_payload(
         self,
@@ -208,8 +200,6 @@ class OpenAICompletionsAPI(LocalCompletionsAPI):
             base_url=base_url, tokenizer_backend=tokenizer_backend, **kwargs
         )
 
-        self.headers = {"Authorization": f"Bearer {self.api_key}"}
-
     @cached_property
     def api_key(self):
         """Override this property to return the API key for the API request."""
@@ -253,8 +243,6 @@ class OpenAIChatCompletion(LocalChatCompletion):
             tokenized_requests=tokenized_requests,
             **kwargs,
         )
-
-        self.headers = {"Authorization": f"Bearer {self.api_key}"}
 
     @cached_property
     def api_key(self):

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -30,7 +30,7 @@ class LocalCompletionsAPI(TemplateAPI):
         # Assign custom model name
         if custom_model_name is not None:
             self.model = custom_model_name
-    
+
     @cached_property
     def header(self) -> dict:
         """Override to include custom headers if defined."""
@@ -151,7 +151,7 @@ class LocalChatCompletion(LocalCompletionsAPI):
         self.custom_headers = custom_headers
         if custom_model_name is not None:
             self.model = custom_model_name
-    
+
     @cached_property
     def header(self) -> dict:
         """Override to include custom headers if defined."""
@@ -161,7 +161,7 @@ class LocalChatCompletion(LocalCompletionsAPI):
         else:
             # Fallback to default
             return super().header
-        
+
     def _create_payload(
         self,
         messages: List[Dict],

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -17,29 +17,20 @@ class LocalCompletionsAPI(TemplateAPI):
     def __init__(
         self,
         base_url: str = None,
-        custom_headers: dict[str, str] = None,
-        custom_model_name: str = None,
+        headers: dict[str, str] = None,
         tokenizer_backend: str = "huggingface",
         **kwargs,
     ):
         super().__init__(
             base_url=base_url, tokenizer_backend=tokenizer_backend, **kwargs
         )
-        # Assign custom headers
-        self.custom_headers = custom_headers
-        # Assign custom model name
-        if custom_model_name is not None:
-            self.model = custom_model_name
+        # Assign headers
+        self.headers = headers
 
     @cached_property
     def header(self) -> dict:
-        """Override to include custom headers if defined."""
-        if self.custom_headers is not None:
-            # Return custom
-            return self.custom_headers
-        else:
-            # Fallback to default
-            return super().header
+        """Set API headers."""
+        return self.headers
 
     def _create_payload(
         self,
@@ -126,8 +117,6 @@ class LocalChatCompletion(LocalCompletionsAPI):
     def __init__(
         self,
         base_url: str = None,
-        custom_headers: dict[str, str] = None,
-        custom_model_name: str = None,
         tokenizer_backend: str = None,
         tokenized_requests: bool = False,
         **kwargs,
@@ -146,21 +135,6 @@ class LocalChatCompletion(LocalCompletionsAPI):
                 "Chat completions does not support batching. Defaulting to batch size 1."
             )
             self._batch_size = 1
-
-        # Assign custom headers
-        self.custom_headers = custom_headers
-        if custom_model_name is not None:
-            self.model = custom_model_name
-
-    @cached_property
-    def header(self) -> dict:
-        """Override to include custom headers if defined."""
-        if self.custom_headers is not None:
-            # Return custom
-            return self.custom_headers
-        else:
-            # Fallback to default
-            return super().header
 
     def _create_payload(
         self,
@@ -234,6 +208,8 @@ class OpenAICompletionsAPI(LocalCompletionsAPI):
             base_url=base_url, tokenizer_backend=tokenizer_backend, **kwargs
         )
 
+        self.headers = {"Authorization": f"Bearer {self.api_key}"}
+
     @cached_property
     def api_key(self):
         """Override this property to return the API key for the API request."""
@@ -270,12 +246,15 @@ class OpenAIChatCompletion(LocalChatCompletion):
             eval_logger.warning(
                 "o1 models do not support `stop` and only support temperature=1"
             )
+
         super().__init__(
             base_url=base_url,
             tokenizer_backend=tokenizer_backend,
             tokenized_requests=tokenized_requests,
             **kwargs,
         )
+
+        self.headers = {"Authorization": f"Bearer {self.api_key}"}
 
     @cached_property
     def api_key(self):

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -16,13 +16,30 @@ eval_logger = logging.getLogger(__name__)
 class LocalCompletionsAPI(TemplateAPI):
     def __init__(
         self,
-        base_url=None,
-        tokenizer_backend="huggingface",
+        base_url: str = None,
+        custom_headers: dict[str, str] = None,
+        custom_model_name: str = None,
+        tokenizer_backend: str = "huggingface",
         **kwargs,
     ):
         super().__init__(
             base_url=base_url, tokenizer_backend=tokenizer_backend, **kwargs
         )
+        # Assign custom headers
+        self.custom_headers = custom_headers
+        # Assign custom model name
+        if custom_model_name is not None:
+            self.model = custom_model_name
+    
+    @cached_property
+    def header(self) -> dict:
+        """Override to include custom headers if defined."""
+        if self.custom_headers is not None:
+            # Return custom
+            return self.custom_headers
+        else:
+            # Fallback to default
+            return super().header
 
     def _create_payload(
         self,
@@ -108,9 +125,11 @@ class LocalCompletionsAPI(TemplateAPI):
 class LocalChatCompletion(LocalCompletionsAPI):
     def __init__(
         self,
-        base_url=None,
-        tokenizer_backend=None,
-        tokenized_requests=False,
+        base_url: str = None,
+        custom_headers: dict[str, str] = None,
+        custom_model_name: str = None,
+        tokenizer_backend: str = None,
+        tokenized_requests: bool = False,
         **kwargs,
     ):
         eval_logger.warning(
@@ -128,6 +147,21 @@ class LocalChatCompletion(LocalCompletionsAPI):
             )
             self._batch_size = 1
 
+        # Assign custom headers
+        self.custom_headers = custom_headers
+        if custom_model_name is not None:
+            self.model = custom_model_name
+    
+    @cached_property
+    def header(self) -> dict:
+        """Override to include custom headers if defined."""
+        if self.custom_headers is not None:
+            # Return custom
+            return self.custom_headers
+        else:
+            # Fallback to default
+            return super().header
+        
     def _create_payload(
         self,
         messages: List[Dict],


### PR DESCRIPTION
This PR includes:

### Custom Headers
An option was included to pass custom headers to `local-chat-completions` and `local-completions` endpoints. It is done through the `model_args` parameter:
```bash
lm_eval \
..... \
--model_args '{"base_url":"https://some.ednpoint.com", .... ,"headers":{"authorization": "some_custom_string". "other_header":"some_other_data"}}'
```
This is useful on some cases where the endpoint needs custom authentication or...  headers. Also was asked for here: https://github.com/EleutherAI/lm-evaluation-harness/issues/2782 .

### Trust Remote Code Bug

Finally, while making these changes I found that the parameter `--trust_remote_code` was not working correctly. The behavior of `--model_args` was changed in https://github.com/EleutherAI/lm-evaluation-harness/pull/2629 but the flag behavior was left unchanged. This means that when `--model_args` is a proper json and it is converted into a `dict()` the current implementation will fail (see https://github.com/EleutherAI/lm-evaluation-harness/blob/9fbe48c230c2649d9430c133290d6882b55105ea/lm_eval/__main__.py#L438).
This PR includes a conditional handling of the `args.model_args` variable to account for its `str` or `dict` nature.

EDIT: Removed `custom_model_name` header description, it was removed from the PR because it was redundant to the use of `tokenizer`.





