### PR TITLE
Fix: respect `target_delimiter` when using a `gen_prefix` on multiple-choice tasks

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1456,7 +1456,7 @@ class ConfigurableTask(Task):
         elif self.OUTPUT_TYPE == "multiple_choice":
             choices = self.doc_to_choice(doc)
             target_delimiter = self.config.target_delimiter
-            if apply_chat_template:
+            if apply_chat_template and not self.config.gen_prefix:
                 target_delimiter = ""
             if self.multiple_input:
                 # If there are multiple inputs, choices are placed in the ctx


### PR DESCRIPTION
This PR fixes how `gen_prefix` interacts with multiple-choice tasks.
Specifically not forcing `target_delimiter` to an empty string.

{"role": "assistant", "content": <gen_prefix><choice>}
to
{"role": "assistant", "content": <gen_prefix><target_delimiter>\<choice>} 
