### PR TITLE
llama3 task: update README.md

### DIFF
--- a/lm_eval/tasks/llama3/README.md
+++ b/lm_eval/tasks/llama3/README.md
@@ -39,7 +39,6 @@ BibTeX-formatted citation goes here
 * `mmlu_hi_llama`: `Hindi version of generation MMLU`
 * `mmlu_es_llama`: `Spanish version of generation MMLU`
 * `mmlu_de_llama`: `German version of generation MMLU`
-* `arc_chalenge_chat`: `generation variant of ARC-Challenge using MMLU format`
 * `arc_challenge_llama`: `generation variant of ARC-Challenge following Meta pre-processing`
 * `gsm8k_llama`: `Chain-of-though variant of GSM8k`
 

--- a/lm_eval/tasks/mmlu/README.md
+++ b/lm_eval/tasks/mmlu/README.md
@@ -36,11 +36,11 @@ Note: The `Flan` variants are derived from [here](https://github.com/jasonwei20/
 
 * `mmlu`: `Original multiple-choice MMLU benchmark`
 * `mmlu_continuation`: `MMLU but with continuation prompts`
-* `mmlu_generation`: `MMLU generation`
+* `mmlu_generative`: `MMLU generation`
 
 MMLU is the original benchmark as implemented by Hendrycks et al. with the choices in context and the answer letters (e.g `A`, `B`, `C`, `D`) in the continuation.
 `mmlu_continuation` is a cloze-style variant without the choices in context and the full answer choice in the continuation.
-`mmlu_generation` is a generation variant, similar to the original but the LLM is asked to generate the correct answer letter.
+`mmlu_generative` is a generation variant, similar to the original but the LLM is asked to generate the correct answer letter.
 
 
 #### Subgroups


### PR DESCRIPTION
"arc_chalenge_chat" doesn't exist: I think it should be "arc_challenge_chat", but this task is not implemented here (see arc task folder).
