### PR TITLE
Leverage vllm's `tokenizer_info` endpoint to avoid manual duplication 

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -8,12 +8,14 @@ import json
 import logging
 import os
 import re
+import threading
 from dataclasses import asdict, is_dataclass
 from itertools import islice
 from pathlib import Path
 from typing import Any, Callable, Generator, List, Optional, Tuple
 
 import numpy as np
+import requests
 import yaml
 from jinja2 import BaseLoader, Environment, StrictUndefined
 
@@ -623,3 +625,218 @@ def hash_dict_images(data_dict):
         if importlib.util.find_spec("PIL")
         else data_dict
     )
+
+
+class RemoteTokenizer:
+    """
+    Minimal robust tokenizer that uses vLLM server's tokenizer endpoints.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        timeout: int = 30,
+        verify_certificate: bool = True,
+        ca_cert_path: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        max_retries: int = 3,
+    ):
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self._lock = threading.RLock()
+        self._tokenizer_info = None
+        self._chat_template_obj = None
+
+        # Certificate logic
+        self.cert_config = (
+            ca_cert_path if verify_certificate and ca_cert_path else verify_certificate
+        )
+
+        # Auth header logic
+        self.headers = {"Content-Type": "application/json"}
+        if auth_token:
+            self.headers["Authorization"] = f"Bearer {auth_token}"
+
+        # Normalize base URL - remove API endpoints to get server base
+        self.base_url = (
+            base_url.replace("/v1/completions", "")
+            .replace("/v1/chat/completions", "")
+            .rstrip("/")
+        )
+
+        # Use a session for connection pooling
+        self.session = requests.Session()
+        self.session.headers.update(self.headers)
+
+        # Validate server supports tokenizer_info endpoint
+        self._validate_server()
+
+    def _request_with_retries(self, method, url, **kwargs):
+        last_exc = None
+        for _ in range(self.max_retries):
+            try:
+                resp = self.session.request(
+                    method,
+                    url,
+                    timeout=kwargs.pop("timeout", self.timeout),
+                    verify=self.cert_config,
+                    **kwargs,
+                )
+                resp.raise_for_status()
+                return resp
+            except requests.RequestException as e:
+                last_exc = e
+        raise RuntimeError(
+            f"RemoteTokenizer: {method} {url} failed after {self.max_retries} attempts: {last_exc}"
+        )
+
+    def _validate_server(self):
+        url = f"{self.base_url}/tokenizer_info"
+        resp = self._request_with_retries("GET", url)
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Server does not support tokenizer_info endpoint. Status: {resp.status_code}"
+            )
+
+    @property
+    def tokenizer_info(self) -> dict:
+        with self._lock:
+            if self._tokenizer_info is None:
+                url = f"{self.base_url}/tokenizer_info"
+                resp = self._request_with_retries("GET", url)
+                self._tokenizer_info = resp.json()
+            return self._tokenizer_info
+
+    @property
+    def eos_token(self) -> Optional[str]:
+        return self.tokenizer_info.get("eos_token")
+
+    @property
+    def bos_token(self) -> Optional[str]:
+        return self.tokenizer_info.get("bos_token")
+
+    @property
+    def pad_token(self) -> Optional[str]:
+        return self.tokenizer_info.get("pad_token")
+
+    @property
+    def eos_token_id(self) -> Optional[int]:
+        if self.eos_token is None:
+            return None
+        return self.encode(self.eos_token)[0]
+
+    @property
+    def bos_token_id(self) -> Optional[int]:
+        if self.bos_token is None:
+            return None
+        return self.encode(self.bos_token)[0]
+
+    @property
+    def eot_token(self) -> Optional[int]:
+        return self.eos_token_id
+
+    def encode(self, text: str) -> List[int]:
+        url = f"{self.base_url}/tokenize"
+        payload = {"prompt": text, "add_special_tokens": False}
+        resp = self._request_with_retries("POST", url, json=payload)
+        tokens = resp.json().get("tokens")
+        if not isinstance(tokens, list):
+            raise RuntimeError("Malformed response from /tokenize endpoint.")
+        return tokens
+
+    def decode(self, tokens: List[int]) -> str:
+        url = f"{self.base_url}/detokenize"
+        payload = {"tokens": tokens}
+        resp = self._request_with_retries("POST", url, json=payload)
+        prompt = resp.json().get("prompt")
+        if not isinstance(prompt, str):
+            raise RuntimeError("Malformed response from /detokenize endpoint.")
+        return prompt
+
+    def batch_decode(self, tokens_list: List[List[int]]) -> List[str]:
+        return [self.decode(tokens) for tokens in tokens_list]
+
+    def apply_chat_template(
+        self, chat_history: list, add_generation_prompt: bool = True, **kwargs
+    ) -> str:
+        with self._lock:
+            if self._chat_template_obj is None:
+                template_str = self.tokenizer_info.get("chat_template")
+                if not template_str:
+                    raise ValueError("No chat template available from server")
+                self._chat_template_obj = env.from_string(template_str)
+        return self._chat_template_obj.render(
+            messages=chat_history, add_generation_prompt=add_generation_prompt, **kwargs
+        )
+
+    def __call__(self, text: str, add_special_tokens: bool = False, **kwargs) -> dict:
+        tokens = self.encode(text)
+        return {"input_ids": tokens}
+
+
+def check_remote_tokenizer_support(
+    base_url: str,
+    timeout: int = 5,
+    verify_certificate: bool = True,
+    ca_cert_path: Optional[str] = None,
+    auth_token: Optional[str] = None,
+    max_retries: int = 3,
+) -> bool:
+    """
+    Check if server supports remote tokenizer endpoints.
+    Returns True if both /tokenizer_info and /tokenize endpoints are available and functional, False otherwise.
+    """
+    if not base_url:
+        return False
+
+    server_base = (
+        base_url.replace("/v1/completions", "")
+        .replace("/v1/chat/completions", "")
+        .rstrip("/")
+    )
+    cert_config = (
+        ca_cert_path if verify_certificate and ca_cert_path else verify_certificate
+    )
+    headers = {"Content-Type": "application/json"}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+
+    session = requests.Session()
+    session.headers.update(headers)
+
+    def _request_with_retries(method, url, **kwargs):
+        for _ in range(max_retries):
+            try:
+                resp = session.request(
+                    method,
+                    url,
+                    timeout=kwargs.pop("timeout", timeout),
+                    verify=cert_config,
+                    **kwargs,
+                )
+                resp.raise_for_status()
+                return resp
+            except requests.RequestException:
+                pass
+        return None
+
+    # Check /tokenizer_info
+    info_url = f"{server_base}/tokenizer_info"
+    resp = _request_with_retries("GET", info_url)
+    if not resp:
+        return False
+    info = resp.json()
+    if not isinstance(info, dict) or "eos_token" not in info:
+        return False
+
+    # Check /tokenize
+    tokenize_url = f"{server_base}/tokenize"
+    test_payload = {"prompt": "test", "add_special_tokens": False}
+    resp = _request_with_retries("POST", tokenize_url, json=test_payload)
+    if not resp:
+        return False
+    tokens = resp.json().get("tokens")
+    if not isinstance(tokens, list):
+        return False
+
+    return True

--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -226,3 +226,99 @@ def test_get_batched_requests_with_no_ssl(
 
         mock_connector.assert_called_with(limit=2, ssl=False)
         assert result_batches
+
+
+def test_local_completionsapi_remote_tokenizer_authenticated(monkeypatch):
+    captured = {}
+
+    class DummyTokenizer:
+        def __init__(
+            self, base_url, timeout, verify_certificate, ca_cert_path, auth_token
+        ):
+            captured.update(locals())
+
+    monkeypatch.setattr("lm_eval.utils.RemoteTokenizer", DummyTokenizer)
+    LocalCompletionsAPI(
+        base_url="https://secure-server",
+        tokenizer_backend="remote",
+        verify_certificate=True,
+        ca_cert_path="secure.crt",
+        auth_token="secure-token",
+    )
+    assert captured["base_url"] == "https://secure-server"
+    assert captured["verify_certificate"] is True
+    assert captured["ca_cert_path"] == "secure.crt"
+    assert captured["auth_token"] == "secure-token"
+
+
+def test_local_completionsapi_remote_tokenizer_unauthenticated(monkeypatch):
+    captured = {}
+
+    class DummyTokenizer:
+        def __init__(
+            self, base_url, timeout, verify_certificate, ca_cert_path, auth_token
+        ):
+            captured.update(locals())
+
+    monkeypatch.setattr("lm_eval.utils.RemoteTokenizer", DummyTokenizer)
+    LocalCompletionsAPI(
+        base_url="http://localhost:8000",
+        tokenizer_backend="remote",
+        verify_certificate=False,
+        ca_cert_path=None,
+        auth_token=None,
+    )
+    assert captured["base_url"] == "http://localhost:8000"
+    assert captured["verify_certificate"] is False
+    assert captured["ca_cert_path"] is None
+    assert captured["auth_token"] is None
+
+
+def test_localchatcompletion_remote_tokenizer_authenticated(monkeypatch):
+    captured = {}
+
+    class DummyTokenizer:
+        def __init__(
+            self, base_url, timeout, verify_certificate, ca_cert_path, auth_token
+        ):
+            captured.update(locals())
+
+    monkeypatch.setattr("lm_eval.utils.RemoteTokenizer", DummyTokenizer)
+    from lm_eval.models.openai_completions import LocalChatCompletion
+
+    LocalChatCompletion(
+        base_url="https://secure-server",
+        tokenizer_backend="remote",
+        verify_certificate=True,
+        ca_cert_path="secure.crt",
+        auth_token="secure-token",
+    )
+    assert captured["base_url"] == "https://secure-server"
+    assert captured["verify_certificate"] is True
+    assert captured["ca_cert_path"] == "secure.crt"
+    assert captured["auth_token"] == "secure-token"
+
+
+def test_localchatcompletion_remote_tokenizer_unauthenticated(monkeypatch):
+    captured = {}
+
+    class DummyTokenizer:
+        def __init__(
+            self, base_url, timeout, verify_certificate, ca_cert_path, auth_token
+        ):
+            captured.update(locals())
+
+    monkeypatch.setattr("lm_eval.utils.RemoteTokenizer", DummyTokenizer)
+    from lm_eval.models.openai_completions import LocalChatCompletion
+
+    LocalChatCompletion(
+        base_url="http://localhost:8000",
+        tokenizer_backend="remote",
+        verify_certificate=False,
+        ca_cert_path=None,
+        auth_token=None,
+    )
+    assert captured["base_url"] == "http://localhost:8000"
+    assert captured["verify_certificate"] is False
+    assert captured["ca_cert_path"] is None
+    assert captured["auth_token"] is None


### PR DESCRIPTION
## Purpose

A contribution to [vllm](https://github.com/vllm-project/vllm) was recently made to provide tokenizer/chat-template information ([PR 20575](https://github.com/vllm-project/vllm/pull/20575)). Consequently, if a vllm server is started with the following argument `--enable-tokenizer-info-endpoint` (i.e.vllm serve INSERT_MODEL_NAME --enable-tokenizer-info-endpoint), the tokenizer and chat template information can be accessed by querying the `tokenizer_info` endpoint. 

In instances where we try to evaluate models deployed on such vllm servers, it would be quite handy to be able to leverage this `tokenizer_info` endpoint in the context of `local-completions` and `local-chat-completions` to format the inbound prompt accordingly for the model; having to e.g. download the tokenizer again from HF is inefficient and could be error prone.

## Quick illustration

1. start the vllm server, e.g. locally on a Mac:

```
podman run --rm \                                                             
    --shm-size=4g \
    -p 8000:8000 \
    -e VLLM_CPU_KVCACHE_SPACE=4 \
    -e VLLM_CPU_OMP_THREADS_BIND=0-3 \
    vllm-cpu-env \
    --model=Qwen/Qwen2.5-0.5B-Instruct \
    --enable-tokenizer-info-endpoint \
    --max-num-batched-tokens 32768
```

2. make a request to the `tokenizer_info` endpoint:

```
curl "http://localhost:8000/tokenizer_info" | jq
```
this should return
```json
{
  "tokenizer_class": "CachedQwen2TokenizerFast",
  "unk_token": null,
  "bos_token": null,
  "eos_token": "<|im_end|>",
  "pad_token": "<|endoftext|>",
  "add_bos_token": false,
  "add_prefix_space": false,
  "additional_special_tokens": [
    "<|im_start|>",
    "<|im_end|>",
    "<|object_ref_start|>",
    "<|object_ref_end|>",
    "<|box_start|>",
    "<|box_end|>",
    "<|quad_start|>",
    "<|quad_end|>",
    "<|vision_start|>",
    "<|vision_end|>",
    "<|vision_pad|>",
    "<|image_pad|>",
    "<|video_pad|>"
  ],
  "chat_template": "{%- if tools %}\n    {{- '<|im_start|>system\\n' }}\n    {%- if messages[0]['role'] == 'system' %}\n        {{- messages[0]['content'] }}\n    {%- else %}\n        {{- 'You are Qwen, created by Alibaba Cloud. You are a helpful assistant.' }}\n    {%- endif %}\n    {{- \"\\n\\n# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\\"name\\\": <function-name>, \\\"arguments\\\": <args-json-object>}\\n</tool_call><|im_end|>\\n\" }}\n{%- else %}\n    {%- if messages[0]['role'] == 'system' %}\n        {{- '<|im_start|>system\\n' + messages[0]['content'] + '<|im_end|>\\n' }}\n    {%- else %}\n        {{- '<|im_start|>system\\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- for message in messages %}\n    {%- if (message.role == \"user\") or (message.role == \"system\" and not loop.first) or (message.role == \"assistant\" and not message.tool_calls) %}\n        {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {{- '<|im_start|>' + message.role }}\n        {%- if message.content %}\n            {{- '\\n' + message.content }}\n        {%- endif %}\n        {%- for tool_call in message.tool_calls %}\n            {%- if tool_call.function is defined %}\n                {%- set tool_call = tool_call.function %}\n            {%- endif %}\n            {{- '\\n<tool_call>\\n{\"name\": \"' }}\n            {{- tool_call.name }}\n            {{- '\", \"arguments\": ' }}\n            {{- tool_call.arguments | tojson }}\n            {{- '}\\n</tool_call>' }}\n        {%- endfor %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != \"tool\") %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- message.content }}\n        {{- '\\n</tool_response>' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != \"tool\") %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n{%- endif %}\n",
  "clean_up_tokenization_spaces": false,
  "errors": "replace",
  "model_max_length": 131072,
  "split_special_tokens": false,
  "max_loras": 0,
  "truncation_side": "left",
  "name_or_path": "Qwen/Qwen2.5-0.5B-Instruct"
}
```

3. Run a demo evaluation
```
lm_eval --model local-chat-completions \
    --model_args base_url=http://localhost:8000/v1/chat/completions \
    --tasks gsm8k \
    --limit 5
```

in the logs, the following info should be displayed
```
2025-07-25:10:57:22 WARNING  [__main__:369]  --limit SHOULD ONLY BE USED FOR TESTING.REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT.
2025-07-25:10:57:22 INFO     [__main__:446] Selected Tasks: ['gsm8k']
2025-07-25:10:57:22 WARNING  [evaluator:172] pretrained=base_url=http://localhost:8000/v1/chat/completions appears to be an instruct or chat variant but chat template is not applied.
        Recommend setting `apply_chat_template` (optionally `fewshot_as_multiturn`).
2025-07-25:10:57:22 INFO     [evaluator:202] Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234 | Setting fewshot manual seed to 1234
2025-07-25:10:57:22 INFO     [evaluator:240] Initializing local-chat-completions model, with arguments: {'base_url': 'http://localhost:8000/v1/chat/completions'}
2025-07-25:10:57:22 INFO     [models.openai_completions:163] Auto-detected remote tokenizer support. Chat template will be applied automatically.
2025-07-25:10:57:22 INFO     [models.api_models:172] Using max length 2048 - 1
2025-07-25:10:57:22 INFO     [models.api_models:175] Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2025-07-25:10:57:22 INFO     [models.api_models:193] Using tokenizer remote
2025-07-25:10:57:22 INFO     [models.api_models:239] Using remote tokenizer from http://localhost:8000/v1/chat/completions
2025-07-25:10:57:26 INFO     [evaluator:305] gsm8k: Using gen_kwargs: {'until': ['Question:', '</s>', '<|im_end|>'], 'do_sample': False, 'temperature': 0.0}
2025-07-25:10:57:26 INFO     [api.task:434] Building contexts for gsm8k on rank 0...
100%|█████████████████████████████████████| 5/5 [00:00<00:00, 681.38it/s]
2025-07-25:10:57:26 INFO     [evaluator:574] Running generate_until requests
```

## Test Plan

In addition to local testing. e.g. 

```
lm_eval --model local-chat-completions \
    --model_args base_url=http://localhost:8000/v1/chat/completions \
    --tasks gsm8k \
    --limit 5
```
and
```
lm_eval --model local-completions \     
    --model_args base_url=http://localhost:8000/v1/completions \     
    --tasks arc_easy \
    --limit 5
```

as well as their secured counterparts
```
lm_eval --model local-chat-completions \
    --model_args base_url=https://localhost:8443/v1/chat/completions,verify_certificate=True,ca_cert_path=/opt/homebrew/etc/nginx/cert.pem,auth_token=lol \    
    --tasks gsm8k \   
    --limit 5
```
and 
```
lm_eval --model local-completions \     
    --model_args base_url=https://localhost:8443/v1/completions,verify_certificate=True,ca_cert_path=/opt/homebrew/etc/nginx/cert.pem,auth_token=lol \         
    --tasks arc_easy \
    --limit 5
```

Additional tests were added to `tests/models/test_api.py` and `tests/test_utils.py`; these tests can be ran from the top-level directory using, e.g. 

```
pytest -v tests/models/test_api.py
```

and 

```
pytest -v tests/test_utils.py
```

