### PR TITLE
Update ```mmlu_continuation``` subgroup names to fit Readme

### DIFF
--- a/lm_eval/tasks/mmlu/continuation/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/continuation/_mmlu.yaml
@@ -3,25 +3,25 @@ group_alias: mmlu (continuation)
 task:
   - group: stem
     task:
-      - mmlu_continuation_stem
+      - mmlu_stem_continuation
     aggregate_metric_list:
       - metric: acc
         weight_by_size: True
   - group: other
     task:
-      - mmlu_continuation_other
+      - mmlu_other_continuation
     aggregate_metric_list:
       - metric: acc
         weight_by_size: True
   - group: social sciences
     task:
-      - mmlu_continuation_social_sciences
+      - mmlu_social_sciences_continuation
     aggregate_metric_list:
       - metric: acc
         weight_by_size: True
   - group: humanities
     task:
-      - mmlu_continuation_humanities
+      - mmlu_humanities_continuation
     aggregate_metric_list:
       - metric: acc
         weight_by_size: True

--- a/lm_eval/tasks/mmlu/continuation/mmlu_abstract_algebra.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_abstract_algebra.yaml
@@ -3,4 +3,4 @@
   \ algebra.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_abstract_algebra"
+"task": "mmlu_abstract_algebra_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_anatomy.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_anatomy.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_anatomy"
+"task": "mmlu_anatomy_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_astronomy.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_astronomy.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_astronomy"
+"task": "mmlu_astronomy_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_business_ethics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_business_ethics.yaml
@@ -3,4 +3,4 @@
   \ ethics.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_business_ethics"
+"task": "mmlu_business_ethics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_clinical_knowledge.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_clinical_knowledge.yaml
@@ -3,4 +3,4 @@
   \ knowledge.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_clinical_knowledge"
+"task": "mmlu_clinical_knowledge_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_college_biology.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_college_biology.yaml
@@ -3,4 +3,4 @@
   \ biology.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_college_biology"
+"task": "mmlu_college_biology_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_college_chemistry.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_college_chemistry.yaml
@@ -3,4 +3,4 @@
   \ chemistry.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_college_chemistry"
+"task": "mmlu_college_chemistry_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_college_computer_science.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_college_computer_science.yaml
@@ -3,4 +3,4 @@
   \ computer science.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_college_computer_science"
+"task": "mmlu_college_computer_science_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_college_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_college_mathematics.yaml
@@ -3,4 +3,4 @@
   \ mathematics.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_college_mathematics"
+"task": "mmlu_college_mathematics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_college_medicine.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_college_medicine.yaml
@@ -3,4 +3,4 @@
   \ medicine.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_college_medicine"
+"task": "mmlu_college_medicine_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_college_physics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_college_physics.yaml
@@ -3,4 +3,4 @@
   \ physics.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_college_physics"
+"task": "mmlu_college_physics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_computer_security.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_computer_security.yaml
@@ -3,4 +3,4 @@
   \ security.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_computer_security"
+"task": "mmlu_computer_security_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_conceptual_physics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_conceptual_physics.yaml
@@ -3,4 +3,4 @@
   \ physics.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_conceptual_physics"
+"task": "mmlu_conceptual_physics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_econometrics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_econometrics.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_econometrics"
+"task": "mmlu_econometrics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_electrical_engineering.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_electrical_engineering.yaml
@@ -3,4 +3,4 @@
   \ engineering.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_electrical_engineering"
+"task": "mmlu_electrical_engineering_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_elementary_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_elementary_mathematics.yaml
@@ -3,4 +3,4 @@
   \ mathematics.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_elementary_mathematics"
+"task": "mmlu_elementary_mathematics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_formal_logic.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_formal_logic.yaml
@@ -3,4 +3,4 @@
   \ logic.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_formal_logic"
+"task": "mmlu_formal_logic_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_global_facts.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_global_facts.yaml
@@ -3,4 +3,4 @@
   \ facts.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_global_facts"
+"task": "mmlu_global_facts_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_biology.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_biology.yaml
@@ -3,4 +3,4 @@
   \ school biology.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_biology"
+"task": "mmlu_high_school_biology_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_chemistry.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_chemistry.yaml
@@ -3,4 +3,4 @@
   \ school chemistry.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_chemistry"
+"task": "mmlu_high_school_chemistry_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_computer_science.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_computer_science.yaml
@@ -3,4 +3,4 @@
   \ school computer science.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_computer_science"
+"task": "mmlu_high_school_computer_science_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_european_history.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_european_history.yaml
@@ -3,4 +3,4 @@
   \ school european history.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_european_history"
+"task": "mmlu_high_school_european_history_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_geography.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_geography.yaml
@@ -3,4 +3,4 @@
   \ school geography.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_geography"
+"task": "mmlu_high_school_geography_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_government_and_politics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_government_and_politics.yaml
@@ -3,4 +3,4 @@
   \ school government and politics.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_government_and_politics"
+"task": "mmlu_high_school_government_and_politics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_macroeconomics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_macroeconomics.yaml
@@ -3,4 +3,4 @@
   \ school macroeconomics.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_macroeconomics"
+"task": "mmlu_high_school_macroeconomics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_mathematics.yaml
@@ -3,4 +3,4 @@
   \ school mathematics.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_mathematics"
+"task": "mmlu_high_school_mathematics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_microeconomics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_microeconomics.yaml
@@ -3,4 +3,4 @@
   \ school microeconomics.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_microeconomics"
+"task": "mmlu_high_school_microeconomics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_physics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_physics.yaml
@@ -3,4 +3,4 @@
   \ school physics.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_physics"
+"task": "mmlu_high_school_physics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_psychology.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_psychology.yaml
@@ -3,4 +3,4 @@
   \ school psychology.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_psychology"
+"task": "mmlu_high_school_psychology_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_statistics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_statistics.yaml
@@ -3,4 +3,4 @@
   \ school statistics.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_statistics"
+"task": "mmlu_high_school_statistics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_us_history.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_us_history.yaml
@@ -3,4 +3,4 @@
   \ school us history.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_us_history"
+"task": "mmlu_high_school_us_history_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_high_school_world_history.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_high_school_world_history.yaml
@@ -3,4 +3,4 @@
   \ school world history.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_high_school_world_history"
+"task": "mmlu_high_school_world_history_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_human_aging.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_human_aging.yaml
@@ -3,4 +3,4 @@
   \ aging.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_human_aging"
+"task": "mmlu_human_aging_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_human_sexuality.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_human_sexuality.yaml
@@ -3,4 +3,4 @@
   \ sexuality.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_human_sexuality"
+"task": "mmlu_human_sexuality_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_international_law.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_international_law.yaml
@@ -3,4 +3,4 @@
   \ law.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_international_law"
+"task": "mmlu_international_law_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_jurisprudence.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_jurisprudence.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_jurisprudence"
+"task": "mmlu_jurisprudence_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_logical_fallacies.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_logical_fallacies.yaml
@@ -3,4 +3,4 @@
   \ fallacies.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_logical_fallacies"
+"task": "mmlu_logical_fallacies_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_machine_learning.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_machine_learning.yaml
@@ -3,4 +3,4 @@
   \ learning.\n\n"
 "tag": "mmlu_continuation_stem"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_machine_learning"
+"task": "mmlu_machine_learning_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_management.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_management.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_management"
+"task": "mmlu_management_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_marketing.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_marketing.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_marketing"
+"task": "mmlu_marketing_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_medical_genetics.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_medical_genetics.yaml
@@ -3,4 +3,4 @@
   \ genetics.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_medical_genetics"
+"task": "mmlu_medical_genetics_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_miscellaneous.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_miscellaneous.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_miscellaneous"
+"task": "mmlu_miscellaneous_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_moral_disputes.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_moral_disputes.yaml
@@ -3,4 +3,4 @@
   \ disputes.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_moral_disputes"
+"task": "mmlu_moral_disputes_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_moral_scenarios.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_moral_scenarios.yaml
@@ -3,4 +3,4 @@
   \ scenarios.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_moral_scenarios"
+"task": "mmlu_moral_scenarios_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_nutrition.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_nutrition.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_nutrition"
+"task": "mmlu_nutrition_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_philosophy.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_philosophy.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_philosophy"
+"task": "mmlu_philosophy_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_prehistory.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_prehistory.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_prehistory"
+"task": "mmlu_prehistory_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_professional_accounting.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_professional_accounting.yaml
@@ -3,4 +3,4 @@
   \ accounting.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_professional_accounting"
+"task": "mmlu_professional_accounting_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_professional_law.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_professional_law.yaml
@@ -3,4 +3,4 @@
   \ law.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_professional_law"
+"task": "mmlu_professional_law_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_professional_medicine.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_professional_medicine.yaml
@@ -3,4 +3,4 @@
   \ medicine.\n\n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_professional_medicine"
+"task": "mmlu_professional_medicine_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_professional_psychology.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_professional_psychology.yaml
@@ -3,4 +3,4 @@
   \ psychology.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_professional_psychology"
+"task": "mmlu__professional_psychologycontinuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_professional_psychology.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_professional_psychology.yaml
@@ -3,4 +3,4 @@
   \ psychology.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu__professional_psychologycontinuation"
+"task": "mmlu_professional_psychology_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_public_relations.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_public_relations.yaml
@@ -3,4 +3,4 @@
   \ relations.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_public_relations"
+"task": "mmlu_public_relations_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_security_studies.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_security_studies.yaml
@@ -3,4 +3,4 @@
   \ studies.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_security_studies"
+"task": "mmlu_security_studies_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_sociology.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_sociology.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_sociology"
+"task": "mmlu_sociology_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_us_foreign_policy.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_us_foreign_policy.yaml
@@ -3,4 +3,4 @@
   \ foreign policy.\n\n"
 "tag": "mmlu_continuation_social_sciences"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_us_foreign_policy"
+"task": "mmlu_us_foreign_policy_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_virology.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_virology.yaml
@@ -3,4 +3,4 @@
   \n"
 "tag": "mmlu_continuation_other"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_virology"
+"task": "mmlu_virology_continuation"

--- a/lm_eval/tasks/mmlu/continuation/mmlu_world_religions.yaml
+++ b/lm_eval/tasks/mmlu/continuation/mmlu_world_religions.yaml
@@ -3,4 +3,4 @@
   \ religions.\n\n"
 "tag": "mmlu_continuation_humanities"
 "include": "_continuation_template_yaml"
-"task": "mmlu_continuation_world_religions"
+"task": "mmlu_world_religions_continuation"


### PR DESCRIPTION
The MMLU readme states that "_Subgroup variants are prefixed with the subgroup name, e.g. ```mmlu_stem_continuation```_". Funnily enough, this was not true for the subgroup the example was made of.

This PR includes changes in the subgroup names for the _continuation_ variant that change the naming convention from _```mmlu_continuation_variant```_ to _```mmlu_variant_continuation```_, as described in the Readme and also in line with the _generative_ and default variants.