### PR TITLE
Fix extra backtick in README Contributing code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ To get started with development, first clone the repository and install the dev 
 git clone https://github.com/EleutherAI/lm-evaluation-harness
 cd lm-evaluation-harness
 pip install -e ".[dev,hf]"
-````
+```
 
 ### Implementing new tasks
 


### PR DESCRIPTION
## Summary
- The Contributing section's code block was closed with 4 backticks (``````) instead of 3 (` ``` `), which breaks markdown rendering
- Single character deletion

## Test plan
- [x] Verified the code block now renders correctly with matched backticks