### PR TITLE
Fix model mapping for anthropic-chat and anthropic-chat-completions

### DIFF
--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -23,8 +23,8 @@ Adding New Models
 """
 
 MODEL_MAPPING = {
-    "anthropic-chat": "lm_eval.models.anthropic_llms:AnthropicChatLM",
-    "anthropic-chat-completions": "lm_eval.models.anthropic_llms:AnthropicCompletionsLM",
+    "anthropic-chat": "lm_eval.models.anthropic_llms:AnthropicChat",
+    "anthropic-chat-completions": "lm_eval.models.anthropic_llms:AnthropicChat",
     "anthropic-completions": "lm_eval.models.anthropic_llms:AnthropicLM",
     "dummy": "lm_eval.models.dummy:DummyLM",
     "ggml": "lm_eval.models.gguf:GGUFLM",


### PR DESCRIPTION
Previous values for "anthropic-chat" and "anthropic-chat-completions" in `models/__init__.py` did not exist, and thus would raise ValueErrors. I swapped them out with the correct class, namely "lm_eval.models.anthropic_llms:AnthropicChat", see its decorator below:

```
@register_model("anthropic-chat", "anthropic-chat-completions")
class AnthropicChat(LocalCompletionsAPI):
    def __init__(
```

With this change, calling the Anthropic chat API works.