### PR TITLE
fix(gsm8k): align README to yaml file

### DIFF
--- a/lm_eval/tasks/gsm8k/README.md
+++ b/lm_eval/tasks/gsm8k/README.md
@@ -41,7 +41,7 @@ Homepage: https://github.com/openai/grade-school-math
 
 #### Tasks
 
-- `gsm8k_yaml`
+- `gsm8k`
 - `gsm8k_cot`: GSM8K with Chain-of-Thought
 - `gsm8k_cot_self_consistency`: GSM8K with Chain-of-Thought and Self-Consistency
 - `gsm8k_cot_llama`: GSM8K with prompt formatting modified to conform to the evaluation settings described by Meta here: https://huggingface.co/datasets/meta-llama/Meta-Llama-3.1-8B-Instruct-evals/viewer/Meta-Llama-3.1-8B-Instruct-evals__gsm8k__details?row=0


### PR DESCRIPTION
This is a minor fix to `gsm8k/README.md`, correcting the incorrect reference to `gsm8k_yaml` and replacing it with the proper name `gsm8k`.