### PR TITLE
fix(gsm8k_cot_llama): remove `target_delimiter`

### DIFF
--- a/lm_eval/tasks/gsm8k/README.md
+++ b/lm_eval/tasks/gsm8k/README.md
@@ -60,3 +60,6 @@ Homepage: https://github.com/openai/grade-school-math
 - [ ] Variant with Calculator (see https://github.com/openai/grade-school-math/blob/master/grade_school_math/calculator.py for example implementation)
 - [ ] Using Verifiers
 - [ ] Majority voting "without CoT"
+
+Change log:
+- [2026-01-27] `gsm8k_cot_llama` (v4.0): set 'target_delimiter' to empty as the prompt ends with newline.

--- a/lm_eval/tasks/gsm8k/gsm8k-cot-llama.yaml
+++ b/lm_eval/tasks/gsm8k/gsm8k-cot-llama.yaml
@@ -2,6 +2,7 @@ dataset_name: main
 dataset_path: openai/gsm8k
 doc_to_target: '{{answer.split(''####'')[-1].strip() if answer is defined else target}}'
 doc_to_text: "Given the following problem, reason and give a final answer to the problem.\nProblem: {{question}}\nYour response should end with \"The final answer is [answer]\" where [answer] is the response to the problem.\n"
+target_delimiter: ""
 fewshot_config:
   sampler: first_n
   samples:
@@ -64,8 +65,6 @@ generation_kwargs:
   - <|im_end|>
 tag:
 - chain_of_thought
-metadata:
-  version: 3.0
 metric_list:
 - aggregation: mean
   higher_is_better: true
@@ -82,3 +81,5 @@ output_type: generate_until
 repeats: 1
 task: gsm8k_cot_llama
 test_split: test
+metadata:
+  version: 4.0


### PR DESCRIPTION
`doc_to_text` ends with newline, but `target_delimiter` was set as space, so adding an unnecessary separator in the fewshots.