### PR TITLE
Add support for evaluating with fine-tuned Gemma3

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -680,10 +680,17 @@ class HFLM(TemplateLM):
                 "0.4.0"
             ):
                 raise AssertionError("load_in_4bit requires peft >= 0.4.0")
-            if self._model.config.vocab_size != len(self.tokenizer):
+
+            # Compatible with Gemma3 (multimodal) and old models
+            if hasattr(self._model.config, "text_config") and hasattr(self._model.config.text_config, "vocab_size"):
+                vocab_size = self._model.config.text_config.vocab_size
+            else:
+                vocab_size = self._model.config.vocab_size
+            
+            if vocab_size != len(self.tokenizer):
                 # resize model for LoRAs with added tokens
                 eval_logger.info(
-                    f"Model config indicates vocab_size='{self._model.config.vocab_size}', but found tokenizer with vocab size '{len(self.tokenizer)}'. Resizing model embedding layer..."
+                    f"Model config indicates vocab_size='{vocab_size}', but found tokenizer with vocab size '{len(self.tokenizer)}'. Resizing model embedding layer..."
                 )
                 self._model.resize_token_embeddings(len(self.tokenizer))
             self._model = PeftModel.from_pretrained(


### PR DESCRIPTION
This PR adds support for evaluating with fine-tuned Gemma3.

Before this PR, if you try to evaluate with a fine-tuned Gemma3 model, it will report as below:
```
AttributeError: 'Gemma3Config' object has no attribute 'vocab_size'.
```
That's because Gemma3, as a series of multimodal models, has turned to use `config.text_config.vocab_size` instead of `config.vocab_size`.