### PR TITLE
Add support for OpenVINO text2text generation models 

### DIFF
--- a/lm_eval/models/optimum_lm.py
+++ b/lm_eval/models/optimum_lm.py
@@ -28,9 +28,8 @@ class OptimumLM(HFLM):
         **kwargs,
     ) -> None:
         if "backend" in kwargs:
-            # optimum currently only supports causal models
-            assert kwargs["backend"] == "causal", (
-                "Currently, only OVModelForCausalLM is supported."
+            assert kwargs["backend"] in ["causal", "seq2seq"], (
+                "Currently, only OVModelForCausalLM or OVModelForSeq2SeqLM are supported."
             )
 
         self.openvino_device = device
@@ -54,7 +53,7 @@ class OptimumLM(HFLM):
                 "package `optimum` is not installed. Please install it via `pip install optimum[openvino]`"
             )
         else:
-            from optimum.intel.openvino import OVModelForCausalLM
+            from optimum.intel.openvino import OVModelForCausalLM, OVModelForSeq2SeqLM
 
         model_kwargs = kwargs if kwargs else {}
         if "ov_config" in model_kwargs:
@@ -76,17 +75,12 @@ class OptimumLM(HFLM):
                 model_kwargs["ov_config"]["MODEL_DISTRIBUTION_POLICY"] = (
                     "PIPELINE_PARALLEL"
                 )
-        model_file = Path(pretrained) / "openvino_model.xml"
-        if model_file.exists():
-            export = False
-        else:
-            export = True
 
-        self._model = OVModelForCausalLM.from_pretrained(
+        model_cls = OVModelForCausalLM if self.backend == "causal" else OVModelForSeq2SeqLM
+        self._model = model_cls.from_pretrained(
             pretrained,
             revision=revision,
             trust_remote_code=trust_remote_code,
-            export=export,
             device=self.openvino_device.upper(),
             **model_kwargs,
         )


### PR DESCRIPTION
Add support for OpenVINO text2text generation models  represented by `OVModelForSeq2SeqLM` class in optimum-intel. This allows to validate such models as for example https://huggingface.co/google-t5/t5-small.

This PR depends on https://github.com/huggingface/optimum-intel/pull/1359 .