### PR TITLE
Fix `add_bos_token` not updated for Gemma tokenizer

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -195,6 +195,12 @@ class VLLM(TemplateLM):
             self.batch_size = "auto"
             eval_logger.info("Manual batching is not compatible with data parallelism.")
 
+        if "gemma" in pretrained.lower():
+            add_bos_token = True
+            eval_logger.info(
+                "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
+            )
+
         from transformers import AutoConfig
 
         self._config = AutoConfig.from_pretrained(
@@ -213,11 +219,6 @@ class VLLM(TemplateLM):
             "enable_thinking", enable_thinking
         )
         self.add_bos_token = add_bos_token
-        if "gemma" in pretrained.lower():
-            self.add_bos_token = True
-            eval_logger.info(
-                "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
-            )
 
         if parse_version(version("vllm")) >= parse_version("0.8.3"):
             kwargs_resolve_hf_chat_template = {


### PR DESCRIPTION
Inside the initializer of `VLLM`, the override for `add_bos_token` for Gemma models failed to be applied to the tokenizer because it is set after `get_tokenizer`. This PR moves the relevant code earlier so `add_bos_token` gets correctly updated for both `tokenizer` and the `VLLM` instance.