### PR TITLE
Fixes #3391 avoid error on no-output

### DIFF
--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -38,6 +38,8 @@ class RegexFilter(Filter):
         def filter_set(inst):
             filtered = []
             for resp in inst:
+                if not isinstance(resp, str):
+                    resp = ""
                 match = self.regex.findall(resp)
                 if match:
                     match = match[self.group_select]
@@ -159,6 +161,8 @@ class MultiChoiceRegexFilter(RegexFilter):
         # independently (and keep them a list.)
 
         def find_match(regex, resp, convert_dict={}):
+            if not isinstance(resp, str):
+                resp = ""
             match = regex.findall(resp)
             if match:
                 match = match[self.group_select]


### PR DESCRIPTION
Thinking models can fail due to reasons:
- Reasoning tokens > limit
- No output field, might be because response is within reasoning tokens

As #3391 shows, this causes a hard crash when it can just be marked as wrong. This PR thus:
1. Checks if `resp` is a string
2. If not, `resp = ""`
