### PR TITLE
Fix humaneval_instruct

### DIFF
--- a/lm_eval/tasks/humaneval/humaneval_64_instruct.yaml
+++ b/lm_eval/tasks/humaneval/humaneval_64_instruct.yaml
@@ -1,6 +1,6 @@
 include: humaneval_64.yaml
 task: humaneval_64_instruct
-doc_to_text: "Write a solution to the following problem and make sure that it passes the tests:\n```{{prompt}}"
+doc_to_text: "Write a solution to the following problem and make sure that it passes the tests:\n```python\n{{ prompt }}\n```\n"
 gen_prefix: "Here is the completed function:\n```python\n{{prompt}}\n"
 filter_list:
   - name: "create_test"


### PR DESCRIPTION
- Sync doc_to_text in `humaneval_64_instruct.yaml` with `humaneval_instruct.yaml`