### PR TITLE
Fix pretty_print_task for external custom task configs

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -680,7 +680,10 @@ def get_task_dict(
         yaml_path = task_manager.task_index[task_name]["yaml_path"]
         yaml_path = Path(yaml_path)
         lm_eval_tasks_path = Path(__file__).parent
-        relative_yaml_path = yaml_path.relative_to(lm_eval_tasks_path)
+        try:
+            relative_yaml_path = yaml_path.relative_to(lm_eval_tasks_path)
+        except ValueError:
+            relative_yaml_path = yaml_path
 
         pad = "  " * indent
         eval_logger.info(f"{pad}Task: {task_name} ({relative_yaml_path})")


### PR DESCRIPTION
Fix issue number: #3435

This pull request fixes a cosmetic bug in `get_task_dict` / `pretty_print_task` in `lm_eval/tasks/__init__.py`, where `lm_eval` would crash when loading custom task configs that live outside the `lm_eval/tasks/` directory.

The root cause is the following line:

```python
relative_yaml_path = yaml_path.relative_to(lm_eval_tasks_path)
```

This assumes that every task's yaml_path is a subpath of `lm_eval/tasks/`. For external/custom configs in user project directories, this raises:

> ValueError: '<path/to/custom.yaml>' is not in the subpath of '<path/to/lm_eval/tasks>' OR one path is relative and the other is absolute.

Since this is only used for logging/pretty-printing selected tasks, the crash is unnecessary and breaks previously valid usage patterns.

### What this PR changes

Makes `pretty_print_task` robust to external YAML paths by falling back to the original path when `relative_to()` fails.