### PR TITLE
fix: preserve chat_template_args when enable_thinking is None

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -351,11 +351,10 @@ class HFLM(TemplateLM):
         self.vocab_size = self.tokenizer.vocab_size
         # select (or create) a pad token to use
         self.tokenizer = configure_pad_token(self.tokenizer, model_config=self.config)
-        self.chat_template_args = (
-            chat_template_args or {} | dict(enable_thinking=enable_thinking)
-            if enable_thinking is not None
-            else {}
-        )
+        if enable_thinking is not None:
+            self.chat_template_args = (chat_template_args or {}) | {"enable_thinking": enable_thinking}
+        else:
+            self.chat_template_args = chat_template_args or {}
 
         self.add_bos_token = add_bos_token
 


### PR DESCRIPTION
## Problem

`chat_template_args` passed to HFLM is silently discarded when `enable_thinking` is `None` (the default).

The ternary expression in `huggingface.py`:

```python
self.chat_template_args = (
    chat_template_args or {} | dict(enable_thinking=enable_thinking)
    if enable_thinking is not None
    else {}
)
```

When `enable_thinking=None`, the `else` branch returns `{}`, ignoring any user-provided `chat_template_args`.

This means `HFLM(chat_template_args={"enable_thinking": False})` has no effect, the model silently runs with default behavior.

## Fix

```python
if enable_thinking is not None:
    self.chat_template_args = (chat_template_args or {}) | {"enable_thinking": enable_thinking}
else:
    self.chat_template_args = chat_template_args or {}
```

When `enable_thinking` is explicitly passed, it merges into `chat_template_args` (existing behavior). When it's `None`, `chat_template_args` is preserved as-is.

## Reproduction

```python
from lm_eval.models.huggingface import HFLM

model = HFLM(
    pretrained="Qwen/Qwen3-0.6B",
    chat_template_args={"enable_thinking": False},
)

print(model.chat_template_args)
# Before fix: {}
# After fix: {"enable_thinking": False}
```

Fixes #3639