### PR TITLE
Update BLiMP dataset path

### DIFF
--- a/lm_eval/tasks/blimp/_template_yaml
+++ b/lm_eval/tasks/blimp/_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: blimp
+dataset_path: nyu-mll/blimp
 output_type: multiple_choice
 validation_split: train
 doc_to_text: ""


### PR DESCRIPTION
The original BLiMP dataset path (`blimp`) no longer automatically links to the current Hugging Face repository (`nyu-mll/blimp`). This pull request updates the path.