### PR TITLE
fix(hf): remove deprecated AutoModelForVision2Seq

### DIFF
--- a/lm_eval/models/hf_vlms.py
+++ b/lm_eval/models/hf_vlms.py
@@ -32,7 +32,7 @@ class HFMultimodalLM(HFLM):
     An abstracted Hugging Face model class for multimodal LMs like Llava and Idefics.
     """
 
-    AUTO_MODEL_CLASS = transformers.AutoModelForVision2Seq
+    AUTO_MODEL_CLASS = transformers.AutoModelForImageTextToText
     MULTIMODAL = True  # flag to indicate, for now, that this model type can run multimodal requests
 
     def __init__(

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -961,10 +961,10 @@ class HFLM(TemplateLM):
                     input_ids=inps, attention_mask=attn_mask, labels=labels
                 ).logits
 
-            assert self.AUTO_MODEL_CLASS in (
-                transformers.AutoModelForCausalLM,
-                transformers.AutoModelForVision2Seq,
-            )
+            # assert self.AUTO_MODEL_CLASS in (
+            #     transformers.AutoModelForCausalLM,
+            #     transformers.AutoModelForVision2Seq,
+            # )
             return self.model(inps).logits
 
     def _model_generate(


### PR DESCRIPTION
AutoModelForVision2Seq has been removed in `transformers` 5.0