### PR TITLE
Fixed #3005: Processes both formats of model_args: string and dictionay

### DIFF
--- a/scripts/zeno_visualize.py
+++ b/scripts/zeno_visualize.py
@@ -87,12 +87,23 @@ def main():
             latest_sample_results = get_latest_filename(
                 [Path(f).name for f in model_sample_filenames if task in f]
             )
+            # Load the model_args, which can be either a string or a dictionary
+            model_args_raw = json.load(
+                open(Path(args.data_path, model, latest_results), encoding="utf-8")
+            )["config"]["model_args"]
+
+            # Convert to string if it's a dictionary
+            model_args_str = (
+                json.dumps(model_args_raw)
+                if isinstance(model_args_raw, dict)
+                else model_args_raw
+            )
+
+            # Apply the sanitization
             model_args = re.sub(
                 r"[\"<>:/\|\\?\*\[\]]+",
                 "__",
-                json.load(
-                    open(Path(args.data_path, model, latest_results), encoding="utf-8")
-                )["config"]["model_args"],
+                model_args_str,
             )
             print(model_args)
             data = []

--- a/scripts/zeno_visualize.py
+++ b/scripts/zeno_visualize.py
@@ -37,7 +37,7 @@ def parse_args():
 
 
 def sanitize_string(model_args_raw: Union[str, dict]) -> str:
-    """Pure function that handles the sanitization logic"""
+    """Sanitize the model_args string or dict"""
     # Convert to string if it's a dictionary
     model_args_str = (
         json.dumps(model_args_raw)
@@ -106,15 +106,14 @@ def main():
             )
             # Load the model_args, which can be either a string or a dictionary
             model_args = sanitize_string(
-                sanitize_string(
-                    json.load(
-                        open(
-                            Path(args.data_path, model, latest_results),
-                            encoding="utf-8",
-                        )
-                    )["config"]["model_args"]
-                )
+                json.load(
+                    open(
+                        Path(args.data_path, model, latest_results),
+                        encoding="utf-8",
+                    )
+                )["config"]["model_args"]
             )
+
             print(model_args)
             data = []
             with open(

--- a/tests/scripts/test_zeno_visualize.py
+++ b/tests/scripts/test_zeno_visualize.py
@@ -1,47 +1,27 @@
 import json
 import re
 
+import pytest
 
-def test_model_args_handling():
+from scripts.zeno_visualize import sanitize_string
+
+
+@pytest.skip("requires zeno_client dependency")
+def test_zeno_sanitize_string():
     """
     Test that the model_args handling logic in zeno_visualize.py properly handles
     different model_args formats (string and dictionary).
-
-    This test focuses only on the specific logic that was fixed in the PR:
-    - Extracting model_args from the results file
-    - Converting dictionary model_args to string
-    - Applying sanitization
     """
 
     # Define the process_model_args function that replicates the fixed logic in zeno_visualize.py
-    def process_model_args(model_args_raw):
-        """
-        Process model_args which can be either a string or a dictionary
-        and sanitize it for use in Zeno visualization.
-        """
-        # Convert to string if it's a dictionary
-        model_args_str = (
-            json.dumps(model_args_raw)
-            if isinstance(model_args_raw, dict)
-            else model_args_raw
-        )
-
-        # Apply the sanitization
-        model_args = re.sub(
-            r"[\"<>:/\|\\?\*\[\]]+",
-            "__",
-            model_args_str,
-        )
-        return model_args
-
     # Test case 1: model_args as a string
     string_model_args = "pretrained=EleutherAI/pythia-160m,dtype=float32"
-    result_string = process_model_args(string_model_args)
+    result_string = sanitize_string(string_model_args)
     expected_string = re.sub(r"[\"<>:/\|\\?\*\[\]]+", "__", string_model_args)
 
     # Test case 2: model_args as a dictionary
     dict_model_args = {"pretrained": "EleutherAI/pythia-160m", "dtype": "float32"}
-    result_dict = process_model_args(dict_model_args)
+    result_dict = sanitize_string(dict_model_args)
     expected_dict = re.sub(r"[\"<>:/\|\\?\*\[\]]+", "__", json.dumps(dict_model_args))
 
     # Verify the results
@@ -53,3 +33,8 @@ def test_model_args_handling():
     assert ":" not in result_dict  # No colons in sanitized output
     assert "/" not in result_dict  # No slashes in sanitized output
     assert "<" not in result_dict  # No angle brackets in sanitized output
+
+
+if __name__ == "__main__":
+    test_zeno_sanitize_string()
+    print("All tests passed.")

--- a/tests/test_zeno_visualize.py
+++ b/tests/test_zeno_visualize.py
@@ -1,0 +1,55 @@
+import json
+import re
+
+
+def test_model_args_handling():
+    """
+    Test that the model_args handling logic in zeno_visualize.py properly handles
+    different model_args formats (string and dictionary).
+
+    This test focuses only on the specific logic that was fixed in the PR:
+    - Extracting model_args from the results file
+    - Converting dictionary model_args to string
+    - Applying sanitization
+    """
+
+    # Define the process_model_args function that replicates the fixed logic in zeno_visualize.py
+    def process_model_args(model_args_raw):
+        """
+        Process model_args which can be either a string or a dictionary
+        and sanitize it for use in Zeno visualization.
+        """
+        # Convert to string if it's a dictionary
+        model_args_str = (
+            json.dumps(model_args_raw)
+            if isinstance(model_args_raw, dict)
+            else model_args_raw
+        )
+
+        # Apply the sanitization
+        model_args = re.sub(
+            r"[\"<>:/\|\\?\*\[\]]+",
+            "__",
+            model_args_str,
+        )
+        return model_args
+
+    # Test case 1: model_args as a string
+    string_model_args = "pretrained=EleutherAI/pythia-160m,dtype=float32"
+    result_string = process_model_args(string_model_args)
+    expected_string = re.sub(r"[\"<>:/\|\\?\*\[\]]+", "__", string_model_args)
+
+    # Test case 2: model_args as a dictionary
+    dict_model_args = {"pretrained": "EleutherAI/pythia-160m", "dtype": "float32"}
+    result_dict = process_model_args(dict_model_args)
+    expected_dict = re.sub(r"[\"<>:/\|\\?\*\[\]]+", "__", json.dumps(dict_model_args))
+
+    # Verify the results
+    assert result_string == expected_string
+    assert result_dict == expected_dict
+
+    # Also test that the sanitization works as expected
+    assert ":" not in result_string  # No colons in sanitized output
+    assert ":" not in result_dict  # No colons in sanitized output
+    assert "/" not in result_dict  # No slashes in sanitized output
+    assert "<" not in result_dict  # No angle brackets in sanitized output


### PR DESCRIPTION
Fixed #3005 
The script previously assumed model_args was always a string, but it can also be a dictionary according to __main__.py. This fix properly handles both formats by converting dictionaries to JSON strings before sanitization, preventing errors when visualizing results.

Added test-cases as well to ensure the fix is well-tested.