### PR TITLE
fix: Include model identity in response cache keys

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -227,8 +227,8 @@ class LM(abc.ABC):
 
 
 ### SQLite-based caching of LM responses
-def hash_args(attr: str, args: Iterable[Any]) -> str:
-    dat = json.dumps([attr] + list(args))
+def hash_args(attr: str, args: Iterable[Any], model_id: str = "") -> str:
+    dat = json.dumps([attr, model_id] + list(args))
     return hashlib.sha256(dat.encode("utf-8")).hexdigest()
 
 
@@ -236,29 +236,35 @@ class CacheHook:
     def __init__(self, cachinglm: Optional["CachingLM"]) -> None:
         if cachinglm is None:
             self.dbdict: SqliteDict | None = None
+            self.model_id: str = ""
             return
 
         self.dbdict = cachinglm.dbdict
+        self.model_id = cachinglm.model_id
 
     def add_partial(self, attr: str, req: Iterable[Any], res: Any) -> None:
         if self.dbdict is None:
             return
-        hsh = hash_args(attr, req)
+        hsh = hash_args(attr, req, model_id=self.model_id)
         self.dbdict[hsh] = res
 
 
 class CachingLM:
-    def __init__(self, lm: LM, cache_db: str) -> None:
+    def __init__(self, lm: LM, cache_db: str, model_id: str = "") -> None:
         """LM wrapper that returns cached results when available, falling back to the underlying model.
 
         Args:
             lm: The underlying language model to wrap.
             cache_db: Path to the SQLite cache database.
+            model_id: A string identifying the model. Included in cache keys
+                so that different models sharing the same cache DB file do not
+                return each other's results.
         """
         from sqlitedict import SqliteDict
 
         self.lm: LM = lm
         self.cache_db: str = cache_db
+        self.model_id: str = model_id
         if os.path.dirname(cache_db):
             os.makedirs(os.path.dirname(cache_db), exist_ok=True)
         self.dbdict = SqliteDict(cache_db, autocommit=True)
@@ -281,7 +287,7 @@ class CachingLM:
                 f"Loading '{attr}' responses from cache '{self.cache_db}' where possible..."
             )
             for req in tqdm(requests, desc="Checking cached requests"):
-                hsh = hash_args(attr, req.args)
+                hsh = hash_args(attr, req.args, model_id=self.model_id)
                 if attr == "generate_until" and req.args[1].get("do_sample", False):
                     # when we are doing non-greedy generation, don't use the cache
                     # (else every "randomly sampled" generation would be identical for repeats > 1).
@@ -316,7 +322,7 @@ class CachingLM:
                 res[resptr] = r
 
                 # caching
-                hsh = hash_args(attr, req.args)
+                hsh = hash_args(attr, req.args, model_id=self.model_id)
                 self.dbdict[hsh] = r
             self.dbdict.commit()
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -271,6 +271,14 @@ def simple_evaluate(
 
     if use_cache is not None:
         eval_logger.info(f"Using cache at {use_cache + '_rank' + str(lm.rank) + '.db'}")
+        # Build a model identifier so that different models sharing the same
+        # cache DB file produce distinct cache keys (see #2715).
+        if isinstance(model, str):
+            _model_id = (
+                f"{model}__{model_args}" if model_args else model
+            )
+        else:
+            _model_id = type(model).__name__
         lm = lm_eval.api.model.CachingLM(
             lm,
             use_cache
@@ -279,6 +287,7 @@ def simple_evaluate(
             + "_rank"
             + str(lm.rank)
             + ".db",
+            model_id=_model_id,
         )
 
     if task_manager is None:

--- a/tests/test_response_cache.py
+++ b/tests/test_response_cache.py
@@ -1,0 +1,156 @@
+"""Tests for the SQLite response cache (--use_cache).
+
+Validates that cache keys include model identity so that different models
+sharing the same cache DB file do not return each other's results (#2715).
+"""
+
+import pytest
+
+from lm_eval.api.model import LM, CachingLM, hash_args
+
+
+# ---------------------------------------------------------------------------
+# hash_args
+# ---------------------------------------------------------------------------
+
+
+def test_hash_args_different_models_produce_different_hashes():
+    """Two different model_ids with the same prompt must not collide."""
+    args = ("What is 2+2?", "The answer is 4.")
+    h1 = hash_args("loglikelihood", args, model_id="hf__pretrained=model-a")
+    h2 = hash_args("loglikelihood", args, model_id="hf__pretrained=model-b")
+    assert h1 != h2
+
+
+def test_hash_args_same_model_produces_same_hash():
+    """Same model_id and prompt must produce the same hash (cache hit)."""
+    args = ("What is 2+2?", "The answer is 4.")
+    h1 = hash_args("loglikelihood", args, model_id="hf__pretrained=model-a")
+    h2 = hash_args("loglikelihood", args, model_id="hf__pretrained=model-a")
+    assert h1 == h2
+
+
+def test_hash_args_empty_model_id_differs_from_named():
+    """An empty model_id and a named one must produce different hashes."""
+    args = ("prompt",)
+    h_empty = hash_args("loglikelihood", args, model_id="")
+    h_named = hash_args("loglikelihood", args, model_id="hf__pretrained=foo")
+    assert h_empty != h_named
+
+
+def test_hash_args_default_model_id_is_empty():
+    """Backward compat: calling hash_args without model_id defaults to ''."""
+    args = ("prompt",)
+    h1 = hash_args("loglikelihood", args)
+    h2 = hash_args("loglikelihood", args, model_id="")
+    assert h1 == h2
+
+
+# ---------------------------------------------------------------------------
+# CachingLM with model_id — end-to-end through the cache
+# ---------------------------------------------------------------------------
+
+
+class _DummyLM(LM):
+    """Minimal LM stub that returns a fixed value per call."""
+
+    def __init__(self, value):
+        super().__init__()
+        self._value = value
+
+    def loglikelihood(self, requests):
+        return [(self._value, True)] * len(requests)
+
+    def loglikelihood_rolling(self, requests):
+        return [self._value] * len(requests)
+
+    def generate_until(self, requests):
+        return [str(self._value)] * len(requests)
+
+
+class _FakeInstance:
+    """Minimal Instance stand-in carrying .args."""
+
+    def __init__(self, args):
+        self.args = args
+
+
+@pytest.fixture
+def cache_db(tmp_path):
+    """Return a path to a temporary cache DB (cleaned up after the test)."""
+    return str(tmp_path / "test_cache_rank0.db")
+
+
+def test_caching_lm_different_models_do_not_collide(cache_db):
+    """Two CachingLMs with different model_ids must not share cached results."""
+    lm_a = _DummyLM(value=-1.0)
+    lm_b = _DummyLM(value=-2.0)
+
+    clm_a = CachingLM(lm_a, cache_db, model_id="model-a")
+    clm_b = CachingLM(lm_b, cache_db, model_id="model-b")
+
+    req = _FakeInstance(args=("context", "continuation"))
+
+    # First call populates the cache for model-a
+    res_a = clm_a.loglikelihood([req])
+    assert res_a == [(-1.0, True)]
+
+    # Second call with model-b should NOT return model-a's cached value
+    res_b = clm_b.loglikelihood([req])
+    assert res_b == [(-2.0, True)]
+
+
+def test_caching_lm_same_model_returns_cached(cache_db):
+    """Same model_id should return cached results on the second call."""
+    call_count = 0
+
+    class _CountingLM(LM):
+        def loglikelihood(self, requests):
+            nonlocal call_count
+            call_count += len(requests)
+            return [(-1.0, True)] * len(requests)
+
+        def loglikelihood_rolling(self, requests):
+            return [0.0] * len(requests)
+
+        def generate_until(self, requests):
+            return [""] * len(requests)
+
+    lm = _CountingLM()
+    clm = CachingLM(lm, cache_db, model_id="my-model")
+
+    req = _FakeInstance(args=("context", "continuation"))
+
+    # First call runs the model
+    clm.loglikelihood([req])
+    assert call_count == 1
+
+    # Second call should hit the cache, not the model
+    clm.loglikelihood([req])
+    assert call_count == 1  # still 1 — no additional model call
+
+
+# ---------------------------------------------------------------------------
+# CacheHook with model_id
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hook_uses_model_id(cache_db):
+    """CacheHook.add_partial should include model_id in cache keys."""
+    lm = _DummyLM(value=0)
+    clm = CachingLM(lm, cache_db, model_id="hook-model")
+    hook = clm.get_cache_hook()
+
+    assert hook.model_id == "hook-model"
+
+    # Write via hook
+    hook.add_partial("loglikelihood", ("ctx", "cont"), (-3.0, True))
+
+    # Verify it's stored under the model-id-aware key
+    expected_hash = hash_args("loglikelihood", ("ctx", "cont"), model_id="hook-model")
+    assert expected_hash in clm.dbdict
+    assert clm.dbdict[expected_hash] == (-3.0, True)
+
+    # A different model_id should NOT find this entry
+    other_hash = hash_args("loglikelihood", ("ctx", "cont"), model_id="other-model")
+    assert other_hash not in clm.dbdict


### PR DESCRIPTION
## Summary

Fixes #2715.

I ran into this while evaluating multiple models on the same benchmark with `--use_cache` pointing to a shared DB file. The second model returned the first model's cached loglikelihoods because the cache key was just `SHA256(method_name + prompt_text)` with no model identity.

**Root cause**: `hash_args()` in `lm_eval/api/model.py` hashes only the method name (e.g. `"loglikelihood"`) and the request arguments (prompt text). Since different models receive identical prompts for the same task, their cache keys collide.

**Fix**: Added a `model_id` parameter to `hash_args()`, `CachingLM`, and `CacheHook`. In `simple_evaluate()`, I construct the model identifier from the model type + model_args string (or `type(model).__name__` for pre-initialized model objects). This gets included in the hash so different models produce different cache keys even when sharing the same DB file.

**Changes**:
- `lm_eval/api/model.py`: `hash_args()` now accepts `model_id`, `CachingLM` stores and threads it through, `CacheHook` propagates it
- `lm_eval/evaluator.py`: `simple_evaluate()` builds a model identifier and passes it to `CachingLM`
- `tests/test_response_cache.py`: 7 new tests covering hash collision avoidance, cache hit behavior, backward compat, and hook propagation

**Backward compatibility**: The `model_id` parameter defaults to `""`, so existing code calling `hash_args()` or `CachingLM()` directly without it will continue to work. Existing cache DB files will effectively be invalidated for the new code path (cache misses, not errors), which is the correct behavior since those entries had no model identity guarantees.

## Reproduction

```python
from lm_eval.api.model import hash_args

# Before fix: identical hashes
args = ("What is 2+2?", "The answer is 4.")
hash_a = hash_args("loglikelihood", args)  # same hash
hash_b = hash_args("loglikelihood", args)  # same hash — bug

# After fix: different hashes per model
hash_a = hash_args("loglikelihood", args, model_id="hf__pretrained=Qwen/Qwen2.5-3B")
hash_b = hash_args("loglikelihood", args, model_id="hf__pretrained=meta-llama/Llama-3.2-3B")
assert hash_a != hash_b  # correct
```

## Test plan

- [x] All 7 new tests pass (`pytest tests/test_response_cache.py -v`)
- [x] ruff clean on all changed files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)