### PR TITLE
fix: use np.median for correct median aggregation

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -38,7 +38,7 @@ def mean(arr):
 
 @register_aggregation("median")
 def median(arr):
-    return arr[len(arr) // 2]
+    return np.median(arr)
 
 
 # Certain metrics must be calculated across all documents in a benchmark.


### PR DESCRIPTION
## Summary
- The `median` aggregation function returned `arr[len(arr) // 2]` without sorting, producing incorrect results for unsorted inputs. For example, `median([5, 1, 3])` returned `1` instead of `3`.
- While no tasks currently use `median` aggregation, this function is registered via `@register_aggregation("median")` and available for any task config to reference. Fixing it now prevents silent incorrect results when someone does use it.
- Replace with `np.median(arr)` which correctly sorts and handles both odd and even-length arrays. `numpy` is already imported in this module, so no new dependency is introduced.

## Testing
- Verified with unsorted arrays (`[5,1,3]` → `3`) and even-length arrays (`[4,1,3,2]` → `2.5`)
- All existing tests pass (575 passed, 14 skipped)