### PR TITLE
Fix: Reduce CLI loading time from 2.2s to 0.05s

### DIFF
--- a/lm_eval/__init__.py
+++ b/lm_eval/__init__.py
@@ -1,7 +1,19 @@
 import logging
 import os
 
-from .evaluator import evaluate, simple_evaluate
-
 
 __version__ = "0.4.9"
+
+
+# Lazy-load .evaluator module to improve CLI startup
+def __getattr__(name):
+    if name == "evaluate":
+        from .evaluator import evaluate
+        return evaluate
+    elif name == "simple_evaluate":
+        from .evaluator import simple_evaluate
+        return simple_evaluate
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["evaluate", "simple_evaluate", "__version__"]

--- a/lm_eval/__init__.py
+++ b/lm_eval/__init__.py
@@ -9,9 +9,11 @@ __version__ = "0.4.9"
 def __getattr__(name):
     if name == "evaluate":
         from .evaluator import evaluate
+
         return evaluate
     elif name == "simple_evaluate":
         from .evaluator import simple_evaluate
+
         return simple_evaluate
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -7,16 +7,6 @@ from functools import partial
 from pathlib import Path
 from typing import Union
 
-from lm_eval import evaluator, utils
-from lm_eval.evaluator import request_caching_arg_to_dict
-from lm_eval.loggers import EvaluationTracker, WandbLogger
-from lm_eval.tasks import TaskManager
-from lm_eval.utils import (
-    handle_non_serializable,
-    make_table,
-    simple_parse_args_string,
-)
-
 
 def try_parse_json(value: str) -> Union[str, dict, None]:
     if value is None:
@@ -313,6 +303,17 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         # we allow for args to be passed externally, else we parse them ourselves
         parser = setup_parser()
         args = parse_eval_args(parser)
+
+    # defer loading `lm_eval` submodules for faster CLI load
+    from lm_eval import evaluator, utils
+    from lm_eval.evaluator import request_caching_arg_to_dict
+    from lm_eval.loggers import EvaluationTracker, WandbLogger
+    from lm_eval.tasks import TaskManager
+    from lm_eval.utils import (
+        handle_non_serializable,
+        make_table,
+        simple_parse_args_string,
+    )
 
     if args.wandb_args:
         wandb_args_dict = simple_parse_args_string(args.wandb_args)


### PR DESCRIPTION
Running `lm_eval -h` takes 2-3s as the `.evaluator` submodule loads `torch`, `transformers` and other dependencies. 

This change defers loading imports until after CLI args are parsed. (See https://peps.python.org/pep-0562/#rationale for a similar example)

Before:
```console
lm_eval -h  2.21s user 0.37s system 73% cpu 3.518 total
```

After:
```console
lm_eval -h  0.05s user 0.01s system 96% cpu 0.057 total
```

We can extend this to other commands for task management if this change is good. There are no functional changes to evaluation.
