### PR TITLE
Adding New Task SLR-Bench : Scalable Logical Reasoning Benchmark

### DIFF
--- a/lm_eval/tasks/slr_bench/README.md
+++ b/lm_eval/tasks/slr_bench/README.md
@@ -1,6 +1,6 @@
 # SLR-Bench
 
-SLR-Bench is a benchmark for scalable logical reasoning with language models. The tasks require generating Prolog rules that correctly classify train compositions.
+SLR-Bench is a benchmark for scalable logical reasoning with language models. The tasks require generating Prolog rules that correctly classify trains based on their compositions.
 
 ### Paper
 
@@ -8,6 +8,18 @@ Title: `SLR: Automated Synthesis for Scalable Logical Reasoning`
 
 Abstract: [https://arxiv.org/abs/2506.15787](https://arxiv.org/abs/2506.15787)
 
+### Dataset
+
+The complete dataset can be found at:
+[https://huggingface.co/datasets/AIML-TUDA/SLR-Bench](https://huggingface.co/datasets/AIML-TUDA/SLR-Bench)
+
+### Verifier
+
+- Generated rules are evaluated using a symbolic verifier (`AIML-TUDA/VerifiableRewardsForScalableLogicalReasoning`).
+
+###  Automated Synthesis Framework to Generate new Tasks
+
+[https://github.com/ml-research/ScalableLogicalReasoning](https://github.com/ml-research/ScalableLogicalReasoning)
 
 ## Prerequisites
 
@@ -15,8 +27,7 @@ Abstract: [https://arxiv.org/abs/2506.15787](https://arxiv.org/abs/2506.15787)
 
 #### Tasks
 
-
-The following variants are available (by difficulty and scope):
+The following variants are available:
 
 - `slr_bench_all` &mdash; Full dataset (`v1-All`)
 - `slr_bench_basic` &mdash; Basic subset (`v1-Basic`)
@@ -24,19 +35,16 @@ The following variants are available (by difficulty and scope):
 - `slr_bench_medium` &mdash; Medium subset (`v1-Medium`)
 - `slr_bench_hard` &mdash; Hard subset (`v1-Hard`)
 
-## Notes
-
-- Generated rules are evaluated using a symbolic verifier (`AIML-TUDA/VerifiableRewardsForScalableLogicalReasoning`).
 
 ## Citation
 ```
 @misc{helff2025slrautomatedsynthesisframework,
-      title={SLR: An Automated Synthesis Framework for Scalable Logical Reasoning}, 
+      title={SLR: An Automated Synthesis Framework for Scalable Logical Reasoning},
       author={Lukas Helff and Ahmad Omar and Felix Friedrich and Wolfgang Stammer and Antonia Wüst and Tim Woydt and Rupert Mitchell and Patrick Schramowski and Kristian Kersting},
       year={2025},
       eprint={2506.15787},
       archivePrefix={arXiv},
       primaryClass={cs.AI},
-      url={https://arxiv.org/abs/2506.15787}, 
+      url={https://arxiv.org/abs/2506.15787},
 }
 ```

--- a/lm_eval/tasks/slr_bench/README.md
+++ b/lm_eval/tasks/slr_bench/README.md
@@ -1,0 +1,42 @@
+# SLR-Bench
+
+SLR-Bench is a benchmark for scalable logical reasoning with language models. The tasks require generating Prolog rules that correctly classify train compositions.
+
+### Paper
+
+Title: `SLR: Automated Synthesis for Scalable Logical Reasoning`
+
+Abstract: [https://arxiv.org/abs/2506.15787](https://arxiv.org/abs/2506.15787)
+
+
+## Prerequisites
+
+- **SWI-Prolog**: Required for evaluating generated rules. Make sure `swipl` is installed and available in your system PATH.
+
+#### Tasks
+
+
+The following variants are available (by difficulty and scope):
+
+- `slr_bench_all` &mdash; Full dataset (`v1-All`)
+- `slr_bench_basic` &mdash; Basic subset (`v1-Basic`)
+- `slr_bench_easy` &mdash; Easy subset (`v1-Easy`)
+- `slr_bench_medium` &mdash; Medium subset (`v1-Medium`)
+- `slr_bench_hard` &mdash; Hard subset (`v1-Hard`)
+
+## Notes
+
+- Generated rules are evaluated using a symbolic verifier (`AIML-TUDA/VerifiableRewardsForScalableLogicalReasoning`).
+
+## Citation
+```
+@misc{helff2025slrautomatedsynthesisframework,
+      title={SLR: An Automated Synthesis Framework for Scalable Logical Reasoning}, 
+      author={Lukas Helff and Ahmad Omar and Felix Friedrich and Wolfgang Stammer and Antonia Wüst and Tim Woydt and Rupert Mitchell and Patrick Schramowski and Kristian Kersting},
+      year={2025},
+      eprint={2506.15787},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2506.15787}, 
+}
+```

--- a/lm_eval/tasks/slr_bench/lm_eval_slr_bench.py
+++ b/lm_eval/tasks/slr_bench/lm_eval_slr_bench.py
@@ -1,0 +1,52 @@
+from evaluate import load
+import shutil
+import sys
+
+if shutil.which("swipl") is None:
+    sys.exit("Error: SWI-Prolog (swipl) is not installed or not in PATH. Please install SWI-Prolog to use this task.")
+
+try:
+    symbolic_judge = load("AIML-TUDA/VerifiableRewardsForScalableLogicalReasoning")
+except Exception as e:
+    print(f"Warning: Could not load VerifiableRewards: {e}")
+    symbolic_judge = None
+
+def process_results(doc, results):
+    """
+    Process results for the SLR-Bench task.
+    
+    Args:
+        doc: Document with ground truth and validation program
+        results: Model output (generated text)
+    
+    Returns:
+        Dictionary with metrics
+    """
+
+    prediction = results[0]
+
+    # Create the reference in the required format
+    try:
+        reference = [{
+            "validation_program": doc.get("validation program", ""),
+            "evaluation_config": {
+                "positive_predicate": "eastbound",
+                "negative_predicate": "westbound"
+            }
+        }]
+        
+        # Use symbolic judge if available
+        if symbolic_judge is not None:
+            results = symbolic_judge.compute(predictions=[prediction], references=reference)
+            
+            if isinstance(results, dict) and 'accuracy' in results:
+                return {"verifiable_reward": results['accuracy']}
+
+        # Fallback: exact match
+        target = doc.get("ground-truth rule", "")
+        exact_match = float(prediction.strip() == target.strip())
+        return {"verifiable_reward": exact_match}
+        
+    except Exception as e:
+        print(f"Error in process_results: {e}")
+        return {"verifiable_reward": 0.0}

--- a/lm_eval/tasks/slr_bench/slr_bench_all.yaml
+++ b/lm_eval/tasks/slr_bench/slr_bench_all.yaml
@@ -1,0 +1,3 @@
+dataset_name: v1-All
+include: slr_bench_common_yaml
+task: slr_bench_all

--- a/lm_eval/tasks/slr_bench/slr_bench_basic.yaml
+++ b/lm_eval/tasks/slr_bench/slr_bench_basic.yaml
@@ -1,0 +1,3 @@
+dataset_name: v1-Basic
+include: slr_bench_common_yaml
+task: slr_bench_basic

--- a/lm_eval/tasks/slr_bench/slr_bench_common_yaml
+++ b/lm_eval/tasks/slr_bench/slr_bench_common_yaml
@@ -1,0 +1,17 @@
+# SLR-Bench Task Definition
+dataset_path: AIML-TUDA/SLR-Bench
+dataset_name: null
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "{{prompt}}"
+doc_to_target: "{{['ground-truth rule']}}"
+generation_kwargs:
+  until: ["\n\n\n"]  
+process_results: !function lm_eval_slr_bench.process_results
+metric_list:
+  - metric: verifiable_reward
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slr_bench/slr_bench_easy.yaml
+++ b/lm_eval/tasks/slr_bench/slr_bench_easy.yaml
@@ -1,0 +1,3 @@
+dataset_name: v1-Easy
+include: slr_bench_common_yaml
+task: slr_bench_easy

--- a/lm_eval/tasks/slr_bench/slr_bench_group.yaml
+++ b/lm_eval/tasks/slr_bench/slr_bench_group.yaml
@@ -1,0 +1,13 @@
+group: slr_bench_group
+task:
+  - slr_bench_all
+  - slr_bench_basic
+  - slr_bench_easy
+  - slr_bench_medium
+  - slr_bench_hard
+metric_list:
+  - metric: verifiable_reward
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slr_bench/slr_bench_hard.yaml
+++ b/lm_eval/tasks/slr_bench/slr_bench_hard.yaml
@@ -1,0 +1,3 @@
+dataset_name: v1-Hard
+include: slr_bench_common_yaml
+task: slr_bench_hard

--- a/lm_eval/tasks/slr_bench/slr_bench_medium.yaml
+++ b/lm_eval/tasks/slr_bench/slr_bench_medium.yaml
@@ -1,0 +1,3 @@
+dataset_name: v1-Medium
+include: slr_bench_common_yaml
+task: slr_bench_medium


### PR DESCRIPTION
In This PR we would like to add the SLR-Bench task to the lm-evaluation-harness.

SLR-Bench is a large-scale benchmark for scalable logical reasoning with language models, comprising 19,000 prompts organized into 20 curriculum levels. The tasks progressively increase in relational, arithmetic, and recursive complexity, requiring models to synthesize Prolog rules that classify train compositions.

More information can be found in the paper: [SLR: Automated Synthesis for Scalable Logical Reasoning](https://arxiv.org/abs/2506.15787)