### PR TITLE
fix(models): default add_special_tokens to True instead of None

### DIFF
--- a/lm_eval/models/anthropic_llms.py
+++ b/lm_eval/models/anthropic_llms.py
@@ -371,7 +371,7 @@ class AnthropicChat(LocalCompletionsAPI):
         self,
         string: str,
         left_truncate_len=None,
-        add_special_tokens=None,
+        add_special_tokens=True,
         **kwargs,
     ) -> List[str]:
         return [string]

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -230,7 +230,7 @@ class LocalChatCompletion(LocalCompletionsAPI):
         self,
         string: Union[str, Any],
         left_truncate_len=None,
-        add_special_tokens=None,
+        add_special_tokens=True,
         **kwargs,
     ) -> Union[List[str], List[int], Any]:
         return string

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -357,17 +357,17 @@ class VLLM(TemplateLM):
 
     @overload
     def tok_encode(
-        self, string: str, add_special_tokens=None, **kwargs
+        self, string: str, add_special_tokens=True, **kwargs
     ) -> list[int]: ...
     @overload
     def tok_encode(
-        self, string: list[str], add_special_tokens=None, **kwargs
+        self, string: list[str], add_special_tokens=True, **kwargs
     ) -> list[list[int]]: ...
 
     def tok_encode(
         self,
         string: str | list[str],
-        add_special_tokens=None,
+        add_special_tokens=True,
         **kwargs,
     ) -> list[int] | list[list[int]]:  # type:ignore[invalid-method-override]
         assert self.tokenizer


### PR DESCRIPTION
## Problem

The 0.4.8 → 0.4.9 upgrade introduced a regression: `add_special_tokens` defaults to `None` which is forwarded to the Hugging Face tokenizer. Modern HF fast-tokenizers (backed by the Rust `tokenizers` crate) now reject `None` for this parameter:

```
TypeError: argument 'add_special_tokens': 'NoneType' object cannot be converted to 'PyBool'
```

## Fix

Default `add_special_tokens` to `True` instead of `None`. This matches the effective prior behaviour (HF tokenizers also default to `True` when not specified) and makes the type explicit.

## Testing

Running `lm_eval` with any HF model on any task that calls `generate_until` no longer raises `TypeError`.

Closes #3075