### PR TITLE
Fix leading whitespace leakage in MMLU-Pro

### DIFF
--- a/lm_eval/tasks/mmlu_pro/README.md
+++ b/lm_eval/tasks/mmlu_pro/README.md
@@ -66,3 +66,5 @@ If other tasks on this dataset are already supported:
   * Changed default max_length from 2048 to 8192 and max_gen_toks from 256 to 2048.
 * (tasks, group) 2025-05-20 -- (version 2.1 --> version 3)
   * changed stop sequence from "Q:" to "Question:" PR #2945
+* (tasks, group) 2026-01-16 -- (version 2.1 --> version 3)
+  * trimmed whitespace from options: [see](https://x.com/fujikanaeda/status/2011565035408277996)

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -29,4 +29,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 2.1
+  version: 3.0

--- a/lm_eval/tasks/mmlu_pro/utils.py
+++ b/lm_eval/tasks/mmlu_pro/utils.py
@@ -6,15 +6,15 @@ choices = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
 
 def format_cot_example(example, including_answer=True):
     prompt = "Question:\n"
-    question = example["question"]
-    options = example["options"]
+    question: str = example["question"]
+    options: list[str] = example["options"]
     prompt += question + "\n"
     prompt += "Options:\n"
 
     for i, opt in enumerate(options):
         if i >= len(choices):
             break
-        prompt += "{}. {}\n".format(choices[i], opt)
+        prompt += f"{choices[i]}. {opt.strip()}\n"
 
     if including_answer:
         cot_content = example["cot_content"].replace(


### PR DESCRIPTION
As discovered by [Eric Tramel](https://x.com/fujikanaeda/status/2011565035408277996), some MMLU-Pro subjects have inconsistent whitespace formatting where correct answer choices contain leading whitespace that distractors lack. Added `strip()` to normalize all choices while constructing the prompt. 