### PR TITLE
fix: harden Megatron GPT layer spec setup for eval

### DIFF
--- a/lm_eval/models/megatron_lm.py
+++ b/lm_eval/models/megatron_lm.py
@@ -472,7 +472,7 @@ class MegatronLMEval(LM):
                 transformer_impl = getattr(args, "transformer_impl", "local")
                 use_transformer_engine = transformer_impl == "transformer_engine"
                 if args.num_experts:
-                    assert not (config.transformer_impl == "inference_optimized"), (
+                    assert config.transformer_impl != "inference_optimized", (
                         "MoE is not supported with inference_optimized transformer_impl."
                     )
                     transformer_layer_spec = get_gpt_decoder_block_spec(
@@ -482,7 +482,7 @@ class MegatronLMEval(LM):
                         qk_l2_norm=getattr(args, "qk_l2_norm", False),
                     )
                 elif args.heterogeneous_layers_config_path is not None:
-                    assert not (config.transformer_impl == "inference_optimized"), (
+                    assert config.transformer_impl != "inference_optimized", (
                         "Heterogeneous layers are not supported with inference_optimized transformer_impl."
                     )
                     transformer_layer_spec = get_gpt_heterogeneous_layer_spec(


### PR DESCRIPTION
## Description

1. Disable torch compile by default to avoid runtime issues.
2. Add support for MoE/heterogeneous layer spec selection to enable mixed MoE/dense models., and robustly override arbitrary attention masks across both single-layer and decoder-block specs.

## Tests

### Tests on [Qwen3-4B](https://github.com/shangxiaokang/lm-evaluation-harness/tree/test-megatron-lm/Qwen3-4B) using bfloat16 precision.
| Task | batch_size | TP | DP | Megatron-LM | HF | vLLM | 
|--------------|---------------|---------------|-----------------|---------------|-----------------|---------------|
|lambada_standard| 64 | 1 | 1 | \ | 0.5459 | 0.5496 |
|lambada_standard| 64 | 1 | 8 | 0.5434 | \ | \ |
|arc_easy| 64 | 1 | 1 | \ | 0.8027 | 0.8039 |
|arc_easy| 64 | 1 | 8 | 0.8039 | \ | \ |
|gsm8k| 64 | 1 | 1 | \ | 0.5186 | 0.5186 |
|gsm8k| 64 | 1 | 8 | 0.5163 | \ | \ |
|triviaqa| 64 | 1 | 1 | \ | 0.1963 | 0.2284 |
|triviaqa| 64 | 1 | 8 | 0.2264 | \ | \ |

### Test on [Qwen3-30B-A3B](https://github.com/shangxiaokang/lm-evaluation-harness/tree/test-megatron-lm/Qwen3-30B-A3B) using bfloat16 precision.
| Task | batch_size | EP | DP | Megatron-LM | HF | vLLM | 
|--------------|---------------|---------------|-----------------|---------------|-----------------|---------------|
|lambada_standard| 64 | 1 | 1 | \ | 0.6305 | 0.6381 |
|lambada_standard| 64 | 8 | 8 | 0.6299 | \ | \ |
|arc_easy| 64 | 1 | 1 | \ | 0.7883 | 0.7955 |
|arc_easy| 64 | 8 | 8 | 0.7946 | \ | \ |
|gsm8k| 64 | 1 | 1 | \ | 0.2745 | 0.2654 |
|gsm8k| 64 | 8 | 8| 0.2616 | \ | \ |
|triviaqa| 64 | 1 | 1 | \ | \ | 0.3814 |
|triviaqa| 64 | 8 | 8 | 0.3823 | \ | \ |