### PR TITLE
Update all mentions of the `CohereForAI` organization to `CohereLabs`

### DIFF
--- a/lm_eval/tasks/afrobench/afrisenti/prompt_1/run.sh
+++ b/lm_eval/tasks/afrobench/afrisenti/prompt_1/run.sh
@@ -3,7 +3,7 @@
 models=(
 
   "google/gemma-1.1-7b-it"
-  "CohereForAI/aya-101"
+  "CohereLabs/aya-101"
   "meta-llama/Llama-2-7b-chat-hf"
   "meta-llama/Meta-Llama-3-8B-Instruct"
   "google/gemma-2-9b-it"

--- a/lm_eval/tasks/afrobench/afrisenti/prompt_2/run.sh
+++ b/lm_eval/tasks/afrobench/afrisenti/prompt_2/run.sh
@@ -3,7 +3,7 @@
 models=(
 
   "google/gemma-1.1-7b-it"
-  "CohereForAI/aya-101"
+  "CohereLabs/aya-101"
   "meta-llama/Llama-2-7b-chat-hf"
   "meta-llama/Meta-Llama-3-8B-Instruct"
   "google/gemma-2-9b-it"

--- a/lm_eval/tasks/afrobench/sample_run_scripts/run_afrobench.sh
+++ b/lm_eval/tasks/afrobench/sample_run_scripts/run_afrobench.sh
@@ -15,7 +15,7 @@ model_names=(
   "meta-llama/Llama-3.1-8B-Instruct",
   "meta-llama/Llama-3.1-70B-Instruct",
   "meta-llama/Meta-Llama-3-8B-Instruct",
-  "CohereForAI/aya-101"
+  "CohereLabs/aya-101"
 )
 
 for model_name in "${model_names[@]}"

--- a/lm_eval/tasks/afrobench/sample_run_scripts/run_afrobench_lite.sh
+++ b/lm_eval/tasks/afrobench/sample_run_scripts/run_afrobench_lite.sh
@@ -15,7 +15,7 @@ model_names=(
   "meta-llama/Llama-3.1-8B-Instruct",
   "meta-llama/Llama-3.1-70B-Instruct",
   "meta-llama/Meta-Llama-3-8B-Instruct",
-  "CohereForAI/aya-101"
+  "CohereLabs/aya-101"
 )
 
 for model_name in "${model_names[@]}"

--- a/lm_eval/tasks/global_mmlu/README.md
+++ b/lm_eval/tasks/global_mmlu/README.md
@@ -8,11 +8,11 @@ Abstract: [https://arxiv.org/abs/2412.03304](https://arxiv.org/abs/2412.03304)
 
 Global-MMLU 🌍 is a multilingual evaluation set spanning 42 languages, including English. This dataset combines machine translations for MMLU questions along with professional translations and crowd-sourced post-edits. It also includes cultural sensitivity annotations for a subset of the questions (2850 questions per language) and classifies them as Culturally Sensitive (CS) 🗽 or Culturally Agnostic (CA) ⚖️. These annotations were collected as part of an open science initiative led by Cohere For AI in collaboration with many external collaborators from both industry and academia.
 
-Global-MMLU-Lite is a balanced collection of culturally sensitive and culturally agnostic MMLU tasks. It is designed for efficient evaluation of multilingual models in 15 languages (including English). Only languages with human translations and post-edits in the original [Global-MMLU](https://huggingface.co/datasets/CohereForAI/Global-MMLU) 🌍 dataset have been included in the lite version.
+Global-MMLU-Lite is a balanced collection of culturally sensitive and culturally agnostic MMLU tasks. It is designed for efficient evaluation of multilingual models in 15 languages (including English). Only languages with human translations and post-edits in the original [Global-MMLU](https://huggingface.co/datasets/CohereLabs/Global-MMLU) 🌍 dataset have been included in the lite version.
 
 Homepage: \
-[https://huggingface.co/datasets/CohereForAI/Global-MMLU](https://huggingface.co/datasets/CohereForAI/Global-MMLU) \
-[https://huggingface.co/datasets/CohereForAI/Global-MMLU-Lite](https://huggingface.co/datasets/CohereForAI/Global-MMLU-Lite)
+[https://huggingface.co/datasets/CohereLabs/Global-MMLU](https://huggingface.co/datasets/CohereLabs/Global-MMLU) \
+[https://huggingface.co/datasets/CohereLabs/Global-MMLU-Lite](https://huggingface.co/datasets/CohereLabs/Global-MMLU-Lite)
 
 
 #### Groups

--- a/lm_eval/tasks/global_mmlu/default/ar/_ar_template_yaml
+++ b/lm_eval/tasks/global_mmlu/default/ar/_ar_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: CohereForAI/Global-MMLU-Lite
+dataset_path: CohereLabs/Global-MMLU-Lite
 dataset_name: ar
 test_split: test
 fewshot_split: dev

--- a/lm_eval/tasks/global_mmlu/default/bn/_bn_template_yaml
+++ b/lm_eval/tasks/global_mmlu/default/bn/_bn_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: CohereForAI/Global-MMLU-Lite
+dataset_path: CohereLabs/Global-MMLU-Lite
 dataset_name: bn
 test_split: test
 fewshot_split: dev

--- a/lm_eval/tasks/global_mmlu/default/de/_de_template_yaml
+++ b/lm_eval/tasks/global_mmlu/default/de/_de_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: CohereForAI/Global-MMLU-Lite
+dataset_path: CohereLabs/Global-MMLU-Lite
 dataset_name: de
 test_split: test
 fewshot_split: dev

--- a/lm_eval/tasks/global_mmlu/default/en/_en_template_yaml
+++ b/lm_eval/tasks/global_mmlu/default/en/_en_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: CohereForAI/Global-MMLU-Lite
+dataset_path: CohereLabs/Global-MMLU-Lite
 dataset_name: en
 test_split: test
 fewshot_split: dev

--- a/lm_eval/tasks/global_mmlu/default/es/_es_template_yaml
+++ b/lm_eval/tasks/global_mmlu/default/es/_es_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: CohereForAI/Global-MMLU-Lite
+dataset_path: CohereLabs/Global-MMLU-Lite
 dataset_name: es
 test_split: test
 fewshot_split: dev

--- a/lm_eval/tasks/global_mmlu/default/fr/_fr_template_yaml
+++ b/lm_eval/tasks/global_mmlu/default/fr/_fr_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: CohereForAI/Global-MMLU-Lite
+dataset_path: CohereLabs/Global-MMLU-Lite
 dataset_name: fr
 test_split: test
 fewshot_split: dev

--- a/lm_eval/tasks/global_mmlu/default/hi/_hi_template_yaml
+++ b/lm_eval/tasks/global_mmlu/default/hi/_hi_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: CohereForAI/Global-MMLU-Lite
+dataset_path: CohereLabs/Global-MMLU-Lite
 dataset_name: hi
 test_split: test
 fewshot_split: dev


### PR DESCRIPTION
All the models and datasets that belonged to `CohereForAI` on HuggingFace are now in the `CohereLabs` organization, so I renamed all mentions to it.