### PR TITLE
Remove gen_prefix space and add warning

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1269,7 +1269,7 @@ class ConfigurableTask(Task):
             elif gen_prefix:
                 prefix = gen_prefix
             else:
-                prefix = " "
+                prefix = ""
             answer_txt = prefix + (a if not isinstance(a, list) else a[0])
             msgs.append(Message("assistant", answer_txt))
         else:


### PR DESCRIPTION
Following [this issue](https://github.com/EleutherAI/lm-evaluation-harness/issues/3231), removed extra space appended to `gen_prefix` in `ContextSampler.get_context` and `ContextSampler.get_chat_context` and added deprecation warnings.
 
Note regarding tests: I added `--ignore=tests/scripts/test_zeno_visualize.py` since these tests weren't working in in `main` already when I tried a clean install.

Fixes #3231 