### PR TITLE
[fix] crows_pairs dataset

### DIFF
--- a/lm_eval/tasks/crows_pairs/crows_pairs_english.yaml
+++ b/lm_eval/tasks/crows_pairs/crows_pairs_english.yaml
@@ -1,7 +1,7 @@
 tag:
   - crows_pairs
 task: crows_pairs_english
-dataset_path: BigScienceBiasEval/crows_pairs_multilingual
+dataset_path: jannalu/crows_pairs_multilingual
 dataset_name: english
 test_split: test
 output_type: multiple_choice


### PR DESCRIPTION
## What does this PR do
`crows_pairs` uses `trust_remote_code` per issue #3171, and I converted the dataset using the `datasets-cli convert_to_parquet BigScienceBiasEval/crows_pairs_multilingual` [utility](https://github.com/EleutherAI/lm-evaluation-harness/issues/3171#issuecomment-3453330918) and re-uploaded the dataset.