### PR TITLE
fix: super_glue is moved to aps/super_glue

### DIFF
--- a/examples/lm-eval-overview.ipynb
+++ b/examples/lm-eval-overview.ipynb
@@ -288,7 +288,7 @@
    "source": [
     "YAML_boolq_string = \"\"\"\n",
     "task: demo_boolq\n",
-    "dataset_path: super_glue\n",
+    "dataset_path: aps/super_glue\n",
     "dataset_name: boolq\n",
     "output_type: multiple_choice\n",
     "training_split: train\n",

--- a/lm_eval/tasks/benchmarks/t0_eval.yaml
+++ b/lm_eval/tasks/benchmarks/t0_eval.yaml
@@ -1,7 +1,7 @@
 group: t0_eval
 task:
   # Coreference Resolution
-  - dataset_path: super_glue
+  - dataset_path: aps/super_glue
     dataset_name: wsc.fixed
     use_prompt: promptsource:*
     training_split: train
@@ -27,7 +27,7 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Natural Language Inference
-  - dataset_path: super_glue
+  - dataset_path: aps/super_glue
     dataset_name: cb
     use_prompt: promptsource:*
     training_split: train
@@ -39,7 +39,7 @@ task:
         higher_is_better: true
         ignore_case: true
         ignore_punctuation: true
-  - dataset_path: super_glue
+  - dataset_path: aps/super_glue
     dataset_name: rte
     use_prompt: promptsource:*
     training_split: train
@@ -88,7 +88,7 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Sentence Completion
-  - dataset_path: super_glue
+  - dataset_path: aps/super_glue
     dataset_name: copa
     use_prompt: promptsource:*
     training_split: train
@@ -113,7 +113,7 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Word Sense Disambiguation
-  - dataset_path: super_glue
+  - dataset_path: aps/super_glue
     dataset_name: wic
     use_prompt: promptsource:*
     training_split: train

--- a/lm_eval/tasks/super_glue/boolq/default.yaml
+++ b/lm_eval/tasks/super_glue/boolq/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: boolq
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: boolq
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/boolq/seq2seq.yaml
+++ b/lm_eval/tasks/super_glue/boolq/seq2seq.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1-seq2seq
 task: "boolq-seq2seq"
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: boolq
 output_type: generate_until
 training_split: train

--- a/lm_eval/tasks/super_glue/boolq/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/boolq/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-boolq-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: boolq
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/super_glue/cb/default.yaml
+++ b/lm_eval/tasks/super_glue/cb/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: cb
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: cb
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/cb/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/cb/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-cb-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: cb
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/super_glue/copa/default.yaml
+++ b/lm_eval/tasks/super_glue/copa/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: copa
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: copa
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/copa/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/copa/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-copa-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: copa
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/super_glue/multirc/default.yaml
+++ b/lm_eval/tasks/super_glue/multirc/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: multirc
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: multirc
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/multirc/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/multirc/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-multirc-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: multirc
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/super_glue/record/default.yaml
+++ b/lm_eval/tasks/super_glue/record/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: record
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: record
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/record/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/record/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-record-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: record
 validation_split: validation
 output_type: generate_until

--- a/lm_eval/tasks/super_glue/rte/default.yaml
+++ b/lm_eval/tasks/super_glue/rte/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: sglue_rte
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: rte
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/rte/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/rte/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-rte-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: rte
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/super_glue/wic/default.yaml
+++ b/lm_eval/tasks/super_glue/wic/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: "wic"
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: wic
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/wic/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/wic/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-wic-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: wic
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/super_glue/wsc/default.yaml
+++ b/lm_eval/tasks/super_glue/wsc/default.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-lm-eval-v1
 task: wsc
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: wsc.fixed
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/super_glue/wsc/t5-prompt.yaml
+++ b/lm_eval/tasks/super_glue/wsc/t5-prompt.yaml
@@ -1,7 +1,7 @@
 tag:
   - super-glue-t5-prompt
 task: super_glue-wsc-t5-prompt
-dataset_path: super_glue
+dataset_path: aps/super_glue
 dataset_name: wsc.fixed
 training_split: train
 validation_split: validation


### PR DESCRIPTION
The repo_id for the super_glue dataset has been changed to aps/super_glue. Therefore, errors occur when attempting to import tasks included in super_glue, such as boolq. Consequently, the repo_id has been updated to ensure the dataset can be imported from the correct path.


```log
---------------------------------------------------------------------------
DatasetNotFoundError                      Traceback (most recent call last)
Cell In[2], line 1
----> 1 tasks.get_task_dict("boolq")

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/lm_eval/tasks/__init__.py:646, in get_task_dict(task_name_list, task_manager)
    643     if task_manager is None:
    644         task_manager = TaskManager()
--> 646     task_name_from_string_dict = task_manager.load_task_or_group(
    647         string_task_name_list
    648     )
    650 for task_element in others_task_name_list:
    651     if isinstance(task_element, dict):

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/lm_eval/tasks/__init__.py:428, in TaskManager.load_task_or_group(self, task_list)
    424 if isinstance(task_list, str):
    425     task_list = [task_list]
    427 all_loaded_tasks = dict(
--> 428     collections.ChainMap(
    429         *map(
    430             lambda task: self._load_individual_task_or_group(task),
    431             task_list,
    432         )
    433     )
    434 )
    435 return all_loaded_tasks

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/lm_eval/tasks/__init__.py:430, in TaskManager.load_task_or_group.<locals>.<lambda>(task)
    424 if isinstance(task_list, str):
    425     task_list = [task_list]
    427 all_loaded_tasks = dict(
    428     collections.ChainMap(
    429         *map(
--> 430             lambda task: self._load_individual_task_or_group(task),
    431             task_list,
    432         )
    433     )
    434 )
    435 return all_loaded_tasks

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/lm_eval/tasks/__init__.py:328, in TaskManager._load_individual_task_or_group(self, name_or_config, parent_name, update_config)
    324 elif self._name_is_task(name_or_config) or self._name_is_python_task(
    325     name_or_config
    326 ):
    327     task_config = self._get_config(name_or_config)
--> 328     return _load_task(task_config, task=name_or_config)
    329 else:
    330     subtask_list = self._get_tasklist(name_or_config)

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/lm_eval/tasks/__init__.py:288, in TaskManager._load_individual_task_or_group.<locals>._load_task(config, task)
    286     else:
    287         config["metadata"] = config.get("metadata", {})
--> 288     task_object = ConfigurableTask(config=config)
    290 return {task: task_object}

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/lm_eval/api/task.py:748, in ConfigurableTask.__init__(self, data_dir, cache_dir, download_mode, config)
    741             eval_logger.warning(
    742                 f"[Task: {self.config.task}] metric {metric_name} is defined, but higher_is_better is not. "
    743                 f"using default "
    744                 f"higher_is_better={is_higher_better(metric_name)}"
    745             )
    746             self._higher_is_better[metric_name] = is_higher_better(metric_name)
--> 748 self.download(self.config.dataset_kwargs)
    749 self._training_docs = None
    750 self._fewshot_docs = None

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/lm_eval/api/task.py:864, in ConfigurableTask.download(self, dataset_kwargs, **kwargs)
    860     self.dataset = self.config.custom_dataset(
    861         **(self.config.metadata or {}), **(self.config.dataset_kwargs or {})
    862     )
    863 else:
--> 864     self.dataset = datasets.load_dataset(
    865         path=self.DATASET_PATH,
    866         name=self.DATASET_NAME,
    867         **dataset_kwargs if dataset_kwargs is not None else {},
    868     )

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/datasets/load.py:2548, in load_dataset(path, name, data_dir, data_files, split, cache_dir, features, download_config, download_mode, verification_mode, ignore_verifications, keep_in_memory, save_infos, revision, token, use_auth_token, task, streaming, num_proc, storage_options, trust_remote_code, **config_kwargs)
   2543 verification_mode = VerificationMode(
   2544     (verification_mode or VerificationMode.BASIC_CHECKS) if not save_infos else VerificationMode.ALL_CHECKS
   2545 )
   2547 # Create a dataset builder
-> 2548 builder_instance = load_dataset_builder(
   2549     path=path,
   2550     name=name,
   2551     data_dir=data_dir,
   2552     data_files=data_files,
   2553     cache_dir=cache_dir,
   2554     features=features,
   2555     download_config=download_config,
   2556     download_mode=download_mode,
   2557     revision=revision,
   2558     token=token,
   2559     storage_options=storage_options,
   2560     trust_remote_code=trust_remote_code,
   2561     _require_default_config_name=name is None,
   2562     **config_kwargs,
   2563 )
   2565 # Return iterable dataset in case of streaming
   2566 if streaming:

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/datasets/load.py:2220, in load_dataset_builder(path, name, data_dir, data_files, cache_dir, features, download_config, download_mode, revision, token, use_auth_token, storage_options, trust_remote_code, _require_default_config_name, **config_kwargs)
   2218     download_config = download_config.copy() if download_config else DownloadConfig()
   2219     download_config.storage_options.update(storage_options)
-> 2220 dataset_module = dataset_module_factory(
   2221     path,
   2222     revision=revision,
   2223     download_config=download_config,
   2224     download_mode=download_mode,
   2225     data_dir=data_dir,
   2226     data_files=data_files,
   2227     cache_dir=cache_dir,
   2228     trust_remote_code=trust_remote_code,
   2229     _require_default_config_name=_require_default_config_name,
   2230     _require_custom_configs=bool(config_kwargs),
   2231 )
   2232 # Get dataset builder class from the processing script
   2233 builder_kwargs = dataset_module.builder_kwargs

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/datasets/load.py:1865, in dataset_module_factory(path, revision, download_config, download_mode, dynamic_modules_path, data_dir, data_files, cache_dir, trust_remote_code, _require_default_config_name, _require_custom_configs, **download_kwargs)
   1863     raise ConnectionError(f"Couldn't reach the Hugging Face Hub for dataset '{path}': {e1}") from None
   1864 if isinstance(e1, (DataFilesNotFoundError, DatasetNotFoundError, EmptyDatasetError)):
-> 1865     raise e1 from None
   1866 if isinstance(e1, FileNotFoundError):
   1867     raise FileNotFoundError(
   1868         f"Couldn't find a dataset script at {relative_to_absolute_path(combined_path)} or any data file in the same directory. "
   1869         f"Couldn't find '{path}' on the Hugging Face Hub either: {type(e1).__name__}: {e1}"
   1870     ) from None

File /workspace/QuaRot/.venv/lib/python3.12/site-packages/datasets/load.py:1808, in dataset_module_factory(path, revision, download_config, download_mode, dynamic_modules_path, data_dir, data_files, cache_dir, trust_remote_code, _require_default_config_name, _require_custom_configs, **download_kwargs)
   1806 elif "404" in str(e):
   1807     msg = f"Dataset '{path}' doesn't exist on the Hub"
-> 1808     raise DatasetNotFoundError(msg + f" at revision '{revision}'" if revision else msg)
   1809 elif "401" in str(e):
   1810     msg = f"Dataset '{path}' doesn't exist on the Hub"

DatasetNotFoundError: Dataset 'super_glue' doesn't exist on the Hub
```