### PR TITLE
Bugfix: set default SamplingParams based on `generation_config`

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -375,7 +375,7 @@ class VLLM(TemplateLM):
             sampling_params = self.model.get_default_sampling_params().clone()
             sampling_params.max_tokens = max_tokens
             sampling_params.stop = stop
-            unused_kwargs = {}
+            unused_kwargs = {} # to collect unused kwargs
             for key, value in kwargs.items():
                 if hasattr(sampling_params, key):
                     setattr(sampling_params, key, value)


### PR DESCRIPTION
fix bug #3154. 

Specially, the original `SamplingParams` is solely initialized without considering the parameters in `generation_config` file (e.g.  `repetition_penalty`). This PR modifies the initialization based on `self.model.get_default_sampling_params().clone()`, where `generation_config` parameters has been automatically handled inside `vllm`.