### PR TITLE
Update vLLM import of `resolve_hf_chat_template`

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -38,7 +38,11 @@ from lm_eval.utils import (
 
 
 if parse_version(version("vllm")) >= parse_version("0.8.3"):
-    from vllm.entrypoints.chat_utils import resolve_hf_chat_template
+    try:
+        # Moved since vllm-project/vllm#30200
+        from vllm.renderers.hf import resolve_chat_template as resolve_hf_chat_template
+    except ImportError:
+        from vllm.entrypoints.chat_utils import resolve_hf_chat_template
 
 try:
     # Moved since vllm-project/vllm#29793


### PR DESCRIPTION
The old location has been deprecated since vllm-project/vllm#30200 and will be removed in an upcoming version.

This is needed for https://github.com/vllm-project/vllm/pull/35024