### PR TITLE
[BUGFIX] Consistent handling of None answers and cache

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -549,8 +549,7 @@ class TemplateAPI(TemplateLM):
             for a in tmp_answers:
                 if a is None:
                     eval_logger.warning(
-                        (f"API returned null content. Content filled with `LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER = {LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER}`. ")
-                        ("Check reasoning_content field or generation limits.")
+                        f"API returned null content. Content filled with `LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER = {LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER}`. Check reasoning_content field or generation limits."
                     )
                     answers.append(LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER)
                 else:
@@ -793,7 +792,7 @@ class TemplateAPI(TemplateLM):
                     # even if generation failed (generated_text is None)
                     if generated_text is None:
                         eval_logger.warning(
-                            "API returned null content. Check reasoning_content field or generation limits..."
+                            f"API returned null content. Content filled with `LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER = {LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER}`. Check reasoning_content field or generation limits."
                         )
                         # Patch "None" answer with consistent value (async and sync calls)
                         res.append(LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER)

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -21,9 +21,6 @@ from typing import (
     Union,
 )
 
-from lm_eval.tasks.super_glue.wsc.t5_utils import clean
-
-
 try:
     import requests
     from aiohttp import ClientSession, ClientTimeout, TCPConnector

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -21,6 +21,8 @@ from typing import (
     Union,
 )
 
+from lm_eval.tasks.super_glue.wsc.t5_utils import clean
+
 
 try:
     import requests
@@ -533,7 +535,7 @@ class TemplateAPI(TemplateLM):
                 # raising exception will retry the request
                 response.raise_for_status()
                 outputs = await response.json()
-            answers = (
+            tmp_answers = (
                 self.parse_generations(
                     outputs=outputs,
                 )
@@ -544,12 +546,21 @@ class TemplateAPI(TemplateLM):
                     ctxlens=ctxlens,
                 )
             )
+
+            # Convert `None`` values to `LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER` string to maintain consistency
+            answers = []
+            for a in tmp_answers:
+                if a is None:
+                    eval_logger.warning(
+                        (f"API returned null content. Content filled with `LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER = {LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER}`. ")
+                        ("Check reasoning_content field or generation limits.")
+                    )
+                    answers.append(LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER)
+                else:
+                    answers.append(a)
+
             if cache_keys:
                 for res, cache in zip(answers, cache_keys):
-                    if res is None:
-                        # Patch "None" answer with consistent value (async and sync calls)
-                        res = LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER
-                    # Add to cache
                     self.cache_hook.add_partial(cache_method, cache, res)
             return answers
         # If the retries also fail
@@ -829,15 +840,9 @@ class TemplateAPI(TemplateLM):
                         )
                     )
                 )
-                # Convert None values to empty strings to maintain consistency
+                # Append results to res list
                 for r in results:
-                    if r is None:
-                        eval_logger.warning(
-                            "API returned null content. Check reasoning_content field or generation limits."
-                        )
-                        res.append("")
-                    else:
-                        res.append(r)
+                    res.append(r)
 
         return re_ord.get_original(res)
 

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -4,6 +4,7 @@ import copy
 import itertools
 import json
 import logging
+import os
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
@@ -44,6 +45,13 @@ from lm_eval.models.utils import Collator, chunks, configure_pad_token
 if TYPE_CHECKING:
     from PIL import Image
 
+# Set a placeholder to use as model output when the returned answer is "None"
+# This commonly occurs when the model runs out of tokens during the thinking
+# process and returns an empty answer but no error.
+# Default value is an empty string, but it can be edited if this is problematic.
+LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER = os.environ.get(
+    "LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER", ""
+)
 
 eval_logger = logging.getLogger(__name__)
 
@@ -538,8 +546,11 @@ class TemplateAPI(TemplateLM):
             )
             if cache_keys:
                 for res, cache in zip(answers, cache_keys):
-                    if res is not None:
-                        self.cache_hook.add_partial(cache_method, cache, res)
+                    if res is None:
+                        # Patch "None" answer with consistent value (async and sync calls)
+                        res = LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER
+                    # Add to cache
+                    self.cache_hook.add_partial(cache_method, cache, res)
             return answers
         # If the retries also fail
         except BaseException as e:
@@ -776,7 +787,8 @@ class TemplateAPI(TemplateLM):
                         eval_logger.warning(
                             "API returned null content. Check reasoning_content field or generation limits..."
                         )
-                        res.append("")
+                        # Patch "None" answer with consistent value (async and sync calls)
+                        res.append(LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER)
                     else:
                         res.append(generated_text)
 


### PR DESCRIPTION
Under some circumstances the returned request to a model can be successful (no errors) but the response can be empty (i.e. be `None`). This is common for "thinking" models, where they run out of tokens before finishing its thinking process.

The current handling of this issue is not consistent:
- Sync calls to `generate_until` will result in replacing the `None` with an empty string. See https://github.com/EleutherAI/lm-evaluation-harness/blob/ee7e8f4fe58e13d6760c066474f0d01477317d1d/lm_eval/models/api_models.py#L779
- Async calls (to `amodel_call`) will result in a plain skip, leaving the `None` as answer. See: https://github.com/EleutherAI/lm-evaluation-harness/blob/ee7e8f4fe58e13d6760c066474f0d01477317d1d/lm_eval/models/api_models.py#L541 The replacement occurs later, where the replacement for the empty string is hardcoded again: https://github.com/EleutherAI/lm-evaluation-harness/blob/ee7e8f4fe58e13d6760c066474f0d01477317d1d/lm_eval/models/api_models.py#L826

Moreover, the treatment of the `amodel_call`, introduced in https://github.com/EleutherAI/lm-evaluation-harness/pull/3633 is not correct. While it solves the crashes of the cache in re-runs it does so by completely ignoring it, meaning that the generation is effectively lost. In other words, the generations that returned `None` due to **exhaustion of tokens** in the thinking process will be re-evaluated in subsequent runs, since they are never included in the cache. This means that the slower (and most expensive, if the endpoint is paid) requests never reach the cache.

This is a long-standing issue, reported on August 2025 (https://github.com/EleutherAI/lm-evaluation-harness/issues/3244) and March 2026 (https://github.com/EleutherAI/lm-evaluation-harness/issues/3632). 

We hope we can solve this recurrent issue with this PR.

P.S.: The linting process is failing due to code that is not part of this PR. If we lint this file the actual changes introduced here will be harder to follow.
