### PR TITLE
Fix: handle optional vllm imports for type checking and runtime

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -43,7 +43,8 @@ except ModuleNotFoundError:
     pass
 
 if TYPE_CHECKING:
-    pass
+    from vllm import SamplingParams
+    from vllm.lora.request import LoRARequest
 
 eval_logger = logging.getLogger(__name__)
 
@@ -364,7 +365,7 @@ class VLLM(TemplateLM):
         self,
         requests: List[List[int]] = None,
         generate: bool = False,
-        sampling_params: Union[List[SamplingParams], SamplingParams, None] = None,
+        sampling_params: "Union[List[SamplingParams], SamplingParams, None]" = None,
     ):
         if not generate or sampling_params is None:
             sampling_params = SamplingParams(
@@ -379,7 +380,7 @@ class VLLM(TemplateLM):
             @ray.remote
             def run_inference_one_model(
                 model_args: dict,
-                sampling_params: List[SamplingParams],
+                sampling_params: "List[SamplingParams]",
                 requests: List[List[int]],
                 lora_request: LoRARequest,
             ):


### PR DESCRIPTION
- Import vllm modules in a try/except block to prevent runtime errors if vllm is not installed.
- Move type-only imports (SamplingParams, LoRARequest, etc.) under `if TYPE_CHECKING:` to support static analysis without requiring vllm at runtime.
- Use forward references (string annotations) for vllm types in function signatures to avoid NameError if vllm is missing.
- Ensures the codebase supports both type checking and optional use of vllm features without blocking execution.