### PR TITLE
Remove literal <image> tokens from ChartQA dataset

### DIFF
--- a/lm_eval/tasks/chartqa/chartqa.yaml
+++ b/lm_eval/tasks/chartqa/chartqa.yaml
@@ -5,7 +5,7 @@ task: chartqa
 doc_to_image:
   - image
 doc_to_text: |
-  <image>{{query}}
+  {{query}}
   Analyze the image and question carefully, using step-by-step reasoning.
   First, describe any image provided in detail. Then, present your reasoning. And finally your final answer in this format:
   Final Answer: <answer>
@@ -35,4 +35,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/chartqa/chartqa_llama.yaml
+++ b/lm_eval/tasks/chartqa/chartqa_llama.yaml
@@ -1,3 +1,3 @@
 include: chartqa.yaml
-doc_to_text: "<image>You are provided a chart image and will be asked a question. You have to think through your answer and provide a step-by-step solution. Once you have the solution, write the final answer in at most a few words at the end with the phrase \"FINAL ANSWER:\". The question is: {{query}}\nLet's think step by step."
+doc_to_text: "You are provided a chart image and will be asked a question. You have to think through your answer and provide a step-by-step solution. Once you have the solution, write the final answer in at most a few words at the end with the phrase \"FINAL ANSWER:\". The question is: {{query}}\nLet's think step by step."
 task: chartqa_llama

--- a/lm_eval/tasks/chartqa/chartqa_llama_90.yaml
+++ b/lm_eval/tasks/chartqa/chartqa_llama_90.yaml
@@ -1,7 +1,7 @@
 include: chartqa_llama.yaml
 task: chartqa_llama_90
 doc_to_text: |
-  <image>You are provided a chart image and will be asked a question. Follow these steps carefully:
+  You are provided a chart image and will be asked a question. Follow these steps carefully:
   Step 1: Analyze the question to understand what specific data or information is being asked for. Focus on whether the question is asking for a specific number or category from the chart image.
   Step 2: Identify any numbers, categories, or groups mentioned in the question and take note of them. Focus on detecting and matching them directly to the image.
   Step 3: Study the image carefully and find the relevant data corresponding to the categories or numbers mentioned. Avoid unnecessary assumptions or calculations; simply read the correct data from the image.


### PR DESCRIPTION
This PR removes `<image>` placeholder strings from the ChartQA prompt text. 
The server should handle image token insertion, not the client.

Different models use different image tokens - LLaVA uses `<image>`, Qwen-VL uses `<img>` tags etc. 
The server knows which model it's serving and has the processor that knows how to tokenize for that specific model. Image token placement also varies - some models want it inline, others prepend it, others have special handling.