### PR TITLE
fix: handle a=0 as valid answer index in build_qa_turn

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1069,18 +1069,20 @@ class ConfigurableTask(Task):
                 whether an answer or gen_prefix is provided.
         """
         assert isinstance(q, str), f"Context is not a string! : {q}"
+        # Check if answer is provided (handle a=0 as valid answer index)
+        has_answer = a is not None and a != ""
         msgs = [
             Message(
                 "user",
                 q,
                 tgt_delim
-                if a and not gen_prefix
+                if has_answer and not gen_prefix
                 else tgt_delim
                 if gen_prefix and requires_delimiter(q, gen_prefix)
                 else "",
             )
         ]
-        if a is not None and a != "":
+        if has_answer:
             answer_text = (
                 c[a]
                 if (c and isinstance(a, int))


### PR DESCRIPTION
## Summary
Fixes #3452 - Performance decreasing when passing from 0 to few shots

## Root Cause
In `build_qa_turn()`, the condition `if a and not gen_prefix` incorrectly treated `a=0` (a valid answer index) as falsy, causing the `target_delimiter` to be skipped for few-shot examples where the answer was the first choice.

## The Bug
When a few-shot example has `answer=0`:
- **Before:** `Answer:A` (no space - wrong)
- **After:** `Answer: A` (with space - correct)

This inconsistency confused models because few-shot examples showed a different format than what the model was asked to predict.

## The Fix
Changed truthiness check to explicit None/empty check:
```python
# Before (buggy)
if a and not gen_prefix

# After (fixed) 
has_answer = a is not None and a != ""
if has_answer and not gen_prefix 
```

## Testing
Added 2 regression tests for answer index 0 and non-zero cases
All 48 fewshot context tests pass