### PR TITLE
Fixes bugs when using gpt series model

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -337,7 +337,12 @@ class OpenAIChatCompletion(LocalChatCompletion):
             "seed": seed,
             **gen_kwargs,
         }
-        if "o1" in self.model or "5" in self.model or "o3" in self.model or "o4" in self.model:
+        if (
+            "o1" in self.model
+            or "5" in self.model
+            or "o3" in self.model
+            or "o4" in self.model
+        ):
             output.pop("stop")
             output["temperature"] = 1
         return output


### PR DESCRIPTION
Fixes bugs when using GPT models like:
```python
lm_eval --model openai-chat-completions \
    --model_args pretrained=gpt-4.1 \   
    --tasks mmlu_pro --limit 10 --apply_chat_template
```
and fixes support for o3 and o4-mini

Original implementation will result in errors like:
```
TypeError: lm_eval.models.openai_completions.LocalCompletionsAPI.__init__() got multiple values for keyword argument 'tokenizer_backend'

WARNING:lm_eval.models.api_models:API request failed with error message: {
  "error": {
    "message": "Unsupported parameter: 'stop' is not supported with this model.",
    "type": "invalid_request_error",
    "param": "stop",
    "code": "unsupported_parameter"
  }
}. Retrying...
```