### PR TITLE
feat: Add AIME 2026 task configuration and documentation.

### DIFF
--- a/lm_eval/tasks/aime/README.md
+++ b/lm_eval/tasks/aime/README.md
@@ -26,6 +26,14 @@
   publisher = {Huggingface},
   url = {https://huggingface.co/datasets/math-ai/aime25}
 }
+
+@dataset{aime_2026,
+  author = {math-ai},
+  title = {AIME Problem Set 2026},
+  year = {2026},
+  publisher = {Huggingface},
+  url = {https://huggingface.co/datasets/math-ai/aime26}
+}
 ```
 
 ### Groups, Tags, and Tasks
@@ -39,6 +47,7 @@
 * `aime`: `AIME 1983-2024 problems`
 * `aime24`: `AIME 2024 problems`
 * `aime25`: `AIME 2025 problems`
+* `aime26`: `AIME 2026 problems`
 
 ### Checklist
 

--- a/lm_eval/tasks/aime/aime26.yaml
+++ b/lm_eval/tasks/aime/aime26.yaml
@@ -1,0 +1,29 @@
+tag:
+  - math_word_problems
+task: aime26
+dataset_path: math-ai/aime26
+# dataset_name: null
+output_type: generate_until
+training_split: test
+fewshot_split: test
+test_split: test
+doc_to_text: "Question: {{problem}}\nAnswer:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+generation_kwargs:
+  until:
+    - "Question:"
+    - "</s>"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 32768
+repeats: 1
+num_fewshot: 0
+metadata:
+  version: 0.0


### PR DESCRIPTION
## What does this PR do?
This PR adds support for recent [AIME26 dataset](https://huggingface.co/datasets/math-ai/aime26).

### Implementation
It copies the exact implementation from [AIME25](https://github.com/EleutherAI/lm-evaluation-harness/pull/3248) and just changes the source dataset.