### PR TITLE
feat(tasks): rename `afrobench_belebele, `evalita-mp_sum_fp_small` and `incude` variants

### DIFF
--- a/lm_eval/tasks/afrobench/belebele/README.md
+++ b/lm_eval/tasks/afrobench/belebele/README.md
@@ -10,6 +10,10 @@ Paper Link: https://aclanthology.org/2023.emnlp-main.862/
 
 HomePage: https://github.com/facebookresearch/belebele
 
+### Changelog
+
+- **v3**: Renamed group from `belebele` to `afrobench_belebele` to resolve duplicate group name conflict with `belebele/_belebele.yaml`.
+
 ### Citation
 
 ```

--- a/lm_eval/tasks/afrobench/belebele/belebele.yaml
+++ b/lm_eval/tasks/afrobench/belebele/belebele.yaml
@@ -1,4 +1,4 @@
-group: belebele
+group: afrobench_belebele
 task:
   - belebele_prompt_1
   - belebele_prompt_2
@@ -10,4 +10,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: true
 metadata:
-  version: 2
+  version: 3

--- a/lm_eval/tasks/evalita_llm/README.md
+++ b/lm_eval/tasks/evalita_llm/README.md
@@ -49,6 +49,10 @@ The following Evalita-LLM tasks can also be evaluated in isolation:
 lm_eval --model hf --model_args pretrained=meta-llama/Llama-2-7b-hf --tasks evalita-mp --device cuda:0 --batch_size auto
 ```
 
+### Changelog
+
+- **v0.1**: Renamed `evalita-mp_sum_fp` small variant group to `evalita-mp_sum_fp_small` to resolve duplicate group name conflict with the full variant.
+
 ### Checklist
 
 * [x] Is the task an existing benchmark in the literature?

--- a/lm_eval/tasks/evalita_llm/_evalita-mp_sum_fp-small_task.yaml
+++ b/lm_eval/tasks/evalita_llm/_evalita-mp_sum_fp-small_task.yaml
@@ -1,4 +1,4 @@
-group: evalita-mp_sum_fp
+group: evalita-mp_sum_fp_small
 group_alias: summarization-fanpage
 task:
 - evalita-mp_sum_fp-small_tasks
@@ -6,4 +6,4 @@ aggregate_metric_list:
   - metric: rouge1
     weight_by_size: True
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/README.md
+++ b/lm_eval/tasks/include/README.md
@@ -30,6 +30,10 @@ Albanian, Arabic, Armenian, Azerbaijani, Basque, Belarusian, Bengali, Bulgarian,
 **Licenses:** Driving License, Marine License, Medical License, Professional Certifications
 
 
+### Changelog
+
+- **v0.1**: Renamed `few_shot_en` and `few_shot_og` variant group names from `include_base_44_<lang>` to `include_base_44_<lang>_few_shot_en` and `include_base_44_<lang>_few_shot_og` respectively, to resolve duplicate group name conflicts with the `default` variants.
+
 ### Citation
 
 ```bibtex

--- a/lm_eval/tasks/include/few_shot_en/Albanian/_include_base_44_albanian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Albanian/_include_base_44_albanian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_albanian
+group: include_base_44_albanian_few_shot_en
 task:
 - include_base_44_albanian_few_shot_en_arts_humanities
 - include_base_44_albanian_few_shot_en_stem
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Arabic/_include_base_44_arabic.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Arabic/_include_base_44_arabic.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_arabic
+group: include_base_44_arabic_few_shot_en
 task:
 - include_base_44_arabic_few_shot_en_arts_humanities
 - include_base_44_arabic_few_shot_en_stem
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Armenian/_include_base_44_armenian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Armenian/_include_base_44_armenian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_armenian
+group: include_base_44_armenian_few_shot_en
 task:
 - include_base_44_armenian_few_shot_en_driving_license
 - include_base_44_armenian_few_shot_en_social_science
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Azerbaijani/_include_base_44_azerbaijani.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Azerbaijani/_include_base_44_azerbaijani.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_azerbaijani
+group: include_base_44_azerbaijani_few_shot_en
 task:
 - include_base_44_azerbaijani_few_shot_en_business_commerce
 - include_base_44_azerbaijani_few_shot_en_applied_science
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Basque/_include_base_44_basque.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Basque/_include_base_44_basque.yaml
@@ -1,8 +1,8 @@
-group: include_base_44_basque
+group: include_base_44_basque_few_shot_en
 task:
 - include_base_44_basque_few_shot_en_professional_certification
 aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Belarusian/_include_base_44_belarusian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Belarusian/_include_base_44_belarusian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_belarusian
+group: include_base_44_belarusian_few_shot_en
 task:
 - include_base_44_belarusian_few_shot_en_arts_humanities
 - include_base_44_belarusian_few_shot_en_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Bengali/_include_base_44_bengali.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Bengali/_include_base_44_bengali.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_bengali
+group: include_base_44_bengali_few_shot_en
 task:
 - include_base_44_bengali_few_shot_en_arts_humanities
 - include_base_44_bengali_few_shot_en_stem
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Bulgarian/_include_base_44_bulgarian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Bulgarian/_include_base_44_bulgarian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_bulgarian
+group: include_base_44_bulgarian_few_shot_en
 task:
 - include_base_44_bulgarian_few_shot_en_stem
 - include_base_44_bulgarian_few_shot_en_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Chinese/_include_base_44_chinese.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Chinese/_include_base_44_chinese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_chinese
+group: include_base_44_chinese_few_shot_en
 task:
 - include_base_44_chinese_few_shot_en_applied_science
 - include_base_44_chinese_few_shot_en_health_oriented_education
@@ -12,4 +12,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Croatian/_include_base_44_croatian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Croatian/_include_base_44_croatian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_croatian
+group: include_base_44_croatian_few_shot_en
 task:
 - include_base_44_croatian_few_shot_en_stem
 - include_base_44_croatian_few_shot_en_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Dutch/_include_base_44_dutch.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Dutch/_include_base_44_dutch.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_dutch
+group: include_base_44_dutch_few_shot_en
 task:
 - include_base_44_dutch_few_shot_en_arts_humanities
 - include_base_44_dutch_few_shot_en_stem
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Estonian/_include_base_44_estonian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Estonian/_include_base_44_estonian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_estonian
+group: include_base_44_estonian_few_shot_en
 task:
 - include_base_44_estonian_few_shot_en_health_oriented_education
 - include_base_44_estonian_few_shot_en_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Finnish/_include_base_44_finnish.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Finnish/_include_base_44_finnish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_finnish
+group: include_base_44_finnish_few_shot_en
 task:
 - include_base_44_finnish_few_shot_en_stem
 - include_base_44_finnish_few_shot_en_arts_humanities
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/French/_include_base_44_french.yaml
+++ b/lm_eval/tasks/include/few_shot_en/French/_include_base_44_french.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_french
+group: include_base_44_french_few_shot_en
 task:
 - include_base_44_french_few_shot_en_stem
 - include_base_44_french_few_shot_en_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Georgian/_include_base_44_georgian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Georgian/_include_base_44_georgian.yaml
@@ -1,8 +1,8 @@
-group: include_base_44_georgian
+group: include_base_44_georgian_few_shot_en
 task:
 - include_base_44_georgian_few_shot_en_arts_humanities
 aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/German/_include_base_44_german.yaml
+++ b/lm_eval/tasks/include/few_shot_en/German/_include_base_44_german.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_german
+group: include_base_44_german_few_shot_en
 task:
 - include_base_44_german_few_shot_en_stem
 - include_base_44_german_few_shot_en_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Greek/_include_base_44_greek.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Greek/_include_base_44_greek.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_greek
+group: include_base_44_greek_few_shot_en
 task:
 - include_base_44_greek_few_shot_en_stem
 - include_base_44_greek_few_shot_en_arts_humanities
@@ -11,4 +11,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Hebrew/_include_base_44_hebrew.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Hebrew/_include_base_44_hebrew.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_hebrew
+group: include_base_44_hebrew_few_shot_en
 task:
 - include_base_44_hebrew_few_shot_en_arts_humanities
 - include_base_44_hebrew_few_shot_en_driving_license
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Hindi/_include_base_44_hindi.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Hindi/_include_base_44_hindi.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_hindi
+group: include_base_44_hindi_few_shot_en
 task:
 - include_base_44_hindi_few_shot_en_professional_certification
 - include_base_44_hindi_few_shot_en_stem
@@ -12,4 +12,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Hungarian/_include_base_44_hungarian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Hungarian/_include_base_44_hungarian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_hungarian
+group: include_base_44_hungarian_few_shot_en
 task:
 - include_base_44_hungarian_few_shot_en_stem
 - include_base_44_hungarian_few_shot_en_applied_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Indonesian/_include_base_44_indonesian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Indonesian/_include_base_44_indonesian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_indonesian
+group: include_base_44_indonesian_few_shot_en
 task:
 - include_base_44_indonesian_few_shot_en_arts_humanities
 - include_base_44_indonesian_few_shot_en_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Italian/_include_base_44_italian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Italian/_include_base_44_italian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_italian
+group: include_base_44_italian_few_shot_en
 task:
 - include_base_44_italian_few_shot_en_stem
 - include_base_44_italian_few_shot_en_arts_humanities
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Japanese/_include_base_44_japanese.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Japanese/_include_base_44_japanese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_japanese
+group: include_base_44_japanese_few_shot_en
 task:
 - include_base_44_japanese_few_shot_en_driving_license
 - include_base_44_japanese_few_shot_en_medical_license
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Kazakh/_include_base_44_kazakh.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Kazakh/_include_base_44_kazakh.yaml
@@ -1,8 +1,8 @@
-group: include_base_44_kazakh
+group: include_base_44_kazakh_few_shot_en
 task:
 - include_base_44_kazakh_few_shot_en_arts_humanities
 aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Korean/_include_base_44_korean.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Korean/_include_base_44_korean.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_korean
+group: include_base_44_korean_few_shot_en
 task:
 - include_base_44_korean_few_shot_en_professional_certification
 - include_base_44_korean_few_shot_en_social_science
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Lithuanian/_include_base_44_lithuanian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Lithuanian/_include_base_44_lithuanian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_lithuanian
+group: include_base_44_lithuanian_few_shot_en
 task:
 - include_base_44_lithuanian_few_shot_en_arts_humanities
 - include_base_44_lithuanian_few_shot_en_stem
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Malay/_include_base_44_malay.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Malay/_include_base_44_malay.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_malay
+group: include_base_44_malay_few_shot_en
 task:
 - include_base_44_malay_few_shot_en_social_science
 - include_base_44_malay_few_shot_en_business_commerce
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Malayalam/_include_base_44_malayalam.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Malayalam/_include_base_44_malayalam.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_malayalam
+group: include_base_44_malayalam_few_shot_en
 task:
 - include_base_44_malayalam_few_shot_en_stem
 - include_base_44_malayalam_few_shot_en_marine_license
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Nepali/_include_base_44_nepali.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Nepali/_include_base_44_nepali.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_nepali
+group: include_base_44_nepali_few_shot_en
 task:
 - include_base_44_nepali_few_shot_en_driving_license
 - include_base_44_nepali_few_shot_en_professional_certification
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/North Macedonian/_include_base_44_north macedonian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/North Macedonian/_include_base_44_north macedonian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_north macedonian
+group: include_base_44_north macedonian_few_shot_en
 task:
 - include_base_44_north macedonian_few_shot_en_arts_humanities
 - include_base_44_north macedonian_few_shot_en_stem
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Persian/_include_base_44_persian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Persian/_include_base_44_persian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_persian
+group: include_base_44_persian_few_shot_en
 task:
 - include_base_44_persian_few_shot_en_arts_humanities
 - include_base_44_persian_few_shot_en_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Polish/_include_base_44_polish.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Polish/_include_base_44_polish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_polish
+group: include_base_44_polish_few_shot_en
 task:
 - include_base_44_polish_few_shot_en_professional_certification
 - include_base_44_polish_few_shot_en_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Portuguese/_include_base_44_portuguese.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Portuguese/_include_base_44_portuguese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_portuguese
+group: include_base_44_portuguese_few_shot_en
 task:
 - include_base_44_portuguese_few_shot_en_stem
 - include_base_44_portuguese_few_shot_en_social_science
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Russian/_include_base_44_russian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Russian/_include_base_44_russian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_russian
+group: include_base_44_russian_few_shot_en
 task:
 - include_base_44_russian_few_shot_en_stem
 - include_base_44_russian_few_shot_en_health_oriented_education
@@ -12,4 +12,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Serbian/_include_base_44_serbian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Serbian/_include_base_44_serbian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_serbian
+group: include_base_44_serbian_few_shot_en
 task:
 - include_base_44_serbian_few_shot_en_stem
 - include_base_44_serbian_few_shot_en_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Spanish/_include_base_44_spanish.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Spanish/_include_base_44_spanish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_spanish
+group: include_base_44_spanish_few_shot_en
 task:
 - include_base_44_spanish_few_shot_en_stem
 - include_base_44_spanish_few_shot_en_social_science
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Tagalog/_include_base_44_tagalog.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Tagalog/_include_base_44_tagalog.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_tagalog
+group: include_base_44_tagalog_few_shot_en
 task:
 - include_base_44_tagalog_few_shot_en_arts_humanities
 - include_base_44_tagalog_few_shot_en_driving_license
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Tamil/_include_base_44_tamil.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Tamil/_include_base_44_tamil.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_tamil
+group: include_base_44_tamil_few_shot_en
 task:
 - include_base_44_tamil_few_shot_en_stem
 - include_base_44_tamil_few_shot_en_general_knowledge
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Telugu/_include_base_44_telugu.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Telugu/_include_base_44_telugu.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_telugu
+group: include_base_44_telugu_few_shot_en
 task:
 - include_base_44_telugu_few_shot_en_arts_humanities
 - include_base_44_telugu_few_shot_en_applied_science
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Turkish/_include_base_44_turkish.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Turkish/_include_base_44_turkish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_turkish
+group: include_base_44_turkish_few_shot_en
 task:
 - include_base_44_turkish_few_shot_en_business_commerce
 - include_base_44_turkish_few_shot_en_stem
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Ukrainian/_include_base_44_ukrainian.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Ukrainian/_include_base_44_ukrainian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_ukrainian
+group: include_base_44_ukrainian_few_shot_en
 task:
 - include_base_44_ukrainian_few_shot_en_arts_humanities
 - include_base_44_ukrainian_few_shot_en_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Urdu/_include_base_44_urdu.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Urdu/_include_base_44_urdu.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_urdu
+group: include_base_44_urdu_few_shot_en
 task:
 - include_base_44_urdu_few_shot_en_stem
 - include_base_44_urdu_few_shot_en_health_oriented_education
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Uzbek/_include_base_44_uzbek.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Uzbek/_include_base_44_uzbek.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_uzbek
+group: include_base_44_uzbek_few_shot_en
 task:
 - include_base_44_uzbek_few_shot_en_arts_humanities
 - include_base_44_uzbek_few_shot_en_medical_license
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_en/Vietnamese/_include_base_44_vietnamese.yaml
+++ b/lm_eval/tasks/include/few_shot_en/Vietnamese/_include_base_44_vietnamese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_vietnamese
+group: include_base_44_vietnamese_few_shot_en
 task:
 - include_base_44_vietnamese_few_shot_en_stem
 - include_base_44_vietnamese_few_shot_en_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Albanian/_include_base_44_albanian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Albanian/_include_base_44_albanian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_albanian
+group: include_base_44_albanian_few_shot_og
 task:
 - include_base_44_albanian_few_shot_og_arts_humanities
 - include_base_44_albanian_few_shot_og_stem
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Arabic/_include_base_44_arabic.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Arabic/_include_base_44_arabic.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_arabic
+group: include_base_44_arabic_few_shot_og
 task:
 - include_base_44_arabic_few_shot_og_arts_humanities
 - include_base_44_arabic_few_shot_og_stem
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Armenian/_include_base_44_armenian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Armenian/_include_base_44_armenian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_armenian
+group: include_base_44_armenian_few_shot_og
 task:
 - include_base_44_armenian_few_shot_og_driving_license
 - include_base_44_armenian_few_shot_og_social_science
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Azerbaijani/_include_base_44_azerbaijani.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Azerbaijani/_include_base_44_azerbaijani.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_azerbaijani
+group: include_base_44_azerbaijani_few_shot_og
 task:
 - include_base_44_azerbaijani_few_shot_og_business_commerce
 - include_base_44_azerbaijani_few_shot_og_applied_science
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Basque/_include_base_44_basque.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Basque/_include_base_44_basque.yaml
@@ -1,8 +1,8 @@
-group: include_base_44_basque
+group: include_base_44_basque_few_shot_og
 task:
 - include_base_44_basque_few_shot_og_professional_certification
 aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Belarusian/_include_base_44_belarusian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Belarusian/_include_base_44_belarusian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_belarusian
+group: include_base_44_belarusian_few_shot_og
 task:
 - include_base_44_belarusian_few_shot_og_arts_humanities
 - include_base_44_belarusian_few_shot_og_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Bengali/_include_base_44_bengali.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Bengali/_include_base_44_bengali.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_bengali
+group: include_base_44_bengali_few_shot_og
 task:
 - include_base_44_bengali_few_shot_og_arts_humanities
 - include_base_44_bengali_few_shot_og_stem
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Bulgarian/_include_base_44_bulgarian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Bulgarian/_include_base_44_bulgarian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_bulgarian
+group: include_base_44_bulgarian_few_shot_og
 task:
 - include_base_44_bulgarian_few_shot_og_stem
 - include_base_44_bulgarian_few_shot_og_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Chinese/_include_base_44_chinese.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Chinese/_include_base_44_chinese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_chinese
+group: include_base_44_chinese_few_shot_og
 task:
 - include_base_44_chinese_few_shot_og_applied_science
 - include_base_44_chinese_few_shot_og_health_oriented_education
@@ -12,4 +12,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Croatian/_include_base_44_croatian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Croatian/_include_base_44_croatian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_croatian
+group: include_base_44_croatian_few_shot_og
 task:
 - include_base_44_croatian_few_shot_og_stem
 - include_base_44_croatian_few_shot_og_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Dutch/_include_base_44_dutch.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Dutch/_include_base_44_dutch.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_dutch
+group: include_base_44_dutch_few_shot_og
 task:
 - include_base_44_dutch_few_shot_og_arts_humanities
 - include_base_44_dutch_few_shot_og_stem
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Estonian/_include_base_44_estonian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Estonian/_include_base_44_estonian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_estonian
+group: include_base_44_estonian_few_shot_og
 task:
 - include_base_44_estonian_few_shot_og_health_oriented_education
 - include_base_44_estonian_few_shot_og_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Finnish/_include_base_44_finnish.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Finnish/_include_base_44_finnish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_finnish
+group: include_base_44_finnish_few_shot_og
 task:
 - include_base_44_finnish_few_shot_og_stem
 - include_base_44_finnish_few_shot_og_arts_humanities
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/French/_include_base_44_french.yaml
+++ b/lm_eval/tasks/include/few_shot_og/French/_include_base_44_french.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_french
+group: include_base_44_french_few_shot_og
 task:
 - include_base_44_french_few_shot_og_stem
 - include_base_44_french_few_shot_og_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Georgian/_include_base_44_georgian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Georgian/_include_base_44_georgian.yaml
@@ -1,8 +1,8 @@
-group: include_base_44_georgian
+group: include_base_44_georgian_few_shot_og
 task:
 - include_base_44_georgian_few_shot_og_arts_humanities
 aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/German/_include_base_44_german.yaml
+++ b/lm_eval/tasks/include/few_shot_og/German/_include_base_44_german.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_german
+group: include_base_44_german_few_shot_og
 task:
 - include_base_44_german_few_shot_og_stem
 - include_base_44_german_few_shot_og_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Greek/_include_base_44_greek.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Greek/_include_base_44_greek.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_greek
+group: include_base_44_greek_few_shot_og
 task:
 - include_base_44_greek_few_shot_og_stem
 - include_base_44_greek_few_shot_og_arts_humanities
@@ -11,4 +11,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Hebrew/_include_base_44_hebrew.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Hebrew/_include_base_44_hebrew.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_hebrew
+group: include_base_44_hebrew_few_shot_og
 task:
 - include_base_44_hebrew_few_shot_og_arts_humanities
 - include_base_44_hebrew_few_shot_og_driving_license
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Hindi/_include_base_44_hindi.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Hindi/_include_base_44_hindi.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_hindi
+group: include_base_44_hindi_few_shot_og
 task:
 - include_base_44_hindi_few_shot_og_professional_certification
 - include_base_44_hindi_few_shot_og_stem
@@ -12,4 +12,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Hungarian/_include_base_44_hungarian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Hungarian/_include_base_44_hungarian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_hungarian
+group: include_base_44_hungarian_few_shot_og
 task:
 - include_base_44_hungarian_few_shot_og_stem
 - include_base_44_hungarian_few_shot_og_applied_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Indonesian/_include_base_44_indonesian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Indonesian/_include_base_44_indonesian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_indonesian
+group: include_base_44_indonesian_few_shot_og
 task:
 - include_base_44_indonesian_few_shot_og_arts_humanities
 - include_base_44_indonesian_few_shot_og_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Italian/_include_base_44_italian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Italian/_include_base_44_italian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_italian
+group: include_base_44_italian_few_shot_og
 task:
 - include_base_44_italian_few_shot_og_stem
 - include_base_44_italian_few_shot_og_arts_humanities
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Japanese/_include_base_44_japanese.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Japanese/_include_base_44_japanese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_japanese
+group: include_base_44_japanese_few_shot_og
 task:
 - include_base_44_japanese_few_shot_og_driving_license
 - include_base_44_japanese_few_shot_og_medical_license
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Kazakh/_include_base_44_kazakh.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Kazakh/_include_base_44_kazakh.yaml
@@ -1,8 +1,8 @@
-group: include_base_44_kazakh
+group: include_base_44_kazakh_few_shot_og
 task:
 - include_base_44_kazakh_few_shot_og_arts_humanities
 aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Korean/_include_base_44_korean.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Korean/_include_base_44_korean.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_korean
+group: include_base_44_korean_few_shot_og
 task:
 - include_base_44_korean_few_shot_og_professional_certification
 - include_base_44_korean_few_shot_og_social_science
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Lithuanian/_include_base_44_lithuanian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Lithuanian/_include_base_44_lithuanian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_lithuanian
+group: include_base_44_lithuanian_few_shot_og
 task:
 - include_base_44_lithuanian_few_shot_og_arts_humanities
 - include_base_44_lithuanian_few_shot_og_stem
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Malay/_include_base_44_malay.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Malay/_include_base_44_malay.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_malay
+group: include_base_44_malay_few_shot_og
 task:
 - include_base_44_malay_few_shot_og_social_science
 - include_base_44_malay_few_shot_og_business_commerce
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Malayalam/_include_base_44_malayalam.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Malayalam/_include_base_44_malayalam.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_malayalam
+group: include_base_44_malayalam_few_shot_og
 task:
 - include_base_44_malayalam_few_shot_og_stem
 - include_base_44_malayalam_few_shot_og_marine_license
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Nepali/_include_base_44_nepali.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Nepali/_include_base_44_nepali.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_nepali
+group: include_base_44_nepali_few_shot_og
 task:
 - include_base_44_nepali_few_shot_og_driving_license
 - include_base_44_nepali_few_shot_og_professional_certification
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/North Macedonian/_include_base_44_north macedonian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/North Macedonian/_include_base_44_north macedonian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_north macedonian
+group: include_base_44_north macedonian_few_shot_og
 task:
 - include_base_44_north macedonian_few_shot_og_arts_humanities
 - include_base_44_north macedonian_few_shot_og_stem
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Persian/_include_base_44_persian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Persian/_include_base_44_persian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_persian
+group: include_base_44_persian_few_shot_og
 task:
 - include_base_44_persian_few_shot_og_arts_humanities
 - include_base_44_persian_few_shot_og_social_science
@@ -9,4 +9,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Polish/_include_base_44_polish.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Polish/_include_base_44_polish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_polish
+group: include_base_44_polish_few_shot_og
 task:
 - include_base_44_polish_few_shot_og_professional_certification
 - include_base_44_polish_few_shot_og_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Portuguese/_include_base_44_portuguese.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Portuguese/_include_base_44_portuguese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_portuguese
+group: include_base_44_portuguese_few_shot_og
 task:
 - include_base_44_portuguese_few_shot_og_stem
 - include_base_44_portuguese_few_shot_og_social_science
@@ -10,4 +10,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Russian/_include_base_44_russian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Russian/_include_base_44_russian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_russian
+group: include_base_44_russian_few_shot_og
 task:
 - include_base_44_russian_few_shot_og_stem
 - include_base_44_russian_few_shot_og_health_oriented_education
@@ -12,4 +12,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Serbian/_include_base_44_serbian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Serbian/_include_base_44_serbian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_serbian
+group: include_base_44_serbian_few_shot_og
 task:
 - include_base_44_serbian_few_shot_og_stem
 - include_base_44_serbian_few_shot_og_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Spanish/_include_base_44_spanish.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Spanish/_include_base_44_spanish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_spanish
+group: include_base_44_spanish_few_shot_og
 task:
 - include_base_44_spanish_few_shot_og_stem
 - include_base_44_spanish_few_shot_og_social_science
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Tagalog/_include_base_44_tagalog.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Tagalog/_include_base_44_tagalog.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_tagalog
+group: include_base_44_tagalog_few_shot_og
 task:
 - include_base_44_tagalog_few_shot_og_arts_humanities
 - include_base_44_tagalog_few_shot_og_driving_license
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Tamil/_include_base_44_tamil.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Tamil/_include_base_44_tamil.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_tamil
+group: include_base_44_tamil_few_shot_og
 task:
 - include_base_44_tamil_few_shot_og_stem
 - include_base_44_tamil_few_shot_og_general_knowledge
@@ -6,4 +6,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Telugu/_include_base_44_telugu.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Telugu/_include_base_44_telugu.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_telugu
+group: include_base_44_telugu_few_shot_og
 task:
 - include_base_44_telugu_few_shot_og_arts_humanities
 - include_base_44_telugu_few_shot_og_applied_science
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Turkish/_include_base_44_turkish.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Turkish/_include_base_44_turkish.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_turkish
+group: include_base_44_turkish_few_shot_og
 task:
 - include_base_44_turkish_few_shot_og_business_commerce
 - include_base_44_turkish_few_shot_og_stem
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Ukrainian/_include_base_44_ukrainian.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Ukrainian/_include_base_44_ukrainian.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_ukrainian
+group: include_base_44_ukrainian_few_shot_og
 task:
 - include_base_44_ukrainian_few_shot_og_arts_humanities
 - include_base_44_ukrainian_few_shot_og_social_science
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Urdu/_include_base_44_urdu.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Urdu/_include_base_44_urdu.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_urdu
+group: include_base_44_urdu_few_shot_og
 task:
 - include_base_44_urdu_few_shot_og_stem
 - include_base_44_urdu_few_shot_og_health_oriented_education
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Uzbek/_include_base_44_uzbek.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Uzbek/_include_base_44_uzbek.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_uzbek
+group: include_base_44_uzbek_few_shot_og
 task:
 - include_base_44_uzbek_few_shot_og_arts_humanities
 - include_base_44_uzbek_few_shot_og_medical_license
@@ -8,4 +8,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1

--- a/lm_eval/tasks/include/few_shot_og/Vietnamese/_include_base_44_vietnamese.yaml
+++ b/lm_eval/tasks/include/few_shot_og/Vietnamese/_include_base_44_vietnamese.yaml
@@ -1,4 +1,4 @@
-group: include_base_44_vietnamese
+group: include_base_44_vietnamese_few_shot_og
 task:
 - include_base_44_vietnamese_few_shot_og_stem
 - include_base_44_vietnamese_few_shot_og_arts_humanities
@@ -7,4 +7,4 @@ aggregate_metric_list:
 - metric: acc
   weight_by_size: true
 metadata:
-  version: 0.0
+  version: 0.1


### PR DESCRIPTION
Resolve duplicate group name warnings across task configs.                                                                                                                    
                                                                                                                                                                                
  - `belebele`: Renamed `afrobench` variant group to `afrobench_belebele`                                                                                                   
  - `evalita`: Renamed small variant group to `evalita-mp_sum_fp_small`                                                                                                            
  - `include`: Suffixed few_shot_en/few_shot_og variant groups with _few_shot_en/_few_shot_og (88 files)                                                                          
  
incremented config versions and added to changelog         