### PR TITLE
Adding support for Structured Generation with XGrammar

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -1,16 +1,52 @@
+import ipaddress
+import json
 import logging
 import math
 import os
 import random
 import re
 import string
+import uuid
 from collections.abc import Iterable
-from typing import Callable, List, Optional, Sequence, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar
 
 import numpy as np
 import sacrebleu
 
+
+# check if jsonschema is installed
+try:
+    import jsonschema
+    from jsonschema import Draft202012Validator, FormatChecker, ValidationError
+except ImportError as e:
+    raise ImportError(
+        "jsonschema is not installed. Please install it using 'pip install jsonschema[format]'"
+    ) from e
+
 from lm_eval.api.registry import register_aggregation, register_metric
+
+
+eval_logger = logging.getLogger(__name__)
+
+
+# Initialize the FormatChecker
+format_checker = FormatChecker()
+
+
+# Add custom format checkers
+@format_checker.checks("ipv4")
+def ipv4_check(value):
+    ipaddress.IPv4Address(value)
+
+
+@format_checker.checks("ipv6")
+def ipv6_check(value):
+    ipaddress.IPv6Address(value)
+
+
+@format_checker.checks("uuid")
+def uuid_check(value):
+    uuid.UUID(value)
 
 
 T = TypeVar("T")
@@ -307,6 +343,129 @@ def mean_stderr(arr):
 )
 def bypass(items):
     return None
+
+
+def is_json_schema_valid(schema: dict):
+    """
+    Check if a JSON schema is valid.
+
+    :param schema: A JSON schema.
+    :return: True if the schema is valid, False otherwise.
+    """
+    try:
+        # Check if the schema is valid
+        jsonschema.Draft202012Validator.check_schema(schema)
+        return True
+    except jsonschema.SchemaError:
+        return False
+
+
+def schema_conform_with_format_checker(
+    instance: Dict[str, Any], schema: Dict[str, Any]
+) -> bool:
+    """
+    Validate a JSON instance against a schema with enhanced format checking.
+
+    :param schema: The JSON schema to validate against.
+    :param instance: The JSON instance to validate.
+    :raises ValidationError: If the validation fails.
+    """
+    # first check if the schema is valid
+    if not is_json_schema_valid(schema):
+        raise ValidationError("The JSON schema is invalid.")
+    validator = Draft202012Validator(schema, format_checker=format_checker)
+    try:
+        validator.validate(instance)
+    except ValidationError as e:
+        raise ValidationError(e.message)
+    return True
+
+
+@register_metric(
+    metric="json_validity",
+    higher_is_better=True,
+    output_type=["generate_until"],
+    aggregation="mean",
+)
+def json_validity(references: list[str], predictions: list[str], strip: True) -> bool:
+    assert len(predictions) == 1, (
+        "Currently, we don't support pass@k for JSON schema validation."
+    )
+    prediction = predictions[0]  # Since predictions is a list of lists
+
+    if strip:
+        prediction = prediction.strip().strip("```").strip("json").strip()
+
+    try:
+        json.loads(prediction)
+    except json.JSONDecodeError:
+        return False
+    return True
+
+
+@register_metric(
+    metric="grammar_compliance",
+    higher_is_better=True,
+    output_type=["generate_until"],
+    aggregation="mean",
+)
+def grammar_compliance(
+    references: list[str],
+    predictions: list[str],
+    grammar_file_path: str,
+    grammar_type: str,
+    tokenizer: str = None,
+) -> bool:
+    assert len(references) == 1, (
+        "We only have one reference for this task, which is the JSON schema."
+    )
+    assert len(predictions) == 1, (
+        "Currently, we don't support pass@k for JSON schema validation."
+    )
+
+    prediction = predictions[0]  # Since predictions is a list of lists
+
+    with open(grammar_file_path, "r") as f:
+        grammar_str = f.read().strip()
+
+    if grammar_type == "json":
+        json_schema = json.loads(grammar_str)
+        try:
+            json_obj = json.loads(prediction.strip().strip("```").strip("json"))
+        except json.JSONDecodeError:
+            return False
+
+        try:
+            schema_conform = schema_conform_with_format_checker(json_obj, json_schema)
+        except Exception as e:
+            eval_logger.error(f"Error: {e}")
+            return False
+
+        return schema_conform
+
+    if grammar_type == "regex":
+        return bool(re.fullmatch(grammar_str, prediction.strip()))
+
+    if grammar_type == "gbnf":
+        try:
+            import xgrammar as xgr
+            from transformers import AutoTokenizer
+
+            tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B")
+
+            tokenizer_info = xgr.TokenizerInfo.from_huggingface(
+                tokenizer, vocab_size=tokenizer.vocab_size
+            )
+            grammar_compiler = xgr.GrammarCompiler(tokenizer_info)
+            compiled_grammar = grammar_compiler.compile_grammar(grammar_str)
+            matcher = xgr.GrammarMatcher(compiled_grammar)
+
+            return matcher.accept_string(prediction.strip())
+
+        except Exception:
+            return False
+
+    raise ValueError(f"Unknown grammar type: {grammar_type}")
 
 
 @register_metric(

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -5,6 +5,7 @@ from . import (
     gguf,
     hf_audiolm,
     hf_steered,
+    hf_structured,
     hf_vlms,
     huggingface,
     ibm_watsonx_ai,

--- a/lm_eval/models/hf_structured.py
+++ b/lm_eval/models/hf_structured.py
@@ -1,0 +1,75 @@
+import logging
+
+import xgrammar as xgr
+
+from lm_eval.api.registry import register_model
+from lm_eval.models.huggingface import HFLM
+
+
+eval_logger = logging.getLogger(__name__)
+
+ALL_GRAMMAR_TYPES = ("gbnf", "json", "regex")
+
+
+@register_model("hf-structured")
+class HFStructuredLM(HFLM):
+    """
+    An abstracted Hugging Face model class for structured LMs.
+    """
+
+    def _get_logits_processor(self, grammar_file_path, grammar_type):
+        if grammar_type not in ALL_GRAMMAR_TYPES:
+            raise ValueError(
+                f"Got invalid grammar_type '{grammar_type}', must be in '{','.join(ALL_GRAMMAR_TYPES)}'"
+            )
+
+        tokenizer_info = xgr.TokenizerInfo.from_huggingface(
+            self.tokenizer, vocab_size=self.config.vocab_size
+        )
+        compiler = xgr.GrammarCompiler(tokenizer_info)
+
+        with open(grammar_file_path, "r") as f:
+            grammar_str = f.read().strip()
+
+        if grammar_type == "gbnf":
+            compiled_grammar = compiler.compile_grammar(grammar_str)
+        elif grammar_type == "json":
+            compiled_grammar = compiler.compile_json_schema(grammar_str)
+        elif grammar_type == "regex":
+            compiled_grammar = compiler.compile_regex(grammar_str)
+
+        return xgr.contrib.hf.LogitsProcessor(compiled_grammar)
+
+    def _model_generate(
+        self,
+        context,
+        max_length,
+        stop,
+        grammar_file_path,
+        grammar_type,
+        **generation_kwargs,
+    ):
+        # temperature = 0.0 if not set
+        # if do_sample is false and temp==0.0:
+        # remove temperature, as do_sample=False takes care of this
+        # and we don't want a warning from HF
+        generation_kwargs["temperature"] = generation_kwargs.get("temperature", 0.0)
+        do_sample = generation_kwargs.get("do_sample", None)
+
+        # The temperature has to be a strictly positive float -- if it is 0.0, use greedy decoding strategies
+        if generation_kwargs.get("temperature") == 0.0 and do_sample is None:
+            generation_kwargs["do_sample"] = do_sample = False
+
+        if do_sample is False and generation_kwargs.get("temperature") == 0.0:
+            generation_kwargs.pop("temperature")
+
+        logits_processor = self._get_logits_processor(grammar_file_path, grammar_type)
+
+        return self.model.generate(
+            input_ids=context,
+            max_length=max_length,
+            pad_token_id=self.tokenizer.pad_token_id,
+            use_cache=True,
+            logits_processor=[logits_processor],
+            **generation_kwargs,
+        )


### PR DESCRIPTION
This PR adds support for structured generation (SG) to lm-evalution-harness. @saibo-creator and I have been working on this direction for a few weeks, and we already use our fork for internal experiments.

## Motivation
SG is an established feature of most major LLM engines and it is used widely in both agentic systems and various reasoning tasks. There are alreay benchmarks that are intended to be used with SG (see [JSONSchemaBench](https://arxiv.org/abs/2501.10868v3), [StructEval](https://tiger-ai-lab.github.io/StructEval/)). It is also possible (and an intereting area of exploration) to run other benchmarks with SG. We have made certain changes to lm-evaluation-harness to create such tasks easily.

## A new model: `HFStructuredLM`
This PR adds a new model, `HFStructuredLM` that supports SG with [XGrammar](https://xgrammar.mlc.ai/) engine. It accepts three different grammars: json, regex, and GBNF. Two task setups are possible:
* A separate grammar for each record: Add a separate `grammar` column to the dataset.
* A common grammar for the entire task: create a grammar file.

## Changes to the API
We also add three new metrics:
* `json_validity`: Given a JSON string, returns 1 if the JSON is valid, 0 if not.
* `grammar_compliance`: Given a grammar (JSON, regex, or GBNF) string, return 1 if the prediction matches the grammar, 0 if not.
* `json_answer_match`: Given a JSON string and the target field, performs exact match.

## Sample tasks
We have extended the existing GSM8K task as a working sample of SG with JSON output. The following GitHub Gist contains two files:

https://gist.github.com/ceferisbarov/88b85b0423486807f5b633ab4bf9baaa

You can place them in `lm_eval/tasks/gsm8k` or another task folder and test SG.

## Plans
This is an ongoing work and we appreciate any feedback. Our backlog so far:
- [ ] `json_answer_match` metric is an *ad hoc* solution. We need a more generalizable alternative. We can extend `exact_match` metric by adding new parameters.
- [ ] `grammar_compliance` metric also contains *ad hoc* solutions, especially for JSON. We can make `grammar_compliance` an extensible metric where users import it to their task's `metrics.py` file and modify it.
- [ ] Add documentation & tutorials.
- [ ] Add other SG engines (we added only XGrammar for now).
- [ ] Update jsonschemabench task to use default metrics instead of custom ones.
