### PR TITLE
Fix: VLLM model when data_parallel_size>1

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -419,7 +419,7 @@ class VLLM(TemplateLM):
             procs, resq = [], Queue()
             # We use Process as it is non-daemonic
             try:
-                for rank, (sp, req) in enumerate(zip(requests, sampling_params)):
+                for rank, (req, sp) in enumerate(zip(requests, sampling_params)):
                     proc = Process(
                         target=_vllm_mp_worker,
                         args=(


### PR DESCRIPTION
When data_parallel_size>1 using vllm, minor bug during iteration.