### PR TITLE
Add `acc_norm` metric to BLiMP-NL

### DIFF
--- a/lm_eval/tasks/blimp_nl/_template_yaml
+++ b/lm_eval/tasks/blimp_nl/_template_yaml
@@ -10,5 +10,8 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 0


### PR DESCRIPTION
Because the original implementation uses a custom length normalization, it makes sense to include the length-normalized accuracy as implemented in the Harness.