### PR TITLE
[FIX] Initial code to disable multi-proc for stderr

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,6 @@
+import unittest.mock as mock
+
+from lm_eval.api.metrics import _bootstrap_internal_no_mp, mean
 from lm_eval.api.task import ConfigurableTask, TaskConfig
 
 
@@ -149,8 +152,34 @@ def test_acc_mutual_info_without_metric():
     assert result_dict["acc"] == 1.0
 
 
+def test_bootstrap_internal_no_mp():
+    """Test basic functionality of _bootstrap_internal_no_mp"""
+
+    data = [1, 2, 3, 4, 5]
+
+    # Mock tqdm to avoid progress bar output during testing
+    with mock.patch("tqdm.tqdm") as mock_tqdm:
+        mock_tqdm.return_value = range(1)  # Single chunk
+
+        # Mock print to avoid output during testing
+        with mock.patch("builtins.print"):
+            result = _bootstrap_internal_no_mp(mean, data, 100)
+
+    # Should return 100 bootstrap replicates
+    assert len(result) == 100
+
+    # All results should be numbers (means)
+    assert all(isinstance(x, (int, float)) for x in result)
+
+    # Bootstrap means should be close to original mean
+    bootstrap_mean = mean(result)
+    original_mean = mean(data)
+    assert abs(bootstrap_mean - original_mean) < 0.5  # Should be reasonably close
+
+
 if __name__ == "__main__":
     test_acc_mutual_info_slicing()
     test_acc_mutual_info_different_predictions()
     test_acc_mutual_info_without_metric()
+    test_bootstrap_internal_no_mp()
     print("All tests passed!")


### PR DESCRIPTION
Jax doesn't like multi-threading. When using the eval harness during some jax code, the multithreading causes deadlocks blocking everything.

This PR just adds an optional flag to disable multi-threading, specifically in the `stderr` calculation in `metrics.py` since that seems to be the main culprit.

The idea is that JAX users can simply disable pass this flag and disable all MP. This will also have to be documented somewhere, I have no idea where.