### PR TITLE
feat: refine Chain-of-Thought removal logic

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -290,6 +290,12 @@ def setup_parser() -> argparse.ArgumentParser:
         default=None,
         help="""JSON string metadata to pass to task configs, for example '{"max_seq_lengths":[4096,8192]}'. Will be merged with model_args. Can also be set in task config.""",
     )
+    parser.add_argument(
+        "--think_tokens",
+        type=try_parse_json,
+        default=None,
+        help="""JSON string defining the start and end tokens for 'thinking' steps, e.g., '{"think_start_token":"<think>","think_end_token":"</think>"}'"""
+    )
     return parser
 
 
@@ -357,6 +363,9 @@ def cli_evaluate(args: Union[argparse.Namespace, None] = None) -> None:
         if isinstance(args.metadata, dict)
         else simple_parse_args_string(args.metadata)
     )
+
+    if args.think_tokens is not None:
+        metadata["think_tokens"] = args.think_tokens
 
     task_manager = TaskManager(include_path=args.include_path, metadata=metadata)
 

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -238,8 +238,7 @@ class Task(abc.ABC):
         self._instances: Optional[List[Instance]] = None
 
         self._config: TaskConfig = TaskConfig({**config}) if config else TaskConfig()
-
-        self._filters = [build_filter_ensemble("none", [["take_first", None]])]
+        self._filters = [build_filter_ensemble("none", [["take_first", None]], self._config.metadata["think_tokens"])]
         self.fewshot_rnd: Optional[random.Random] = (
             None  # purposely induce errors in case of improper usage
         )
@@ -877,14 +876,14 @@ class ConfigurableTask(Task):
                         key: function[key] for key in function if key != "function"
                     }
                     components.append([function["function"], kwargs])
-                filter_pipeline = build_filter_ensemble(filter_name, components)
+                filter_pipeline = build_filter_ensemble(filter_name, components, self._config.metadata["think_tokens"])
                 self._filters.append(filter_pipeline)
         else:
             # TODO: handle repeats in a more general way rather than just discarding
             eval_logger.debug(
                 "No custom filters defined. Using default 'take_first' filter for handling repeats."
             )
-            self._filters = [build_filter_ensemble("none", [["take_first", None]])]
+            self._filters = [build_filter_ensemble("none", [["take_first", None]], self._config.metadata["think_tokens"])]
 
         if self.config.use_prompt is not None:
             eval_logger.info(f"loading prompt {self.config.use_prompt}")
@@ -1582,7 +1581,6 @@ class ConfigurableTask(Task):
             # retrieve choices in List[str] form, to compute choice lengths, etc.
             choices = self.doc_to_choice(doc)
             completion_len = np.array([float(len(i)) for i in choices])
-            byte_length = np.array([float(len(i.encode("utf-8"))) for i in choices])
 
             if (
                 2 * len(choices) == len(lls)
@@ -1599,7 +1597,6 @@ class ConfigurableTask(Task):
 
             pred = np.argmax(lls)
             pred_norm = np.argmax(lls / completion_len)
-            pred_byte = np.argmax(lls / byte_length)
 
             if self.multiple_input:
                 gold = self.doc_to_text(doc)
@@ -1629,12 +1626,10 @@ class ConfigurableTask(Task):
             if self.multiple_target:
                 acc = 1.0 if pred in gold else 0.0
                 acc_norm = 1.0 if pred_norm in gold else 0.0
-                acc_bytes = 1.0 if pred_byte in gold else 0.0
                 exact_match = int(any([is_greedy[i] if i != -100 else 0 for i in gold]))
             else:
                 acc = 1.0 if pred == gold else 0.0
                 acc_norm = 1.0 if pred_norm == gold else 0.0
-                acc_bytes = 1.0 if pred_byte == gold else 0.0
                 # TODO: this gets score of 0 on arc_challenge for pythia-70m. need to test that this works properly
                 exact_match = int(is_greedy[gold]) if gold != -100 else 0
 
@@ -1647,7 +1642,6 @@ class ConfigurableTask(Task):
                 **({"f1": (gold, pred)} if "f1" in use_metric else {}),
                 **({"mcc": (gold, pred)} if "mcc" in use_metric else {}),
                 **({"acc_norm": acc_norm} if "acc_norm" in use_metric else {}),
-                **({"acc_bytes": acc_bytes} if "acc_bytes" in use_metric else {}),
                 **({"exact_match": exact_match} if "exact_match" in use_metric else {}),
                 **(
                     {"brier_score": (gold, prob_norm)}

--- a/lm_eval/filters/__init__.py
+++ b/lm_eval/filters/__init__.py
@@ -8,7 +8,7 @@ from . import custom, extraction, selection, transformation
 
 
 def build_filter_ensemble(
-    filter_name: str, components: List[List[str]]
+    filter_name: str, components: List[List[str]], think_tokens: dict
 ) -> FilterEnsemble:
     """
     Create a filtering pipeline.
@@ -22,4 +22,4 @@ def build_filter_ensemble(
         # add the filter as a pipeline step
         filters.append(f)
 
-    return FilterEnsemble(name=filter_name, filters=filters)
+    return FilterEnsemble(name=filter_name, filters=filters, think_tokens=think_tokens)


### PR DESCRIPTION
### Description

This PR introduces an update to the "think" tokens (Chain of Thought) stripping logic, primarily to handle cases where a model fails to complete its thought process. #3382

It allows users to provide `think_start_token` and `think_end_token` via command-line arguments. The logic is as follows:

1.  **If `think_end_token` is found** in the raw response: The behavior is consistent with the existing logic, and the think chain portion is stripped as expected.
2.  **If `think_end_token` is NOT found, but `think_start_token` is found:** This is treated as an incomplete thought process. The logic will now strip the first `think_start_token` and **all content that follows it**.

Additionally, this PR modifies the logging behavior. The `resp` field in the log will now store the **complete, original model response** rather than the response *after* the think chain has been stripped. #3196

### Notes & Known Issues

* The original think chain removal logic has **not** been removed in this PR.
* Currently, the `think_tokens` information is passed via a predefined `metadata` parameter.
* There is a known issue where the stripping logic may execute multiple times. While this is redundant, it does not currently introduce a bug.

This PR is intended as an **interim solution** to address the immediate issue. We hope to implement a more robust, clean, and stylistically consistent solution in the future.