### PR TITLE
Fix chat_template_args handling when enable_thinking is None

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -351,11 +351,11 @@ class HFLM(TemplateLM):
         self.vocab_size = self.tokenizer.vocab_size
         # select (or create) a pad token to use
         self.tokenizer = configure_pad_token(self.tokenizer, model_config=self.config)
-        self.chat_template_args = (
-            chat_template_args or {} | dict(enable_thinking=enable_thinking)
-            if enable_thinking is not None
-            else {}
-        )
+        base_chat_template_args = chat_template_args or {}
+        if enable_thinking is not None:
+            self.chat_template_args = base_chat_template_args | {"enable_thinking": enable_thinking}
+        else:
+            self.chat_template_args = base_chat_template_args
 
         self.add_bos_token = add_bos_token
 


### PR DESCRIPTION
### Summary
Fixes a bug in `HFLM` where `chat_template_args` is silently discarded when `enable_thinking=None`.

### Root cause
The current expression returns `{}` when `enable_thinking is None`, which overwrites any user-provided `chat_template_args`.

### Fix
- Preserve `chat_template_args` when `enable_thinking` is `None`
- Only merge `enable_thinking` into the dict when it is explicitly provided

### Reproduction

**Before:**
```python
chat_template_args = {"foo": "bar"}
enable_thinking = None
# result: {}
```

**After:**
```python
chat_template_args = {"foo": "bar"}
enable_thinking = None
# result: {"foo": "bar"}
```

### Notes
Refactored slightly to avoid duplicating `(chat_template_args or {})` and improve readability.

Fixes #3639.