### PR TITLE
Remove "device" from vllm_causallms.py

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -131,7 +131,6 @@ class VLLM(TemplateLM):
         max_model_len: int = None,
         seed: int = 1234,
         gpu_memory_utilization: float = 0.9,
-        device: str = "cuda",
         data_parallel_size: int = 1,
         lora_local_path: str = None,
         # VLLM: enable thinking tags in the prompt.
@@ -172,7 +171,6 @@ class VLLM(TemplateLM):
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
-            "device": str(device),
             "enable_lora": True if lora_local_path else False,
             "max_lora_rank": int(max_lora_rank),
         }


### PR DESCRIPTION
Device has been a deprecated arg for a few releases of vLLM and is now removed in 0.10.0 https://github.com/vllm-project/vllm/pull/21349