### PR TITLE
  fix: migrate pubmedqa to script-less qiaojin/pubmed_qa dataset #3645

### DIFF
--- a/lm_eval/tasks/pubmedqa/preprocess_pubmedqa.py
+++ b/lm_eval/tasks/pubmedqa/preprocess_pubmedqa.py
@@ -1,6 +1,6 @@
 def doc_to_text(doc) -> str:
-    ctxs = "\n".join(doc["CONTEXTS"])
+    ctxs = "\n".join(doc["context"]["contexts"])
     return "Abstract: {}\nQuestion: {}\nAnswer:".format(
         ctxs,
-        doc["QUESTION"],
+        doc["question"],
     )

--- a/lm_eval/tasks/pubmedqa/pubmedqa.yaml
+++ b/lm_eval/tasks/pubmedqa/pubmedqa.yaml
@@ -1,6 +1,11 @@
 task: pubmedqa
-dataset_path: bigbio/pubmed_qa
-dataset_name: pubmed_qa_labeled_fold0_source
+dataset_path: qiaojin/pubmed_qa
+dataset_name: pqa_labeled
+dataset_kwargs:
+  split:
+    train: train[:500]
+    validation: train[:50]
+    test: train[500:]
 output_type: multiple_choice
 training_split: train
 validation_split: validation


### PR DESCRIPTION
This PR fixes the RuntimeError: Dataset scripts are no longer supported error currently affecting the pubmedqa task. The issue arises because the previous configuration relied on bigbio/pubmed_qa, which uses a deprecated loading script.

### Changes
   - Updated YAML: Switched dataset_path to qiaojin/pubmed_qa (Parquet-based) to remove the dependency on custom loading scripts.
   - Restored Splits: The qiaojin/pubmed_qa dataset aggregates all 1,000 labeled examples into a single train split. I added dataset_kwargs to slice this split, preserving the
     standard benchmark configuration:
       - Train: First 500 examples (train[:500])
       - Test: Last 500 examples (train[500:])
       - Validation: First 50 examples (train[:50])
   - Updated Preprocessing: Modified preprocess_pubmedqa.py to handle the schema differences (keys are now lowercase context instead of CONTEXTS).

### Validation
  Ran the task locally with lm_eval to confirm it loads and runs without error:

   lm_eval --model dummy --tasks pubmedqa --limit 10

### Output:


   1 |     Tasks    |Version| Filter |n-shot | Metric|   |Value|   |Stderr|
   2 |pubmedqa|      1     |none  |  0  |acc   |↑  |  0.2|±  |0.1333|

  Fixes #3645