### PR TITLE
[MMLU redux] Do not use samples which do not have `error_type="ok"`

### DIFF
--- a/lm_eval/tasks/mmlu-redux/generative/README.md
+++ b/lm_eval/tasks/mmlu-redux/generative/README.md
@@ -57,5 +57,7 @@ If other tasks on this dataset are already supported:
 - [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
 - [ ] Have you noted which, if any, published evaluation setups are matched by this variant?
 
-ver 1: PR #2705
-First implementation
+
+
+- version 3: First implementation from PR https://github.com/EleutherAI/lm-evaluation-harness/pull/2705.
+- version 4: Filter out the answers not marked as `error_type="ok"` in https://github.com/EleutherAI/lm-evaluation-harness/pull/3410 (~6.5% of questions, 370 out of 5700 are filtered out).

--- a/lm_eval/tasks/mmlu-redux/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu-redux/generative/_default_template_yaml
@@ -29,4 +29,4 @@ filter_list:
       - function: take_first
 
 metadata:
-  version: 3.0
+  version: 4.0

--- a/lm_eval/tasks/mmlu-redux/generative/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu-redux/generative/_mmlu.yaml
@@ -30,4 +30,4 @@ aggregate_metric_list:
     metric: exact_match
     weight_by_size: true
 metadata:
-  version: 3
+  version: 4


### PR DESCRIPTION
As per title.

Fixes https://github.com/EleutherAI/lm-evaluation-harness/issues/3409

See the dataset description at https://huggingface.co/datasets/fxmarty/mmlu-redux-2.0-ok

cc @baberabb 