### PR TITLE
Fix medical benchmarks import

### DIFF
--- a/lm_eval/tasks/meddialog/utils.py
+++ b/lm_eval/tasks/meddialog/utils.py
@@ -11,7 +11,9 @@ try:
 
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
-        "Please install evaluation metrics via pip install evaluate and pip install bert-score",
+        "Please install evaluation metrics via pip install evaluate bert-score "
+        "rouge_score>=0.1.2 nltk absl-py "
+        "git+https://github.com/google-research/bleurt.git"
     )
 except Exception as e:
     raise RuntimeError(

--- a/lm_eval/tasks/mediqa_qa2019/utils.py
+++ b/lm_eval/tasks/mediqa_qa2019/utils.py
@@ -11,7 +11,9 @@ try:
 
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
-        "Please install evaluation metrics via pip install evaluate and pip install bert-score",
+        "Please install evaluation metrics via pip install evaluate bert-score "
+        "rouge_score>=0.1.2 nltk absl-py "
+        "git+https://github.com/google-research/bleurt.git"
     )
 except Exception as e:
     raise RuntimeError(

--- a/lm_eval/tasks/medtext/utils.py
+++ b/lm_eval/tasks/medtext/utils.py
@@ -11,7 +11,9 @@ try:
 
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
-        "Please install evaluation metrics via pip install evaluate and pip install bert-score",
+        "Please install evaluation metrics via pip install evaluate bert-score "
+        "rouge_score>=0.1.2 nltk absl-py "
+        "git+https://github.com/google-research/bleurt.git"
     )
 except Exception as e:
     raise RuntimeError(

--- a/lm_eval/tasks/meqsum/utils.py
+++ b/lm_eval/tasks/meqsum/utils.py
@@ -11,7 +11,9 @@ try:
 
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
-        "Please install evaluation metrics via pip install evaluate and pip install bert-score",
+        "Please install evaluation metrics via pip install evaluate bert-score "
+        "rouge_score>=0.1.2 nltk absl-py "
+        "git+https://github.com/google-research/bleurt.git"
     )
 except Exception as e:
     raise RuntimeError(

--- a/lm_eval/tasks/mimic_repsum/utils.py
+++ b/lm_eval/tasks/mimic_repsum/utils.py
@@ -15,7 +15,9 @@ try:
 
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
-        "Please install evaluation metrics via pip install evaluate and pip install bert-score",
+        "Please install evaluation metrics via pip install evaluate bert-score "
+        "rouge_score>=0.1.2 nltk absl-py radgraph"
+        "git+https://github.com/google-research/bleurt.git"
     )
 except Exception as e:
     raise RuntimeError(

--- a/lm_eval/tasks/mts_dialog/utils.py
+++ b/lm_eval/tasks/mts_dialog/utils.py
@@ -11,7 +11,9 @@ try:
 
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
-        "Please install evaluation metrics via pip install evaluate and pip install bert-score",
+        "Please install evaluation metrics via pip install evaluate bert-score "
+        "rouge_score>=0.1.2 nltk absl-py "
+        "git+https://github.com/google-research/bleurt.git"
     )
 except Exception as e:
     raise RuntimeError(

--- a/lm_eval/tasks/olaph/utils.py
+++ b/lm_eval/tasks/olaph/utils.py
@@ -12,7 +12,9 @@ try:
 
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
-        "Please install evaluation metrics via pip install evaluate and pip install bert-score",
+        "Please install evaluation metrics via pip install evaluate bert-score "
+        "rouge_score>=0.1.2 nltk absl-py "
+        "git+https://github.com/google-research/bleurt.git"
     )
 except Exception as e:
     raise RuntimeError(


### PR DESCRIPTION
In #2714, all added benchmarks have a duplicated error, specifically masking any messages from the underlying [evaluate](https://pypi.org/project/evaluate/) package.

Personally I'd remove the try-except surrounding the import and load statements and let the error propagate up as needed, but, to maintain the benchmark code as close as possible to the original, I think at least the exception message should be altered to reflect the required packages.
The added packages are taken strictly from evaluate's repository, from each of the required metrics' requirements.txt file.
