### PR TITLE
check pil dep when hashing images

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -752,6 +752,7 @@ def evaluate(
             samples = (
                 hash_dict_images(samples)
                 if os.environ.get("LMEVAL_HASHMM", "1") != "0"
+                and (hasattr(lm, "MULTIMODAL"))
                 else samples
             )
             results_dict["samples"] = dict(samples)

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -576,10 +576,11 @@ def hash_dict_images(data_dict):
         dict: A new dictionary with the same structure as `data_dict`, but with all
               bytes and PIL.Image.Image objects replaced by their hashes.
     """
-    from PIL import Image
 
     def _process_value(value):
         # Bytes -> hash
+        from PIL import Image
+
         if isinstance(value, (bytes, bytearray)):
             return convert_bytes_to_hash(value)
         # PIL Image -> hash
@@ -600,4 +601,8 @@ def hash_dict_images(data_dict):
     if not isinstance(data_dict, dict):
         raise TypeError("Input must be a dictionary")
 
-    return {key: _process_value(val) for key, val in data_dict.items()}
+    return (
+        {key: _process_value(val) for key, val in data_dict.items()}
+        if importlib.util.find_spec("PIL")
+        else data_dict
+    )


### PR DESCRIPTION
PR #2973 accidentally called a helper that depends on `pillow`, even though PIL is optional.