### PR TITLE
Fix `gsm8k_platinum` description

### DIFF
--- a/lm_eval/tasks/gsm8k_platinum/gsm8k-platinum.yaml
+++ b/lm_eval/tasks/gsm8k_platinum/gsm8k-platinum.yaml
@@ -43,4 +43,4 @@ filter_list:
         regex_pattern: "(-?[$0-9.,]{2,})|(-?[0-9]+)"
       - function: "take_first"
 metadata:
-  version: 3.0
+  version: 4.0


### PR DESCRIPTION
As per title, this is in the same line as https://github.com/EleutherAI/lm-evaluation-harness/pull/2924. We prompt the model with previous examples, but actually not give any instruction to answer the last question / follow the format of example answers, this is not great.

I take inspiration from https://github.com/EleutherAI/lm-evaluation-harness/blob/fcddf195ec6bb69c63e36d54d75354f6ecaabab7/lm_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml#L9.

The resolves https://github.com/EleutherAI/lm-evaluation-harness/issues/2707

cc @baberabb 

cc @Qubitium FYI, probably interesting to you as well.

For reference, on `main`:

```
hf ({'pretrained': '/models/openai_gpt-oss-20b', 'dtype': 'auto', 'chat_template_args': {'reasoning_effort': 'low'}, 'enable_thinking': True, 'think_end_token': 200008}), gen_kwargs: (max_gen_toks=4048), limit: None, num_fewshot: None, batch_size: 16
|    Tasks     |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|--------------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_platinum|      3|flexible-extract|     5|exact_match|↑  |0.8983|±  |0.0087|
|              |       |strict-match    |     5|exact_match|↑  |0.0596|±  |0.0068|
```

With this PR:

```
hf ({'pretrained': '/models/openai_gpt-oss-20b', 'dtype': 'auto', 'chat_template_args': {'reasoning_effort': 'low'}, 'enable_thinking': True, 'think_end_token': 200008}), gen_kwargs: (max_gen_toks=4048), limit: None, num_fewshot: None, batch_size: 16
|    Tasks     |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|--------------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_platinum|      3|flexible-extract|     5|exact_match|↑  |0.9404|±  |0.0068|
|              |       |strict-match    |     5|exact_match|↑  |0.7072|±  |0.0131|
```