### PR TITLE
Resolve deprecation of `vllm.utils.get_open_port`

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -47,7 +47,7 @@ try:
         # Moved since vllm-project/vllm#27164
         from vllm.utils.network_utils import get_open_port
     except ModuleNotFoundError:
-        from vllm.network_utils import get_open_port
+        from vllm.utils import get_open_port
 except ModuleNotFoundError:
     pass
 


### PR DESCRIPTION
`vllm.utils.get_open_port` was moved to `vllm.utils.network_utils.get_open_port` in https://github.com/vllm-project/vllm/pull/27164 with a compatibility warning for the old import, let's update lm-eval code to use the new import.