### PR TITLE
Add evaluation task for PolyMath (multilingual math reasoning benchmark)

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -422,7 +422,11 @@ class TemplateLM(LM):
             A list of ``(logprob, is_greedy)`` tuples, one per request.
         """
         new_reqs = []
-        for context, continuation in [req.args for req in requests]:
+        for context, continuation in tqdm(
+            [req.args for req in requests],
+            desc="Tokenizing inputs",
+            disable=disable_tqdm,
+        ):
             if context == "":
                 continuation_enc = self.tok_encode(
                     continuation, add_special_tokens=False

--- a/lm_eval/models/megatron_lm.py
+++ b/lm_eval/models/megatron_lm.py
@@ -308,6 +308,11 @@ class MegatronLMEval(LM):
 
     def _initialize_megatron(self, **kwargs):
         """Initialize Megatron distributed environment and load model."""
+        # Avoid torch.compile/inductor runtime failures when torch/triton versions are mismatched.
+        # Users can still override these env vars externally before launch if needed.
+        os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
+        os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
+
         from megatron.training import (
             get_args,
             get_model,
@@ -450,17 +455,40 @@ class MegatronLMEval(LM):
                 """Build GPT model."""
                 from megatron.core.models.gpt import GPTModel
                 from megatron.core.models.gpt.gpt_layer_specs import (
+                    get_gpt_decoder_block_spec,
                     get_gpt_layer_local_spec,
                     get_gpt_layer_with_transformer_engine_spec,
+                )
+                from megatron.core.models.gpt.heterogeneous.heterogeneous_layer_specs import (
+                    get_gpt_heterogeneous_layer_spec,
                 )
 
                 # Get config from args if not provided
                 if config is None:
                     config = core_transformer_config_from_args(args)
 
-                # Select layer spec
+                # Select layer spec.
+                # For MoE models, use decoder block spec so each layer follows moe_layer_freq.
                 transformer_impl = getattr(args, "transformer_impl", "local")
-                if transformer_impl == "transformer_engine":
+                use_transformer_engine = transformer_impl == "transformer_engine"
+                if args.num_experts:
+                    assert config.transformer_impl != "inference_optimized", (
+                        "MoE is not supported with inference_optimized transformer_impl."
+                    )
+                    transformer_layer_spec = get_gpt_decoder_block_spec(
+                        config,
+                        use_transformer_engine=use_transformer_engine,
+                        normalization=getattr(args, "normalization", None),
+                        qk_l2_norm=getattr(args, "qk_l2_norm", False),
+                    )
+                elif args.heterogeneous_layers_config_path is not None:
+                    assert config.transformer_impl != "inference_optimized", (
+                        "Heterogeneous layers are not supported with inference_optimized transformer_impl."
+                    )
+                    transformer_layer_spec = get_gpt_heterogeneous_layer_spec(
+                        config, use_transformer_engine=use_transformer_engine
+                    )
+                elif use_transformer_engine:
                     transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
                         getattr(args, "num_experts", None),
                         getattr(args, "moe_grouped_gemm", False),
@@ -485,13 +513,42 @@ class MegatronLMEval(LM):
                 )
 
                 try:
-                    transformer_layer_spec.submodules.self_attention.params[
-                        "attn_mask_type"
-                    ] = AttnMaskType.arbitrary
+                    updated = 0
+
+                    # Single layer spec.
+                    self_attention = getattr(
+                        getattr(transformer_layer_spec, "submodules", None),
+                        "self_attention",
+                        None,
+                    )
+                    params = getattr(self_attention, "params", None)
+                    if isinstance(params, dict):
+                        params["attn_mask_type"] = AttnMaskType.arbitrary
+                        updated += 1
+
+                    # Decoder block spec (list of layer specs).
+                    layer_specs = getattr(transformer_layer_spec, "layer_specs", None)
+                    if layer_specs is not None:
+                        for layer_spec in layer_specs:
+                            layer_self_attention = getattr(
+                                getattr(layer_spec, "submodules", None),
+                                "self_attention",
+                                None,
+                            )
+                            layer_params = getattr(layer_self_attention, "params", None)
+                            if isinstance(layer_params, dict):
+                                layer_params["attn_mask_type"] = AttnMaskType.arbitrary
+                                updated += 1
+
+                    if updated == 0:
+                        eval_logger.warning(
+                            "No self_attention params found to override attn_mask_type; "
+                            "proceeding with original spec defaults."
+                        )
                 except Exception as e:
                     raise RuntimeError(
                         "Failed to override attn_mask_type on transformer_layer_spec. "
-                        "Expected transformer_layer_spec.submodules.self_attention.params to exist."
+                        "Expected ModuleSpec or decoder block layer specs with self_attention.params."
                     ) from e
 
                 model = GPTModel(
@@ -587,6 +644,23 @@ class MegatronLMEval(LM):
     def accelerator(self):
         """Return accelerator interface for distributed operations (NeMo-style)."""
         return self._Accelerator(self._world_size, self._device)
+
+    def all_gather(self, tensor: torch.Tensor) -> torch.Tensor:
+        """All-gather a tensor across data-parallel ranks."""
+        return self.accelerator.gather(tensor)
+
+    def gather_object(self, obj, dst: int = 0):
+        """Gather Python objects and return list on dst, None on others."""
+        if not torch.distributed.is_initialized() or self.world_size == 1:
+            return [obj]
+
+        gathered_objects = [None] * self.world_size
+        torch.distributed.all_gather_object(gathered_objects, obj)
+        return gathered_objects if self.rank == dst else None
+
+    def barrier(self) -> None:
+        """Synchronize processes."""
+        self.accelerator.wait_for_everyone()
 
     class _Accelerator:
         """

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -38,7 +38,11 @@ from lm_eval.utils import (
 
 
 if parse_version(version("vllm")) >= parse_version("0.8.3"):
-    from vllm.entrypoints.chat_utils import resolve_hf_chat_template
+    try:
+        # Moved since vllm-project/vllm#30200
+        from vllm.renderers.hf import resolve_chat_template as resolve_hf_chat_template
+    except ImportError:
+        from vllm.entrypoints.chat_utils import resolve_hf_chat_template
 
 try:
     # Moved since vllm-project/vllm#29793

--- a/lm_eval/tasks/polymath/README.md
+++ b/lm_eval/tasks/polymath/README.md
@@ -1,0 +1,88 @@
+# PolyMath
+
+### Paper
+
+PolyMath: Evaluating Mathematical Reasoning in Multilingual Contexts
+
+PolyMath is a multilingual mathematical reasoning benchmark covering 18 languages and 4 easy-to-hard difficulty levels, with 9,000 high-quality problem samples. The benchmark ensures difficulty comprehensiveness, language diversity, and high-quality translation, making it a highly discriminative multilingual mathematical benchmark in the era of reasoning LLMs.
+
+Homepage: https://arxiv.org/abs/2504.18428
+
+GitHub: https://github.com/QwenLM/PolyMath
+
+Hugging Face: https://huggingface.co/datasets/Qwen/PolyMath
+
+### Citation
+
+```
+@article{wang2025polymath,
+title={PolyMath: Evaluating Mathematical Reasoning in Multilingual Contexts},
+author={Yiming Wang and Pei Zhang and Jialong Tang and Haoran Wei and Baosong Yang and Rui Wang and Chenshu Sun and Feitong Sun and Jiran Zhang and Junxuan Wu and Qiqian Cang and Yichang Zhang and Fei Huang and Junyang Lin and Fei Huang and Jingren Zhou},
+journal={arXiv preprint arXiv:2504.18428},
+year={2025},
+primaryClass={cs.CL},
+url={https://arxiv.org/abs/2504.18428}, 
+}
+```
+
+### Groups and Tasks
+
+PolyMath tasks follow a two-dimensional structure: **language** × **difficulty**.
+
+There are 18 supported languages: `ar`, `bn`, `de`, `en`, `es`, `fr`, `id`, `it`, `ja`, `ko`, `ms`, `pt`, `ru`, `sw`, `te`, `th`, `vi`, `zh`.
+
+| Language code | Language name |
+|----------------|---------------|
+| `ar` | Arabic |
+| `bn` | Bengali |
+| `de` | German |
+| `en` | English |
+| `es` | Spanish |
+| `fr` | French |
+| `id` | Indonesian |
+| `it` | Italian |
+| `ja` | Japanese |
+| `ko` | Korean |
+| `ms` | Malay |
+| `pt` | Portuguese |
+| `ru` | Russian |
+| `sw` | Swahili |
+| `te` | Telugu |
+| `th` | Thai |
+| `vi` | Vietnamese |
+| `zh` | Chinese |
+
+There are 4 difficulty tiers: `low`, `medium`, `high`, `top`.
+
+| Difficulty tier | Description |
+|---|---|
+| `low` | Arithmetic problems from MGSM and P-MMeval |
+| `medium` | Undergraduate exercises, entrance exams (Gaokao, postgraduate), entry-level competitions (AMC, provincial CNMO) |
+| `high` | Mid-tier national competitions (AIME, national CNMO) |
+| `top` | International/national Olympiads (IMO, Putnam, USAMO) and HLE frontier math |
+
+#### Groups
+
+| Group | Description | Number of tasks |
+|---|---|---|
+| `polymath` | All languages (18) × All difficulty tiers (4) | 72 |
+| `polymath_<lang>` | All difficulty tiers (4) for one language, e.g. `polymath_fr` | 4 |
+| `polymath_<difficulty>` | All languages (18) at one difficulty tier, e.g. `polymath_high` | 18 |
+
+#### Tasks
+
+Each of the 72 individual task contains a total of 125 math problems and can be run using the naming pattern `polymath_<lang>_<difficulty>` (e.g., `polymath_vi_top`).
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+* [x] Have you referenced the original paper that introduced the task?
+* [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+If other tasks on this dataset are already supported:
+* [x] Is the "Main" variant of this task clearly denoted?
+* [x] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [x] Have you noted which, if any, published evaluation setups are matched by this variant?
+* [ ] Checked for equivalence with v0.3.0 LM Evaluation Harness
+

--- a/lm_eval/tasks/polymath/README.md
+++ b/lm_eval/tasks/polymath/README.md
@@ -21,7 +21,7 @@ author={Yiming Wang and Pei Zhang and Jialong Tang and Haoran Wei and Baosong Ya
 journal={arXiv preprint arXiv:2504.18428},
 year={2025},
 primaryClass={cs.CL},
-url={https://arxiv.org/abs/2504.18428}, 
+url={https://arxiv.org/abs/2504.18428},
 }
 ```
 
@@ -85,4 +85,3 @@ If other tasks on this dataset are already supported:
 * [x] Have you provided a short sentence in a README on what each new variant adds / evaluates?
 * [x] Have you noted which, if any, published evaluation setups are matched by this variant?
 * [ ] Checked for equivalence with v0.3.0 LM Evaluation Harness
-

--- a/lm_eval/tasks/polymath/_generate_configs.py
+++ b/lm_eval/tasks/polymath/_generate_configs.py
@@ -1,0 +1,196 @@
+"""
+Generate per-language task YAMLs and per-language group YAMLs for PolyMath.
+
+Produces (18 languages × 4 difficulties) = 72 task YAMLs, e.g.:
+    polymath_ar_low.yaml
+    polymath_ar_medium.yaml
+    ...
+    polymath_zh_high.yaml
+    polymath_zh_top.yaml
+
+Plus one group YAML per language, e.g.:
+    polymath_en.yaml   (groups polymath_en_{low,medium,high,top})
+
+Plus one group YAML per difficulty tier, e.g.:
+    polymath_top.yaml   (groups polymath_{ar,bn,de,en,es,...,vi,zh}_{top})
+
+Plus one top-level group YAML:
+    polymath.yaml      (groups all 18 per-language groups)
+
+Total: (18 × 4) + 18 + 4 + 1 = 95 YAML configuration files.
+
+Usage:
+    python _generate_configs.py
+    python _generate_configs.py --output-dir /path/to/output
+"""
+
+import argparse
+import os
+import yaml
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+LANGUAGES = [
+    "ar", "bn", "de", "en", "es", "fr", "id", "it", "ja",
+    "ko", "ms", "pt", "ru", "sw", "te", "th", "vi", "zh"
+]
+
+DIFFICULTIES = ["low", "medium", "high", "top"]
+
+TEMPLATE_NAME = "_template_yaml"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def make_task_yaml(language: str, difficulty: str, split: str) -> dict:
+    """Single task config for one language × difficulty combination."""
+    return {
+        "include": TEMPLATE_NAME,
+        "task": f"polymath_{language}_{difficulty}",
+        "dataset_name": language,
+        "test_split": split,
+    }
+
+
+def make_language_group_yaml(language: str) -> dict:
+    """Group YAML that bundles the 4 difficulty tiers for one language."""
+    return {
+        "group": f"polymath_{language}",
+        "task": [f"polymath_{language}_{d}" for d in DIFFICULTIES],
+        "aggregate_metric_list": [
+            {
+                "metric": "math_verify",
+                "aggregation": "!function utils.aggregate_dw_acc",
+                "weight_by_size": False,
+            }
+        ],
+        "metadata": {"version": 1},
+    }
+
+
+def make_difficulty_group_yaml(difficulty: str) -> dict:
+    """Group YAML that bundles all 18 languages for one difficulty tier."""
+    return {
+        "group": f"polymath_{difficulty}",
+        "task": [f"polymath_{language}_{difficulty}" for language in LANGUAGES],
+        "aggregate_metric_list": [
+            {
+                "metric": "math_verify",
+                "aggregation": "mean",
+                "weight_by_size": False,
+            }
+        ],
+        "metadata": {"version": 1},
+    }
+
+
+def make_top_level_group_yaml() -> dict:
+    """Top-level group that bundles all 18 per-language groups."""
+    return {
+        "group": "polymath",
+        "task": [f"polymath_{language}" for language in LANGUAGES],
+        "metadata": {"version": 1},
+    }
+
+
+# ── YAML serialisation ────────────────────────────────────────────────────────
+
+class _PolyMathDumper(yaml.Dumper):
+    """Custom dumper that avoids mutating the global yaml.Dumper singleton."""
+    pass
+
+
+# Represent None as bare null (matches harness convention)
+_PolyMathDumper.add_representer(
+    type(None),
+    lambda dumper, _: dumper.represent_scalar("tag:yaml.org,2002:null", ""),
+)
+
+
+def _dump(data: dict) -> str:
+    """Serialise to YAML, preserving insertion order, no flow style."""
+    return yaml.dump(
+        data,
+        Dumper=_PolyMathDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+
+
+def _fix_function_tag(text: str) -> str:
+    """
+    yaml.dump cannot natively emit custom YAML tags on mapping values.
+    Post-process the one known case so lm-eval can parse it:
+        aggregation: '!function utils.aggregate_dw_acc'
+    →   aggregation: !function utils.aggregate_dw_acc
+    """
+    return text.replace(
+        "aggregation: '!function utils.aggregate_dw_acc'",
+        "aggregation: !function utils.aggregate_dw_acc",
+    )
+
+
+# ── Writer ────────────────────────────────────────────────────────────────────
+
+def write_yaml(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    if os.path.exists(path):
+        print(f"  overwriting {path}")
+    raw = _fix_function_tag(_dump(data))
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(raw)
+    print(f"  wrote {path}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def generate(output_dir: str) -> None:
+    total = 0
+
+    # Generate 72 task YAMLs  (language × difficulty)
+    for language in LANGUAGES:
+        for difficulty in DIFFICULTIES:
+            data = make_task_yaml(language, difficulty, difficulty)
+            fname = f"polymath_{language}_{difficulty}.yaml"
+            write_yaml(os.path.join(output_dir, fname), data)
+            total += 1
+
+    # Generate 18 per-language group YAMLs
+    for language in LANGUAGES:
+        data = make_language_group_yaml(language)
+        fname = f"polymath_{language}.yaml"
+        write_yaml(os.path.join(output_dir, fname), data)
+        total += 1
+
+    # Generate 4 per-difficulty group YAMLs
+    for difficulty in DIFFICULTIES:
+        data = make_difficulty_group_yaml(difficulty)
+        fname = f"polymath_{difficulty}.yaml"
+        write_yaml(os.path.join(output_dir, fname), data)
+        total += 1
+
+    # Generate 1 top-level group YAML
+    data = make_top_level_group_yaml()
+    write_yaml(os.path.join(output_dir, "polymath.yaml"), data)
+    total += 1
+
+    print(f"\nDone — {total} files written to '{output_dir}'")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate PolyMath lm-eval task YAML configs."
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory to write generated YAML files into (default: current dir).",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    generate(args.output_dir)

--- a/lm_eval/tasks/polymath/_generate_configs.py
+++ b/lm_eval/tasks/polymath/_generate_configs.py
@@ -26,14 +26,31 @@ Usage:
 
 import argparse
 import os
+
 import yaml
 
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 LANGUAGES = [
-    "ar", "bn", "de", "en", "es", "fr", "id", "it", "ja",
-    "ko", "ms", "pt", "ru", "sw", "te", "th", "vi", "zh"
+    "ar",
+    "bn",
+    "de",
+    "en",
+    "es",
+    "fr",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "ms",
+    "pt",
+    "ru",
+    "sw",
+    "te",
+    "th",
+    "vi",
+    "zh",
 ]
 
 DIFFICULTIES = ["low", "medium", "high", "top"]
@@ -42,6 +59,7 @@ TEMPLATE_NAME = "_template_yaml"
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def make_task_yaml(language: str, difficulty: str, split: str) -> dict:
     """Single task config for one language × difficulty combination."""
@@ -96,8 +114,10 @@ def make_top_level_group_yaml() -> dict:
 
 # ── YAML serialisation ────────────────────────────────────────────────────────
 
+
 class _PolyMathDumper(yaml.Dumper):
     """Custom dumper that avoids mutating the global yaml.Dumper singleton."""
+
     pass
 
 
@@ -134,6 +154,7 @@ def _fix_function_tag(text: str) -> str:
 
 # ── Writer ────────────────────────────────────────────────────────────────────
 
+
 def write_yaml(path: str, data: dict) -> None:
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     if os.path.exists(path):
@@ -145,6 +166,7 @@ def write_yaml(path: str, data: dict) -> None:
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
+
 
 def generate(output_dir: str) -> None:
     total = 0

--- a/lm_eval/tasks/polymath/_template_yaml
+++ b/lm_eval/tasks/polymath/_template_yaml
@@ -1,0 +1,20 @@
+tag:
+  - math_word_problems
+dataset_path: Qwen/PolyMath
+training_split: null
+validation_split: null
+output_type: generate_until
+process_docs: !function utils.process_docs
+process_results: !function utils.process_results
+doc_to_text: "Problem: {{question}}\nPlease reason step-by-step and put your final answer within \\boxed{}.\nReasoning:"
+doc_to_target: "{{answer}}"
+generation_kwargs:
+  until:
+    - "Problem:"
+  do_sample: false
+  temperature: 0
+metric_list:
+  - metric: math_verify
+    aggregation: mean
+    higher_is_better: true
+

--- a/lm_eval/tasks/polymath/_template_yaml
+++ b/lm_eval/tasks/polymath/_template_yaml
@@ -17,4 +17,3 @@ metric_list:
   - metric: math_verify
     aggregation: mean
     higher_is_better: true
-

--- a/lm_eval/tasks/polymath/polymath.yaml
+++ b/lm_eval/tasks/polymath/polymath.yaml
@@ -1,0 +1,22 @@
+group: polymath
+task:
+- polymath_ar
+- polymath_bn
+- polymath_de
+- polymath_en
+- polymath_es
+- polymath_fr
+- polymath_id
+- polymath_it
+- polymath_ja
+- polymath_ko
+- polymath_ms
+- polymath_pt
+- polymath_ru
+- polymath_sw
+- polymath_te
+- polymath_th
+- polymath_vi
+- polymath_zh
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_ar.yaml
+++ b/lm_eval/tasks/polymath/polymath_ar.yaml
@@ -1,0 +1,12 @@
+group: polymath_ar
+task:
+- polymath_ar_low
+- polymath_ar_medium
+- polymath_ar_high
+- polymath_ar_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_ar_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_ar_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ar_high
+dataset_name: ar
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_ar_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_ar_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ar_low
+dataset_name: ar
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_ar_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_ar_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ar_medium
+dataset_name: ar
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_ar_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_ar_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ar_top
+dataset_name: ar
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_bn.yaml
+++ b/lm_eval/tasks/polymath/polymath_bn.yaml
@@ -1,0 +1,12 @@
+group: polymath_bn
+task:
+- polymath_bn_low
+- polymath_bn_medium
+- polymath_bn_high
+- polymath_bn_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_bn_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_bn_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_bn_high
+dataset_name: bn
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_bn_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_bn_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_bn_low
+dataset_name: bn
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_bn_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_bn_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_bn_medium
+dataset_name: bn
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_bn_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_bn_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_bn_top
+dataset_name: bn
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_de.yaml
+++ b/lm_eval/tasks/polymath/polymath_de.yaml
@@ -1,0 +1,12 @@
+group: polymath_de
+task:
+- polymath_de_low
+- polymath_de_medium
+- polymath_de_high
+- polymath_de_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_de_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_de_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_de_high
+dataset_name: de
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_de_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_de_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_de_low
+dataset_name: de
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_de_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_de_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_de_medium
+dataset_name: de
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_de_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_de_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_de_top
+dataset_name: de
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_en.yaml
+++ b/lm_eval/tasks/polymath/polymath_en.yaml
@@ -1,0 +1,12 @@
+group: polymath_en
+task:
+- polymath_en_low
+- polymath_en_medium
+- polymath_en_high
+- polymath_en_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_en_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_en_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_en_high
+dataset_name: en
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_en_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_en_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_en_low
+dataset_name: en
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_en_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_en_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_en_medium
+dataset_name: en
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_en_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_en_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_en_top
+dataset_name: en
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_es.yaml
+++ b/lm_eval/tasks/polymath/polymath_es.yaml
@@ -1,0 +1,12 @@
+group: polymath_es
+task:
+- polymath_es_low
+- polymath_es_medium
+- polymath_es_high
+- polymath_es_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_es_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_es_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_es_high
+dataset_name: es
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_es_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_es_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_es_low
+dataset_name: es
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_es_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_es_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_es_medium
+dataset_name: es
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_es_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_es_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_es_top
+dataset_name: es
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_fr.yaml
+++ b/lm_eval/tasks/polymath/polymath_fr.yaml
@@ -1,0 +1,12 @@
+group: polymath_fr
+task:
+- polymath_fr_low
+- polymath_fr_medium
+- polymath_fr_high
+- polymath_fr_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_fr_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_fr_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_fr_high
+dataset_name: fr
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_fr_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_fr_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_fr_low
+dataset_name: fr
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_fr_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_fr_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_fr_medium
+dataset_name: fr
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_fr_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_fr_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_fr_top
+dataset_name: fr
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_high.yaml
@@ -1,0 +1,26 @@
+group: polymath_high
+task:
+- polymath_ar_high
+- polymath_bn_high
+- polymath_de_high
+- polymath_en_high
+- polymath_es_high
+- polymath_fr_high
+- polymath_id_high
+- polymath_it_high
+- polymath_ja_high
+- polymath_ko_high
+- polymath_ms_high
+- polymath_pt_high
+- polymath_ru_high
+- polymath_sw_high
+- polymath_te_high
+- polymath_th_high
+- polymath_vi_high
+- polymath_zh_high
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: mean
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_id.yaml
+++ b/lm_eval/tasks/polymath/polymath_id.yaml
@@ -1,0 +1,12 @@
+group: polymath_id
+task:
+- polymath_id_low
+- polymath_id_medium
+- polymath_id_high
+- polymath_id_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_id_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_id_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_id_high
+dataset_name: id
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_id_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_id_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_id_low
+dataset_name: id
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_id_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_id_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_id_medium
+dataset_name: id
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_id_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_id_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_id_top
+dataset_name: id
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_it.yaml
+++ b/lm_eval/tasks/polymath/polymath_it.yaml
@@ -1,0 +1,12 @@
+group: polymath_it
+task:
+- polymath_it_low
+- polymath_it_medium
+- polymath_it_high
+- polymath_it_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_it_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_it_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_it_high
+dataset_name: it
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_it_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_it_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_it_low
+dataset_name: it
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_it_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_it_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_it_medium
+dataset_name: it
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_it_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_it_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_it_top
+dataset_name: it
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_ja.yaml
+++ b/lm_eval/tasks/polymath/polymath_ja.yaml
@@ -1,0 +1,12 @@
+group: polymath_ja
+task:
+- polymath_ja_low
+- polymath_ja_medium
+- polymath_ja_high
+- polymath_ja_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_ja_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_ja_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ja_high
+dataset_name: ja
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_ja_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_ja_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ja_low
+dataset_name: ja
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_ja_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_ja_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ja_medium
+dataset_name: ja
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_ja_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_ja_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ja_top
+dataset_name: ja
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_ko.yaml
+++ b/lm_eval/tasks/polymath/polymath_ko.yaml
@@ -1,0 +1,12 @@
+group: polymath_ko
+task:
+- polymath_ko_low
+- polymath_ko_medium
+- polymath_ko_high
+- polymath_ko_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_ko_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_ko_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ko_high
+dataset_name: ko
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_ko_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_ko_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ko_low
+dataset_name: ko
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_ko_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_ko_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ko_medium
+dataset_name: ko
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_ko_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_ko_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ko_top
+dataset_name: ko
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_low.yaml
@@ -1,0 +1,26 @@
+group: polymath_low
+task:
+- polymath_ar_low
+- polymath_bn_low
+- polymath_de_low
+- polymath_en_low
+- polymath_es_low
+- polymath_fr_low
+- polymath_id_low
+- polymath_it_low
+- polymath_ja_low
+- polymath_ko_low
+- polymath_ms_low
+- polymath_pt_low
+- polymath_ru_low
+- polymath_sw_low
+- polymath_te_low
+- polymath_th_low
+- polymath_vi_low
+- polymath_zh_low
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: mean
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_medium.yaml
@@ -1,0 +1,26 @@
+group: polymath_medium
+task:
+- polymath_ar_medium
+- polymath_bn_medium
+- polymath_de_medium
+- polymath_en_medium
+- polymath_es_medium
+- polymath_fr_medium
+- polymath_id_medium
+- polymath_it_medium
+- polymath_ja_medium
+- polymath_ko_medium
+- polymath_ms_medium
+- polymath_pt_medium
+- polymath_ru_medium
+- polymath_sw_medium
+- polymath_te_medium
+- polymath_th_medium
+- polymath_vi_medium
+- polymath_zh_medium
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: mean
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_ms.yaml
+++ b/lm_eval/tasks/polymath/polymath_ms.yaml
@@ -1,0 +1,12 @@
+group: polymath_ms
+task:
+- polymath_ms_low
+- polymath_ms_medium
+- polymath_ms_high
+- polymath_ms_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_ms_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_ms_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ms_high
+dataset_name: ms
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_ms_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_ms_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ms_low
+dataset_name: ms
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_ms_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_ms_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ms_medium
+dataset_name: ms
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_ms_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_ms_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ms_top
+dataset_name: ms
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_pt.yaml
+++ b/lm_eval/tasks/polymath/polymath_pt.yaml
@@ -1,0 +1,12 @@
+group: polymath_pt
+task:
+- polymath_pt_low
+- polymath_pt_medium
+- polymath_pt_high
+- polymath_pt_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_pt_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_pt_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_pt_high
+dataset_name: pt
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_pt_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_pt_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_pt_low
+dataset_name: pt
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_pt_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_pt_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_pt_medium
+dataset_name: pt
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_pt_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_pt_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_pt_top
+dataset_name: pt
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_ru.yaml
+++ b/lm_eval/tasks/polymath/polymath_ru.yaml
@@ -1,0 +1,12 @@
+group: polymath_ru
+task:
+- polymath_ru_low
+- polymath_ru_medium
+- polymath_ru_high
+- polymath_ru_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_ru_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_ru_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ru_high
+dataset_name: ru
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_ru_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_ru_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ru_low
+dataset_name: ru
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_ru_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_ru_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ru_medium
+dataset_name: ru
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_ru_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_ru_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_ru_top
+dataset_name: ru
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_sw.yaml
+++ b/lm_eval/tasks/polymath/polymath_sw.yaml
@@ -1,0 +1,12 @@
+group: polymath_sw
+task:
+- polymath_sw_low
+- polymath_sw_medium
+- polymath_sw_high
+- polymath_sw_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_sw_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_sw_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_sw_high
+dataset_name: sw
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_sw_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_sw_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_sw_low
+dataset_name: sw
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_sw_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_sw_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_sw_medium
+dataset_name: sw
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_sw_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_sw_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_sw_top
+dataset_name: sw
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_te.yaml
+++ b/lm_eval/tasks/polymath/polymath_te.yaml
@@ -1,0 +1,12 @@
+group: polymath_te
+task:
+- polymath_te_low
+- polymath_te_medium
+- polymath_te_high
+- polymath_te_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_te_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_te_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_te_high
+dataset_name: te
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_te_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_te_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_te_low
+dataset_name: te
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_te_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_te_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_te_medium
+dataset_name: te
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_te_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_te_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_te_top
+dataset_name: te
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_th.yaml
+++ b/lm_eval/tasks/polymath/polymath_th.yaml
@@ -1,0 +1,12 @@
+group: polymath_th
+task:
+- polymath_th_low
+- polymath_th_medium
+- polymath_th_high
+- polymath_th_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_th_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_th_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_th_high
+dataset_name: th
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_th_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_th_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_th_low
+dataset_name: th
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_th_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_th_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_th_medium
+dataset_name: th
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_th_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_th_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_th_top
+dataset_name: th
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_top.yaml
@@ -1,0 +1,26 @@
+group: polymath_top
+task:
+- polymath_ar_top
+- polymath_bn_top
+- polymath_de_top
+- polymath_en_top
+- polymath_es_top
+- polymath_fr_top
+- polymath_id_top
+- polymath_it_top
+- polymath_ja_top
+- polymath_ko_top
+- polymath_ms_top
+- polymath_pt_top
+- polymath_ru_top
+- polymath_sw_top
+- polymath_te_top
+- polymath_th_top
+- polymath_vi_top
+- polymath_zh_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: mean
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_vi.yaml
+++ b/lm_eval/tasks/polymath/polymath_vi.yaml
@@ -1,0 +1,12 @@
+group: polymath_vi
+task:
+- polymath_vi_low
+- polymath_vi_medium
+- polymath_vi_high
+- polymath_vi_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_vi_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_vi_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_vi_high
+dataset_name: vi
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_vi_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_vi_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_vi_low
+dataset_name: vi
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_vi_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_vi_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_vi_medium
+dataset_name: vi
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_vi_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_vi_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_vi_top
+dataset_name: vi
+test_split: top

--- a/lm_eval/tasks/polymath/polymath_zh.yaml
+++ b/lm_eval/tasks/polymath/polymath_zh.yaml
@@ -1,0 +1,12 @@
+group: polymath_zh
+task:
+- polymath_zh_low
+- polymath_zh_medium
+- polymath_zh_high
+- polymath_zh_top
+aggregate_metric_list:
+- metric: math_verify
+  aggregation: !function utils.aggregate_dw_acc
+  weight_by_size: false
+metadata:
+  version: 1

--- a/lm_eval/tasks/polymath/polymath_zh_high.yaml
+++ b/lm_eval/tasks/polymath/polymath_zh_high.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_zh_high
+dataset_name: zh
+test_split: high

--- a/lm_eval/tasks/polymath/polymath_zh_low.yaml
+++ b/lm_eval/tasks/polymath/polymath_zh_low.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_zh_low
+dataset_name: zh
+test_split: low

--- a/lm_eval/tasks/polymath/polymath_zh_medium.yaml
+++ b/lm_eval/tasks/polymath/polymath_zh_medium.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_zh_medium
+dataset_name: zh
+test_split: medium

--- a/lm_eval/tasks/polymath/polymath_zh_top.yaml
+++ b/lm_eval/tasks/polymath/polymath_zh_top.yaml
@@ -1,0 +1,4 @@
+include: _template_yaml
+task: polymath_zh_top
+dataset_name: zh
+test_split: top

--- a/lm_eval/tasks/polymath/utils.py
+++ b/lm_eval/tasks/polymath/utils.py
@@ -1,0 +1,87 @@
+import logging
+import re
+import signal
+import datasets
+from importlib.metadata import version
+from typing import Dict, List, Optional
+
+# Adapted from lm_eval/tasks/minerva_math/utils.py [1].
+# Key differences: evaluation relies exclusively on math_verify's symbolic parsing,
+# dropping the exact-match fallback (is_equiv) used in minerva_math, which is insufficient
+# for the algebraic complexity of PolyMath's high and top difficulty tiers.
+# aggregate_dw_acc is original to this task.
+# [1] https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/minerva_math/utils.py
+
+eval_logger = logging.getLogger(__name__)
+
+try:
+    import antlr4
+    from math_verify import parse, verify
+    from math_verify.parser import LatexExtractionConfig, ExprExtractionConfig
+
+    assert version("antlr4-python3-runtime").startswith("4.11")
+except (ModuleNotFoundError, AssertionError) as e:
+    raise type(e)(
+        "`math_verify` and `antlr4-python3-runtime==4.11` are required because the evaluation logic "
+        "relies on symbolic parsing to verify mathematical equivalence."
+        "Please install the required packages via pip install lm-eval[math] or pip install -e .[math]"
+    ) from e
+
+
+def aggregate_dw_acc(answers: Dict[str, float]) -> float:
+    """
+    Compute the Difficulty-Weighted Accuracy (DW-ACC). See section "2.5 Benchmark Score: Difficulty-Weighted Accuracy"
+        in the PolyMAth paper (https://arxiv.org/pdf/2504.18428).
+
+    Args:
+        answers: Dictionary mapping task names to their accuracy scores. The task name must contain a difficulty
+            keyword: 'low', 'medium', 'high', or 'top'.
+
+    Returns:
+        float: Difficulty-weighted average accuracy across all tasks.
+    """
+    weights = {"low": 1, "medium": 2, "high": 4, "top": 8}
+    weighted_sum = 0
+    total_weight = 0
+    for task_name, score in answers.items():
+        level = next((l for l in weights if l in task_name.lower()), None)
+        if level:
+            w = weights[level]
+            weighted_sum += score * w
+            total_weight += w
+    return weighted_sum / total_weight if total_weight > 0 else 0
+
+
+# Diverges from minerva_math:
+# https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/minerva_math/utils.py
+# Uses math_verify symbolic parsing only (no exact_match fallback via is_equiv/normalize_final_answer),
+# and reads from doc["answer"] directly instead of doc["solution"].
+# \boxed{} extraction is handled natively by parse() via LatexExtractionConfig(boxed_match_priority=0),
+# making manual extraction (e.g. remove_boxed, last_boxed_only_string) unnecessary.
+def process_results(doc: dict, results: list[str]) -> dict[str, int]:
+    _mvres = verify(
+        gold=parse(doc["answer"]),
+        target=parse(
+            results[0],
+            extraction_config=[
+                LatexExtractionConfig(boxed_match_priority=0),
+                ExprExtractionConfig(),
+            ]
+        ),
+    )
+    return {"math_verify": 1 if _mvres else 0}
+
+
+# Diverges from minerva_math:
+# https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/minerva_math/utils.py
+# Uses raw "question"/"answer" fields directly; no normalize_final_answer, remove_boxed,
+# or few_shot handling, as the PolyMath dataset provides pre-cleaned answers.
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc: dict) -> dict:
+        out_doc = {
+            "question": doc["question"],
+            "answer": doc["answer"],
+        }
+        return out_doc
+    return dataset.map(_process_doc)
+

--- a/lm_eval/tasks/polymath/utils.py
+++ b/lm_eval/tasks/polymath/utils.py
@@ -1,9 +1,7 @@
 import logging
-import re
-import signal
+
 import datasets
-from importlib.metadata import version
-from typing import Dict, List, Optional
+
 
 # Adapted from lm_eval/tasks/minerva_math/utils.py [1].
 # Key differences: evaluation relies exclusively on math_verify's symbolic parsing,
@@ -15,20 +13,21 @@ from typing import Dict, List, Optional
 eval_logger = logging.getLogger(__name__)
 
 try:
-    import antlr4
-    from math_verify import parse, verify
-    from math_verify.parser import LatexExtractionConfig, ExprExtractionConfig
+    from importlib.metadata import version as get_version
 
-    assert version("antlr4-python3-runtime").startswith("4.11")
+    from math_verify import parse, verify
+    from math_verify.parser import ExprExtractionConfig, LatexExtractionConfig
+
+    assert get_version("antlr4-python3-runtime").startswith("4.11")
 except (ModuleNotFoundError, AssertionError) as e:
     raise type(e)(
         "`math_verify` and `antlr4-python3-runtime==4.11` are required because the evaluation logic "
-        "relies on symbolic parsing to verify mathematical equivalence."
+        "relies on symbolic parsing to verify mathematical equivalence. "
         "Please install the required packages via pip install lm-eval[math] or pip install -e .[math]"
     ) from e
 
 
-def aggregate_dw_acc(answers: Dict[str, float]) -> float:
+def aggregate_dw_acc(answers: dict[str, float]) -> float:
     """
     Compute the Difficulty-Weighted Accuracy (DW-ACC). See section "2.5 Benchmark Score: Difficulty-Weighted Accuracy"
         in the PolyMAth paper (https://arxiv.org/pdf/2504.18428).
@@ -66,7 +65,7 @@ def process_results(doc: dict, results: list[str]) -> dict[str, int]:
             extraction_config=[
                 LatexExtractionConfig(boxed_match_priority=0),
                 ExprExtractionConfig(),
-            ]
+            ],
         ),
     )
     return {"math_verify": 1 if _mvres else 0}
@@ -83,5 +82,5 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
             "answer": doc["answer"],
         }
         return out_doc
-    return dataset.map(_process_doc)
 
+    return dataset.map(_process_doc)

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -154,12 +154,42 @@ def escaped_split(text, sep_char, maxsplit=-1):
 
 
 def handle_arg_string(arg):
-    if arg.lower() == "true":
+    """Attempt to infer and cast the type of a single argument value string.
+
+    Supports:
+    - Booleans: "true"/"false" (case-insensitive)
+    - None: "None" / "none"
+    - Explicit strings: values wrapped in matching quotes are preserved as-is
+      (e.g. ``"123"`` or ``'hello'`` -> str)
+    - Integers: optional sign, digits only (e.g. "42", "-1")
+    - Floats: anything ``float()`` accepts, including scientific notation
+    - Fallback: return as string unchanged
+    """
+    # Strip surrounding whitespace
+    arg = arg.strip()
+
+    # Explicit quoting -> always a string
+    if len(arg) >= 2 and arg[0] == arg[-1] and arg[0] in ("'", '"'):
+        return arg[1:-1]
+
+    lower = arg.lower()
+    if lower == "true":
         return True
-    elif arg.lower() == "false":
+    if lower == "false":
         return False
-    elif arg.isnumeric():
-        return int(arg)
+    if lower == "none":
+        return None
+
+    # Try integer first (supports negative numbers unlike str.isnumeric)
+    try:
+        # Guard against strings like "1e3" being parsed as int via float path
+        # Only pure digit strings (with optional leading sign) should become int
+        if arg.lstrip("+-").isdigit() and arg not in ("", "+", "-"):
+            return int(arg)
+    except ValueError:
+        pass
+
+    # Try float (handles decimals, scientific notation, inf, etc.)
     try:
         return float(arg)
     except ValueError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 import torch
 
+from lm_eval.utils import handle_arg_string, simple_parse_args_string
+
 from lm_eval.api.metrics import (
     aggregate_subtask_metrics,
     mean,
@@ -625,3 +627,87 @@ class TestMaybeDelimit:
     def test_prefix_ends_with_newline_no_extra_delimiter(self):
         """Prefix ends with newline - no extra delimiter added."""
         assert maybe_delimit("line1\n", "line2", delimiter=" ") == "line1\nline2"
+
+
+class TestHandleArgString:
+    """Tests for handle_arg_string type coercion."""
+
+    def test_bool_true(self):
+        assert handle_arg_string("true") is True
+        assert handle_arg_string("True") is True
+        assert handle_arg_string("TRUE") is True
+
+    def test_bool_false(self):
+        assert handle_arg_string("false") is False
+        assert handle_arg_string("False") is False
+
+    def test_none(self):
+        assert handle_arg_string("None") is None
+        assert handle_arg_string("none") is None
+
+    def test_positive_int(self):
+        assert handle_arg_string("42") == 42
+        assert isinstance(handle_arg_string("42"), int)
+
+    def test_negative_int(self):
+        assert handle_arg_string("-1") == -1
+        assert isinstance(handle_arg_string("-1"), int)
+
+    def test_float(self):
+        assert handle_arg_string("3.14") == 3.14
+        assert isinstance(handle_arg_string("3.14"), float)
+
+    def test_negative_float(self):
+        assert handle_arg_string("-0.5") == -0.5
+
+    def test_scientific_notation(self):
+        assert handle_arg_string("1e-5") == 1e-5
+        assert isinstance(handle_arg_string("1e-5"), float)
+
+    def test_plain_string(self):
+        assert handle_arg_string("hello") == "hello"
+
+    def test_explicit_quoted_string_preserves_numeric(self):
+        """Quoting a numeric value should keep it as a string (e.g. revision)."""
+        assert handle_arg_string('"123123"') == "123123"
+        assert isinstance(handle_arg_string('"123123"'), str)
+
+    def test_explicit_single_quoted_string(self):
+        assert handle_arg_string("'true'") == "true"
+        assert isinstance(handle_arg_string("'true'"), str)
+
+    def test_empty_string(self):
+        assert handle_arg_string("") == ""
+
+    def test_whitespace_stripped(self):
+        assert handle_arg_string("  42  ") == 42
+
+
+class TestSimpleParseArgsString:
+    """Tests for simple_parse_args_string."""
+
+    def test_basic_parsing(self):
+        result = simple_parse_args_string("pretrained=gpt2,revision=main")
+        assert result == {"pretrained": "gpt2", "revision": "main"}
+
+    def test_numeric_revision_stays_int_by_default(self):
+        """Without quoting, numeric revision becomes int (existing behavior)."""
+        result = simple_parse_args_string("pretrained=gpt2,revision=123123")
+        assert result["revision"] == 123123
+
+    def test_quoted_revision_stays_string(self):
+        """Users can quote numeric values to force string type."""
+        result = simple_parse_args_string('pretrained=gpt2,revision="123123"')
+        assert result["revision"] == "123123"
+        assert isinstance(result["revision"], str)
+
+    def test_none_input(self):
+        assert simple_parse_args_string(None) == {}
+
+    def test_empty_input(self):
+        assert simple_parse_args_string("") == {}
+
+    def test_bool_and_float_coercion(self):
+        result = simple_parse_args_string("trust_remote_code=true,temperature=0.7")
+        assert result["trust_remote_code"] is True
+        assert result["temperature"] == 0.7


### PR DESCRIPTION
# Summary

PolyMath [[1]](https://arxiv.org/abs/2504.18428) is a multilingual mathematical reasoning benchmark covering 18 languages and 4 difficulty tiers (low, medium, high, top), with 125 problems per tier per language. This PR adds lm-eval support for PolyMath.

# Task structure

Tasks follow a `polymath_<lang>_<difficulty>` naming pattern (e.g. `polymath_en_high`). Four levels of granularity are supported:

`polymath` — all 18 languages × 4 difficulty tiers
`polymath_<lang>` — all difficulty tiers for one language (e.g. `polymath_fr`)
`polymath_<difficulty>` — all languages at one difficulty tier (e.g. `polymath_top`)
`polymath_<lang>_<difficulty>` — single task (e.g. `polymath_en_high`)

The 95 task/group YAML files are generated by `_generate_configs.py`.

# Evaluation

Answer correctness is evaluated using `math_verify` symbolic parsing with `LatexExtractionConfig(boxed_match_priority=0)`, which handles the algebraic complexity of the high and top difficulty tiers where exact-match approaches are insufficient. The per-language score is reported as Difficulty-Weighted Accuracy (DW-ACC) as defined in the paper (section 2.5).

# Tests

- `pytest tests/test_tasks.py` passes
- `tests/test_evaluator.py::test_printed_results[lambada_openai]` fails identically on both `main` and this branch — pre-existing numerical instability unrelated to this contribution

# Dependencies

Requires `math_verify` and `antlr4-python3-runtime==4.11`, available via `pip install lm-eval[math]`