### PR TITLE
Add the MultiBLiMP benchmark

### DIFF
--- a/lm_eval/tasks/multiblimp/README.md
+++ b/lm_eval/tasks/multiblimp/README.md
@@ -1,0 +1,143 @@
+# MultiBLiMP: A Massively Multilingual Benchmark of Linguistic Minimal Pairs
+
+## Task Description
+MultiBLiMP is a massively multilingual benchmark of linguistic minimal pairs, covering 101 languages, 6 linguistic phenomena and containing more than 125,000 minimal pairs. 
+
+* Paper: https://arxiv.org/abs/2504.02768
+* GitHub Repo: https://github.com/jumelet/multiblimp/
+* Hugging Face Dataset Repo: https://huggingface.co/datasets/jumelet/multiblimp
+
+## Implementation
+
+* `multiblimp_{lang}` runs MultiBLiMP for a given language, where `{lang}` must be replaced by the language's ISO 639-3 code (e.g., `eng` for English, `abk` for Abkhazian, `wbp` for Warlpiri, etc.).
+* `multiblimp` tag runs MultiBLiMP for all languages
+
+Note: The original implementation is provided [here](https://github.com/jumelet/multiblimp), and the [dataset repository](https://huggingface.co/datasets/jumelet/multiblimp) also includes a link to a more flexible version of the implementation [here](https://github.com/catherinearnett/multiblimp). This implementation follows these as closely as possible, but the original implementations normalize length by number of tokens, which is not supported by the Language Model Evaluation Harness (see [[1](https://blog.eleuther.ai/multiple-choice-normalization/)], [[2](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/task_guide.md)], [[3](https://github.com/EleutherAI/lm-evaluation-harness/issues/1396)]). For this reason, the implementation provided here includes both the `acc` (accuracy based on comparing the unnormalized log-probability of the correct and incorrect versions of each sentence) and `acc_norm` (the same as `acc` but with sentence log-probability normalized by number of bytes) metrics.
+
+## Dataset Details
+
+This table (from the [Hugging Face Dataset Repo](https://huggingface.co/datasets/jumelet/multiblimp)) lists the languages covered in MultiBLiMP and the number of items for each language. 
+
+| ISO Code |      Language      |   n  |
+|:--------:|:------------------:|:----:|
+| abk      | Abkhazian          | 40   |
+| aqz      | Akuntsu            | 14   |
+| sqi      | Albanian           | 243  |
+| amh      | Amharic            | 112  |
+| grc      | Ancient Greek      | 3695 |
+| hbo      | Ancient Hebrew     | 983  |
+| apu      | Apurinã            | 28   |
+| hye      | Armenian           | 1415 |
+| eus      | Basque             | 273  |
+| bel      | Belarusian         | 2570 |
+| ben      | Bengali            | 21   |
+| bho      | Bhojpuri           | 34   |
+| bor      | Borôro             | 241  |
+| bre      | Breton             | 260  |
+| bul      | Bulgarian          | 2458 |
+| bua      | Buriat             | 103  |
+| cat      | Catalan            | 2284 |
+| chu      | Church Slavonic    | 4166 |
+| xcl      | Classical Armenian | 1623 |
+| ces      | Czech              | 4256 |
+| dan      | Danish             | 50   |
+| nld      | Dutch              | 2331 |
+| egy      | Egyptian (Ancient) | 22   |
+| eng      | English            | 770  |
+| myv      | Erzya              | 464  |
+| est      | Estonian           | 2575 |
+| fao      | Faroese            | 232  |
+| fin      | Finnish            | 2570 |
+| fra      | French             | 2548 |
+| glg      | Galician           | 753  |
+| kat      | Georgian           | 204  |
+| deu      | German             | 2298 |
+| aln      | Gheg Albanian      | 677  |
+| got      | Gothic             | 1579 |
+| guj      | Gujarati           | 7    |
+| heb      | Hebrew             | 2330 |
+| azz      | H-P Nahuatl        | 207  |
+| hin      | Hindi              | 1447 |
+| hit      | Hittite            | 50   |
+| hun      | Hungarian          | 845  |
+| isl      | Icelandic          | 2801 |
+| gle      | Irish              | 28   |
+| ita      | Italian            | 2999 |
+| quc      | K'iche'            | 131  |
+| xnr      | Kangri             | 86   |
+| krl      | Karelian           | 260  |
+| kxh      | Karo (Ethiopia)    | 120  |
+| kaz      | Kazakh             | 173  |
+| kir      | Kirghiz            | 185  |
+| koi      | Komi-Permyak       | 43   |
+| kpv      | Komi-Zyrian        | 320  |
+| lat      | Latin              | 3149 |
+| lav      | Latvian            | 3032 |
+| lij      | Ligurian           | 254  |
+| lit      | Lithuanian         | 1180 |
+| olo      | Livvi              | 190  |
+| nds      | Low German         | 1774 |
+| mkd      | Macedonian         | 39   |
+| mar      | Marathi            | 460  |
+| frm      | Middle French      | 294  |
+| ell      | Modern Greek       | 1096 |
+| mdf      | Moksha             | 82   |
+| yrl      | Nhengatu           | 720  |
+| pcm      | Nigerian Pidgin    | 26   |
+| kmr      | Northern Kurdish   | 544  |
+| sme      | Northern Sami      | 2536 |
+| fro      | Old French         | 1976 |
+| orv      | Old Russian        | 4615 |
+| ota      | Ottoman Turkish    | 99   |
+| fas      | Persian            | 2553 |
+| xpg      | Phrygian           | 50   |
+| pol      | Polish             | 3272 |
+| por      | Portuguese         | 3048 |
+| ron      | Romanian           | 2056 |
+| rus      | Russian            | 3832 |
+| san      | Sanskrit           | 4442 |
+| gla      | Scottish Gaelic    | 66   |
+| hbs      | Serbo-Croatian     | 3286 |
+| sms      | Skolt Sami         | 263  |
+| slk      | Slovak             | 4145 |
+| slv      | Slovenian          | 4483 |
+| spa      | Spanish            | 2541 |
+| arb      | Standard Arabic    | 1215 |
+| swe      | Swedish            | 201  |
+| tam      | Tamil              | 382  |
+| ttc      | Tektiteko          | 69   |
+| tpn      | Tupinambá          | 9    |
+| tur      | Turkish            | 1742 |
+| uig      | Uighur             | 758  |
+| ukr      | Ukrainian          | 2744 |
+| hsb      | Upper Sorbian      | 186  |
+| urd      | Urdu               | 550  |
+| urb      | Urubú-Kaapor       | 13   |
+| uzb      | Uzbek              | 50   |
+| vep      | Veps               | 187  |
+| wbp      | Warlpiri           | 12   |
+| cym      | Welsh              | 1120 |
+| hyw      | Western Armenian   | 1153 |
+| wol      | Wolof              | 705  |
+| sah      | Yakut              | 144  |
+| nhi      | Tenango Nahuatl    | 38   |
+
+
+## Citation
+```
+@misc{jumelet2025multiblimp10massivelymultilingual,
+      title={MultiBLiMP 1.0: A Massively Multilingual Benchmark of Linguistic Minimal Pairs}, 
+      author={Jaap Jumelet and Leonie Weissweiler and Arianna Bisazza},
+      year={2025},
+      eprint={2504.02768},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2504.02768}, 
+}
+```
+
+## New Task Checklist
+
+- [x] Is the task an existing benchmark in the literature?
+  - [x] Have you referenced the original paper that introduced the task?
+  - [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?

--- a/lm_eval/tasks/multiblimp/_template_yaml
+++ b/lm_eval/tasks/multiblimp/_template_yaml
@@ -1,0 +1,18 @@
+dataset_path: jumelet/multiblimp
+tag: multiblimp
+output_type: multiple_choice
+test_split: train
+doc_to_text: ""
+target_delimiter: ""
+doc_to_target: 0
+doc_to_choice: "{{[sen,wrong_sen]}}"
+num_fewshot: 0
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0

--- a/lm_eval/tasks/multiblimp/multiblimp_abk.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_abk.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: abk
+task: multiblimp_abk

--- a/lm_eval/tasks/multiblimp/multiblimp_aln.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_aln.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: aln
+task: multiblimp_aln

--- a/lm_eval/tasks/multiblimp/multiblimp_amh.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_amh.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: amh
+task: multiblimp_amh

--- a/lm_eval/tasks/multiblimp/multiblimp_apu.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_apu.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: apu
+task: multiblimp_apu

--- a/lm_eval/tasks/multiblimp/multiblimp_aqz.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_aqz.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: aqz
+task: multiblimp_aqz

--- a/lm_eval/tasks/multiblimp/multiblimp_arb.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_arb.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: arb
+task: multiblimp_arb

--- a/lm_eval/tasks/multiblimp/multiblimp_azz.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_azz.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: azz
+task: multiblimp_azz

--- a/lm_eval/tasks/multiblimp/multiblimp_bel.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_bel.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: bel
+task: multiblimp_bel

--- a/lm_eval/tasks/multiblimp/multiblimp_ben.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ben.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ben
+task: multiblimp_ben

--- a/lm_eval/tasks/multiblimp/multiblimp_bho.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_bho.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: bho
+task: multiblimp_bho

--- a/lm_eval/tasks/multiblimp/multiblimp_bor.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_bor.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: bor
+task: multiblimp_bor

--- a/lm_eval/tasks/multiblimp/multiblimp_bre.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_bre.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: bre
+task: multiblimp_bre

--- a/lm_eval/tasks/multiblimp/multiblimp_bua.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_bua.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: bua
+task: multiblimp_bua

--- a/lm_eval/tasks/multiblimp/multiblimp_bul.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_bul.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: bul
+task: multiblimp_bul

--- a/lm_eval/tasks/multiblimp/multiblimp_cat.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_cat.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: cat
+task: multiblimp_cat

--- a/lm_eval/tasks/multiblimp/multiblimp_ces.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ces.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ces
+task: multiblimp_ces

--- a/lm_eval/tasks/multiblimp/multiblimp_chu.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_chu.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: chu
+task: multiblimp_chu

--- a/lm_eval/tasks/multiblimp/multiblimp_cym.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_cym.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: cym
+task: multiblimp_cym

--- a/lm_eval/tasks/multiblimp/multiblimp_dan.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_dan.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: dan
+task: multiblimp_dan

--- a/lm_eval/tasks/multiblimp/multiblimp_deu.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_deu.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: deu
+task: multiblimp_deu

--- a/lm_eval/tasks/multiblimp/multiblimp_egy.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_egy.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: egy
+task: multiblimp_egy

--- a/lm_eval/tasks/multiblimp/multiblimp_ell.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ell.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ell
+task: multiblimp_ell

--- a/lm_eval/tasks/multiblimp/multiblimp_eng.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_eng.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: eng
+task: multiblimp_eng

--- a/lm_eval/tasks/multiblimp/multiblimp_est.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_est.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: est
+task: multiblimp_est

--- a/lm_eval/tasks/multiblimp/multiblimp_eus.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_eus.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: eus
+task: multiblimp_eus

--- a/lm_eval/tasks/multiblimp/multiblimp_fao.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_fao.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: fao
+task: multiblimp_fao

--- a/lm_eval/tasks/multiblimp/multiblimp_fas.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_fas.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: fas
+task: multiblimp_fas

--- a/lm_eval/tasks/multiblimp/multiblimp_fin.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_fin.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: fin
+task: multiblimp_fin

--- a/lm_eval/tasks/multiblimp/multiblimp_fra.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_fra.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: fra
+task: multiblimp_fra

--- a/lm_eval/tasks/multiblimp/multiblimp_frm.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_frm.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: frm
+task: multiblimp_frm

--- a/lm_eval/tasks/multiblimp/multiblimp_fro.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_fro.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: fro
+task: multiblimp_fro

--- a/lm_eval/tasks/multiblimp/multiblimp_gla.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_gla.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: gla
+task: multiblimp_gla

--- a/lm_eval/tasks/multiblimp/multiblimp_gle.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_gle.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: gle
+task: multiblimp_gle

--- a/lm_eval/tasks/multiblimp/multiblimp_glg.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_glg.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: glg
+task: multiblimp_glg

--- a/lm_eval/tasks/multiblimp/multiblimp_got.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_got.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: got
+task: multiblimp_got

--- a/lm_eval/tasks/multiblimp/multiblimp_grc.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_grc.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: grc
+task: multiblimp_grc

--- a/lm_eval/tasks/multiblimp/multiblimp_guj.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_guj.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: guj
+task: multiblimp_guj

--- a/lm_eval/tasks/multiblimp/multiblimp_hbo.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hbo.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hbo
+task: multiblimp_hbo

--- a/lm_eval/tasks/multiblimp/multiblimp_hbs.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hbs.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hbs
+task: multiblimp_hbs

--- a/lm_eval/tasks/multiblimp/multiblimp_heb.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_heb.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: heb
+task: multiblimp_heb

--- a/lm_eval/tasks/multiblimp/multiblimp_hin.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hin.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hin
+task: multiblimp_hin

--- a/lm_eval/tasks/multiblimp/multiblimp_hit.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hit.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hit
+task: multiblimp_hit

--- a/lm_eval/tasks/multiblimp/multiblimp_hsb.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hsb.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hsb
+task: multiblimp_hsb

--- a/lm_eval/tasks/multiblimp/multiblimp_hun.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hun.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hun
+task: multiblimp_hun

--- a/lm_eval/tasks/multiblimp/multiblimp_hye.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hye.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hye
+task: multiblimp_hye

--- a/lm_eval/tasks/multiblimp/multiblimp_hyw.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_hyw.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: hyw
+task: multiblimp_hyw

--- a/lm_eval/tasks/multiblimp/multiblimp_isl.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_isl.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: isl
+task: multiblimp_isl

--- a/lm_eval/tasks/multiblimp/multiblimp_ita.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ita.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ita
+task: multiblimp_ita

--- a/lm_eval/tasks/multiblimp/multiblimp_kat.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_kat.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: kat
+task: multiblimp_kat

--- a/lm_eval/tasks/multiblimp/multiblimp_kaz.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_kaz.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: kaz
+task: multiblimp_kaz

--- a/lm_eval/tasks/multiblimp/multiblimp_kir.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_kir.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: kir
+task: multiblimp_kir

--- a/lm_eval/tasks/multiblimp/multiblimp_kmr.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_kmr.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: kmr
+task: multiblimp_kmr

--- a/lm_eval/tasks/multiblimp/multiblimp_koi.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_koi.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: koi
+task: multiblimp_koi

--- a/lm_eval/tasks/multiblimp/multiblimp_kpv.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_kpv.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: kpv
+task: multiblimp_kpv

--- a/lm_eval/tasks/multiblimp/multiblimp_krl.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_krl.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: krl
+task: multiblimp_krl

--- a/lm_eval/tasks/multiblimp/multiblimp_kxh.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_kxh.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: kxh
+task: multiblimp_kxh

--- a/lm_eval/tasks/multiblimp/multiblimp_lat.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_lat.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: lat
+task: multiblimp_lat

--- a/lm_eval/tasks/multiblimp/multiblimp_lav.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_lav.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: lav
+task: multiblimp_lav

--- a/lm_eval/tasks/multiblimp/multiblimp_lij.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_lij.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: lij
+task: multiblimp_lij

--- a/lm_eval/tasks/multiblimp/multiblimp_lit.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_lit.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: lit
+task: multiblimp_lit

--- a/lm_eval/tasks/multiblimp/multiblimp_mar.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_mar.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: mar
+task: multiblimp_mar

--- a/lm_eval/tasks/multiblimp/multiblimp_mdf.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_mdf.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: mdf
+task: multiblimp_mdf

--- a/lm_eval/tasks/multiblimp/multiblimp_mkd.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_mkd.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: mkd
+task: multiblimp_mkd

--- a/lm_eval/tasks/multiblimp/multiblimp_myv.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_myv.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: myv
+task: multiblimp_myv

--- a/lm_eval/tasks/multiblimp/multiblimp_nds.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_nds.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: nds
+task: multiblimp_nds

--- a/lm_eval/tasks/multiblimp/multiblimp_nhi.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_nhi.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: nhi
+task: multiblimp_nhi

--- a/lm_eval/tasks/multiblimp/multiblimp_nld.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_nld.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: nld
+task: multiblimp_nld

--- a/lm_eval/tasks/multiblimp/multiblimp_olo.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_olo.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: olo
+task: multiblimp_olo

--- a/lm_eval/tasks/multiblimp/multiblimp_orv.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_orv.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: orv
+task: multiblimp_orv

--- a/lm_eval/tasks/multiblimp/multiblimp_ota.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ota.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ota
+task: multiblimp_ota

--- a/lm_eval/tasks/multiblimp/multiblimp_pcm.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_pcm.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: pcm
+task: multiblimp_pcm

--- a/lm_eval/tasks/multiblimp/multiblimp_pol.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_pol.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: pol
+task: multiblimp_pol

--- a/lm_eval/tasks/multiblimp/multiblimp_por.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_por.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: por
+task: multiblimp_por

--- a/lm_eval/tasks/multiblimp/multiblimp_quc.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_quc.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: quc
+task: multiblimp_quc

--- a/lm_eval/tasks/multiblimp/multiblimp_ron.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ron.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ron
+task: multiblimp_ron

--- a/lm_eval/tasks/multiblimp/multiblimp_rus.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_rus.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: rus
+task: multiblimp_rus

--- a/lm_eval/tasks/multiblimp/multiblimp_sah.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_sah.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: sah
+task: multiblimp_sah

--- a/lm_eval/tasks/multiblimp/multiblimp_san.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_san.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: san
+task: multiblimp_san

--- a/lm_eval/tasks/multiblimp/multiblimp_slk.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_slk.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: slk
+task: multiblimp_slk

--- a/lm_eval/tasks/multiblimp/multiblimp_slv.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_slv.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: slv
+task: multiblimp_slv

--- a/lm_eval/tasks/multiblimp/multiblimp_sme.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_sme.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: sme
+task: multiblimp_sme

--- a/lm_eval/tasks/multiblimp/multiblimp_sms.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_sms.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: sms
+task: multiblimp_sms

--- a/lm_eval/tasks/multiblimp/multiblimp_spa.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_spa.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: spa
+task: multiblimp_spa

--- a/lm_eval/tasks/multiblimp/multiblimp_sqi.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_sqi.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: sqi
+task: multiblimp_sqi

--- a/lm_eval/tasks/multiblimp/multiblimp_swe.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_swe.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: swe
+task: multiblimp_swe

--- a/lm_eval/tasks/multiblimp/multiblimp_tam.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_tam.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: tam
+task: multiblimp_tam

--- a/lm_eval/tasks/multiblimp/multiblimp_tpn.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_tpn.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: tpn
+task: multiblimp_tpn

--- a/lm_eval/tasks/multiblimp/multiblimp_ttc.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ttc.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ttc
+task: multiblimp_ttc

--- a/lm_eval/tasks/multiblimp/multiblimp_tur.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_tur.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: tur
+task: multiblimp_tur

--- a/lm_eval/tasks/multiblimp/multiblimp_uig.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_uig.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: uig
+task: multiblimp_uig

--- a/lm_eval/tasks/multiblimp/multiblimp_ukr.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_ukr.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: ukr
+task: multiblimp_ukr

--- a/lm_eval/tasks/multiblimp/multiblimp_urb.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_urb.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: urb
+task: multiblimp_urb

--- a/lm_eval/tasks/multiblimp/multiblimp_urd.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_urd.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: urd
+task: multiblimp_urd

--- a/lm_eval/tasks/multiblimp/multiblimp_uzb.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_uzb.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: uzb
+task: multiblimp_uzb

--- a/lm_eval/tasks/multiblimp/multiblimp_vep.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_vep.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: vep
+task: multiblimp_vep

--- a/lm_eval/tasks/multiblimp/multiblimp_wbp.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_wbp.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: wbp
+task: multiblimp_wbp

--- a/lm_eval/tasks/multiblimp/multiblimp_wol.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_wol.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: wol
+task: multiblimp_wol

--- a/lm_eval/tasks/multiblimp/multiblimp_xcl.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_xcl.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: xcl
+task: multiblimp_xcl

--- a/lm_eval/tasks/multiblimp/multiblimp_xnr.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_xnr.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: xnr
+task: multiblimp_xnr

--- a/lm_eval/tasks/multiblimp/multiblimp_xpg.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_xpg.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: xpg
+task: multiblimp_xpg

--- a/lm_eval/tasks/multiblimp/multiblimp_yrl.yaml
+++ b/lm_eval/tasks/multiblimp/multiblimp_yrl.yaml
@@ -1,0 +1,3 @@
+include: _template_yaml
+dataset_name: yrl
+task: multiblimp_yrl


### PR DESCRIPTION
This pull request adds the [MultiBLiMP](https://arxiv.org/abs/2504.02768) benchmark to the harness.

This implementation is as faithful as possible to the original, but because the harness does not support normalization based on number of tokens (as in the original implementation), it includes both `acc` and `acc_norm` as metrics.