### PR TITLE
fix: correct watsonx_llm alias to point to WatsonxLLM class

### DIFF
--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -51,7 +51,7 @@ MODEL_MAPPING = {
     "textsynth": "lm_eval.models.textsynth:TextSynthLM",
     "vllm": "lm_eval.models.vllm_causallms:VLLM",
     "vllm-vlm": "lm_eval.models.vllm_vlms:VLLM_VLM",
-    "watsonx_llm": "lm_eval.models.ibm_watsonx_ai:IBMWatsonxAI",
+    "watsonx_llm": "lm_eval.models.ibm_watsonx_ai:WatsonxLLM",
     "winml": "lm_eval.models.winml:WindowsML",
 }
 

--- a/lm_eval/models/ibm_watsonx_ai.py
+++ b/lm_eval/models/ibm_watsonx_ai.py
@@ -185,10 +185,11 @@ class WatsonxLLM(LM):
 
     def __init__(
         self,
-        watsonx_credentials: Dict,
-        model_id,
-        deployment_id,
+        watsonx_credentials: Optional[Dict] = None,
+        model_id=None,
+        deployment_id=None,
         generate_params: Optional[Dict[Any, Any]] = None,
+        **kwargs,
     ) -> None:
         try:
             from ibm_watsonx_ai import APIClient


### PR DESCRIPTION
## Summary

Fixes #3590 - Running lm-eval for watsonx_llm model fails with 'alias already registered'.

## Problem

After #3428, the `watsonx_llm` entry in `lm_eval/models/__init__.py` pointed to `IBMWatsonxAI`, but the `@register_model('watsonx_llm')` decorator on the `WatsonxLLM` class in `ibm_watsonx_ai.py` tried to register the same alias, causing a conflict.

## Changes

- **`lm_eval/models/__init__.py`**: Update the `watsonx_llm` mapping to point to `WatsonxLLM` instead of `IBMWatsonxAI`
- **`lm_eval/models/ibm_watsonx_ai.py`**: Default `watsonx_credentials` and `deployment_id` to `None` in `WatsonxLLM.__init__()`, and add `**kwargs` for forward compatibility