### PR TITLE
Replace deprecated typing imports with modern syntax in lm_eval/api/

### DIFF
--- a/lm_eval/api/filter.py
+++ b/lm_eval/api/filter.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Callable, Iterable, List, Union
 
 from lm_eval.api.instance import Instance
 
@@ -20,7 +20,7 @@ class Filter(ABC):
         """
 
     @abstractmethod
-    def apply(self, resps: Union[List, Iterable], docs: List[dict]) -> Iterable:
+    def apply(self, resps: list | Iterable, docs: list[dict]) -> Iterable:
         """
         Defines the operation to perform on a list of the `inst.resps` properties of `Instance` objects.
         Should return the list of (filtered) response lists *in the same order as they were input*, e.g.
@@ -40,9 +40,9 @@ class FilterEnsemble:
     """
 
     name: str
-    filters: List[Callable[[], Filter]]
+    filters: list[Callable[[], Filter]]
 
-    def apply(self, instances: List[Instance]) -> None:
+    def apply(self, instances: list[Instance]) -> None:
         resps, docs = zip(*((inst.resps, inst.doc) for inst in instances))
         resps, docs = list(resps), list(docs)
 

--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Literal, Optional, Tuple
+from typing import Literal
 
 
 OutputType = Literal[
@@ -13,16 +13,16 @@ class Instance:
     doc: dict
     arguments: tuple
     idx: int
-    metadata: Tuple[Optional[str], Optional[int], Optional[int]] = field(
+    metadata: tuple[str | None, int | None, int | None] = field(
         default_factory=lambda: (None, None, None)
     )
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
 
     # initialized after init
-    task_name: Optional[str] = None
-    doc_id: Optional[int] = None
-    repeats: Optional[int] = None
+    task_name: str | None = None
+    doc_id: int | None = None
+    repeats: int | None = None
 
     def __post_init__(self) -> None:
         # unpack metadata field

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -4,8 +4,8 @@ import os
 import random
 import re
 import string
-from collections.abc import Iterable
-from typing import Callable, List, Optional, Sequence, TypeVar
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeVar
 
 import numpy as np
 import sacrebleu
@@ -554,7 +554,7 @@ def bootstrap_stderr(
 
 def stderr_for_metric(
     metric: Callable[[Sequence[T]], float], bootstrap_iters: int
-) -> Optional[Callable[[Sequence[T]], float]]:
+) -> Callable[[Sequence[T]], float] | None:
     """
     Return a function that estimates the standard error of `metric(xs)`.
 
@@ -587,7 +587,7 @@ def stderr_for_metric(
     return stderr.get(metric, None)
 
 
-def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
+def pooled_sample_stderr(stderrs: list[float], sizes: list[int]):
     # Used to aggregate bootstrapped stderrs across subtasks in a group,
     # when we are weighting by the size of each subtask.
     #
@@ -605,7 +605,7 @@ def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
     return np.sqrt(pooled_sample_var / sum(sizes))
 
 
-def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None):
+def combined_sample_stderr(stderrs: list[float], sizes: list[int], metrics=None):
     assert metrics is not None, (
         "Need to pass a list of each subtask's metric for this stderr aggregation"
     )

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from tqdm import tqdm
 
@@ -233,7 +233,7 @@ def hash_args(attr: str, args: Iterable[Any]) -> str:
 
 
 class CacheHook:
-    def __init__(self, cachinglm: Optional["CachingLM"]) -> None:
+    def __init__(self, cachinglm: "CachingLM | None") -> None:
         if cachinglm is None:
             self.dbdict: SqliteDict | None = None
             return


### PR DESCRIPTION
## Summary
- Replace deprecated `typing` module imports (`List`, `Dict`, `Tuple`, `Optional`, `Union`, `Callable`) with modern Python 3.10+ equivalents in the core `lm_eval/api/` module
- Use built-in generics (`list`, `dict`, `tuple`) and `X | Y` union syntax instead of `typing.Union`/`typing.Optional`
- Move `Callable`, `Iterable`, `Sequence` imports to `collections.abc` where they were previously imported from `typing`

### Files updated
- `lm_eval/api/metrics.py`
- `lm_eval/api/filter.py`
- `lm_eval/api/instance.py`
- `lm_eval/api/model.py`

This is safe since the project already requires Python >=3.10 (`pyproject.toml`), and other files in the codebase (e.g., `evaluator.py`, `utils.py`) already use the modern syntax.

## Test plan
- [x] All modified files pass Python syntax check (`ast.parse`)
- [x] No behavioral changes -- only type annotation syntax was updated
- [x] Consistent with existing style in `evaluator.py`, `evaluator_utils.py`, and `utils.py`