### PR TITLE
Added mixed_precision_dtype argument to HFLM to enable autocasting

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -76,6 +76,7 @@ class HFLM(TemplateLM):
         device: Optional[str] = "cuda",
         dtype: Optional[Union[str, torch.dtype]] = "auto",
         softmax_dtype: Optional[Union[str, torch.dtype]] = None,
+        mixed_precision_dtype: Optional[Union[str, torch.dtype]] = None,
         batch_size: Optional[Union[int, str]] = 1,
         max_batch_size: Optional[int] = 64,
         trust_remote_code: Optional[bool] = False,
@@ -246,6 +247,11 @@ class HFLM(TemplateLM):
         self.max_batch_size = max_batch_size
         self.softmax_dtype = (
             get_dtype(softmax_dtype) if softmax_dtype is not None else None
+        )
+        self.mixed_precision_dtype = (
+            get_dtype(mixed_precision_dtype)
+            if mixed_precision_dtype is not None
+            else None
         )
 
         if str(batch_size).startswith("auto"):
@@ -903,18 +909,23 @@ class HFLM(TemplateLM):
         logits returned from the model's decoder
         """
         with torch.no_grad():
-            if attn_mask is not None or labels is not None:
-                assert attn_mask is not None and labels is not None
-                assert self.AUTO_MODEL_CLASS == transformers.AutoModelForSeq2SeqLM
-                return self.model(
-                    input_ids=inps, attention_mask=attn_mask, labels=labels
-                ).logits
-            else:
-                assert self.AUTO_MODEL_CLASS in (
-                    transformers.AutoModelForCausalLM,
-                    transformers.AutoModelForVision2Seq,
-                )
-                return self.model(inps).logits
+            with torch.autocast(
+                device_type=self.device.type,
+                dtype=self.mixed_precision_dtype,
+                enabled=self.mixed_precision_dtype is not None,
+            ):
+                if attn_mask is not None or labels is not None:
+                    assert attn_mask is not None and labels is not None
+                    assert self.AUTO_MODEL_CLASS == transformers.AutoModelForSeq2SeqLM
+                    return self.model(
+                        input_ids=inps, attention_mask=attn_mask, labels=labels
+                    ).logits
+                else:
+                    assert self.AUTO_MODEL_CLASS in (
+                        transformers.AutoModelForCausalLM,
+                        transformers.AutoModelForVision2Seq,
+                    )
+                    return self.model(inps).logits
 
     def _model_generate(self, context, max_length, stop, **generation_kwargs):
         # temperature = 0.0 if not set
@@ -934,14 +945,19 @@ class HFLM(TemplateLM):
         stopping_criteria = stop_sequences_criteria(
             self.tokenizer, stop, context.shape[1], context.shape[0]
         )
-        return self.model.generate(
-            input_ids=context,
-            max_length=max_length,
-            stopping_criteria=stopping_criteria,
-            pad_token_id=self.tokenizer.pad_token_id,
-            use_cache=True,
-            **generation_kwargs,
-        )
+        with torch.autocast(
+            device_type=self.device.type,
+            dtype=self.mixed_precision_dtype,
+            enabled=self.mixed_precision_dtype is not None,
+        ):
+            return self.model.generate(
+                input_ids=context,
+                max_length=max_length,
+                stopping_criteria=stopping_criteria,
+                pad_token_id=self.tokenizer.pad_token_id,
+                use_cache=True,
+                **generation_kwargs,
+            )
 
     def _select_cont_toks(
         self, logits: torch.Tensor, contlen: int = None, inplen: int = None


### PR DESCRIPTION
This PR adds a new `mixed_precision_dtype: Optional[Union[str, torch.dtype]]` parameter to `HFML`.

When specified (either as a string or `torch.dtype`) all internal calls to `self.model` will occur inside `torch.autocast` regions for the model's device and given dtype.
- **Scope**: impacts `self._model_call` and `self._model_generate` which affects `loglikelihood`, `loglikelihood_rolling`, `generate_until` and automatic batch size detection.
- **Default**: `None` -> original behaviour (the `torch.autocast` context manager will become a no op).

The addition of this feature results in slightly different behaviour to explicitly loading the model with a specified `dtype` as it relies on torch's internal op-selection and autocasting behaviour. This is primarily useful when working with multi-dtype models (e.g. VLMs, PEFT models) in the CLI or when invoking the harness from the python API during training where a model may be in full precision.

**Usage**
> **Python API**  
> ```py
> lm = HFLM(model_name, mixed_precision_dtype="float16")   # or torch.float16
> ```  
> **CLI**  
> ```bash
> lm_eval --model hf \
>     --model_args pretrained=model_name,dtype="float32",mixed_precision_dtype="float16"
> ```  
Although any `torch.dtype` is accepted, in practice `"float16"` and `"bfloat16"` are the only sensible choices when utilising this feature.

**Docs**
No documentation has been added as the `HFLM` class does not have specific documentation, and the argument name and typing is self explanatory.