### PR TITLE
feat(task): add MMLU-CF contamination-free benchmark

### DIFF
--- a/lm_eval/tasks/mmlu_cf/README.md
+++ b/lm_eval/tasks/mmlu_cf/README.md
@@ -1,0 +1,105 @@
+# MMLU-CF
+
+### Paper
+
+Title: MMLU-CF: A Contamination-free Multi-task Language Understanding Benchmark
+
+Paper (ACL 2025 Main): https://aclanthology.org/2025.acl-long.656/
+
+MMLU-CF is a contamination-free variant of the MMLU benchmark designed to address data leakage issues in evaluating large language models. The benchmark applies decontamination rules to prevent models from memorizing and reproducing identical answer choices from training data.
+
+Homepage: https://huggingface.co/datasets/microsoft/MMLU-CF
+
+### Citation
+
+```bibtex
+@misc{zhao2024mmlucfcontaminationfreemultitasklanguage,
+    title={MMLU-CF: A Contamination-free Multi-task Language Understanding Benchmark},
+    author={Qihao Zhao and Yangyu Huang and Tengchao Lv and Lei Cui and Qinzheng Sun and Shaoguang Mao and Xin Zhang and Ying Xin and Qiufeng Yin and Scarlett Li and Furu Wei},
+    year={2024},
+    eprint={2412.15194},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL},
+    url={https://arxiv.org/abs/2412.15194},
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `mmlu_cf`: All 15 subjects
+  * `mmlu_cf_stem`: STEM subjects (Biology, Math, Chemistry, Physics, Engineering, Computer Science)
+  * `mmlu_cf_social_sciences`: Social science subjects (Economics, Psychology, Business, Law, History)
+  * `mmlu_cf_humanities`: Humanities subjects (Philosophy)
+  * `mmlu_cf_other`: Other subjects (Health, Other)
+
+#### Tasks
+
+| Task | Subject | Category |
+|------|---------|----------|
+| `mmlu_cf_biology` | Biology | STEM |
+| `mmlu_cf_math` | Math | STEM |
+| `mmlu_cf_chemistry` | Chemistry | STEM |
+| `mmlu_cf_physics` | Physics | STEM |
+| `mmlu_cf_engineering` | Engineering | STEM |
+| `mmlu_cf_computer_science` | Computer Science | STEM |
+| `mmlu_cf_economics` | Economics | Social Sciences |
+| `mmlu_cf_psychology` | Psychology | Social Sciences |
+| `mmlu_cf_business` | Business | Social Sciences |
+| `mmlu_cf_law` | Law | Social Sciences |
+| `mmlu_cf_history` | History | Social Sciences |
+| `mmlu_cf_philosophy` | Philosophy | Humanities |
+| `mmlu_cf_health` | Health | Other |
+| `mmlu_cf_miscellaneous` | Other/Miscellaneous | Other |
+
+### Dataset Structure
+
+The dataset contains:
+- **Validation set**: 10,000 questions (open-source, used as test split)
+- **Development set**: 5 questions per subject (used for few-shot examples)
+- **Test set**: 10,000 questions (closed-source, not available)
+
+Each example has the following fields:
+- `Question`: The question text
+- `A`, `B`, `C`, `D`: Four answer choices
+- `Answer`: The correct answer (A, B, C, or D)
+
+### Usage
+
+Run all MMLU-CF tasks:
+```bash
+lm-eval --model hf \
+    --model_args pretrained=<model_name> \
+    --tasks mmlu_cf \
+    --batch_size auto
+```
+
+Run specific category:
+```bash
+lm-eval --model hf \
+    --model_args pretrained=<model_name> \
+    --tasks mmlu_cf_stem \
+    --batch_size auto
+```
+
+Run individual task:
+```bash
+lm-eval --model hf \
+    --model_args pretrained=<model_name> \
+    --tasks mmlu_cf_biology \
+    --batch_size auto
+```
+
+### Differences from Original MMLU
+
+| Aspect | MMLU | MMLU-CF |
+|--------|------|---------|
+| Contamination Prevention | Not addressed | Applies 3 decontamination rules |
+| Test Set | Open-source | Closed-source (prevents leakage) |
+| Data Leakage Risk | Higher | Mitigated through decontamination |
+| Quality Validation | Basic | Reviewed by GPT-4o, Gemini, Claude |
+
+### License
+
+CDLA-2.0 (Community Data License Agreement - Permissive 2.0)

--- a/lm_eval/tasks/mmlu_cf/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_cf/_default_template_yaml
@@ -1,0 +1,15 @@
+dataset_path: microsoft/MMLU-CF
+test_split: val
+fewshot_split: dev
+fewshot_config:
+  sampler: first_n
+output_type: multiple_choice
+doc_to_text: "{{Question.strip()}}\nA.{{A}}\nB.{{B}}\nC.{{C}}\nD.{{D}}\nAnswer:"
+doc_to_choice: ["A", "B", "C", "D"]
+doc_to_target: "{{['A', 'B', 'C', 'D'].index(Answer)}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mmlu_cf/_mmlu_cf.yaml
+++ b/lm_eval/tasks/mmlu_cf/_mmlu_cf.yaml
@@ -1,0 +1,11 @@
+group: mmlu_cf
+task:
+  - mmlu_cf_stem
+  - mmlu_cf_social_sciences
+  - mmlu_cf_humanities
+  - mmlu_cf_other
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mmlu_cf/_mmlu_cf_humanities.yaml
+++ b/lm_eval/tasks/mmlu_cf/_mmlu_cf_humanities.yaml
@@ -1,0 +1,9 @@
+group: mmlu_cf_humanities
+group_alias: humanities
+task:
+  - mmlu_cf_humanities_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mmlu_cf/_mmlu_cf_other.yaml
+++ b/lm_eval/tasks/mmlu_cf/_mmlu_cf_other.yaml
@@ -1,0 +1,9 @@
+group: mmlu_cf_other
+group_alias: other
+task:
+  - mmlu_cf_other_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mmlu_cf/_mmlu_cf_social_sciences.yaml
+++ b/lm_eval/tasks/mmlu_cf/_mmlu_cf_social_sciences.yaml
@@ -1,0 +1,9 @@
+group: mmlu_cf_social_sciences
+group_alias: social_sciences
+task:
+  - mmlu_cf_social_sciences_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mmlu_cf/_mmlu_cf_stem.yaml
+++ b/lm_eval/tasks/mmlu_cf/_mmlu_cf_stem.yaml
@@ -1,0 +1,9 @@
+group: mmlu_cf_stem
+group_alias: stem
+task:
+  - mmlu_cf_stem_tasks
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_biology.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_biology.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_biology
+task_alias: biology
+test_split: Biology_val
+fewshot_split: Biology_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_stem_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_business.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_business.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_business
+task_alias: business
+test_split: Business_val
+fewshot_split: Business_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_social_sciences_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_chemistry.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_chemistry.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_chemistry
+task_alias: chemistry
+test_split: Chemistry_val
+fewshot_split: Chemistry_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_stem_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_computer_science.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_computer_science.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_computer_science
+task_alias: computer_science
+test_split: Computer_Science_val
+fewshot_split: Computer_Science_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_stem_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_economics.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_economics.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_economics
+task_alias: economics
+test_split: Economics_val
+fewshot_split: Economics_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_social_sciences_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_engineering.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_engineering.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_engineering
+task_alias: engineering
+test_split: Engineering_val
+fewshot_split: Engineering_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_stem_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_health.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_health.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_health
+task_alias: health
+test_split: Health_val
+fewshot_split: Health_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_other_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_history.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_history.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_history
+task_alias: history
+test_split: History_val
+fewshot_split: History_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_social_sciences_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_law.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_law.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_law
+task_alias: law
+test_split: Law_val
+fewshot_split: Law_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_social_sciences_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_math.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_math.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_math
+task_alias: math
+test_split: Math_val
+fewshot_split: Math_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_stem_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_miscellaneous.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_miscellaneous.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_miscellaneous
+task_alias: miscellaneous
+test_split: Other_val
+fewshot_split: Other_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_other_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_philosophy.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_philosophy.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_philosophy
+task_alias: philosophy
+test_split: Philosophy_val
+fewshot_split: Philosophy_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_humanities_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_physics.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_physics.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_physics
+task_alias: physics
+test_split: Physics_val
+fewshot_split: Physics_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_stem_tasks
+include: _default_template_yaml

--- a/lm_eval/tasks/mmlu_cf/mmlu_cf_psychology.yaml
+++ b/lm_eval/tasks/mmlu_cf/mmlu_cf_psychology.yaml
@@ -1,0 +1,7 @@
+task: mmlu_cf_psychology
+task_alias: psychology
+test_split: Psychology_val
+fewshot_split: Psychology_dev
+description: "There is a single choice question (with answers). Answer the question by replying A, B, C or D.\n\n"
+tag: mmlu_cf_social_sciences_tasks
+include: _default_template_yaml


### PR DESCRIPTION

  Description:                                                                                    
  ## Summary                                                                                      
                                                                                                  
  Add support for MMLU-CF (Contamination-Free Multi-task Language Understanding Benchmark) from   
  Microsoft Research (ACL 2025 Main).                                                             
                                                                                                  
  MMLU-CF addresses data leakage issues in the original MMLU by applying decontamination rules to 
  prevent models from memorizing identical answer choices from training data.                     
                                                                                                       
  - Paper: https://aclanthology.org/2025.acl-long.656/                                                 
  - Dataset: https://huggingface.co/datasets/microsoft/MMLU-CF                                         
                                                                                                       
  ## Tasks Added                                   
                                                                                                       
  - `mmlu_cf` (main group with 14 subject tasks)                                                       
    - `mmlu_cf_stem`: biology, math, chemistry, physics, engineering, computer_science                 
    - `mmlu_cf_social_sciences`: economics, psychology, business, law, history                         
    - `mmlu_cf_humanities`: philosophy                                                                 
    - `mmlu_cf_other`: health, miscellaneous       
                                                   
  ## Features                                      
                                                                                                       
  - Uses validation split (10k questions) as test set                                                  
  - Uses dev split (5 questions per subject) for few-shot examples                                     
  - Supports both zero-shot and few-shot evaluation
                                                   
  ## Usage                                         
                                                   
  ```bash                                          
  # Zero-shot                                      
  lm-eval run --model hf --model_args pretrained=<model> --tasks mmlu_cf --num_fewshot 0               

  # 5-shot                                         
  lm-eval run --model hf --model_args pretrained=<model> --tasks mmlu_cf --num_fewshot 5               

  Test Plan                                        

  - Tested with lm-eval run --tasks mmlu_cf --limit 5 - all 14 tasks run successfully   

  ---  