### PR TITLE
fix: extract \boxed{} from model response in hendrycks_math

### DIFF
--- a/lm_eval/tasks/hendrycks_math/README.md
+++ b/lm_eval/tasks/hendrycks_math/README.md
@@ -10,6 +10,11 @@ NOTE: This task corresponds to the MATH (`hendrycks_math`) implementation at htt
 
 Homepage: https://github.com/hendrycks/math
 
+## Changes
+
+### v1.1
+- Answer extraction now tries `\boxed{}` from the model response before falling back to `$...$` delimiters. This aligns with the `aime` task behavior and fixes zero accuracy for models that output `\boxed{}` formatted answers.
+
 
 ## Citation
 ```

--- a/lm_eval/tasks/hendrycks_math/README.md
+++ b/lm_eval/tasks/hendrycks_math/README.md
@@ -14,6 +14,7 @@ Homepage: https://github.com/hendrycks/math
 
 ### v1.1
 - Answer extraction now tries `\boxed{}` from the model response before falling back to `$...$` delimiters. This aligns with the `aime` task behavior and fixes zero accuracy for models that output `\boxed{}` formatted answers.
+- Support for multiple `\boxed{}` answers (e.g. `\boxed{3}, \boxed{5}, \boxed{7}` is extracted as `3, 5, 7`). Duplicate boxes are deduplicated.
 
 
 ## Citation

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
@@ -12,4 +12,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
@@ -20,4 +20,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -20,10 +20,23 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     response = results[0]
 
     # Try to extract \boxed{} from the response (matches aime task behavior)
-    boxed = last_boxed_only_string(response)
-    if boxed is not None:
+    # First check for multiple \boxed{} (e.g. \boxed{3}, \boxed{5}, \boxed{7})
+    all_boxed = find_all_boxed_strings(response)
+    # Deduplicate while preserving order (models often repeat the final answer)
+    seen = set()
+    unique_boxed = []
+    for b in all_boxed:
+        if b not in seen:
+            seen.add(b)
+            unique_boxed.append(b)
+    if len(unique_boxed) > 1:
         try:
-            answer = remove_boxed(boxed)
+            answer = ", ".join(remove_boxed(b) for b in unique_boxed)
+        except AssertionError:
+            answer = None
+    elif len(unique_boxed) == 1:
+        try:
+            answer = remove_boxed(all_boxed[0])
         except AssertionError:
             answer = None
     else:
@@ -106,6 +119,40 @@ def last_boxed_only_string(string):
         retval = string[idx : right_brace_idx + 1]
 
     return retval
+
+
+def find_all_boxed_strings(string):
+    """Find all \\boxed{} occurrences in a string, handling nested braces."""
+    results = []
+    search_start = 0
+    while True:
+        idx = string.find("\\boxed", search_start)
+        if idx < 0:
+            break
+        # Skip if this is \boxed (space-separated, not brace)
+        after = idx + len("\\boxed")
+        if after >= len(string) or string[after] != "{":
+            search_start = after
+            continue
+        # Find matching closing brace
+        i = after
+        num_left_braces_open = 0
+        right_brace_idx = None
+        while i < len(string):
+            if string[i] == "{":
+                num_left_braces_open += 1
+            if string[i] == "}":
+                num_left_braces_open -= 1
+                if num_left_braces_open == 0:
+                    right_brace_idx = i
+                    break
+            i += 1
+        if right_brace_idx is not None:
+            results.append(string[idx : right_brace_idx + 1])
+            search_start = right_brace_idx + 1
+        else:
+            search_start = after
+    return results
 
 
 def fix_fracs(string):

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -17,11 +17,25 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
 
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     retval = 0
-    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
-    if len(indices) <= 1:
-        answer = results[0]
+    response = results[0]
+
+    # Try to extract \boxed{} from the response (matches aime task behavior)
+    boxed = last_boxed_only_string(response)
+    if boxed is not None:
+        try:
+            answer = remove_boxed(boxed)
+        except AssertionError:
+            answer = None
     else:
-        answer = results[0][indices[0] + 1 : indices[-1]]
+        answer = None
+
+    # Fall back to $...$ extraction
+    if answer is None:
+        indices = [pos for pos, char in enumerate(response) if char == "$"]
+        if len(indices) <= 1:
+            answer = response
+        else:
+            answer = response[indices[0] + 1 : indices[-1]]
 
     if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
         retval = 1

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -36,11 +36,21 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
             answer = None
     elif len(unique_boxed) == 1:
         try:
-            answer = remove_boxed(all_boxed[0])
+            answer = remove_boxed(unique_boxed[0])
         except AssertionError:
             answer = None
     else:
         answer = None
+
+    # Fall back to legacy single-boxed extraction (handles \boxed space-form
+    # that find_all_boxed_strings skips, plus \fbox).
+    if answer is None:
+        legacy = last_boxed_only_string(response)
+        if legacy is not None:
+            try:
+                answer = remove_boxed(legacy)
+            except (AssertionError, IndexError):
+                answer = None
 
     # Fall back to $...$ extraction
     if answer is None:

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -132,7 +132,7 @@ def last_boxed_only_string(string):
 
 
 def find_all_boxed_strings(string):
-    """Find all \\boxed{} occurrences in a string, handling nested braces."""
+    r"""Find all \boxed{} occurrences in a string, handling nested braces."""
     results = []
     search_start = 0
     while True:

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 import datasets
 
 
@@ -15,7 +13,7 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     return dataset.map(_process_doc)
 
 
-def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
+def process_results(doc: dict, results: list[str]) -> dict[str, int]:
     retval = 0
     response = results[0]
 
@@ -83,7 +81,7 @@ def is_equiv(str1, str2, verbose=False):
         if verbose:
             print(ss1, ss2)
         return ss1 == ss2
-    except Exception:
+    except Exception:  # noqa: BLE001 - normalization is best-effort; fall back to raw compare
         return str1 == str2
 
 
@@ -205,7 +203,7 @@ def fix_a_slash_b(string):
     try:
         a = int(a)
         b = int(b)
-        assert string == "{}/{}".format(a, b)
+        assert string == f"{a}/{b}"
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
     except AssertionError:
@@ -279,9 +277,8 @@ def strip_string(string):
         string = "0" + string
 
     # to consider: get rid of e.g. "k = " or "q = " at beginning
-    if len(string.split("=")) == 2:
-        if len(string.split("=")[0]) <= 2:
-            string = string.split("=")[1]
+    if len(string.split("=")) == 2 and len(string.split("=")[0]) <= 2:
+        string = string.split("=")[1]
 
     # fix sqrt3 --> sqrt{3}
     string = fix_sqrt(string)

--- a/tests/test_hendrycks_math.py
+++ b/tests/test_hendrycks_math.py
@@ -1,0 +1,70 @@
+from lm_eval.tasks.hendrycks_math.utils import (
+    find_all_boxed_strings,
+    process_results,
+)
+
+
+def _doc(boxed):
+    return {"solution": f"... so \\boxed{{{boxed}}}."}
+
+
+def test_boxed_response_matches():
+    assert process_results(_doc("[2,5)"), ["The domain is \\boxed{[2,5)}"]) == {
+        "exact_match": 1
+    }
+
+
+def test_dollar_fallback_still_works():
+    assert process_results(
+        _doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]
+    ) == {"exact_match": 1}
+
+
+def test_space_form_boxed_falls_back_to_last_boxed_only_string():
+    # \boxed 4 (space-form) is intentionally skipped by find_all_boxed_strings;
+    # last_boxed_only_string handles it, terminating on $ or end-of-string.
+    assert process_results(_doc("4"), ["The answer is \\boxed 4"]) == {
+        "exact_match": 1
+    }
+
+
+def test_space_form_boxed_terminated_by_dollar():
+    # Same fallback path, but terminated by a $ delimiter (the way solutions
+    # in the dataset typically wrap the answer).
+    assert process_results(_doc("7"), ["So we get $\\boxed 7$ as the answer."]) == {
+        "exact_match": 1
+    }
+
+
+def test_multi_boxed_joined():
+    assert process_results(
+        {"solution": "... \\boxed{3, 5, 7}."},
+        ["Final answers: \\boxed{3}, \\boxed{5}, \\boxed{7}"],
+    ) == {"exact_match": 1}
+
+
+def test_multi_boxed_deduplicated():
+    # Models often repeat the final answer; dedup keeps a single \boxed{4}
+    # from producing "4, 4".
+    assert process_results(_doc("4"), ["So \\boxed{4}. Therefore \\boxed{4}."]) == {
+        "exact_match": 1
+    }
+
+
+def test_find_all_boxed_strings_returns_all_occurrences():
+    # No dedup at this layer -- dedup is process_results' job.
+    assert find_all_boxed_strings("\\boxed{3}, \\boxed{5}, \\boxed{3}") == [
+        "\\boxed{3}",
+        "\\boxed{5}",
+        "\\boxed{3}",
+    ]
+
+
+def test_find_all_boxed_strings_ignores_space_form():
+    # Documents the intentional scope of this helper; space-form is handled
+    # by the last_boxed_only_string fallback in process_results.
+    assert find_all_boxed_strings("The answer is \\boxed 4.") == []
+
+
+def test_neither_format_does_not_crash():
+    assert process_results(_doc("42"), ["I don't know"]) == {"exact_match": 0}

--- a/tests/test_hendrycks_math.py
+++ b/tests/test_hendrycks_math.py
@@ -15,17 +15,15 @@ def test_boxed_response_matches():
 
 
 def test_dollar_fallback_still_works():
-    assert process_results(
-        _doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]
-    ) == {"exact_match": 1}
+    assert process_results(_doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]) == {
+        "exact_match": 1
+    }
 
 
 def test_space_form_boxed_falls_back_to_last_boxed_only_string():
     # \boxed 4 (space-form) is intentionally skipped by find_all_boxed_strings;
     # last_boxed_only_string handles it, terminating on $ or end-of-string.
-    assert process_results(_doc("4"), ["The answer is \\boxed 4"]) == {
-        "exact_match": 1
-    }
+    assert process_results(_doc("4"), ["The answer is \\boxed 4"]) == {"exact_match": 1}
 
 
 def test_space_form_boxed_terminated_by_dollar():


### PR DESCRIPTION
## Problem

`process_results` in `hendrycks_math/utils.py` applies `remove_boxed(last_boxed_only_string(...))` to the **target** but never to the **model's response**. Instruct models commonly output `\boxed{}` formatted answers, but the extraction only looks for `$...$` delimiters in the response.

This causes correct answers to score 0. For example, when a model outputs `"The domain is \boxed{[2,5)}"`, the extraction gets the entire string (no `$` signs found), and `is_equiv` fails against `"[2,5)"`.

## Fix

1. **Single `\boxed{}` extraction**: Try `\boxed{}` extraction on the response first, fall back to `$...$`. Aligns with `lm_eval/tasks/aime/utils.py`.
2. **Multiple `\boxed{}` extraction**: Handle cases where models output separate boxed answers (e.g. `\boxed{3}, \boxed{5}, \boxed{7}` → `3, 5, 7`). Duplicates are deduplicated to handle models that repeat the final answer.
3. **Version bump**: `metadata.version` bumped to 1.1 in YAML files.
4. **README**: Added changelog entry for v1.1.

## Impact

Affects `hendrycks_math` and `hendrycks_math500` tasks with any model that outputs `\boxed{}` formatted answers (standard for math instruct models).

Fixes #3643
Partially addresses #3652 (multi-boxed answers)