### PR TITLE
Add new task: kmmlu_pro, kmmlu_redux

### DIFF
--- a/lm_eval/tasks/kmmlu_pro/_kmmlu_pro.yaml
+++ b/lm_eval/tasks/kmmlu_pro/_kmmlu_pro.yaml
@@ -1,0 +1,3 @@
+kmmlu_pro:
+  - kmmlu_pro_multiple_choice
+  - kmmlu_pro_generate_until

--- a/lm_eval/tasks/kmmlu_pro/kmmlu_pro_generate_until.yaml
+++ b/lm_eval/tasks/kmmlu_pro/kmmlu_pro_generate_until.yaml
@@ -1,0 +1,31 @@
+task: kmmlu_pro_generate_until
+dataset_path: LGAI-EXAONE/KMMLU-Pro
+test_split: test
+fewshot_split: test
+output_type: generate_until
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+# doc_to_choice: !function utils.doc_to_choice
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    regexes_to_ignore:
+          - " "
+generation_kwargs:
+  until: []
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 2048
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(?<![A-Za-z0-9])(1|2|3|4|5)(?![A-Za-z0-9])"
+      - function: "take_first"
+metadata:
+  version: 1.0
+  group: kmmlu_pro

--- a/lm_eval/tasks/kmmlu_pro/kmmlu_pro_multiple_choice.yaml
+++ b/lm_eval/tasks/kmmlu_pro/kmmlu_pro_multiple_choice.yaml
@@ -1,0 +1,18 @@
+task: kmmlu_pro_multiple_choice
+dataset_path: LGAI-EXAONE/KMMLU-Pro
+test_split: test
+fewshot_split: test
+output_type: multiple_choice
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+doc_to_choice: !function utils.doc_to_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0
+  group: kmmlu_pro

--- a/lm_eval/tasks/kmmlu_pro/utils.py
+++ b/lm_eval/tasks/kmmlu_pro/utils.py
@@ -1,0 +1,14 @@
+def doc_to_text(doc) -> str:
+    options = doc["options"] + [""] * (5 - len(doc["options"])) 
+    choices = "\n".join(f"{i+1}. {v}" for i, v in enumerate(options))
+    return (
+        f"다음은 {doc['license_name']} 자격시험의 {doc['subject']} 과목 기출문제입니다.\n"
+        "문제를 잘 읽고, 보기 중에서 가장 적절한 정답을 고르시오.\n"
+        f"{choices}\n정답:"
+    )
+
+def doc_to_target(doc) -> int:
+    return int(doc["solution"])
+
+def doc_to_choice(doc):
+    return doc["options"] + [""] * (5 - len(doc["options"]))

--- a/lm_eval/tasks/kmmlu_redux/_kmmlu_redux.yaml
+++ b/lm_eval/tasks/kmmlu_redux/_kmmlu_redux.yaml
@@ -1,0 +1,3 @@
+kmmlu_redux:
+  - kmmlu_redux_multiple_choice
+  - kmmlu_redux_generate_until

--- a/lm_eval/tasks/kmmlu_redux/kmmlu_redux_generate_until.yaml
+++ b/lm_eval/tasks/kmmlu_redux/kmmlu_redux_generate_until.yaml
@@ -1,0 +1,31 @@
+task: kmmlu_redux_generate_until
+dataset_path: LGAI-EXAONE/KMMLU-Redux
+test_split: test
+fewshot_split: test
+output_type: generate_until
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+# doc_to_choice: !function utils.doc_to_choice
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    regexes_to_ignore:
+          - " "
+generation_kwargs:
+  until: []
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 2048
+filter_list:
+  - name: "get-answer"
+    filter:
+      - function: "regex"
+        group_select: -1
+        regex_pattern: "(?<![A-Za-z0-9])(1|2|3|4)(?![A-Za-z0-9])"
+      - function: "take_first"
+metadata:
+  version: 1.0
+  group: kmmlu_pro

--- a/lm_eval/tasks/kmmlu_redux/kmmlu_redux_multiple_choice.yaml
+++ b/lm_eval/tasks/kmmlu_redux/kmmlu_redux_multiple_choice.yaml
@@ -1,0 +1,18 @@
+task: kmmlu_redux_multiple_choice
+dataset_path: LGAI-EXAONE/KMMLU-Redux
+test_split: test
+fewshot_split: test
+output_type: multiple_choice
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+doc_to_choice: !function utils.doc_to_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0
+  group: kmmlu_pro

--- a/lm_eval/tasks/kmmlu_redux/utils.py
+++ b/lm_eval/tasks/kmmlu_redux/utils.py
@@ -1,0 +1,14 @@
+def doc_to_text(doc) -> str:
+    options = doc["options"] + [""] * (5 - len(doc["options"])) 
+    choices = "\n".join(f"{i+1}. {v}" for i, v in enumerate(options))
+    return (
+        f"다음은 {doc['license_name']} 자격시험 기출문제입니다.\n"
+        "문제를 잘 읽고, 보기 중에서 가장 적절한 정답을 고르시오.\n"
+        f"{choices}\n정답:"
+    )
+
+def doc_to_target(doc) -> int:
+    return int(doc["solution"])
+
+def doc_to_choice(doc):
+    return doc["options"] + [""] * (5 - len(doc["options"]))


### PR DESCRIPTION
### Overview
We are adding the kmmlu_pro and kmmlu_redux tasks.
These two tasks were recently developed by LG AI Research to address the limitations of the original KMMLU benchmark.

### Dataset
Source: LGAI-EXAONE/KMMLU-Pro, LGAI-EXAONE/KMMLU-Redux
License: Creative Commons Attribution-NonCommercial-NoDerivatives 4.0