### PR TITLE
Fix wrong `gpqa_diamond_generative_n_shot` answer template

### DIFF
--- a/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
@@ -6,9 +6,11 @@ training_split: train
 # Because huggingface dataset only has train split
 validation_split: train
 test_split: null
-description: "Here are some example questions from experts. Answer the final question yourself, following the format of the previous questions exactly.\n"
+description: "Here are some example questions from experts. Answer the final question yourself, following the format of the previous questions exactly, that is finish your answer with \"The answer is (X).\" where X is the correct letter choice.\n"
 doc_to_text: "Question: {{Question}}\nChoices:\n(A) {{choice1}}\n(B) {{choice2}}\n(C) {{choice3}}\n(D) {{choice4}}\nAnswer:"
 doc_to_target: answer
+fewshot_config:
+  doc_to_target: "The answer is {{answer}}."
 filter_list:
   - name: "strict-match"
     filter:


### PR DESCRIPTION
As per title.

Fixes https://github.com/EleutherAI/lm-evaluation-harness/issues/3404, see the context there.

Running

```bash
LOGLEVEL=debug CUDA_VISIBLE_DEVICES=0 lm_eval \
  --model hf \
  --model_args '{"pretrained":"/models/openai_gpt-oss-20b","dtype":"auto","chat_template_args":{"reasoning_effort":"low"},"enable_thinking": true,"think_end_token":200008}' \
  --device "cuda" \
  --gen_kwargs max_gen_toks=4048 \
  --tasks gpqa_diamond_generative_n_shot \
  --apply_chat_template \
  --fewshot_as_multiturn \
  --log_samples \
  --output_path debug_gpqa \
  --num_fewshot 5 \
  --batch_size 16
```

on `main` gives:

```
|            Tasks             |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|------------------------------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gpqa_diamond_generative_n_shot|      2|flexible-extract|     5|exact_match|↑  |0.5455|±  |0.0355|
|                              |       |strict-match    |     5|exact_match|↑  |0.0000|±  |0.0000|
```

and with this fix gives:

```
|            Tasks             |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|------------------------------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gpqa_diamond_generative_n_shot|      2|flexible-extract|     5|exact_match|↑  |0.5303|±  |0.0356|
|                              |       |strict-match    |     5|exact_match|↑  |0.5000|±  |0.0356|
```

NOTE: I also modified the `description` as I noticed certain models (gpt-oss-20b) do not necessarily obey the instruction `following the format of the previous questions exactly`, although the n-shot answer format is correct.


cc @baberabb 