### PR TITLE
Add --include_package support for external model modules

### DIFF
--- a/docs/config_files.md
+++ b/docs/config_files.md
@@ -46,6 +46,7 @@ All configuration keys correspond directly to CLI arguments. See the [CLI Refere
 | `system_instruction` | string/null | `null` | System prompt |
 | `fewshot_as_multiturn` | bool/null | `null` | Multi-turn few-shot |
 | `include_path` | string/null | `null` | External tasks path |
+| `include_package` | string/list/null | `null` | External Python module(s) to import before evaluation |
 | `gen_kwargs` | dict | `{}` | Generation arguments |
 | `wandb_args` | dict | `{}` | W&B init arguments |
 | `hf_hub_log_args` | dict | `{}` | HF Hub logging |

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -119,6 +119,7 @@ lm-eval run --config my_config.yaml --tasks mmlu
 | Argument | Description |
 |----------|-------------|
 | `--include_path` | Additional directory containing external task YAML files. |
+| `--include_package` | Additional Python module(s) or `.py` file(s) to import before evaluation so external models, metrics, or filters can register themselves. |
 
 ### Logging and Tracking
 

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -100,7 +100,7 @@ class MyCustomLM(LM):
 
 Using this decorator results in the class being added to an accounting of the usable LM types maintained internally to the library at `lm_eval.api.registry.MODEL_REGISTRY`. See `lm_eval.api.registry` for more detail on what sorts of registries and decorators exist in the library!
 
-**Tip: be sure to import your model in `lm_eval/models/__init__.py!`**
+**Tip:** when contributing a built-in model backend, import it in `lm_eval/models/__init__.py`. For local experiments or external integrations, you can instead pass `--include_package path/to/my_model.py` (or a dotted module path) at runtime.
 
 ## Testing
 

--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -241,6 +241,14 @@ class Run(SubCommand):
             metavar="<path>",
             help="Additional directory for external tasks",
         )
+        task_group.add_argument(
+            "--include_package",
+            nargs="+",
+            action=SplitArgs,
+            default=None,
+            metavar="<module>",
+            help="Additional module path(s) or Python file(s) to import before evaluation",
+        )
 
         # Logging and Tracking
         logging_group = self._parser.add_argument_group("logging and tracking")
@@ -345,6 +353,7 @@ class Run(SubCommand):
 
         # Create and validate config (most validation now occurs in EvaluationConfig)
         cfg = EvaluatorConfig.from_cli(args)
+        cfg.import_custom_modules()
 
         from lm_eval import simple_evaluate
         from lm_eval.loggers import EvaluationTracker, WandbLogger
@@ -444,7 +453,7 @@ class Run(SubCommand):
             )
 
             if cfg.log_samples:
-                for task_name, _ in results["configs"].items():
+                for task_name in results["configs"].keys():
                     evaluation_tracker.save_results_samples(
                         task_name=task_name, samples=samples[task_name]
                     )

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -148,6 +148,12 @@ class EvaluatorConfig:
     include_path: str | None = field(
         default=None, metadata={"help": "Additional dir path for external tasks"}
     )
+    include_package: str | list[str] | None = field(
+        default=None,
+        metadata={
+            "help": "Module path(s) or Python file(s) to import before evaluation"
+        },
+    )
     gen_kwargs: dict = field(
         default_factory=dict,
         metadata={"help": "Arguments for model generation. Will update Task defaults"},
@@ -323,6 +329,13 @@ class EvaluatorConfig:
                     if (samples_path := Path(cast("str", self.samples))).is_file():
                         self.samples = json.loads(samples_path.read_text())
 
+        if isinstance(self.include_package, str):
+            self.include_package = [
+                item.strip()
+                for item in self.include_package.split(",")
+                if item.strip()
+            ]
+
         # Set up metadata by merging model_args and metadata.
         if self.model_args is None:
             self.model_args = {}
@@ -330,6 +343,24 @@ class EvaluatorConfig:
             self.metadata = {}
 
         self.metadata = self.model_args | self.metadata
+
+        return self
+
+    def import_custom_modules(self) -> "EvaluatorConfig":
+        """Import external modules so they can register models, metrics, or filters."""
+        if not self.include_package:
+            return self
+
+        from lm_eval.utils import import_module_from_specifier
+
+        packages = (
+            self.include_package
+            if isinstance(self.include_package, list)
+            else [self.include_package]
+        )
+        for specifier in packages:
+            import_module_from_specifier(specifier)
+            eval_logger.info(f"Imported external module: {specifier}")
 
         return self
 

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -2,12 +2,14 @@ import collections
 import fnmatch
 import functools
 import hashlib
+import importlib
 import importlib.util
 import inspect
 import json
 import logging
 import os
 import re
+import sys
 import threading
 from collections.abc import Callable, Generator
 from dataclasses import asdict, is_dataclass
@@ -601,6 +603,54 @@ def import_function(loader: yaml.Loader, node, yaml_path: Path):
 
     function = getattr(module, function_name)
     return function
+
+
+def import_module_from_specifier(specifier: str):
+    """Import a module from either a Python module path or a filesystem path.
+
+    Args:
+        specifier: Dotted module path (e.g. ``my_pkg.models``), path to a Python
+            file, or path to a package directory containing ``__init__.py``.
+
+    Returns:
+        The imported module.
+    """
+    path = Path(specifier).expanduser()
+    if path.exists():
+        path = path.resolve()
+        if path.is_dir():
+            init_file = path / "__init__.py"
+            if not init_file.is_file():
+                raise ValueError(
+                    f"Cannot import package from {path}: missing __init__.py"
+                )
+            parent = str(path.parent)
+            if parent not in sys.path:
+                sys.path.insert(0, parent)
+            return importlib.import_module(path.name)
+
+        if path.suffix != ".py":
+            raise ValueError(
+                f"Cannot import module from {path}: expected a .py file or package directory"
+            )
+
+        module_name = (
+            f"_lm_eval_external_{path.stem}_"
+            f"{hashlib.sha256(str(path).encode('utf-8')).hexdigest()[:12]}"
+        )
+        if module_name in sys.modules:
+            return sys.modules[module_name]
+
+        spec = importlib.util.spec_from_file_location(module_name, path.as_posix())
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not import module from {path}")
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    return importlib.import_module(specifier)
 
 
 def regex_replace(string, pattern, repl, count: int = 0):

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -207,6 +207,26 @@ class TestRunCommand:
         )
         assert args.model_args == {"pretrained": "gpt2", "device": "cuda"}
 
+    def test_run_command_include_package_args(self):
+        """Test Run command include_package parsing."""
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        Run.create(subparsers)
+
+        args = parser.parse_args(
+            [
+                "run",
+                "--include_package",
+                "custom.module",
+                "other.module,C:/models/custom_model.py",
+            ]
+        )
+        assert args.include_package == [
+            "custom.module",
+            "other.module",
+            "C:/models/custom_model.py",
+        ]
+
     def test_run_command_batch_size(self):
         """Test Run command batch size arguments."""
         parser = argparse.ArgumentParser()
@@ -261,6 +281,7 @@ class TestRunCommand:
         mock_cfg_instance.output_path = None
         mock_cfg_instance.hf_hub_log_args = {}
         mock_cfg_instance.include_path = None
+        mock_cfg_instance.include_package = None
         mock_cfg_instance.tasks = ["hellaswag"]
         mock_cfg_instance.model = "hf"
         mock_cfg_instance.model_args = {"pretrained": "gpt2"}
@@ -269,6 +290,7 @@ class TestRunCommand:
         mock_cfg_instance.num_fewshot = 0
         mock_cfg_instance.batch_size = 1
         mock_cfg_instance.log_samples = False
+        mock_cfg_instance.import_custom_modules.return_value = mock_cfg_instance
         mock_cfg_instance.process_tasks.return_value = MagicMock()
         mock_config.from_cli.return_value = mock_cfg_instance
 
@@ -292,6 +314,7 @@ class TestRunCommand:
             run_cmd._execute(args)
 
         mock_config.from_cli.assert_called_once()
+        mock_cfg_instance.import_custom_modules.assert_called_once_with()
         mock_simple_evaluate.assert_called_once()
         mock_make_table.assert_called_once()
 
@@ -628,6 +651,61 @@ class TestEvaluatorConfigFromCLI:
 
         with pytest.raises(ValueError, match="output_path"):
             EvaluatorConfig.from_cli(ns)
+
+    def test_include_package_string_normalized_to_list(self):
+        """Test include_package string config is normalized to a list."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        cfg = EvaluatorConfig(
+            tasks=["hellaswag"], include_package="pkg.one,C:/models/custom_model.py"
+        )._process_arguments()
+
+        assert cfg.include_package == ["pkg.one", "C:/models/custom_model.py"]
+
+    def test_import_custom_modules_registers_external_model(self, tmp_path):
+        """Test importing an external module registers its model."""
+        import sys
+
+        from lm_eval.api.registry import get_model, model_registry
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        module_path = tmp_path / "external_model.py"
+        module_path.write_text(
+            """
+from lm_eval.api.model import LM
+from lm_eval.api.registry import register_model
+
+
+@register_model("external-test-model-1457")
+class ExternalTestModel(LM):
+    def loglikelihood(self, requests):
+        return []
+
+    def loglikelihood_rolling(self, requests):
+        return []
+
+    def generate_until(self, requests):
+        return []
+""".strip(),
+            encoding="utf-8",
+        )
+
+        original_registry = dict(model_registry._objs)
+        original_modules = set(sys.modules)
+        try:
+            cfg = EvaluatorConfig(
+                tasks=["hellaswag"], include_package=[str(module_path)]
+            )._process_arguments()
+            cfg.import_custom_modules()
+
+            model_cls = get_model("external-test-model-1457")
+            assert model_cls.__name__ == "ExternalTestModel"
+        finally:
+            model_registry._objs.clear()
+            model_registry._objs.update(original_registry)
+            for module_name in set(sys.modules) - original_modules:
+                if module_name.startswith("_lm_eval_external_"):
+                    sys.modules.pop(module_name, None)
 
 
 class TestCLIUtils:


### PR DESCRIPTION

This PR adds an --include_package flag to the "lm-eval run" command. It allows you to import external Python modules or .py files at runtime right before the evaluation starts. The main benefit here is that you can now use custom @register_model(...) classes without having to hack or modify the core lm_eval/models/init.py file.
To make this work, the PR updates EvaluatorConfig and adds a new helper function to handle the imports. The helper supports standard dotted module paths, direct .py file paths, and package directories.
The docs have been updated to explain the new import path. I also added tests to verify CLI parsing, config normalization, external model registration, and registry cleanup for test isolation.
You can use it like this:
lm-eval run
--include_package ./my_model.py
--model my-custom-model
--tasks hellaswag