### PR TITLE
Fix readme for task-listing CLI command

### DIFF
--- a/lm_eval/tasks/README.md
+++ b/lm_eval/tasks/README.md
@@ -1,6 +1,6 @@
 # Tasks
 
-A list of supported tasks and task groupings can be viewed with `lm-eval --tasks list`.
+A list of supported tasks and task groupings can be viewed with `lm-eval ls tasks`.
 
 For more information, including a full list of task names and their precise meanings or sources, follow the links
 provided to the individual README.md files for each subfolder.


### PR DESCRIPTION
This pull request updates the documentation in `lm_eval/tasks/README.md` to reflect the correct command for listing supported tasks.

- Documentation update:
  * Changed the command for listing supported tasks from `lm-eval --tasks list` to `lm-eval ls tasks` to match the current CLI usage.