### PR TITLE
Trim whitespace in remove_whitespace filter

### DIFF
--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -105,13 +105,13 @@ class POSFilter(Filter):
 
 @register_filter("remove_whitespace")
 class WhitespaceFilter(Filter):
-    """Filters out leading whitespace from responses."""
+    """Filters out leading and trailing whitespace from responses."""
 
     def apply(self, resps: list[list[str]], docs: list[dict]) -> list[list[str]]:
         def filter_set(inst):
             filtered_resp = []
             for resp in inst:
-                resp = resp.lstrip()
+                resp = resp.strip()
                 filtered_resp.append(resp)
             return filtered_resp
 


### PR DESCRIPTION
Fix #3399 

Fixes a drop in TriviaQA EM caused by trailing whitespace in model predictions. This PR updates the `remove_whitespace` filter to strip both leading and trailing whitespace, ensuring normalized outputs match ground-truth aliases correctly.