### PR TITLE
Skip caching None responses in async generation path

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -538,7 +538,8 @@ class TemplateAPI(TemplateLM):
             )
             if cache_keys:
                 for res, cache in zip(answers, cache_keys):
-                    self.cache_hook.add_partial(cache_method, cache, res)
+                    if res is not None:
+                        self.cache_hook.add_partial(cache_method, cache, res)
             return answers
         # If the retries also fail
         except BaseException as e:


### PR DESCRIPTION
When an API returns null content (e.g. reasoning models consuming max_gen_toks), the async path in `amodel_call` caches the None value. On re-runs, the cached None hits `assert ob is not None` in evaluator.py and crashes.

The sync path already guards against this at line 783. This adds the same `if res is not None` check to the async cache write.

Closes #3632