### PR TITLE
fix: sglang generate already registered

### DIFF
--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -45,7 +45,7 @@ MODEL_MAPPING = {
     "openai-completions": "lm_eval.models.openai_completions:OpenAICompletionsAPI",
     "openvino": "lm_eval.models.optimum_lm:OptimumLM",
     "sglang": "lm_eval.models.sglang_causallms:SGLangLM",
-    "sglang-generate": "lm_eval.models.sglang_generate_API:SGAPI",
+    "sglang-generate": "lm_eval.models.sglang_generate_API:SGLANGGENERATEAPI",
     "steered": "lm_eval.models.hf_steered:SteeredHF",
     "textsynth": "lm_eval.models.textsynth:TextSynthLM",
     "vllm": "lm_eval.models.vllm_causallms:VLLM",


### PR DESCRIPTION
Hello, lm-eval team!

Found an error with "sglang-generate already registered"

Just simple typo diff between:
https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/models/__init__.py#L48
and
https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/models/sglang_generate_API.py#L9



Before
<img width="1304" height="903" alt="image" src="https://github.com/user-attachments/assets/378bdd8c-3c77-4974-8811-02f61f715ca0" />


After
<img width="1291" height="577" alt="image" src="https://github.com/user-attachments/assets/31baec3d-b54d-4b90-a9e8-1d52b5cee503" />


So it passes problematic place, error in after just because I used simple command for testing