### PR TITLE
when using vllm with lora, it will have some mistakes, now i fix it.

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -134,6 +134,7 @@ class VLLM(TemplateLM):
         data_parallel_size: int = 1,
         lora_local_path: str = None,
         enable_thinking: bool = False,
+        max_lora_rank: int = 16,
         **kwargs,
     ):
         super().__init__()
@@ -167,6 +168,8 @@ class VLLM(TemplateLM):
             "quantization": quantization,
             "seed": int(seed),
             "device": str(device),
+            "enable_lora": True if lora_local_path else False,
+            "max_lora_rank": int(max_lora_rank),
         }
         self.model_args.update(kwargs)
         self.batch_size = (


### PR DESCRIPTION
1. `enable_lora` is a switch and , deciding whether we need to use lora. This is a necessary parameter for vllm.LLM when using lora.
2. `max_lora_rank`,  the default lora rank of vllm.LLM is 16 sothat sometimes we need to change default lora rank using `max_lora_rank` when our lora rank larger than 16.