### PR TITLE
fix: Reset batch_sizes cache before each _loglikelihood_tokens call

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1306,6 +1306,14 @@ class HFLM(TemplateLM):
             else None
         )
 
+        if batch_fn is not None:
+            # Reset cached batch sizes so that auto-detection runs against the
+            # current set of requests.  Without this, a batch size detected for
+            # short-sequence requests (e.g. ARC) is silently reused for
+            # long-sequence requests (e.g. MMLU), causing CUDA OOM.
+            # See: https://github.com/EleutherAI/lm-evaluation-harness/issues/1678
+            self.batch_sizes = {}
+
         chunks = re_ord.get_batched(n=batch_size, batch_fn=batch_fn)
         pbar = tqdm(
             total=len(requests),


### PR DESCRIPTION
## Problem

When using `batch_size="auto"` and calling `simple_evaluate()` multiple times on the same model instance with different tasks, the second call can OOM even though each task runs fine individually.

I ran into this while evaluating a quantized Gemma3-1B model (RTX 3090, 24GB) on 7 tasks sequentially — arc_easy, arc_challenge, piqa, hellaswag, winogrande, mmlu, wikitext. It consistently crashed on MMLU with "Tried to allocate 31.50 GiB", but MMLU alone worked perfectly.

After digging through the code, I traced it to `self.batch_sizes` in `HFLM`. This dict is initialized once in `__init__` and never cleared. `_batch_scheduler` checks `if sched in self.batch_sizes` and returns the cached value immediately without re-detection. With `batch_schedule=1` (the default), `sched` is always 0, so the very first detection result gets reused for every subsequent call.

The issue is that different tasks have very different sequence lengths. ARC has short sequences (~50 tokens), so `_detect_batch_size` finds that batch_size=64 fits in VRAM. MMLU has much longer sequences (~500 tokens). When the cached batch_size=64 from ARC gets applied to MMLU, the logits tensor becomes 64 × 500 × 262144 × 4 bytes ≈ 31.5 GiB, which obviously doesn't fit on a 24GB card. If MMLU runs first (or alone), detection correctly finds batch_size=13 and everything works.

This pattern — loading a model once and calling `simple_evaluate()` per task — is a natural way to avoid reloading weights between tasks, and it's what lm-eval's own `LM` API supports (accepting a pre-built model instance). The lm-eval CLI doesn't hit this because it processes all tasks in a single `evaluate()` call where requests are combined and sorted together.

## Reproduction

Minimal repro with any model on a single GPU:

```python
import lm_eval
from lm_eval.models.huggingface import HFLM

model = HFLM(pretrained="<any-model>", batch_size="auto")

# Task 1: short sequences → detects large batch size
lm_eval.simple_evaluate(model, tasks=["arc_easy"], limit=50)
print(model.batch_sizes)  # {0: 64}

# Task 2: long sequences → cache hit, uses 64 → OOM
lm_eval.simple_evaluate(model, tasks=["mmlu"], limit=50)  # crashes
```

I ran controlled experiments to confirm:

- MMLU alone: `batch_sizes` starts empty → detects 13 → success (22.64 GiB peak)
- arc_easy then MMLU: `batch_sizes={0: 64}` cached from arc_easy → MMLU hits cache → OOM (31.50 GiB allocation attempt)
- arc_easy then clear `batch_sizes` then MMLU: after clearing, MMLU re-detects 13 → success
- arc_easy then gc.collect + empty_cache (without clearing `batch_sizes`) then MMLU: still OOM — confirms the dict itself is the problem, not GPU memory fragmentation

## Fix

Clear `self.batch_sizes` at the top of `_loglikelihood_tokens` when `batch_fn` is set (i.e., when auto-detection is active). This forces re-detection against the current set of requests on each call.

Within a single `_loglikelihood_tokens` call, the cache still works normally — `_batch_scheduler` detects once at `sched=0` and reuses it for the rest of that call. The only change is that the cache doesn't leak across separate calls.

`generate_until` is unaffected because it sets `adaptive_batch_size` from its own `_detect_batch_size()` call, which makes `batch_fn=None`.

`loglikelihood_rolling` is also unaffected because it passes `override_bs` to `_loglikelihood_tokens`, which also makes `batch_fn=None`.