### PR TITLE
New NorEval tasks

### DIFF
--- a/lm_eval/tasks/noreval/nocola/nocola.yaml
+++ b/lm_eval/tasks/noreval/nocola/nocola.yaml
@@ -1,0 +1,12 @@
+task: nocola
+dataset_path: ltg/nocola
+output_type: multiple_choice
+test_split: test
+doc_to_text: ""
+doc_to_target: 0
+doc_to_choice: "{{[correct_text, incorrect_text]}}"
+metric_list:
+  - metric: acc
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/noreval/nocola/nocola.yaml
+++ b/lm_eval/tasks/noreval/nocola/nocola.yaml
@@ -9,4 +9,4 @@ metric_list:
   - metric: acc
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/noreval/norbelebele/_norbelebele_yaml
+++ b/lm_eval/tasks/noreval/norbelebele/_norbelebele_yaml
@@ -1,6 +1,5 @@
 tag: norbelebele
-dataset_path: facebook/belebele
-dataset_name: nob_Latn
+dataset_path: ltg/norbelebele
 test_split: test
 fewshot_split: test
 fewshot_config:

--- a/lm_eval/tasks/noreval/norbelebele/_norbelebele_yaml
+++ b/lm_eval/tasks/noreval/norbelebele/_norbelebele_yaml
@@ -14,4 +14,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/noreval/norbelebele/norbelebele_p5.yaml
+++ b/lm_eval/tasks/noreval/norbelebele/norbelebele_p5.yaml
@@ -1,0 +1,4 @@
+task: norbelebele_p5
+include: _norbelebele_yaml
+doc_to_text: "Tekst: {{flores_passage}}\nSpørsmål: {{question}}\nSvar:"
+doc_to_choice: "{{[mc_answer1, mc_answer2, mc_answer3, mc_answer4]}}"

--- a/lm_eval/tasks/noreval/norbelebele/norbelebele_p6.yaml
+++ b/lm_eval/tasks/noreval/norbelebele/norbelebele_p6.yaml
@@ -1,0 +1,4 @@
+task: norbelebele_p6
+include: _norbelebele_yaml
+doc_to_text: "Bakgrunn: {{flores_passage}}\nSpørsmål:{{question}}\nRiktig svar:"
+doc_to_choice: "{{[mc_answer1, mc_answer2, mc_answer3, mc_answer4]}}"

--- a/lm_eval/tasks/noreval/noreval_multiblimp/_noreval_multiblimp.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/_noreval_multiblimp.yaml
@@ -1,0 +1,21 @@
+group: noreval_multiblimp
+task:
+  - "noreval_multiblimp_1-2"
+  - "noreval_multiblimp_2-1"
+  - "noreval_multiblimp_1-3"
+  - "noreval_multiblimp_3-1"
+  - "noreval_multiblimp_2-3"
+  - "noreval_multiblimp_3-2"
+  - "noreval_multiblimp_1-23"
+  - "noreval_multiblimp_SG-PL"
+  - "noreval_multiblimp_PL-SG"
+  - "noreval_multiblimp_SG-DU"
+  - "noreval_multiblimp_DU-SG"
+  - "noreval_multiblimp_PL-DU"
+  - "noreval_multiblimp_DU-PL"
+aggregate_metric_list:
+  - metric: acc
+    aggregation: mean
+    weight_by_size: True
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/noreval/noreval_multiblimp/_noreval_multiblimp.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/_noreval_multiblimp.yaml
@@ -18,4 +18,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: True
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/noreval/noreval_multiblimp/_template_yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/_template_yaml
@@ -1,0 +1,20 @@
+task: noreval_multiblimp
+dataset_path: jumelet/multiblimp
+dataset_name: sme
+output_type: multiple_choice
+test_split: train
+fewshot_split: train
+doc_to_text: ""
+doc_to_target: 0
+doc_to_choice: "{{[sen, wrong_sen]}}"
+fewshot_config:
+  process_docs: null
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_1-2.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_1-2.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_1-2
+include: _template_yaml
+process_docs: !function utils.filter_dataset_1_2

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_1-23.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_1-23.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_1-23
+include: _template_yaml
+process_docs: !function utils.filter_dataset_1_23

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_1-3.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_1-3.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_1-3
+include: _template_yaml
+process_docs: !function utils.filter_dataset_1_3

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_2-1.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_2-1.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_2-1
+include: _template_yaml
+process_docs: !function utils.filter_dataset_2_1

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_2-3.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_2-3.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_2-3
+include: _template_yaml
+process_docs: !function utils.filter_dataset_2_3

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_3-1.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_3-1.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_3-1
+include: _template_yaml
+process_docs: !function utils.filter_dataset_3_1

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_3-2.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_3-2.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_3-2
+include: _template_yaml
+process_docs: !function utils.filter_dataset_3_2

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_DU-PL.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_DU-PL.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_DU-PL
+include: _template_yaml
+process_docs: !function utils.filter_dataset_du_pl

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_DU-SG.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_DU-SG.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_DU-SG
+include: _template_yaml
+process_docs: !function utils.filter_dataset_du_sg

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_PL-DU.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_PL-DU.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_PL-DU
+include: _template_yaml
+process_docs: !function utils.filter_dataset_pl_du

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_PL-SG.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_PL-SG.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_PL-SG
+include: _template_yaml
+process_docs: !function utils.filter_dataset_pl_sg

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_SG-DU.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_SG-DU.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_SG-DU
+include: _template_yaml
+process_docs: !function utils.filter_dataset_sg_du

--- a/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_SG-PL.yaml
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/noreval_multiblimp_SG-PL.yaml
@@ -1,0 +1,3 @@
+task: noreval_multiblimp_SG-PL
+include: _template_yaml
+process_docs: !function utils.filter_dataset_sg_pl

--- a/lm_eval/tasks/noreval/noreval_multiblimp/utils.py
+++ b/lm_eval/tasks/noreval/noreval_multiblimp/utils.py
@@ -1,0 +1,39 @@
+def filter_dataset_1_2(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "1 -> 2")
+
+def filter_dataset_2_1(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "2 -> 1")
+
+def filter_dataset_3_1(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "3 -> 1")
+
+def filter_dataset_1_3(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "1 -> 3")
+
+def filter_dataset_3_2(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "3 -> 2")
+
+def filter_dataset_2_3(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "2 -> 3")
+
+def filter_dataset_1_23(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "1 -> 2|3")
+
+def filter_dataset_sg_du(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "SG -> DU")
+
+def filter_dataset_du_sg(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "DU -> SG")
+
+def filter_dataset_sg_pl(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "SG -> PL")
+
+def filter_dataset_pl_sg(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "PL -> SG")
+
+def filter_dataset_pl_du(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "PL -> DU")
+
+def filter_dataset_du_pl(dataset):
+    return dataset.filter(lambda example: example["feature_vals"] == "DU -> PL")
+

--- a/lm_eval/tasks/noreval/noropenbookqa/_noropenbookqa_yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/_noropenbookqa_yaml
@@ -13,4 +13,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p0.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p0.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nno
+task: noropenbookqa_no_fact_nno_p0
+dataset_name: nn
+include: ../_noropenbookqa_yaml
+doc_to_text: "{{question_stem}}"
+doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p1.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p1.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nno
+task: noropenbookqa_no_fact_nno_p1
+dataset_name: nn
+include: ../_noropenbookqa_yaml
+doc_to_text: "Spørsmål: {{question_stem}}\n\nSvaralternativer:\n- {{choices.text[0]}}\n- {{choices.text[1]}}\n- {{choices.text[2]}}\n- {{choices.text[3]}}\n\nKva er rett svar?"
+doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p2.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p2.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nno
+task: noropenbookqa_no_fact_nno_p2
+dataset_name: nn
+include: ../_noropenbookqa_yaml
+doc_to_text: "{{question_stem}}\nA: {{choices.text[0]}}\nB: {{choices.text[1]}}\nC: {{choices.text[2]}}\nD: {{choices.text[3]}}\n\nEr det rette svaret A, B, C, eller D?\n\nSvar:"
+doc_to_choice: "{{choices.label}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p3.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p3.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nno
+task: noropenbookqa_no_fact_nno_p3
+dataset_name: nn
+include: ../_noropenbookqa_yaml
+doc_to_text: "Spørsmål: {{question_stem}}\nA: {{choices.text[0]}}\nB: {{choices.text[1]}}\nC: {{choices.text[2]}}\nD: {{choices.text[3]}}\n\nSvar:"
+doc_to_choice: "{{choices.label}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p4.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p4.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nno
+task: noropenbookqa_no_fact_nno_p4
+dataset_name: nn
+include: ../_noropenbookqa_yaml
+doc_to_text: "{{question_stem}}\nVel rett svar blant desse alternativa:\n– {{choices.text[0]}}\n– {{choices.text[1]}}\n– {{choices.text[2]}}\n– {{choices.text[3]}}\n\nSvar:"
+doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p0.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p0.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nob
+task: noropenbookqa_no_fact_nob_p0
+dataset_name: nb
+include: ../_noropenbookqa_yaml
+doc_to_text: "{{question_stem}}"
+doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p1.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p1.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nob
+task: noropenbookqa_no_fact_nob_p1
+dataset_name: nb
+include: ../_noropenbookqa_yaml
+doc_to_text: "Spørsmål: {{question_stem}}\n\nSvaralternativer:\n- {{choices.text[0]}}\n- {{choices.text[1]}}\n- {{choices.text[2]}}\n- {{choices.text[3]}}\n\nHva er riktig svar?"
+doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p2.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p2.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_no_fact_nob
+task: noropenbookqa_no_fact_nob_p4
+dataset_name: nb
+include: ../_noropenbookqa_yaml
+doc_to_text: "{{question_stem}}\nVelg riktig svar blant disse alternativene:\n– {{choices.text[0]}}\n– {{choices.text[1]}}\n– {{choices.text[2]}}\n– {{choices.text[3]}}\n\nSvar:"
+doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p2.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p2.yaml
@@ -1,6 +1,6 @@
 tag: noropenbookqa_no_fact_nob
-task: noropenbookqa_no_fact_nob_p4
+task: noropenbookqa_no_fact_nob_p2
 dataset_name: nb
 include: ../_noropenbookqa_yaml
-doc_to_text: "{{question_stem}}\nVelg riktig svar blant disse alternativene:\n– {{choices.text[0]}}\n– {{choices.text[1]}}\n– {{choices.text[2]}}\n– {{choices.text[3]}}\n\nSvar:"
-doc_to_choice: "{{choices.text}}"
+doc_to_text: "{{question_stem}}\nA: {{choices.text[0]}}\nB: {{choices.text[1]}}\nC: {{choices.text[2]}}\nD: {{choices.text[3]}}\n\nEr det riktige svaret A, B, C, eller D?\n\nSvar:"
+doc_to_choice: "{{choices.label}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p3.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p3.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_nob
+task: noropenbookqa_nob_p3
+dataset_name: nb
+include: ../_noropenbookqa_yaml
+doc_to_text: "Bakgrunn: {{fact}}\n\nSpørsmål: {{question_stem}}\nA: {{choices.text[0]}}\nB: {{choices.text[1]}}\nC: {{choices.text[2]}}\nD: {{choices.text[3]}}\n\nSvar:"
+doc_to_choice: "{{choices.label}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p3.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p3.yaml
@@ -1,6 +1,6 @@
-tag: noropenbookqa_nob
-task: noropenbookqa_nob_p3
+tag: noropenbookqa_no_fact_nob
+task: noropenbookqa_no_fact_nob_p3
 dataset_name: nb
 include: ../_noropenbookqa_yaml
-doc_to_text: "Bakgrunn: {{fact}}\n\nSpørsmål: {{question_stem}}\nA: {{choices.text[0]}}\nB: {{choices.text[1]}}\nC: {{choices.text[2]}}\nD: {{choices.text[3]}}\n\nSvar:"
+doc_to_text: "Spørsmål: {{question_stem}}\nA: {{choices.text[0]}}\nB: {{choices.text[1]}}\nC: {{choices.text[2]}}\nD: {{choices.text[3]}}\n\nSvar:"
 doc_to_choice: "{{choices.label}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p4.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p4.yaml
@@ -1,0 +1,6 @@
+tag: noropenbookqa_nob
+task: noropenbookqa_nob_p4
+dataset_name: nb
+include: ../_noropenbookqa_yaml
+doc_to_text: "Ta utgangspunkt i følgende fakta når du svarer på spørsmålet: {{fact}}\n\n{{question_stem}}\nVelg riktig svar blant disse alternativene:\n– {{choices.text[0]}}\n– {{choices.text[1]}}\n– {{choices.text[2]}}\n– {{choices.text[3]}}\n\nSvar:"
+doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p4.yaml
+++ b/lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p4.yaml
@@ -1,6 +1,6 @@
-tag: noropenbookqa_nob
-task: noropenbookqa_nob_p4
+tag: noropenbookqa_no_fact_nob
+task: noropenbookqa_no_fact_nob_p4
 dataset_name: nb
 include: ../_noropenbookqa_yaml
-doc_to_text: "Ta utgangspunkt i følgende fakta når du svarer på spørsmålet: {{fact}}\n\n{{question_stem}}\nVelg riktig svar blant disse alternativene:\n– {{choices.text[0]}}\n– {{choices.text[1]}}\n– {{choices.text[2]}}\n– {{choices.text[3]}}\n\nSvar:"
+doc_to_text: "{{question_stem}}\nVelg riktig svar blant disse alternativene:\n– {{choices.text[0]}}\n– {{choices.text[1]}}\n– {{choices.text[2]}}\n– {{choices.text[3]}}\n\nSvar:"
 doc_to_choice: "{{choices.text}}"

--- a/lm_eval/tasks/noreval/norsumm_translation/_norsumm_translation_yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/_norsumm_translation_yaml
@@ -1,0 +1,17 @@
+dataset_path: ltg/norsumm-nob-nno-translation
+training_split: test
+test_split: test
+output_type: generate_until
+metric_list:
+  - metric: bleu
+    higher_is_better: true
+  - metric: chrf
+    higher_is_better: true
+generation_kwargs:
+  until:
+    - "\n"
+  do_sample: false
+  num_beams: 1
+  max_new_tokens: 256
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/noreval/norsumm_translation/_norsumm_translation_yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/_norsumm_translation_yaml
@@ -14,4 +14,4 @@ generation_kwargs:
   num_beams: 1
   max_new_tokens: 256
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p0.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p0.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nno_nob_translation
+doc_to_target: text_nob
+task: norsumm_nno_nob_translation_p0
+include: ../_norsumm_translation_yaml
+doc_to_text: "Nynorsk: {{text_nno}}\nBokmål:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p1.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p1.yaml
@@ -2,4 +2,4 @@ tag: norsumm_nno_nob_translation
 doc_to_target: text_nob
 task: norsumm_nno_nob_translation_p1
 include: ../_norsumm_translation_yaml
-doc_to_text: "Oversett følgende tekst til bokmål: {{text_nno}}\nBokmål:
+doc_to_text: "Oversett følgende tekst til bokmål: {{text_nno}}\nBokmål:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p1.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p1.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nno_nob_translation
+doc_to_target: text_nob
+task: norsumm_nno_nob_translation_p1
+include: ../_norsumm_translation_yaml
+doc_to_text: "Oversett følgende tekst til bokmål: {{text_nno}}\nBokmål:

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p2.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p2.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nno_nob_translation
+doc_to_target: text_nob
+task: norsumm_nno_nob_translation_p2
+include: ../_norsumm_translation_yaml
+doc_to_text: "Gi en bokmål oversettelse av denne teksten: {{text_nno}}\nBokmål:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p3.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p3.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nno_nob_translation
+doc_to_target: text_nob
+task: norsumm_nno_nob_translation_p3
+include: ../_norsumm_translation_yaml
+doc_to_text: "Hva blir \"{{text_nno}}\" på bokmål?\nBokmål:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p0.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p0.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nob_nno_translation
+doc_to_target: text_nno
+task: norsumm_nob_nno_translation_p0
+include: ../_norsumm_translation_yaml
+doc_to_text: "Bokmål: {{text_nob}}\nNynorsk:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p1.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p1.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nob_nno_translation
+doc_to_target: text_nno
+task: norsumm_nob_nno_translation_p1
+include: ../_norsumm_translation_yaml
+doc_to_text: "Oversett følgende tekst til nynorsk: {{text_nob}}\nNynorsk:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p2.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p2.yaml
@@ -2,4 +2,4 @@ tag: norsumm_nob_nno_translation
 doc_to_target: text_nno
 task: norsumm_nob_nno_translation_p2
 include: ../_norsumm_translation_yaml
-doc_to_text: "Gi en samisk oversettelse av denne teksten: {{text_nob}}\nNynorsk:"
+doc_to_text: "Gi en nynorsk oversettelse av denne teksten: {{text_nob}}\nNynorsk:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p2.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p2.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nob_nno_translation
+doc_to_target: text_nno
+task: norsumm_nob_nno_translation_p2
+include: ../_norsumm_translation_yaml
+doc_to_text: "Gi en samisk oversettelse av denne teksten: {{text_nob}}\nNynorsk:"

--- a/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p3.yaml
+++ b/lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p3.yaml
@@ -1,0 +1,5 @@
+tag: norsumm_nob_nno_translation
+doc_to_target: text_nno
+task: norsumm_nob_nno_translation_p3
+include: ../_norsumm_translation_yaml
+doc_to_text: "Hva blir \"{{text_nob}}\" på nynorsk?\nNynorsk:"

--- a/lm_eval/tasks/noreval/slide/_slide_yaml
+++ b/lm_eval/tasks/noreval/slide/_slide_yaml
@@ -1,0 +1,15 @@
+tag: slide
+dataset_path: ltg/slide
+test_split: test
+training_split: train
+validation_split: validation
+fewshot_split: validation
+output_type: multiple_choice
+doc_to_target: "{{correct_indices[0]}}"
+process_results: !function utils.process_multilabel
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/noreval/slide/_slide_yaml
+++ b/lm_eval/tasks/noreval/slide/_slide_yaml
@@ -12,4 +12,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/noreval/slide/slide_p0.yaml
+++ b/lm_eval/tasks/noreval/slide/slide_p0.yaml
@@ -1,0 +1,4 @@
+task: slide_p0
+include: _slide_yaml
+doc_to_text: "Hvilket språk er det i følgende setning?\n{{text}}\nEr det bokmål, nynorsk, dansk, svensk, eller et annet språk?\nSvar:"
+doc_to_choice: ["bokmål", "nynorsk", "dansk", "svensk", "et annet språk"]

--- a/lm_eval/tasks/noreval/slide/slide_p1.yaml
+++ b/lm_eval/tasks/noreval/slide/slide_p1.yaml
@@ -1,0 +1,4 @@
+task: slide_p1
+include: _slide_yaml
+doc_to_text: "Tekst: {{text}}\nHvilket språk er teksten skrevet på? Alternativer:\n- A) Bokmål\n- B) Nynorsk\n- C) Dansk\n- D) Svensk\n- E) Et annet språk\nRiktig svar:"
+doc_to_choice: ["A)", "B)", "C)", "D)", "E)"]

--- a/lm_eval/tasks/noreval/slide/slide_p2.yaml
+++ b/lm_eval/tasks/noreval/slide/slide_p2.yaml
@@ -1,0 +1,4 @@
+task: slide_p2
+include: _slide_yaml
+doc_to_text: "Se på følgende setning: {{text}}\nDet er et godt eksempel på en setning skrevet på"
+doc_to_choice: ["bokmål", "nynorsk", "dansk", "svensk", "et annet språk"]

--- a/lm_eval/tasks/noreval/slide/slide_p3.yaml
+++ b/lm_eval/tasks/noreval/slide/slide_p3.yaml
@@ -1,0 +1,4 @@
+task: slide_p3
+include: _slide_yaml
+doc_to_text: "Setning å vurdere: {{text}}\nEr denne setningen skrevet på bokmål, nynorsk, dansk, svensk eller et annet språk? Hvis jeg må velge, vil jeg si at den er skrevet på"
+doc_to_choice: ["bokmål", "nynorsk", "dansk", "svensk", "et annet språk"]

--- a/lm_eval/tasks/noreval/slide/slide_p4.yaml
+++ b/lm_eval/tasks/noreval/slide/slide_p4.yaml
@@ -1,0 +1,4 @@
+task: slide_p4
+include: _slide_yaml
+doc_to_text: "Folk skriver på mange språk, som bokmål, nynorsk, dansk, svensk eller på mange andre språk. «{{text}}» er et eksempel på en setning skrevet på"
+doc_to_choice: ["bokmål", "nynorsk", "dansk", "svensk", "et annet språk"]

--- a/lm_eval/tasks/noreval/slide/utils.py
+++ b/lm_eval/tasks/noreval/slide/utils.py
@@ -1,0 +1,10 @@
+def process_multilabel(doc, results):
+    # results contains log-likelihoods for each choice
+    # Find the index with highest likelihood
+    predicted_idx = results.index(max(results))
+    correct_indices = doc["correct_indices"]
+    
+    # Check if prediction is among correct answers
+    is_correct = predicted_idx in correct_indices
+    
+    return {"acc": int(is_correct)}

--- a/lm_eval/tasks/noreval/tatoeba/_tatoeba_yaml
+++ b/lm_eval/tasks/noreval/tatoeba/_tatoeba_yaml
@@ -14,4 +14,4 @@ generation_kwargs:
   num_beams: 1
   max_new_tokens: 256
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p0.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p0.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_nob_sme
+doc_to_target: text_sme
+task: tatoeba_nob_sme_p0
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Bokmål: {{text_nob}}\nSamisk:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p1.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p1.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_nob_sme
+doc_to_target: text_sme
+task: tatoeba_nob_sme_p1
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Oversett følgende setning til samisk: {{text_nob}}\nSamisk:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p2.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p2.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_nob_sme
+doc_to_target: text_sme
+task: tatoeba_nob_sme_p2
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Gi en samisk oversettelse av denne setningen: {{text_nob}}\nSamisk:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p3.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p3.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_nob_sme
+doc_to_target: text_sme
+task: tatoeba_nob_sme_p3
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Hva blir \"{{text_nob}}\" på samisk?\nSamisk:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p4.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p4.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_nob_sme
+doc_to_target: text_sme
+task: tatoeba_nob_sme_p4
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Dárogiella: {{text_nob}}\nDavvisámegiella:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p0.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p0.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_sme_nob
+doc_to_target: text_nob
+task: tatoeba_sme_nob_p0
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Samisk: {{text_sme}}\nBokmål:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p1.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p1.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_sme_nob
+doc_to_target: text_nob
+task: tatoeba_sme_nob_p1
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Oversett følgende setning til bokmål: {{text_sme}}\nBokmål:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p2.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p2.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_sme_nob
+doc_to_target: text_nob
+task: tatoeba_sme_nob_p2
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Gi en bokmål oversettelse av denne setningen: {{text_sme}}\nBokmål:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p3.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p3.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_sme_nob
+doc_to_target: text_nob
+task: tatoeba_sme_nob_p3
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Hva blir \"{{text_sme}}\" på bokmål?\nBokmål:"

--- a/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p4.yaml
+++ b/lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p4.yaml
@@ -1,0 +1,7 @@
+dataset_path: ltg/saami-tatoeba
+tag: tatoeba_sme_nob
+doc_to_target: text_nob
+task: tatoeba_sme_nob_p4
+include: ../_tatoeba_yaml
+training_split: test
+doc_to_text: "Davvisámegiella: {{text_sme}}\nDárogiella:"


### PR DESCRIPTION
# NorEval: 8 new tasks and corrected NorBelebele data source

## Summary

This PR extends the NorEval benchmark suite with 8 new evaluation tasks and fixes the data source for 1 existing task:

- **Add NoCola** (Norwegian Corpus of Linguistic Acceptability): a minimal-pair linguistic acceptability task.
- **Add NorOpenBookQA without fact** (Bokmål and Nynorsk): closed-book variants of the existing NorOpenBookQA task that omit the supporting fact from the prompt.
- **Add NorSumm Translation** (Bokmål-Nynorsk, both directions): paragraph-level translation between Norway's two written standards using parallel texts from NorSumm.
- **Add SLIDE** (Scandinavian LID Evaluation): multi-label classification of text into Bokmål, Nynorsk, Danish, Swedish, or other languages.
- **Add Tatoeba Sámi** (Bokmål-Northern Sámi, both directions): machine-translation evaluation between Norwegian Bokmål and Northern Sámi.
- **Add MultiBLiMP for Sámi**: now we include detailed MultiBLiMP evaluation of linguistic acceptability for Northern Sámi. Unlike the multilingual implementation already included in harness, we group the samples by linguistic phenomena being tested for more detailed results.
- **Fix NorBelebele data source** to use the corrected Norwegian translations from `ltg/norbelebele` instead of the original `facebook/belebele`.

Many of these tasks have already been used for evaluating Norwegian language models in *[Small Languages, Big Models: A Study of Continual Training on Languages of Norway](https://aclanthology.org/2025.nodalida-1.61/)*.

## Motivation

### 1. NoCola: linguistic acceptability judgment

The [Norwegian Corpus of Linguistic Acceptability](https://huggingface.co/datasets/ltg/nocola) (Jentoft & Samuel, [NoDaLiDa 2023](https://aclanthology.org/2023.nodalida-1.60/)) contains ~99,000 minimal pairs of grammatically correct and incorrect Norwegian Bokmål sentences. Each pair is annotated with one of 11 error categories (inflection, punctuation, word order, spelling, etc.).

The task is formulated as multiple choice: given a pair of sentences, the model must assign higher likelihood to the grammatically correct sentence. This provides a direct measure of a model's syntactic and grammatical knowledge of Norwegian, analogous to BLiMP for English. Since the evaluation relies solely on comparing log-likelihoods of correct vs. incorrect sentences, it is particularly well-suited for evaluating base language models.

The evaluation is similar to the existing NorEval NCB task, but NoCoLA has many more samples and is not limited only to detecting correct punctuation.

**Task configs:** 1 config (`nocola`), using accuracy as the metric.

### 2. NorOpenBookQA without fact: closed-book science QA

The existing NorOpenBookQA task ([Mikhailov et al., NoDaLiDa 2025](https://aclanthology.org/2025.nodalida-1.43/)) evaluates elementary science knowledge as 4-way multiple-choice QA. The original "open-book" variants include a supporting fact in the prompt that helps answer the question.

The new **no-fact variants** omit this supporting fact, turning the task into a closed-book QA evaluation. This is similar to how the original English OpenBookQA is typically evaluated. This tests whether the model has internalized the relevant world knowledge rather than whether it can use a provided fact to select the correct answer (basically testing its reading-comprehension skills). The closed-book setting is a more demanding evaluation of a model's knowledge and is arguably more representative of how models are used in practice.

Both Bokmål and Nynorsk variants are provided, each with 5 prompt templates (p0-p4) covering different prompt formulations (bare question stem, explicit answer listing, A/B/C/D labeling, etc.).

**Task configs:** 10 configs (5 prompts x 2 languages: `noropenbookqa_no_fact_nob_p{0..4}`, `noropenbookqa_no_fact_nno_p{0..4}`), using accuracy and normalized accuracy.

### 3. NorSumm Translation: Bokmål-Nynorsk translation

The [NorSumm Bokmål-Nynorsk Translation dataset](https://huggingface.co/datasets/ltg/norsumm-nob-nno-translation) provides 189 manually translated parallel paragraphs between Norwegian Bokmål and Nynorsk, extracted from the NorSumm summarization corpus ([Touileb et al.](https://aclanthology.org/)).

Both directions are evaluated (Nynorsk-to-Bokmål and Bokmål-to-Nynorsk), each with 4 prompt templates ranging from minimal ("Nynorsk: ... Bokmål:") to explicit instruction-style prompts.

**Task configs:** 8 configs (4 prompts x 2 directions: `norsumm_nno_nob_translation_p{0..3}`, `norsumm_nob_nno_translation_p{0..3}`), using BLEU and chrF.

### 4. SLIDE: Scandinavian language identification

[SLIDE](https://huggingface.co/datasets/ltg/slide) (Fedorova et al., [RESOURCEFUL 2025](https://aclanthology.org/2025.resourceful-1.33/)) is a multi-label Scandinavian language identification dataset with sentences sourced from Universal Dependencies and Tatoeba. Each sentence is labeled with one or more of 5 categories: Bokmål, Nynorsk, Danish, Swedish, or other. The validation and test sets are manually verified and annotated by native speakers.

Distinguishing between closely related Scandinavian languages is a challenging and linguistically interesting task. Short sentences can be valid in multiple languages simultaneously (e.g., "Det er interessant." is valid in Bokmål, Nynorsk, and Danish), which is why the task uses multi-label classification. The evaluation uses a custom `process_multilabel` function to handle cases where multiple labels are correct. We use the "loose accuracy" metric, which counts a prediction as correct if it matches any of the correct labels.

5 prompt templates are provided, covering different formulations of the language identification question.

**Task configs:** 5 configs (`slide_p{0..4}`), using accuracy.

### 5. Tatoeba Sámi: Northern Sámi-Bokmål translation

The [Saami Tatoeba dataset](https://huggingface.co/datasets/ltg/saami-tatoeba) contains 187 Northern Sámi sentences with parallel Norwegian Bokmål translations, collected from Tatoeba and manually verified or translated where necessary.

Northern Sámi is the most widely-spoken Sámi language, with approximately 25,000 speakers. It is classified as an endangered language. Evaluating translation to and from Northern Sámi provides an important measure of how well language models handle low-resource indigenous languages of Norway, and is especially relevant given ongoing efforts to develop NLP resources for Sámi languages.

Both translation directions are evaluated (Bokmål-to-Sámi and Sámi-to-Bokmål), each with 5 prompt templates. Notably, prompt p4 uses Northern Sámi language names ("Dárogiella" for Norwegian, "Davvisámegiella" for Northern Sámi).

**Task configs:** 10 configs (5 prompts x 2 directions: `tatoeba_nob_sme_p{0..4}`, `tatoeba_sme_nob_p{0..4}`), using BLEU and chrF.

### 6. Fix NorBelebele data source

The existing NorBelebele reading comprehension task was using `facebook/belebele` with the `nob_Latn` subset. This data source contains known Norwegian translation errors originating from the FLORES translations.

The [corrected NorBelebele dataset](https://huggingface.co/datasets/ltg/norbelebele) (`ltg/norbelebele`) incorporates improved Norwegian Bokmål translations from the `openlanguagedata/flores_plus` project, as documented in *[Improved Norwegian Bokmål Translations for FLORES](https://aclanthology.org/2025.wmt-1.86/)* (Maehlum et al., WMT 2025). Using the corrected data source ensures that the reading comprehension evaluation is not confounded by translation artifacts.

**Changes:** Updated `dataset_path` from `facebook/belebele` to `ltg/norbelebele` and removed the now-unnecessary `dataset_name: nob_Latn`.

## Files changed

| File | Change |
|------|--------|
| `lm_eval/tasks/noreval/nocola/nocola.yaml` | **New file**: NoCola linguistic acceptability task config |
| `lm_eval/tasks/noreval/noropenbookqa/nob_no_fact/noropenbookqa_nob_no_fact_p{0..4}.yaml` | **New files**: NorOpenBookQA Bokmål without fact (5 prompt templates) |
| `lm_eval/tasks/noreval/noropenbookqa/nno_no_fact/noropenbookqa_nno_no_fact_p{0..4}.yaml` | **New files**: NorOpenBookQA Nynorsk without fact (5 prompt templates) |
| `lm_eval/tasks/noreval/norsumm_translation/_norsumm_translation_yaml` | **New file**: Base config for NorSumm translation tasks |
| `lm_eval/tasks/noreval/norsumm_translation/norsumm_nno_nob/tatoeba_nno_nob_p{0..3}.yaml` | **New files**: NorSumm Nynorsk-to-Bokmål translation (4 prompt templates) |
| `lm_eval/tasks/noreval/norsumm_translation/norsumm_nob_nno/tatoeba_nob_nno_p{0..3}.yaml` | **New files**: NorSumm Bokmål-to-Nynorsk translation (4 prompt templates) |
| `lm_eval/tasks/noreval/slide/_slide_yaml` | **New file**: Base config for SLIDE language identification |
| `lm_eval/tasks/noreval/slide/slide_p{0..4}.yaml` | **New files**: SLIDE Scandinavian language identification (5 prompt templates) |
| `lm_eval/tasks/noreval/tatoeba/tatoeba_nob_sme/tatoeba_nob_sme_p{0..4}.yaml` | **New files**: Tatoeba Bokmål-to-Northern Sámi translation (5 prompt templates) |
| `lm_eval/tasks/noreval/tatoeba/tatoeba_sme_nob/tatoeba_sme_nob_p{0..4}.yaml` | **New files**: Tatoeba Northern Sámi-to-Bokmål translation (5 prompt templates) |
| `lm_eval/tasks/noreval/tatoeba/noreval_multiblimp/` | **New files**: Detailed MultiBLiMP evaluation of Sámi with specific configs for each grammatical group |
| `lm_eval/tasks/noreval/norbelebele/_norbelebele_yaml` | Fix data source: `facebook/belebele` -> `ltg/norbelebele` |

## Verification of the code changes

We have run the updated NorEval benchmarks on 25 language models, the benchmark is available at https://ltgoslo.github.io/noreval-stats/#models=all. The results are consistent with expectations based on the dataset specifications and the nature of the tasks.
