### PR TITLE
feat: add optional SymPy equivalence and math_verify to hendrycks_math

### DIFF
--- a/lm_eval/tasks/hendrycks_math/README.md
+++ b/lm_eval/tasks/hendrycks_math/README.md
@@ -15,6 +15,13 @@ Homepage: https://github.com/hendrycks/math
 ### v1.1
 - Answer extraction now tries `\boxed{}` from the model response before falling back to `$...$` delimiters. This aligns with the `aime` task behavior and fixes zero accuracy for models that output `\boxed{}` formatted answers.
 - Support for multiple `\boxed{}` answers (e.g. `\boxed{3}, \boxed{5}, \boxed{7}` is extracted as `3, 5, 7`). Duplicate boxes are deduplicated.
+- Optional SymPy symbolic equivalence fallback and `math_verify` metric (see below).
+
+## Optional enhanced equivalence (`pip install lm-eval[math]`)
+
+When `sympy` is installed, `is_equiv` falls back to symbolic comparison via `sympy.simplify` when string matching fails. This handles cases like `9a + 11` vs `11 + 9a` or `\dfrac{1}{2}` vs `\frac{1}{2}` that are mathematically equivalent but differ as strings. Without `sympy`, the task uses string-only comparison (original behavior).
+
+When `math_verify` is installed, an additional `math_verify` metric is reported alongside `exact_match`, providing robust LaTeX-aware answer verification (same as in `minerva_math`).
 
 
 ## Citation

--- a/lm_eval/tasks/hendrycks_math/README.md
+++ b/lm_eval/tasks/hendrycks_math/README.md
@@ -10,6 +10,11 @@ NOTE: This task corresponds to the MATH (`hendrycks_math`) implementation at htt
 
 Homepage: https://github.com/hendrycks/math
 
+## Changes
+
+### v1.1
+- Answer extraction now tries `\boxed{}` from the model response before falling back to `$...$` delimiters. This aligns with the `aime` task behavior and fixes zero accuracy for models that output `\boxed{}` formatted answers.
+
 
 ## Citation
 ```

--- a/lm_eval/tasks/hendrycks_math/README.md
+++ b/lm_eval/tasks/hendrycks_math/README.md
@@ -14,6 +14,7 @@ Homepage: https://github.com/hendrycks/math
 
 ### v1.1
 - Answer extraction now tries `\boxed{}` from the model response before falling back to `$...$` delimiters. This aligns with the `aime` task behavior and fixes zero accuracy for models that output `\boxed{}` formatted answers.
+- Support for multiple `\boxed{}` answers (e.g. `\boxed{3}, \boxed{5}, \boxed{7}` is extracted as `3, 5, 7`). Duplicate boxes are deduplicated.
 
 
 ## Citation

--- a/lm_eval/tasks/hendrycks_math/README.md
+++ b/lm_eval/tasks/hendrycks_math/README.md
@@ -16,6 +16,16 @@ Homepage: https://github.com/hendrycks/math
 - Answer extraction now tries `\boxed{}` from the model response before falling back to `$...$` delimiters. This aligns with the `aime` task behavior and fixes zero accuracy for models that output `\boxed{}` formatted answers.
 - Support for multiple `\boxed{}` answers (e.g. `\boxed{3}, \boxed{5}, \boxed{7}` is extracted as `3, 5, 7`). Duplicate boxes are deduplicated.
 
+### v1.2
+- `is_equiv` falls back to SymPy symbolic comparison when string matching fails (optional, requires `sympy`).
+- An additional `math_verify` metric is reported alongside `exact_match` when `math_verify` is installed.
+
+## Optional enhanced equivalence (`pip install lm-eval[math]`)
+
+When `sympy` is installed, `is_equiv` falls back to symbolic comparison via `sympy.simplify` when string matching fails. This handles cases like `9a + 11` vs `11 + 9a` or `\dfrac{1}{2}` vs `\frac{1}{2}` that are mathematically equivalent but differ as strings. Without `sympy`, the task uses string-only comparison (original behavior).
+
+When `math_verify` is installed, an additional `math_verify` metric is reported alongside `exact_match`, providing robust LaTeX-aware answer verification (same as in `minerva_math`).
+
 
 ## Citation
 ```

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
@@ -11,5 +11,8 @@ aggregate_metric_list:
   - metric: exact_match
     aggregation: mean
     weight_by_size: true
+  - metric: math_verify
+    aggregation: mean
+    weight_by_size: true
 metadata:
   version: 1.1

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
@@ -12,4 +12,4 @@ aggregate_metric_list:
     aggregation: mean
     weight_by_size: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
@@ -11,5 +11,8 @@ aggregate_metric_list:
   - metric: exact_match
     aggregation: mean
     weight_by_size: true
+  - metric: math_verify
+    aggregation: mean
+    weight_by_size: true
 metadata:
-  version: 1.1
+  version: 1.2

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
@@ -19,5 +19,8 @@ metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
+  - metric: math_verify
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 1.1

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
@@ -20,4 +20,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
@@ -19,5 +19,8 @@ metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
+  - metric: math_verify
+    aggregation: mean
+    higher_is_better: true
 metadata:
-  version: 1.1
+  version: 1.2

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -20,10 +20,23 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     response = results[0]
 
     # Try to extract \boxed{} from the response (matches aime task behavior)
-    boxed = last_boxed_only_string(response)
-    if boxed is not None:
+    # First check for multiple \boxed{} (e.g. \boxed{3}, \boxed{5}, \boxed{7})
+    all_boxed = find_all_boxed_strings(response)
+    # Deduplicate while preserving order (models often repeat the final answer)
+    seen = set()
+    unique_boxed = []
+    for b in all_boxed:
+        if b not in seen:
+            seen.add(b)
+            unique_boxed.append(b)
+    if len(unique_boxed) > 1:
         try:
-            answer = remove_boxed(boxed)
+            answer = ", ".join(remove_boxed(b) for b in unique_boxed)
+        except AssertionError:
+            answer = None
+    elif len(unique_boxed) == 1:
+        try:
+            answer = remove_boxed(all_boxed[0])
         except AssertionError:
             answer = None
     else:
@@ -106,6 +119,40 @@ def last_boxed_only_string(string):
         retval = string[idx : right_brace_idx + 1]
 
     return retval
+
+
+def find_all_boxed_strings(string):
+    """Find all \\boxed{} occurrences in a string, handling nested braces."""
+    results = []
+    search_start = 0
+    while True:
+        idx = string.find("\\boxed", search_start)
+        if idx < 0:
+            break
+        # Skip if this is \boxed (space-separated, not brace)
+        after = idx + len("\\boxed")
+        if after >= len(string) or string[after] != "{":
+            search_start = after
+            continue
+        # Find matching closing brace
+        i = after
+        num_left_braces_open = 0
+        right_brace_idx = None
+        while i < len(string):
+            if string[i] == "{":
+                num_left_braces_open += 1
+            if string[i] == "}":
+                num_left_braces_open -= 1
+                if num_left_braces_open == 0:
+                    right_brace_idx = i
+                    break
+            i += 1
+        if right_brace_idx is not None:
+            results.append(string[idx : right_brace_idx + 1])
+            search_start = right_brace_idx + 1
+        else:
+            search_start = after
+    return results
 
 
 def fix_fracs(string):

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -17,11 +17,25 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
 
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     retval = 0
-    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
-    if len(indices) <= 1:
-        answer = results[0]
+    response = results[0]
+
+    # Try to extract \boxed{} from the response (matches aime task behavior)
+    boxed = last_boxed_only_string(response)
+    if boxed is not None:
+        try:
+            answer = remove_boxed(boxed)
+        except AssertionError:
+            answer = None
     else:
-        answer = results[0][indices[0] + 1 : indices[-1]]
+        answer = None
+
+    # Fall back to $...$ extraction
+    if answer is None:
+        indices = [pos for pos, char in enumerate(response) if char == "$"]
+        if len(indices) <= 1:
+            answer = response
+        else:
+            answer = response[indices[0] + 1 : indices[-1]]
 
     if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
         retval = 1

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -1,6 +1,30 @@
+import logging
+import signal
+import warnings
 from typing import Dict, List
 
 import datasets
+
+
+eval_logger = logging.getLogger(__name__)
+
+
+try:
+    import sympy
+    from sympy.parsing.latex import parse_latex
+
+    HAS_SYMPY = True
+except ImportError:
+    HAS_SYMPY = False
+
+try:
+    from math_verify import parse, verify
+
+    HAS_MATH_VERIFY = True
+except ImportError:
+    HAS_MATH_VERIFY = False
+
+_SYMPY_WARNING_ISSUED = False
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
@@ -53,28 +77,106 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
         retval = 1
 
-    results = {
+    out = {
         "exact_match": retval,
     }
-    return results
+
+    # math_verify provides robust LaTeX-aware answer verification
+    if HAS_MATH_VERIFY:
+        mv_result = verify(
+            gold=parse(doc["solution"]),
+            target=parse(response),
+        )
+        out["math_verify"] = 1 if mv_result else 0
+
+    return out
+
+
+class _timeout:
+    """Timeout context manager using SIGALRM (Unix only)."""
+
+    def __init__(self, seconds=1, error_message="Timeout"):
+        self.seconds = seconds
+        self.error_message = error_message
+
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.handle_timeout)
+        signal.alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        signal.alarm(0)
+
+
+def _sympy_equiv(ss1: str, ss2: str) -> bool:
+    """Check symbolic equivalence using SymPy. Returns True/False."""
+    try:
+        with _timeout(seconds=5):
+            try:
+                parsed_1 = parse_latex(ss1)
+                parsed_2 = parse_latex(ss2)
+            except (
+                sympy.parsing.latex.errors.LaTeXParsingError,
+                sympy.SympifyError,
+                TypeError,
+            ):
+                return False
+
+            try:
+                diff = parsed_1 - parsed_2
+            except TypeError:
+                return False
+
+            try:
+                return sympy.simplify(diff) == 0
+            except ValueError:
+                return False
+    except TimeoutError:
+        eval_logger.debug(f"Timed out comparing {ss1} and {ss2}")
+        return False
+    except Exception as e:
+        eval_logger.debug(f"Failed comparing {ss1} and {ss2} with {e}")
+        return False
 
 
 # string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py
 def is_equiv(str1, str2, verbose=False):
+    global _SYMPY_WARNING_ISSUED
+
     if str1 is None and str2 is None:
         print("WARNING: Both None")
         return True
     if str1 is None or str2 is None:
         return False
 
+    # Normalize strings; fall back to raw strings if strip_string fails
+    ss1 = str1
+    ss2 = str2
     try:
         ss1 = strip_string(str1)
         ss2 = strip_string(str2)
-        if verbose:
-            print(ss1, ss2)
-        return ss1 == ss2
     except Exception:
-        return str1 == str2
+        pass
+    if verbose:
+        print(ss1, ss2)
+    if ss1 == ss2:
+        return True
+
+    # Fall back to SymPy symbolic equivalence if available
+    if HAS_SYMPY:
+        if _sympy_equiv(ss1, ss2):
+            return True
+    elif not _SYMPY_WARNING_ISSUED:
+        warnings.warn(
+            "sympy not installed — string-only equivalence used for hendrycks_math. "
+            "Install via `pip install lm-eval[math]` for improved symbolic matching.",
+            stacklevel=2,
+        )
+        _SYMPY_WARNING_ISSUED = True
+
+    return False
 
 
 def remove_boxed(s):

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -36,11 +36,21 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
             answer = None
     elif len(unique_boxed) == 1:
         try:
-            answer = remove_boxed(all_boxed[0])
+            answer = remove_boxed(unique_boxed[0])
         except AssertionError:
             answer = None
     else:
         answer = None
+
+    # Fall back to legacy single-boxed extraction (handles \boxed space-form
+    # that find_all_boxed_strings skips, plus \fbox).
+    if answer is None:
+        legacy = last_boxed_only_string(response)
+        if legacy is not None:
+            try:
+                answer = remove_boxed(legacy)
+            except (AssertionError, IndexError):
+                answer = None
 
     # Fall back to $...$ extraction
     if answer is None:

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -1,4 +1,29 @@
+import logging
+import signal
+import warnings
+
 import datasets
+
+
+eval_logger = logging.getLogger(__name__)
+
+
+try:
+    import sympy
+    from sympy.parsing.latex import parse_latex
+
+    HAS_SYMPY = True
+except ImportError:
+    HAS_SYMPY = False
+
+try:
+    from math_verify import parse, verify
+
+    HAS_MATH_VERIFY = True
+except ImportError:
+    HAS_MATH_VERIFY = False
+
+_SYMPY_WARNING_ISSUED = False
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
@@ -61,28 +86,107 @@ def process_results(doc: dict, results: list[str]) -> dict[str, int]:
     if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
         retval = 1
 
-    results = {
+    out = {
         "exact_match": retval,
     }
-    return results
+
+    # math_verify provides robust LaTeX-aware answer verification
+    if HAS_MATH_VERIFY:
+        mv_result = verify(
+            gold=parse(doc["solution"]),
+            target=parse(response),
+        )
+        out["math_verify"] = 1 if mv_result else 0
+
+    return out
+
+
+class _timeout:
+    """Timeout context manager using SIGALRM (Unix only)."""
+
+    def __init__(self, seconds=1, error_message="Timeout"):
+        self.seconds = seconds
+        self.error_message = error_message
+
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.handle_timeout)
+        signal.alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        signal.alarm(0)
+
+
+def _sympy_equiv(ss1: str, ss2: str) -> bool:
+    """Check symbolic equivalence using SymPy. Returns True/False."""
+    try:
+        with _timeout(seconds=5):
+            try:
+                parsed_1 = parse_latex(ss1)
+                parsed_2 = parse_latex(ss2)
+            except (
+                sympy.parsing.latex.errors.LaTeXParsingError,
+                sympy.SympifyError,
+                TypeError,
+            ):
+                return False
+
+            try:
+                diff = parsed_1 - parsed_2
+            except TypeError:
+                return False
+
+            try:
+                return sympy.simplify(diff) == 0
+            except ValueError:
+                return False
+    except TimeoutError:
+        eval_logger.debug(f"Timed out comparing {ss1} and {ss2}")
+        return False
+    except Exception as e:  # noqa: BLE001 - symbolic comparison is best-effort
+        eval_logger.debug(f"Failed comparing {ss1} and {ss2} with {e}")
+        return False
 
 
 # string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py
 def is_equiv(str1, str2, verbose=False):
+    global _SYMPY_WARNING_ISSUED
+
     if str1 is None and str2 is None:
         print("WARNING: Both None")
         return True
     if str1 is None or str2 is None:
         return False
 
+    # Normalize strings; fall back to raw strings if strip_string fails
+    ss1 = str1
+    ss2 = str2
     try:
         ss1 = strip_string(str1)
         ss2 = strip_string(str2)
-        if verbose:
-            print(ss1, ss2)
-        return ss1 == ss2
-    except Exception:  # noqa: BLE001 - normalization is best-effort; fall back to raw compare
-        return str1 == str2
+    except Exception as e:  # noqa: BLE001 - normalization is best-effort
+        # Keep the raw strings and carry on; comparison below still applies.
+        eval_logger.debug(f"strip_string failed on {str1!r}/{str2!r} with {e}")
+    if verbose:
+        print(ss1, ss2)
+    if ss1 == ss2:
+        return True
+
+    # Fall back to SymPy symbolic equivalence if available
+    if HAS_SYMPY:
+        if _sympy_equiv(ss1, ss2):
+            return True
+    elif not _SYMPY_WARNING_ISSUED:
+        warnings.warn(
+            "sympy not installed — string-only equivalence used for hendrycks_math. "
+            "Install via `pip install lm-eval[math]` for improved symbolic matching.",
+            stacklevel=2,
+        )
+        _SYMPY_WARNING_ISSUED = True
+
+    return False
 
 
 def remove_boxed(s):

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -132,7 +132,7 @@ def last_boxed_only_string(string):
 
 
 def find_all_boxed_strings(string):
-    """Find all \\boxed{} occurrences in a string, handling nested braces."""
+    r"""Find all \boxed{} occurrences in a string, handling nested braces."""
     results = []
     search_start = 0
     while True:

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import signal
 import warnings
 
@@ -119,8 +120,30 @@ class _timeout:
         signal.alarm(0)
 
 
+# A comma that groups digits ("58,500") is safe for parse_latex; a comma that
+# separates list items is not -- see _has_list_comma below.
+_THOUSANDS_SEPARATED_RE = re.compile(r"^-?\d{1,3}(,\d{3})+$")
+
+
+def _has_list_comma(s: str) -> bool:
+    r"""True if `s` uses a comma to separate list items rather than digit groups.
+
+    ``parse_latex`` silently truncates at the first comma -- ``"3, 5, 7"``
+    parses to ``3`` -- so any two comma-separated answers sharing a first
+    element would compare equal. MATH asks for comma-separated answers often
+    enough ("Enter all such integers, separated by commas") that this has to be
+    excluded from symbolic comparison rather than left to chance.
+    """
+    if "," not in s:
+        return False
+    return _THOUSANDS_SEPARATED_RE.match(s.strip()) is None
+
+
 def _sympy_equiv(ss1: str, ss2: str) -> bool:
     """Check symbolic equivalence using SymPy. Returns True/False."""
+    if _has_list_comma(ss1) or _has_list_comma(ss2):
+        # Not representable as a single expression; defer to string comparison.
+        return False
     try:
         with _timeout(seconds=5):
             try:

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 import datasets
 
 
@@ -15,7 +13,7 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     return dataset.map(_process_doc)
 
 
-def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
+def process_results(doc: dict, results: list[str]) -> dict[str, int]:
     retval = 0
     response = results[0]
 
@@ -83,7 +81,7 @@ def is_equiv(str1, str2, verbose=False):
         if verbose:
             print(ss1, ss2)
         return ss1 == ss2
-    except Exception:
+    except Exception:  # noqa: BLE001 - normalization is best-effort; fall back to raw compare
         return str1 == str2
 
 
@@ -205,7 +203,7 @@ def fix_a_slash_b(string):
     try:
         a = int(a)
         b = int(b)
-        assert string == "{}/{}".format(a, b)
+        assert string == f"{a}/{b}"
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
     except AssertionError:
@@ -279,9 +277,8 @@ def strip_string(string):
         string = "0" + string
 
     # to consider: get rid of e.g. "k = " or "q = " at beginning
-    if len(string.split("=")) == 2:
-        if len(string.split("=")[0]) <= 2:
-            string = string.split("=")[1]
+    if len(string.split("=")) == 2 and len(string.split("=")[0]) <= 2:
+        string = string.split("=")[1]
 
     # fix sqrt3 --> sqrt{3}
     string = fix_sqrt(string)

--- a/tests/test_hendrycks_math.py
+++ b/tests/test_hendrycks_math.py
@@ -1,0 +1,70 @@
+from lm_eval.tasks.hendrycks_math.utils import (
+    find_all_boxed_strings,
+    process_results,
+)
+
+
+def _doc(boxed):
+    return {"solution": f"... so \\boxed{{{boxed}}}."}
+
+
+def test_boxed_response_matches():
+    assert process_results(_doc("[2,5)"), ["The domain is \\boxed{[2,5)}"]) == {
+        "exact_match": 1
+    }
+
+
+def test_dollar_fallback_still_works():
+    assert process_results(
+        _doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]
+    ) == {"exact_match": 1}
+
+
+def test_space_form_boxed_falls_back_to_last_boxed_only_string():
+    # \boxed 4 (space-form) is intentionally skipped by find_all_boxed_strings;
+    # last_boxed_only_string handles it, terminating on $ or end-of-string.
+    assert process_results(_doc("4"), ["The answer is \\boxed 4"]) == {
+        "exact_match": 1
+    }
+
+
+def test_space_form_boxed_terminated_by_dollar():
+    # Same fallback path, but terminated by a $ delimiter (the way solutions
+    # in the dataset typically wrap the answer).
+    assert process_results(_doc("7"), ["So we get $\\boxed 7$ as the answer."]) == {
+        "exact_match": 1
+    }
+
+
+def test_multi_boxed_joined():
+    assert process_results(
+        {"solution": "... \\boxed{3, 5, 7}."},
+        ["Final answers: \\boxed{3}, \\boxed{5}, \\boxed{7}"],
+    ) == {"exact_match": 1}
+
+
+def test_multi_boxed_deduplicated():
+    # Models often repeat the final answer; dedup keeps a single \boxed{4}
+    # from producing "4, 4".
+    assert process_results(_doc("4"), ["So \\boxed{4}. Therefore \\boxed{4}."]) == {
+        "exact_match": 1
+    }
+
+
+def test_find_all_boxed_strings_returns_all_occurrences():
+    # No dedup at this layer -- dedup is process_results' job.
+    assert find_all_boxed_strings("\\boxed{3}, \\boxed{5}, \\boxed{3}") == [
+        "\\boxed{3}",
+        "\\boxed{5}",
+        "\\boxed{3}",
+    ]
+
+
+def test_find_all_boxed_strings_ignores_space_form():
+    # Documents the intentional scope of this helper; space-form is handled
+    # by the last_boxed_only_string fallback in process_results.
+    assert find_all_boxed_strings("The answer is \\boxed 4.") == []
+
+
+def test_neither_format_does_not_crash():
+    assert process_results(_doc("42"), ["I don't know"]) == {"exact_match": 0}

--- a/tests/test_hendrycks_math.py
+++ b/tests/test_hendrycks_math.py
@@ -87,6 +87,24 @@ def test_is_equiv_sympy_symbolic_fallback():
     assert is_equiv("9a + 11", "11 + 9a") is True
 
 
+@pytest.mark.skipif(not HAS_SYMPY, reason="requires sympy (pip install lm-eval[math])")
+def test_comma_separated_answers_are_not_symbolically_equated():
+    # parse_latex truncates at the first comma ("3, 5, 7" -> 3), so without a
+    # guard any two lists sharing a first element compare equal. MATH uses this
+    # answer format ("separated by commas") a lot, and process_results joins
+    # multiple \boxed{} values with ", ", so this must not over-match.
+    assert is_equiv("1,-2", "1,-3") is False
+    assert is_equiv("1,2", "1,3") is False
+    assert is_equiv("3, 5, 7", "3, 5, 9") is False
+
+
+@pytest.mark.skipif(not HAS_SYMPY, reason="requires sympy (pip install lm-eval[math])")
+def test_thousands_separator_still_compares_numerically():
+    # The comma guard must not disable digit-grouping commas, which parse_latex
+    # handles correctly.
+    assert is_equiv("58,500", "58500") is True
+
+
 @pytest.mark.skipif(
     not HAS_MATH_VERIFY, reason="requires math_verify (pip install lm-eval[math])"
 )

--- a/tests/test_hendrycks_math.py
+++ b/tests/test_hendrycks_math.py
@@ -15,17 +15,15 @@ def test_boxed_response_matches():
 
 
 def test_dollar_fallback_still_works():
-    assert process_results(
-        _doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]
-    ) == {"exact_match": 1}
+    assert process_results(_doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]) == {
+        "exact_match": 1
+    }
 
 
 def test_space_form_boxed_falls_back_to_last_boxed_only_string():
     # \boxed 4 (space-form) is intentionally skipped by find_all_boxed_strings;
     # last_boxed_only_string handles it, terminating on $ or end-of-string.
-    assert process_results(_doc("4"), ["The answer is \\boxed 4"]) == {
-        "exact_match": 1
-    }
+    assert process_results(_doc("4"), ["The answer is \\boxed 4"]) == {"exact_match": 1}
 
 
 def test_space_form_boxed_terminated_by_dollar():

--- a/tests/test_hendrycks_math.py
+++ b/tests/test_hendrycks_math.py
@@ -1,5 +1,10 @@
+import pytest
+
 from lm_eval.tasks.hendrycks_math.utils import (
+    HAS_MATH_VERIFY,
+    HAS_SYMPY,
     find_all_boxed_strings,
+    is_equiv,
     process_results,
 )
 
@@ -8,45 +13,46 @@ def _doc(boxed):
     return {"solution": f"... so \\boxed{{{boxed}}}."}
 
 
+def _exact_match(doc, resps):
+    # process_results also reports an optional `math_verify` key when
+    # math_verify is installed, so assert on exact_match alone.
+    return process_results(doc, resps)["exact_match"]
+
+
 def test_boxed_response_matches():
-    assert process_results(_doc("[2,5)"), ["The domain is \\boxed{[2,5)}"]) == {
-        "exact_match": 1
-    }
+    assert _exact_match(_doc("[2,5)"), ["The domain is \\boxed{[2,5)}"]) == 1
 
 
 def test_dollar_fallback_still_works():
-    assert process_results(_doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]) == {
-        "exact_match": 1
-    }
+    assert _exact_match(_doc("\\frac{1}{2}"), ["The answer is $\\frac{1}{2}$"]) == 1
 
 
 def test_space_form_boxed_falls_back_to_last_boxed_only_string():
     # \boxed 4 (space-form) is intentionally skipped by find_all_boxed_strings;
     # last_boxed_only_string handles it, terminating on $ or end-of-string.
-    assert process_results(_doc("4"), ["The answer is \\boxed 4"]) == {"exact_match": 1}
+    assert _exact_match(_doc("4"), ["The answer is \\boxed 4"]) == 1
 
 
 def test_space_form_boxed_terminated_by_dollar():
     # Same fallback path, but terminated by a $ delimiter (the way solutions
     # in the dataset typically wrap the answer).
-    assert process_results(_doc("7"), ["So we get $\\boxed 7$ as the answer."]) == {
-        "exact_match": 1
-    }
+    assert _exact_match(_doc("7"), ["So we get $\\boxed 7$ as the answer."]) == 1
 
 
 def test_multi_boxed_joined():
-    assert process_results(
-        {"solution": "... \\boxed{3, 5, 7}."},
-        ["Final answers: \\boxed{3}, \\boxed{5}, \\boxed{7}"],
-    ) == {"exact_match": 1}
+    assert (
+        _exact_match(
+            {"solution": "... \\boxed{3, 5, 7}."},
+            ["Final answers: \\boxed{3}, \\boxed{5}, \\boxed{7}"],
+        )
+        == 1
+    )
 
 
 def test_multi_boxed_deduplicated():
     # Models often repeat the final answer; dedup keeps a single \boxed{4}
     # from producing "4, 4".
-    assert process_results(_doc("4"), ["So \\boxed{4}. Therefore \\boxed{4}."]) == {
-        "exact_match": 1
-    }
+    assert _exact_match(_doc("4"), ["So \\boxed{4}. Therefore \\boxed{4}."]) == 1
 
 
 def test_find_all_boxed_strings_returns_all_occurrences():
@@ -65,4 +71,31 @@ def test_find_all_boxed_strings_ignores_space_form():
 
 
 def test_neither_format_does_not_crash():
-    assert process_results(_doc("42"), ["I don't know"]) == {"exact_match": 0}
+    assert _exact_match(_doc("42"), ["I don't know"]) == 0
+
+
+def test_is_equiv_still_rejects_unequal_answers():
+    # Guards against the SymPy fallback over-matching: these are not equivalent
+    # regardless of whether sympy is installed.
+    assert is_equiv("3", "4") is False
+    assert is_equiv("x + 1", "x + 2") is False
+
+
+@pytest.mark.skipif(not HAS_SYMPY, reason="requires sympy (pip install lm-eval[math])")
+def test_is_equiv_sympy_symbolic_fallback():
+    # String comparison fails on reordered terms; SymPy simplification catches it.
+    assert is_equiv("9a + 11", "11 + 9a") is True
+
+
+@pytest.mark.skipif(
+    not HAS_MATH_VERIFY, reason="requires math_verify (pip install lm-eval[math])"
+)
+def test_math_verify_metric_reported():
+    result = process_results(_doc("4"), ["The answer is \\boxed{4}"])
+    assert result["math_verify"] == 1
+
+
+@pytest.mark.skipif(HAS_MATH_VERIFY, reason="asserts behavior without math_verify")
+def test_math_verify_metric_absent_without_dependency():
+    result = process_results(_doc("4"), ["The answer is \\boxed{4}"])
+    assert "math_verify" not in result


### PR DESCRIPTION
## Summary

- **SymPy symbolic fallback**: When `sympy` is installed (`pip install lm-eval[math]`), `is_equiv` falls back to `sympy.simplify` when string matching fails. Handles mathematically equivalent answers like `9a + 11` vs `11 + 9a` that differ as strings.
- **`math_verify` metric**: When `math_verify` is installed, an additional `math_verify` metric is reported alongside `exact_match`, providing robust LaTeX-aware answer verification (same approach as `minerva_math`).
- Both are **optional**: without them, original string-only behavior is preserved (with a one-time warning suggesting installation).

Builds on #3644 (`\boxed{}` extraction fix).
Addresses equivalence issues raised in #3652.

## Impact

- No breaking changes. Existing behavior is preserved when optional deps are not installed.
- Users who install `lm-eval[math]` get improved accuracy on `hendrycks_math` and `hendrycks_math500` tasks.