### PR TITLE
FixBug: Align the Humaneval with official results for Llama-3.1-70B-Instruct

### DIFF
--- a/lm_eval/tasks/humaneval/README.md
+++ b/lm_eval/tasks/humaneval/README.md
@@ -50,4 +50,5 @@ If other tasks on this dataset are already supported:
 
 ### Changelog
 v2 20-MAR-2025: `humaneval_instruct`, `humaneval_instruct_64`: fixed typo in gen_prefix
+
 v3 30-JUN-2025: Updated prompt generation and output parsing to align with the official `Llama-3.1-70B-Instruct-evals`. This corrects the prompt format and fixes a bug in locating the code block. See PR [#3092](https://github.com/EleutherAI/lm-evaluation-harness/pull/3092).

--- a/lm_eval/tasks/humaneval/README.md
+++ b/lm_eval/tasks/humaneval/README.md
@@ -50,3 +50,4 @@ If other tasks on this dataset are already supported:
 
 ### Changelog
 v2 20-MAR-2025: `humaneval_instruct`, `humaneval_instruct_64`: fixed typo in gen_prefix
+v3 30-JUN-2025: Updated prompt generation and output parsing to align with the official `Llama-3.1-70B-Instruct-evals`. This corrects the prompt format and fixes a bug in locating the code block. See PR [#3092](https://github.com/EleutherAI/lm-evaluation-harness/pull/3092).

--- a/lm_eval/tasks/humaneval/humaneval_instruct.yaml
+++ b/lm_eval/tasks/humaneval/humaneval_instruct.yaml
@@ -1,7 +1,7 @@
 include: humaneval.yaml
 task: humaneval_instruct
-doc_to_text: "Write a solution to the following problem and make sure that it passes the tests:\n```{{prompt}}"
-gen_prefix: "Here is the completed function:\n```python\n{{prompt}}\n"
+doc_to_text: 'Write a solution to the following problem and make sure that it passes the tests:\n```python\n{{ prompt }}\n```\n '
+gen_prefix: 'Here is the completed function:\n```python\n{{ prompt }}\n '
 filter_list:
   - name: "create_test"
     filter:

--- a/lm_eval/tasks/humaneval/humaneval_instruct.yaml
+++ b/lm_eval/tasks/humaneval/humaneval_instruct.yaml
@@ -8,4 +8,4 @@ filter_list:
       - function: "custom"
         filter_fn: !function utils.build_predictions_instruct
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/humaneval/utils.py
+++ b/lm_eval/tasks/humaneval/utils.py
@@ -32,7 +32,7 @@ def build_predictions_instruct(
 ) -> list[list[str]]:
     return [
         [
-            doc["prompt"] + (r if r.rfind("```") == -1 else r[: r.rfind("```")])
+            doc["prompt"] + (r if r.find("```") == -1 else r[: r.find("```")])
             for r in resp
         ]
         for resp, doc in zip(resps, docs)


### PR DESCRIPTION
Ref: [PR#2650](https://github.com/EleutherAI/lm-evaluation-harness/pull/2650)
# Details:
- Modify the `doc_to_text` and `gen_prefix` in the `humaneval_instruct.yaml` file to make them the same as the Prompt in [meta-llama/Llama-3.1-70B-Instruct-evals](https://huggingface.co/datasets/meta-llama/Llama-3.1-70B-Instruct-evals/viewer/Llama-3.1-70B-Instruct-evals__human_eval__details?views%5B%5D=llama_31_70b_instruct_evals__human_eval__details&row=0).

- Change `r.rfind("```")` to `r.find("```")`, so it can locate the first "```", not the last one.

# Results: 
We run with the following command on AMD Instinct MI250 GPU:
```bash

model_70b="meta-llama/Llama-3.1-70B-Instruct"
model_8b="meta-llama/Llama-3.1-8B-Instruct"

export HF_ALLOW_CODE_EVAL=1
export CUDA_VISIBLE_DEVICES='0,1,2,3'
python -m lm_eval \
    --model hf \
    --model_args pretrained=${model_70b},parallelize=True \
    --tasks humaneval_instruct \
    --confirm_run_unsafe_code \
    --show_config \
    --log_samples \
    --batch_size 1 \
    --apply_chat_template \
    --fewshot_as_multiturn
```

The results are as follows:
|  | Original | This PR | Official |
|----------|----------|----------|----------|
| Llama-3.1-8B-Instruct  | 59.2  | 66.5  | 72.6  |
| Llama-3.1-70B-Instruct  | 57.3  | 80.5  | 80.5  |




