### PR TITLE
[bugfix] additional_config parsing

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -169,9 +169,11 @@ class LM(abc.ABC):
         - Instance of the LM class.
         """
 
-        additional_config = additional_config or {} | {
-            k: v for k, v in additional_config.items() if v is not None
-        }
+        additional_config = (
+            {}
+            if additional_config is None
+            else {k: v for k, v in additional_config.items() if v is not None}
+        )
 
         return cls(**arg_dict, **additional_config)
 


### PR DESCRIPTION
The current parsing logic for `additional_config` in `create_from_arg_obj` is incorrect and causes the following snippet to fail on main:

```python
import lm_eval

MODEL_ID = "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"

results = lm_eval.simple_evaluate(
    model="hf",
    model_args={
        "pretrained": MODEL_ID,
        "add_bos_token": True,
        "dtype": "auto",
    },
    tasks=[
        "arc_challenge_llama",
    ],
    limit=10,
)
print(lm_eval.utils.make_table(results))
```
with logs
```
File "/home/brian-dellabetta/projects/_scratch/lmevalrun.py", line 6, in <module>
    results = lm_eval.simple_evaluate(
  File "/home/brian-dellabetta/projects/.venv/lib/python3.10/site-packages/lm_eval/utils.py", line 458, in _wrapper
    return fn(*args, **kwargs)
  File "/home/brian-dellabetta/projects/.venv/lib/python3.10/site-packages/lm_eval/evaluator.py", line 230, in simple_evaluate
    lm = lm_eval.api.registry.get_model(model).create_from_arg_obj(
  File "/home/brian-dellabetta/projects/.venv/lib/python3.10/site-packages/lm_eval/api/model.py", line 176, in create_from_arg_obj
    return cls(**arg_dict, **additional_config)
  File "/home/brian-dellabetta/projects/.venv/lib/python3.10/site-packages/lm_eval/models/huggingface.py", line 125, in __init__
    assert isinstance(device, str)
```
because device is None. 

This resolves the logic to prune any key-value pairs in the config where value is None.