### PR TITLE
fix: Update HF high-performance transfer env vars     

### DIFF
--- a/lm_eval/__init__.py
+++ b/lm_eval/__init__.py
@@ -6,14 +6,9 @@ import os
 __version__ = importlib.metadata.version("lm_eval")
 
 
-# Enable hf_transfer if available
-try:
-    import hf_transfer  # type: ignore
-    import huggingface_hub.constants  # type: ignore
-
-    huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
-except ImportError:
-    pass
+# Enable high-performance transfers
+os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", "1")  # huggingface_hub >= 0.32.0
+os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")  # legacy hf_transfer
 
 
 # Lazy-load .evaluator module to improve CLI startup


### PR DESCRIPTION
`HF_HUB_ENABLE_HF_TRANSFER` has been deprecated in place of `HF_XET_HIGH_PERFORMANCE` for `huggingface_hub >= 0.32.0`. Currently set both for backward compatibility with older versions. 