### PR TITLE
fix(aime): ensure non-empty prompt for API backends

### DIFF
--- a/lm_eval/tasks/aime/aime.yaml
+++ b/lm_eval/tasks/aime/aime.yaml
@@ -7,7 +7,12 @@ output_type: generate_until
 training_split: train
 fewshot_split: train
 test_split: train
-doc_to_text: "Question: {{Question}}\nAnswer:"
+doc_to_text: |
+  Solve the following AIME problem.
+
+  {{ Question }}
+
+  Answer:
 doc_to_target: "{{Answer}}"
 process_results: !function utils.process_results
 metric_list:

--- a/lm_eval/tasks/aime/aime24.yaml
+++ b/lm_eval/tasks/aime/aime24.yaml
@@ -7,7 +7,12 @@ output_type: generate_until
 training_split: train
 fewshot_split: train
 test_split: train
-doc_to_text: "Question: {{Problem}}\nAnswer:"
+doc_to_text: |
+  Solve the following AIME problem.
+
+  {{ Problem }}
+
+  Answer:
 doc_to_target: "{{Answer}}"
 process_results: !function utils.process_results
 metric_list:

--- a/lm_eval/tasks/aime/aime25.yaml
+++ b/lm_eval/tasks/aime/aime25.yaml
@@ -7,7 +7,12 @@ output_type: generate_until
 training_split: test
 fewshot_split: test
 test_split: test
-doc_to_text: "Question: {{problem}}\nAnswer:"
+doc_to_text: |
+  Solve the following AIME problem.
+
+  {{ problem }}
+
+  Answer:
 doc_to_target: "{{answer}}"
 process_results: !function utils.process_results
 metric_list:

--- a/tests/test_aime_prompt.py
+++ b/tests/test_aime_prompt.py
@@ -1,0 +1,17 @@
+"""Regression test: AIME tasks must produce non-empty prompts for API backends."""
+
+import pytest
+
+from lm_eval.tasks import TaskManager, get_task_dict
+
+
+@pytest.mark.parametrize("task_name", ["aime24", "aime", "aime25"])
+def test_aime_prompt_not_empty(task_name):
+    """Ensure AIME doc_to_text never returns empty prompt (fixes API backend errors)."""
+    task_manager = TaskManager()
+    task_dict = get_task_dict([task_name], task_manager)
+    task = task_dict[task_name]
+    doc = next(iter(task.test_docs()))
+    prompt = task.doc_to_text(doc)
+    assert isinstance(prompt, str), "doc_to_text must return a string"
+    assert prompt.strip() != "", "Prompt must be non-empty for API backends"


### PR DESCRIPTION
### Fix AIME'24 empty prompt for API backends

This PR fixes an issue where AIME'24 tasks generate an empty prompt when evaluated using OpenAI-style / local-completions backends, causing API errors like:

> Prompt cannot be empty

HF local models tolerate empty prompts, but API backends do not.

#### Changes
- Ensure `doc_to_text` always returns a non-empty prompt (instructional prefix: "Solve the following AIME problem.")
- Applied to `aime24`, `aime`, and `aime25` with correct dataset fields (`Problem` / `Question` / `problem`)
- Add regression test `tests/test_aime_prompt.py` to prevent future empty prompts

#### Related issue
Fixes #3497