### PR TITLE
Replace deprecated torch_dtype parameter with dtype

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -628,7 +628,7 @@ class HFLM(TemplateLM):
             self._model = self.AUTO_MODEL_CLASS.from_pretrained(
                 pretrained,
                 revision=revision,
-                torch_dtype=get_dtype(dtype),
+                dtype=get_dtype(dtype),
                 trust_remote_code=trust_remote_code,
                 gguf_file=gguf_file,
                 quantization_config=quantization_config,
@@ -712,7 +712,7 @@ class HFLM(TemplateLM):
             _model_delta = self.AUTO_MODEL_CLASS.from_pretrained(
                 delta,
                 revision=revision,
-                torch_dtype=get_dtype(dtype),
+                dtype=get_dtype(dtype),
                 trust_remote_code=trust_remote_code,
                 **model_kwargs,
             )

--- a/lm_eval/models/optimum_ipex.py
+++ b/lm_eval/models/optimum_ipex.py
@@ -73,7 +73,7 @@ class IPEXLM(HFLM):
         self._model = IPEXModelForCausalLM.from_pretrained(
             pretrained,
             revision=revision,
-            torch_dtype=get_dtype(dtype),
+            dtype=get_dtype(dtype),
             trust_remote_code=trust_remote_code,
             **model_kwargs,
         )


### PR DESCRIPTION
## Motivation
- Transformers 4.56.0 (released 2024‑11‑05, see https://newreleases.io/project/pypi/transformers/release/4.56.0) deprecated `torch_dtype` and now prints:
  `UserWarning: torch_dtype is deprecated! Use dtype instead!`
- Any harness run that instantiates `HFLM` or `IPEXLM` logs that warning once per worker, so long evaluations spam the same message.

## Changes
- `lm_eval/models/huggingface.py`: call `from_pretrained(..., dtype=get_dtype(dtype))` in the main load path and the delta-load path.
- `lm_eval/models/optimum_ipex.py`: same change for the IPEX loader.
- CLI stays the same; users still pass `dtype` via `--model_args`.


