### PR TITLE
Fix unknown group key to tag in yaml config for `lambada_multilingual_stablelm`

### DIFF
--- a/lm_eval/tasks/lambada_multilingual_stablelm/lambada_mt_stablelm_en.yaml
+++ b/lm_eval/tasks/lambada_multilingual_stablelm/lambada_mt_stablelm_en.yaml
@@ -1,5 +1,4 @@
-group:
-  - lambada_multilingual_stablelm
+tag: lambada_multilingual_stablelm
 task: lambada_openai_mt_stablelm_en
 dataset_path: marcob/lambada_multilingual
 dataset_name: en


### PR DESCRIPTION
`lambada_mt_stablelm_en.yaml` uses the `group` key which will throw an error as `TaskConfig` does not know it. Changed it to `tag`.

Error reproducable by running evaluation on any of the `lambada_multilingual_stablelm` tasks.