### PR TITLE
Fix: extended to max_gen_toks 8192 for HRM8K math benchmarks

### DIFF
--- a/lm_eval/tasks/hrm8k/default/_hrm8k_yaml
+++ b/lm_eval/tasks/hrm8k/default/_hrm8k_yaml
@@ -11,7 +11,7 @@ generation_kwargs:
     - "<|end_of_text|>"
     - "<|endoftext|>"
     - "<|im_end|>"
-  max_gen_toks: 512
+  max_gen_toks: 8192
   do_sample: false
   temperature: 0
 metric_list:

--- a/lm_eval/tasks/hrm8k/en/_hrm8k_en_yaml
+++ b/lm_eval/tasks/hrm8k/en/_hrm8k_en_yaml
@@ -11,7 +11,7 @@ generation_kwargs:
     - "<|end_of_text|>"
     - "<|endoftext|>"
     - "<|im_end|>"
-  max_gen_toks: 512
+  max_gen_toks: 8192
   do_sample: false
   temperature: 0
 metric_list:


### PR DESCRIPTION
For the HRM8K∙GSM8K series high-level math problem, the chain-of-thought solution easily exceeded 512 tokens, and the answer was cut in the middle, so the exact_match evaluation failed. (8k context support model premise) 

Raise max_gen_toks to 8192.
* Prevent truncation → Reduce missing correct answers and improve accuracy reliability