### PR TITLE
[tests] Added missing fixture in test_unitxt_tasks.py

### DIFF
--- a/tests/test_unitxt_tasks.py
+++ b/tests/test_unitxt_tasks.py
@@ -6,6 +6,9 @@ from lm_eval import tasks as tasks
 from lm_eval.api.task import ConfigurableTask
 from tests.test_tasks import BaseTasks, task_class
 
+@pytest.fixture()
+def limit() -> int:
+    return 10
 
 @pytest.mark.parametrize(
     "task_class",

--- a/tests/test_unitxt_tasks.py
+++ b/tests/test_unitxt_tasks.py
@@ -6,9 +6,11 @@ from lm_eval import tasks as tasks
 from lm_eval.api.task import ConfigurableTask
 from tests.test_tasks import BaseTasks, task_class
 
+
 @pytest.fixture()
 def limit() -> int:
     return 10
+
 
 @pytest.mark.parametrize(
     "task_class",


### PR DESCRIPTION
The `TestUnitxtTasks` tests were failing due to a missing `limit` fixture that was omitted when the tests were moved from `test_tasks.py` into `test_unitxt_tasks.py`

This PR copies the `limit` fixture from `test_tasks.py` into `test_unitxt_tasks.py` which now results in all relevant tests now passing.