### PR TITLE
fix(winml): fix winml incompatible parameters

### DIFF
--- a/lm_eval/models/winml.py
+++ b/lm_eval/models/winml.py
@@ -70,7 +70,7 @@ class WindowsML(TemplateLM):
         max_length: int | None = 4096,
         batch_size: int = 1,
         max_batch_size: int = 64,
-        **kwargs
+        **kwargs,
     ) -> None:
         """
         Initialize WindowsML model.


### PR DESCRIPTION
Fix the winml class constructor so incompatible parameters won't cause a crash. For example: the default device="cuda:0" parameter.
