### PR TITLE
Fix: improve hendrycks_math answer extraction for display math and boxed formats

### DIFF
--- a/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math.yaml
@@ -11,5 +11,8 @@ aggregate_metric_list:
   - metric: exact_match
     aggregation: mean
     weight_by_size: true
+  - metric: flexible_extract
+    aggregation: mean
+    weight_by_size: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
+++ b/lm_eval/tasks/hendrycks_math/hendrycks_math_algebra.yaml
@@ -19,5 +19,8 @@ metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
+  - metric: flexible_extract
+    aggregation: mean
+    higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -15,32 +15,35 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     return dataset.map(_process_doc)
 
 
-def extract_math_answer(text: str) -> str:
-    """Extract a math answer from model output.
+def _extract_answer_strict(text: str) -> str:
+    """Original strict extraction: pull answer from $...$ inline math only."""
+    indices = [pos for pos, char in enumerate(text) if char == "$"]
+    if len(indices) <= 1:
+        return text
+    return text[indices[0] + 1 : indices[-1]]
 
-    Handles multiple LaTeX formats that models commonly produce:
-      - $...$ (inline math)
-      - \\[...\\] (display math)
-      - \\boxed{...} (boxed answer, possibly nested)
-      - \\fbox{...} (alternative boxed answer)
-    Falls back to the full text if no pattern matches.
+
+def _extract_answer_flexible(text: str) -> str:
+    """Flexible extraction that handles multiple LaTeX answer formats.
+
+    Tries formats in priority order:
+      1. \\boxed{...} — most specific, handles nested braces
+      2. \\[...\\] — LaTeX display math
+      3. $...$ — inline math (same as strict)
+      4. Full text fallback
     """
     import re
 
-    if text is None:
-        return ""
-
-    # 1. Try to extract from \boxed{...} (most specific, handles nested braces)
+    # 1. Try \boxed{...} (handles nested braces via last_boxed_only_string)
     boxed_match = last_boxed_only_string(text)
     if boxed_match is not None:
         extracted = remove_boxed(boxed_match)
         if extracted is not None:
             return extracted
 
-    # 2. Try \[...\] (display math)
+    # 2. Try \[...\] (display math) — take last match (final answer)
     display_matches = re.findall(r"\\\[(.+?)\\\]", text, re.DOTALL)
     if display_matches:
-        # Take the last display math block (final answer is usually last)
         return display_matches[-1].strip()
 
     # 3. Try $...$ (inline math)
@@ -53,11 +56,15 @@ def extract_math_answer(text: str) -> str:
 
 
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
-    answer = extract_math_answer(results[0])
+    ref_answer = remove_boxed(last_boxed_only_string(doc["solution"]))
 
-    retval = 1 if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))) else 0
+    strict_answer = _extract_answer_strict(results[0])
+    flexible_answer = _extract_answer_flexible(results[0])
 
-    return {"exact_match": retval}
+    return {
+        "exact_match": 1 if is_equiv(strict_answer, ref_answer) else 0,
+        "flexible_extract": 1 if is_equiv(flexible_answer, ref_answer) else 0,
+    }
 
 
 # string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -15,21 +15,49 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     return dataset.map(_process_doc)
 
 
+def extract_math_answer(text: str) -> str:
+    """Extract a math answer from model output.
+
+    Handles multiple LaTeX formats that models commonly produce:
+      - $...$ (inline math)
+      - \\[...\\] (display math)
+      - \\boxed{...} (boxed answer, possibly nested)
+      - \\fbox{...} (alternative boxed answer)
+    Falls back to the full text if no pattern matches.
+    """
+    import re
+
+    if text is None:
+        return ""
+
+    # 1. Try to extract from \boxed{...} (most specific, handles nested braces)
+    boxed_match = last_boxed_only_string(text)
+    if boxed_match is not None:
+        extracted = remove_boxed(boxed_match)
+        if extracted is not None:
+            return extracted
+
+    # 2. Try \[...\] (display math)
+    display_matches = re.findall(r"\\\[(.+?)\\\]", text, re.DOTALL)
+    if display_matches:
+        # Take the last display math block (final answer is usually last)
+        return display_matches[-1].strip()
+
+    # 3. Try $...$ (inline math)
+    indices = [pos for pos, char in enumerate(text) if char == "$"]
+    if len(indices) >= 2:
+        return text[indices[0] + 1 : indices[-1]]
+
+    # 4. Fallback: return full text
+    return text
+
+
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
-    retval = 0
-    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
-    if len(indices) <= 1:
-        answer = results[0]
-    else:
-        answer = results[0][indices[0] + 1 : indices[-1]]
+    answer = extract_math_answer(results[0])
 
-    if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
-        retval = 1
+    retval = 1 if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))) else 0
 
-    results = {
-        "exact_match": retval,
-    }
-    return results
+    return {"exact_match": retval}
 
 
 # string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py


### PR DESCRIPTION
## Summary

Fixes #2552

The current `process_results` in `hendrycks_math/utils.py` only extracts answers wrapped in `$...$` (inline math). However, many models (especially instruct-tuned ones) output answers using LaTeX display math delimiters `\[...\]` or `\boxed{...}` directly — e.g.:

```
Some reasoning... Thus the answer is \[ \boxed{42} \]
```

This causes valid correct answers to be missed, artificially lowering `exact_match` scores.

## Approach

Following @baberabb suggestion in the issue — adds a **`flexible_extract` metric alongside the existing `exact_match`**, similar to how `gsm8k` reports both `strict-match` and `flexible-extract`.

**`exact_match`** (unchanged): Original `$...$` extraction — preserves backward compatibility and existing benchmark scores.

**`flexible_extract`** (new): Tries multiple formats in priority order:
1. `\boxed{...}` — most specific, handles nested braces via existing `last_boxed_only_string()`
2. `\[...\]` — LaTeX display math delimiters
3. `$...$` — inline math (same as strict)
4. Full text fallback

Both metrics use the same `is_equiv` + `strip_string` normalization pipeline.

## Changes

- **`utils.py`**: Split extraction into `_extract_answer_strict` (original) and `_extract_answer_flexible` (new). `process_results` returns both metrics.
- **`hendrycks_math_algebra.yaml`**: Added `flexible_extract` to `metric_list`, bumped version to 2.0
- **`hendrycks_math.yaml`**: Added `flexible_extract` to `aggregate_metric_list`, bumped version to 2.0

## Testing

Verified extraction with multiple output formats:
- `$42$` → strict: `42`, flexible: `42` ✅
- `\[ \boxed{42} \]` → strict: miss, flexible: `42` ✅ (the reported bug case)
- `\boxed{42}` → strict: miss, flexible: `42` ✅
- `\[42\]` → strict: miss, flexible: `42` ✅
- `42` (plain) → strict: `42`, flexible: `42` ✅