### PR TITLE
feat(scrolls): delete chat_template from kwargs

### DIFF
--- a/lm_eval/tasks/scrolls/task.py
+++ b/lm_eval/tasks/scrolls/task.py
@@ -256,8 +256,9 @@ class _SCROLLSMultipleChoiceTask(_SCROLLSTask):
             "em": acc_norm * 100.0,
         }
 
-    def construct_requests(self, doc, ctx, **kwargs):
-        apply_chat_template = kwargs.pop("apply_chat_template", False)
+    def construct_requests(
+        self, doc, ctx, chat_template=None, apply_chat_template=False, **kwargs
+    ):
         request_list = [
             Instance(
                 request_type="loglikelihood",
@@ -291,8 +292,9 @@ class _SCROLLSSummaryTask(_SCROLLSTask):
             "rougeL": (results[0], doc["outputs"]),
         }
 
-    def construct_requests(self, doc, ctx, **kwargs):
-        kwargs.pop("apply_chat_template", False)
+    def construct_requests(
+        self, doc, ctx, chat_template=None, apply_chat_template=False, **kwargs
+    ):
         return Instance(
             request_type="generate_until",
             doc=doc,
@@ -334,8 +336,9 @@ class Qasper(_SCROLLSTask):
             prediction = results[0]
         return {"f1": (prediction, doc["outputs"])}
 
-    def construct_requests(self, doc, ctx, **kwargs):
-        apply_chat_template = kwargs.pop("apply_chat_template", False)
+    def construct_requests(
+        self, doc, ctx, chat_template=None, apply_chat_template=False, **kwargs
+    ):
         if doc["is_yes_no"]:
             return [
                 Instance(
@@ -416,8 +419,9 @@ class NarrativeQA(_SCROLLSTask):
     def process_results(self, doc, results):
         return {"f1": (results[0], doc["outputs"])}
 
-    def construct_requests(self, doc, ctx, **kwargs):
-        kwargs.pop("apply_chat_template", False)
+    def construct_requests(
+        self, doc, ctx, chat_template=None, apply_chat_template=False, **kwargs
+    ):
         return Instance(
             request_type="generate_until",
             doc=doc,


### PR DESCRIPTION
## Problem
scrolls tasks doesnt pop chat_template callable from kwargs so Instance raises as error
`TypeError: Instance.__init__() got an unexpected keyword argument 'chat_template'`

## Reproduce bug
```bash
HF_TOKEN=hf_xxx python -m lm_eval --model hf --device cpu --model_args pretrained=trl-internal-testing/tiny-random-LlamaForCausalLM --tasks scrolls_quality --trust_remote_code --limit 2
```

## Solution
change `construct_requests` definition to exclude `chat_template` from kwargs.