### PR TITLE
Bugfix: update path for GLUE

### DIFF
--- a/lm_eval/tasks/glue/cola/default.yaml
+++ b/lm_eval/tasks/glue/cola/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: cola
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: cola
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/glue/mnli/default.yaml
+++ b/lm_eval/tasks/glue/mnli/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: mnli
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: mnli
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/glue/mrpc/default.yaml
+++ b/lm_eval/tasks/glue/mrpc/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: mrpc
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: mrpc
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/glue/qnli/default.yaml
+++ b/lm_eval/tasks/glue/qnli/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: qnli
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: qnli
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/glue/qqp/default.yaml
+++ b/lm_eval/tasks/glue/qqp/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: qqp
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: qqp
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/glue/rte/default.yaml
+++ b/lm_eval/tasks/glue/rte/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: rte
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: rte
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/glue/sst2/default.yaml
+++ b/lm_eval/tasks/glue/sst2/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: sst2
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: sst2
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/glue/wnli/default.yaml
+++ b/lm_eval/tasks/glue/wnli/default.yaml
@@ -1,6 +1,6 @@
 tag: glue
 task: wnli
-dataset_path: glue
+dataset_path: nyu-mll/glue
 dataset_name: wnli
 output_type: multiple_choice
 training_split: train


### PR DESCRIPTION
Huggingface has recently changed the datasets endpoint to no longer accept namespace-free aliases for older datasets (e.g. `glue`, `hellaswag`).

This PR replaces the dataset path of GLUE tasks to now include the full namespace, i.e. `nyu-mll/glue`