### PR TITLE
Adding support for evaluating with Mistral and Pixtral models

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -680,10 +680,17 @@ class HFLM(TemplateLM):
                 "0.4.0"
             ):
                 raise AssertionError("load_in_4bit requires peft >= 0.4.0")
-            if self._model.config.vocab_size != len(self.tokenizer):
+
+            # Compatible with Gemma3 (multimodal) and old models
+            if hasattr(self._model.config, "text_config") and hasattr(self._model.config.text_config, "vocab_size"):
+                vocab_size = self._model.config.text_config.vocab_size
+            else:
+                vocab_size = self._model.config.vocab_size
+            
+            if vocab_size != len(self.tokenizer):
                 # resize model for LoRAs with added tokens
                 eval_logger.info(
-                    f"Model config indicates vocab_size='{self._model.config.vocab_size}', but found tokenizer with vocab size '{len(self.tokenizer)}'. Resizing model embedding layer..."
+                    f"Model config indicates vocab_size='{vocab_size}', but found tokenizer with vocab size '{len(self.tokenizer)}'. Resizing model embedding layer..."
                 )
                 self._model.resize_token_embeddings(len(self.tokenizer))
             self._model = PeftModel.from_pretrained(

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -354,12 +354,23 @@ class SGLangLM(TemplateLM):
     ) -> Union[List[int], List[List[int]]]:
         if not add_special_tokens:
             add_special_tokens = False or self.add_bos_token
-        encoding: Union[List[List[int]], List[int]] = self.tokenizer(
-            string,
-            add_special_tokens=add_special_tokens,
-            truncation=truncation,
-            return_attention_mask=False,
-        ).input_ids
+        try:
+            encoding: Union[List[List[int]], List[int]] = self.tokenizer(
+                string,
+                add_special_tokens=add_special_tokens,
+                truncation=truncation,
+                return_attention_mask=False,
+            ).input_ids
+        except TypeError as e:
+            if "return_attention_mask" in str(e):
+                # Fallback for tokenizers like MistralTokenizer that don't support return_attention_mask
+                encoding: Union[List[List[int]], List[int]] = self.tokenizer(
+                    string,
+                    add_special_tokens=add_special_tokens,
+                    truncation=truncation,
+                ).input_ids
+            else:
+                raise
 
         # left-truncate the encoded context to be at most `left_truncate_len` tokens long
         if left_truncate_len:

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -343,12 +343,24 @@ class VLLM(TemplateLM):
     ) -> Union[List[int], List[List[int]]]:
         if not add_special_tokens:
             add_special_tokens = False or self.add_bos_token
-        encoding: Union[List[List[int]], List[int]] = self.tokenizer(
-            string,
-            add_special_tokens=add_special_tokens,
-            truncation=truncation,
-            return_attention_mask=False,
-        ).input_ids
+        try:
+            encoding: Union[List[List[int]], List[int]] = self.tokenizer(
+                string,
+                add_special_tokens=add_special_tokens,
+                truncation=truncation,
+                return_attention_mask=False,
+            ).input_ids
+        except TypeError as e:
+            if "return_attention_mask" in str(e):
+                # Fallback for tokenizers like MistralTokenizer that don't support return_attention_mask
+                encoding: Union[List[List[int]], List[int]] = self.tokenizer(
+                    string,
+                    add_special_tokens=add_special_tokens,
+                    truncation=truncation,
+                ).input_ids
+            else:
+                raise
+            
 
         # left-truncate the encoded context to be at most `left_truncate_len` tokens long
         if left_truncate_len:


### PR DESCRIPTION
This PR adds support for evaluating with a Mistral or Pixtral model.

Before this PR, if you try to evaluate with a Mistral or Pixtral model, you will meet issues like [#2731](https://github.com/EleutherAI/lm-evaluation-harness/issues/2731). That results from `MistralTokenizer`, which doesn't implement common methods like `return_attention_mask`, `sep_token` and `pad_token`.