### PR TITLE
fix(gpqa): remove bracket-stripping regex that corrupts scientific co…

### DIFF
--- a/lm_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
@@ -35,4 +35,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/gpqa/cot_n_shot/utils.py
+++ b/lm_eval/tasks/gpqa/cot_n_shot/utils.py
@@ -1,5 +1,4 @@
 import random
-import re
 
 import datasets
 
@@ -7,11 +6,7 @@ import datasets
 def preprocess(text):
     if text is None:
         return " "
-    text = text.strip()
-    text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
-    text = text.replace("  ", " ")
-    return text
+    return text.strip()
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:

--- a/lm_eval/tasks/gpqa/cot_zeroshot/_gpqa_cot_zeroshot_yaml
+++ b/lm_eval/tasks/gpqa/cot_zeroshot/_gpqa_cot_zeroshot_yaml
@@ -35,4 +35,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/gpqa/cot_zeroshot/utils.py
+++ b/lm_eval/tasks/gpqa/cot_zeroshot/utils.py
@@ -1,5 +1,4 @@
 import random
-import re
 
 import datasets
 
@@ -7,11 +6,7 @@ import datasets
 def preprocess(text):
     if text is None:
         return " "
-    text = text.strip()
-    text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
-    text = text.replace("  ", " ")
-    return text
+    return text.strip()
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:

--- a/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
@@ -36,4 +36,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/gpqa/generative/utils.py
+++ b/lm_eval/tasks/gpqa/generative/utils.py
@@ -1,5 +1,4 @@
 import random
-import re
 
 import datasets
 
@@ -7,11 +6,7 @@ import datasets
 def preprocess(text):
     if text is None:
         return " "
-    text = text.strip()
-    text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
-    text = text.replace("  ", " ")
-    return text
+    return text.strip()
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:

--- a/lm_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
@@ -18,4 +18,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 2.0
+  version: 3.0

--- a/lm_eval/tasks/gpqa/n_shot/utils.py
+++ b/lm_eval/tasks/gpqa/n_shot/utils.py
@@ -1,5 +1,4 @@
 import random
-import re
 
 import datasets
 
@@ -7,11 +6,7 @@ import datasets
 def preprocess(text):
     if text is None:
         return " "
-    text = text.strip()
-    text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
-    text = text.replace("  ", " ")
-    return text
+    return text.strip()
 
 
 rng = random.Random(42)

--- a/lm_eval/tasks/gpqa/zeroshot/_gpqa_zeroshot_yaml
+++ b/lm_eval/tasks/gpqa/zeroshot/_gpqa_zeroshot_yaml
@@ -18,4 +18,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/gpqa/zeroshot/utils.py
+++ b/lm_eval/tasks/gpqa/zeroshot/utils.py
@@ -1,5 +1,4 @@
 import random
-import re
 
 import datasets
 
@@ -7,11 +6,7 @@ import datasets
 def preprocess(text):
     if text is None:
         return " "
-    text = text.strip()
-    text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
-    text = text.replace("  ", " ")
-    return text
+    return text.strip()
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:

--- a/lm_eval/tasks/leaderboard/gpqa/utils.py
+++ b/lm_eval/tasks/leaderboard/gpqa/utils.py
@@ -1,5 +1,4 @@
 import random
-import re
 
 import datasets
 
@@ -7,11 +6,7 @@ import datasets
 def preprocess(text):
     if text is None:
         return " "
-    text = text.strip()
-    text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
-    text = text.replace("  ", " ")
-    return text
+    return text.strip()
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:

--- a/lm_eval/tasks/leaderboard/gpqa/utils.py
+++ b/lm_eval/tasks/leaderboard/gpqa/utils.py
@@ -1,4 +1,5 @@
 import random
+import re
 
 import datasets
 
@@ -6,7 +7,11 @@ import datasets
 def preprocess(text):
     if text is None:
         return " "
-    return text.strip()
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = re.sub("\\[.*?\\]", "", text)
+    text = text.replace("  ", " ")
+    return text
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:


### PR DESCRIPTION
## Summary

The `preprocess()` function in all GPQA task variants strips all bracketed content via `re.sub("\\[.*?\\]", "", text)`. This was likely inherited from HellaSwag preprocessing where `[title]` artifacts need removal? GPQA has **zero** `[]` occurrences that should be removed and **161 legitimate bracket patterns** that get destroyed.

Fixes #2907.

## Impact

**gpqa_main** (448 examples):
- 79/448 (17.6%) have content removed by the regex
- 67 questions affected (e.g. chemical notation, astronomical abundances)
- 27 answer choices affected
- **2 examples have all 4 choices collapsed into duplicates**, making them unanswerable

**gpqa_diamond** (198 examples):
- 40/198 (20.2%) have content removed
- **1 example has all 4 choices collapsed into identical strings**

## Examples of corrupted content

### Critical: answer choices become identical

Row 111 (`recINGR1z01Fh1Z3A`) — all 4 choices become `ln(2) =`:
| | Before | After |
|---|---|---|
| Correct | `ln(2) = [ (T_1 - T_2) / (T1*T2)]` | `ln(2) =` |
| Wrong 1 | `ln(2) = [ (T_1 - T_2) / (T1*T2)^2 ]` | `ln(2) =` |
| Wrong 2 | `ln(2) = [ (T_1 + T_2) / (T1*T2)]` | `ln(2) =` |
| Wrong 3 | `ln(2) = [ T_2 / T_1]` | `ln(2) =` |

Row 110 (`recIN1LyuCWtFwrJ4`) — 4 choices collapse into 2:
| | Before | After |
|---|---|---|
| Correct | `ln(2) [ℏ^2/2mα]` | `ln(2)` |
| Wrong 1 | `ln(2) [ℏ^2/mα^2]` | `ln(2)` |
| Wrong 2 | `ln(4) [ℏ^2/2mα]` | `ln(4)` |
| Wrong 3 | `ln(4) [ℏ^2/mα^2]` | `ln(4)` |

### Chemical nomenclature destroyed

IUPAC ring notation stripped from compound names:
- `bicyclo[2.2.1]hept-5-ene` → `bicyclohept-5-ene`
- `triphenyleno[1,2-c:5,6-c':9,10-c'']trifuran-...` → `triphenylenotrifuran-...`
- `spiro[4.5]decan-6-ol` → `spirodecan-6-ol`
- `[1,1'-biphenyl]-4-ol` → `-4-ol`

### Astronomical notation stripped from questions

`[Fe/H]`, `[Si/Fe]`, `[Mg/Si]`, `[Mg/H]`, `[OI]` — standard astronomical abundance notation removed from astrophysics questions.

### Physics notation stripped

`[gamma^mu, gamma^nu]` (commutator) removed from a question about Dirac field angular momentum.

## Fix

Remove the bracket-stripping regex entirely. GPQA data is expert-curated and clean, there are no `[]` artifacts. The `preprocess()` function now only strips whitespace, matching [LightEval's approach](https://github.com/huggingface/lighteval/blob/main/community_tasks/gpqa.py) to GPQA.

## Testing Done

- [x] Checked for `[]` artifacts, and whether they should be removed or not in GPQA data (0 occurrences to be removed, across all configs)
- [x] Verified affected examples now preserve their full content
- [x] Verified the 2 duplicate-choice examples now have 4 distinct choices
