### PR TITLE
Added `chat_template_args` to pass additional kwargs to tokenizer.apply_chat_template

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -226,6 +226,12 @@ def setup_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--chat_template_args",
+        default=None,
+        type=try_parse_json,
+        help="""Comma separated string or JSON formatted arguments for tokenizer.apply_chat_template(), e.g. `enable_thinking=False` or '{"enable_thinking":false}'""",
+    )
+    parser.add_argument(
         "--verbosity",
         "-v",
         type=str.upper,
@@ -342,6 +348,11 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if args.fewshot_as_multiturn and args.apply_chat_template is False:
         raise ValueError(
             "When `fewshot_as_multiturn` is selected, `apply_chat_template` must be set (either to `True` or to the chosen template name)."
+        )
+
+    if args.chat_template_args and args.apply_chat_template is False:
+        raise ValueError(
+            "When `chat_template_args` are specified, `apply_chat_template` must be set (either to `True` or to the chosen template name)."
         )
 
     if args.include_path is not None:
@@ -469,6 +480,7 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         apply_chat_template=args.apply_chat_template,
         fewshot_as_multiturn=args.fewshot_as_multiturn,
         gen_kwargs=args.gen_kwargs,
+        chat_template_args=args.chat_template_args,
         task_manager=task_manager,
         predict_only=args.predict_only,
         random_seed=args.seed[0],

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -226,12 +226,6 @@ def setup_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--chat_template_args",
-        default=None,
-        type=try_parse_json,
-        help="""Comma separated string or JSON formatted arguments for tokenizer.apply_chat_template(), e.g. `enable_thinking=False` or '{"enable_thinking":false}'""",
-    )
-    parser.add_argument(
         "--verbosity",
         "-v",
         type=str.upper,
@@ -348,11 +342,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
     if args.fewshot_as_multiturn and args.apply_chat_template is False:
         raise ValueError(
             "When `fewshot_as_multiturn` is selected, `apply_chat_template` must be set (either to `True` or to the chosen template name)."
-        )
-
-    if args.chat_template_args and args.apply_chat_template is False:
-        raise ValueError(
-            "When `chat_template_args` are specified, `apply_chat_template` must be set (either to `True` or to the chosen template name)."
         )
 
     if args.include_path is not None:
@@ -480,7 +469,6 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         apply_chat_template=args.apply_chat_template,
         fewshot_as_multiturn=args.fewshot_as_multiturn,
         gen_kwargs=args.gen_kwargs,
-        chat_template_args=args.chat_template_args,
         task_manager=task_manager,
         predict_only=args.predict_only,
         random_seed=args.seed[0],

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -69,6 +69,7 @@ def simple_evaluate(
     apply_chat_template: Union[bool, str] = False,
     fewshot_as_multiturn: bool = False,
     gen_kwargs: Union[str, dict, None] = None,
+    chat_template_args: Union[str, dict, None] = None,
     task_manager: Optional[TaskManager] = None,
     verbosity=None,
     predict_only: bool = False,
@@ -214,6 +215,12 @@ def simple_evaluate(
         if not gen_kwargs:
             gen_kwargs = None
 
+    if chat_template_args is not None:
+        if isinstance(chat_template_args, str):
+            chat_template_args = simple_parse_args_string(chat_template_args)
+        if not chat_template_args:
+            chat_template_args = None
+
     if isinstance(model, str):
         if model_args is None:
             eval_logger.warning("model_args not specified. Using defaults.")
@@ -229,6 +236,7 @@ def simple_evaluate(
                     "batch_size": batch_size,
                     "max_batch_size": max_batch_size,
                     "device": device,
+                    "chat_template_args": chat_template_args,
                 },
             )
 
@@ -242,6 +250,7 @@ def simple_evaluate(
                     "batch_size": batch_size,
                     "max_batch_size": max_batch_size,
                     "device": device,
+                    "chat_template_args": chat_template_args,
                 },
             )
     else:

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -35,6 +35,7 @@ from lm_eval.utils import (
     positional_deprecated,
     setup_logging,
     simple_parse_args_string,
+    wrap_text,
 )
 
 
@@ -169,8 +170,11 @@ def simple_evaluate(
         )
     ) and not apply_chat_template:
         eval_logger.warning(
-            f"pretrained={model_args.get('pretrained') if isinstance(model_args, dict) else model_args} appears to be an instruct or chat variant but chat template is not applied. "
-            "Recommend setting `apply_chat_template` (optionally `fewshot_as_multiturn`)."
+            wrap_text(
+                f"""pretrained={model_args.get("pretrained") if isinstance(model_args, dict) else model_args} appears to be an
+                instruct or chat variant but chat template is not applied.
+                Recommend setting `apply_chat_template` (optionally `fewshot_as_multiturn`).""",
+            )
         )
 
     if delete_requests_cache:
@@ -234,7 +238,9 @@ def simple_evaluate(
 
         else:
             eval_logger.info(
-                f"Initializing {model} model, with arguments: {simple_parse_args_string(model_args)}"
+                wrap_text(
+                    f"Initializing {model} model, with arguments: {simple_parse_args_string(model_args)}"
+                )
             )
             lm = lm_eval.api.registry.get_model(model).create_from_arg_string(
                 model_args,

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -69,7 +69,6 @@ def simple_evaluate(
     apply_chat_template: Union[bool, str] = False,
     fewshot_as_multiturn: bool = False,
     gen_kwargs: Union[str, dict, None] = None,
-    chat_template_args: Union[str, dict, None] = None,
     task_manager: Optional[TaskManager] = None,
     verbosity=None,
     predict_only: bool = False,
@@ -170,7 +169,7 @@ def simple_evaluate(
         )
     ) and not apply_chat_template:
         eval_logger.warning(
-            "Model appears to be an instruct or chat variant but chat template is not applied. "
+            f"pretrained={model_args.get('pretrained') if isinstance(model_args, dict) else model_args} appears to be an instruct or chat variant but chat template is not applied. "
             "Recommend setting `apply_chat_template` (optionally `fewshot_as_multiturn`)."
         )
 
@@ -215,12 +214,6 @@ def simple_evaluate(
         if not gen_kwargs:
             gen_kwargs = None
 
-    if chat_template_args is not None:
-        if isinstance(chat_template_args, str):
-            chat_template_args = simple_parse_args_string(chat_template_args)
-        if not chat_template_args:
-            chat_template_args = None
-
     if isinstance(model, str):
         if model_args is None:
             eval_logger.warning("model_args not specified. Using defaults.")
@@ -236,7 +229,6 @@ def simple_evaluate(
                     "batch_size": batch_size,
                     "max_batch_size": max_batch_size,
                     "device": device,
-                    "chat_template_args": chat_template_args,
                 },
             )
 
@@ -250,7 +242,6 @@ def simple_evaluate(
                     "batch_size": batch_size,
                     "max_batch_size": max_batch_size,
                     "device": device,
-                    "chat_template_args": chat_template_args,
                 },
             )
     else:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -5,7 +5,7 @@ import logging
 import os
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 import jinja2
 import torch
@@ -102,6 +102,7 @@ class HFLM(TemplateLM):
         # splits to get response after this token (if provided).
         think_end_token: Union[str, int, None] = None,
         enable_thinking: bool | None = None,
+        chat_template_args: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -242,7 +243,9 @@ class HFLM(TemplateLM):
         # select (or create) a pad token to use
         self.tokenizer = configure_pad_token(self.tokenizer, model_config=self.config)
         self.chat_template_args = (
-            {"enable_thinking": enable_thinking} if enable_thinking is not None else {}
+            chat_template_args or {} | dict(enable_thinking=enable_thinking)
+            if enable_thinking is not None
+            else {}
         )
 
         self.add_bos_token = add_bos_token

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -99,6 +99,7 @@ class HFLM(TemplateLM):
         # end token for thinking, either the string or int token id.
         # splits to get response after this token (if provided).
         think_end_token: Union[str, int, None] = None,
+        chat_template_args: Optional[dict] = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -238,6 +239,7 @@ class HFLM(TemplateLM):
         self.vocab_size = self.tokenizer.vocab_size
         # select (or create) a pad token to use
         self.tokenizer = configure_pad_token(self.tokenizer, model_config=self.config)
+        self.chat_template_args = chat_template_args or {}
 
         self.add_bos_token = add_bos_token
         if "gemma" in getattr(self.config, "model_type", ""):
@@ -1483,6 +1485,7 @@ class HFLM(TemplateLM):
                 tokenize=False,
                 add_generation_prompt=add_generation_prompt,
                 continue_final_message=not add_generation_prompt,
+                **self.chat_template_args,
             )
         except jinja2.exceptions.TemplateError:
             eval_logger.warning(
@@ -1494,6 +1497,7 @@ class HFLM(TemplateLM):
                 tokenize=False,
                 add_generation_prompt=add_generation_prompt,
                 continue_final_message=not add_generation_prompt,
+                **self.chat_template_args,
             )
 
         return chat_templated

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import logging
 import os
@@ -99,7 +101,7 @@ class HFLM(TemplateLM):
         # end token for thinking, either the string or int token id.
         # splits to get response after this token (if provided).
         think_end_token: Union[str, int, None] = None,
-        chat_template_args: Optional[dict] = None,
+        enable_thinking: bool | None = None,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -239,7 +241,9 @@ class HFLM(TemplateLM):
         self.vocab_size = self.tokenizer.vocab_size
         # select (or create) a pad token to use
         self.tokenizer = configure_pad_token(self.tokenizer, model_config=self.config)
-        self.chat_template_args = chat_template_args or {}
+        self.chat_template_args = (
+            {"enable_thinking": enable_thinking} if enable_thinking is not None else {}
+        )
 
         self.add_bos_token = add_bos_token
         if "gemma" in getattr(self.config, "model_type", ""):

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -136,6 +136,7 @@ class VLLM(TemplateLM):
         lora_local_path: str = None,
         # VLLM: enable thinking tags in the prompt.
         enable_thinking: bool = True,
+        chat_template_args: Optional[dict] = None,
         # End marker for thinking tags - splits to get response after this token (if provided).
         think_end_token: Optional[str] = None,
         max_lora_rank: int = 16,
@@ -209,7 +210,10 @@ class VLLM(TemplateLM):
             add_bos_token=add_bos_token,
         )
         self.tokenizer = configure_pad_token(self.tokenizer, model_config=self._config)
-        self.enable_thinking = enable_thinking
+        self.chat_template_args = chat_template_args or {}
+        self.enable_thinking = chat_template_args.pop(
+            "enable_thinking", enable_thinking
+        )
         self.add_bos_token = add_bos_token
         if "gemma" in pretrained.lower():
             self.add_bos_token = True
@@ -317,6 +321,7 @@ class VLLM(TemplateLM):
                 continue_final_message=not add_generation_prompt,
                 chat_template=self.hf_chat_template,
                 enable_thinking=self.enable_thinking,
+                **self.chat_template_args,
             )
         except jinja2.exceptions.TemplateError:
             eval_logger.warning(
@@ -329,6 +334,7 @@ class VLLM(TemplateLM):
                 continue_final_message=not add_generation_prompt,
                 chat_template=self.hf_chat_template,
                 enable_thinking=self.enable_thinking,
+                **self.chat_template_args,
             )
 
         return chat_templated

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -26,6 +26,23 @@ HIGHER_IS_BETTER_SYMBOLS = {
 }
 
 
+def wrap_text(string: str, width: int = 140, **kwargs) -> Optional[str]:
+    """
+    Wraps the given string to the specified width.
+    """
+    import textwrap
+
+    return textwrap.fill(
+        inspect.cleandoc(string),
+        width=width,
+        initial_indent="",
+        subsequent_indent=" " * 8,
+        break_long_words=False,
+        break_on_hyphens=False,
+        **kwargs,
+    )
+
+
 def setup_logging(verbosity=logging.INFO):
     # Configure the root logger
     class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
This PR adds:
- A new `chat_template_args: Optional[dict]` argument to `HFLM` and `VLLM`
- A new `chat_template_args: Union[str, dict, None]` argument to `simple_evaluate()`
- A new `--chat_template_args` CLI argument

When specified (either as a KV or JSON string on the CLI, or as a dict to HFLM or VLLM) the kwargs will be propagated to all `tokenizer.apply_chat_template` invocations, enabling control such as the inclusion of `<think>` tokens for models that support it.

When using VLLM specifically, when `enable_thinking` is included in `chat_template_args` it will be popped from the dict and used to overwrite `self.enable_thinking` which is normally specified in `model_args`. Currently the `enable_thinking` model argument is VLLM specific and is not standardised across 'thinking' models, so the addition of the `chat_template_args` argument allows users to pass arbitrary directives to the chat template logic in a backend agnostic way, while still maintaining backwards compatibility when passing `enable_thinking` as a model argument to VLLM.

**Usage**
> **Python API**  
> ```py
> lm = HFLM(model_name, chat_template_args={'enable_thinking':False})
> lm = VLLM(model_name, chat_template_args={'enable_thinking':False})
> ```  
> **CLI**  
> ```bash
> lm_eval --model hf --model_args pretrained=model_name --chat_template_args enable_thinking=False
> lm_eval --model vllm --model_args pretrained=model_name --chat_template_args enable_thinking=False
> ```

While this currently only applies to HF and VLLM models, using this with other backends should result in a no op as it will simply be absorbed and ignored by the `**kwargs` in the `__init__` method of other models.

I have also added the relevant help string for the CLI, and added error checking to catch if `--chat_template_args` was specified while ``--apply_chat_template` is False.

I have run unit tests, but have not tested HFLM or VLLM behaviour with this `--chat_template_args` as I currently don't have access to GPUs which can run thinking models to test out the thinking switch, but I am confident the code is correct and would appreciate a review or testing from a maintainer prior to merge.