### PR TITLE
[fix] Display informative warnings and debug logs

### DIFF
--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -1,9 +1,13 @@
+import logging
 import re
 import sys
 import unicodedata
 
 from lm_eval.api.filter import Filter
 from lm_eval.api.registry import register_filter
+
+
+eval_logger = logging.getLogger(__name__)
 
 
 @register_filter("regex")
@@ -48,9 +52,15 @@ class RegexFilter(Filter):
                         if match:
                             match = match[0]
                         else:
+                            eval_logger.debug(
+                                f"No match in the output in RegexFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(resp)}`, regex: {self.regex}"
+                            )
                             match = self.fallback
                     match = match.strip()
                 else:
+                    eval_logger.debug(
+                        f"No match in the output in RegexFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(resp)}`, regex: {self.regex}"
+                    )
                     match = self.fallback
                 filtered.append(match)
             return filtered
@@ -91,7 +101,14 @@ class POSFilter(Filter):
             if isinstance(result, str):
                 result = extract_tagged_tokens(result)
             pos_tags.extend(pos for _, pos in result)
-            return pos_tags if pos_tags else self.fallback
+            if pos_tags:
+                return pos_tags
+            else:
+                eval_logger.debug(
+                    f"No match in the output in POSFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(result)}`"
+                )
+
+                return self.fallback
 
         def filter_set(inst):
             filtered = []
@@ -230,6 +247,9 @@ class MultiChoiceRegexFilter(RegexFilter):
                             without_paren_fallback_regex, resp, without_paren_to_target
                         )
                 if not match:
+                    eval_logger.debug(
+                        f"No match in the output in MultiChoiceRegexFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(resp)}`, regex: {self.regex}"
+                    )
                     match = self.fallback
                 filtered.append(match)
             filtered_resps.append(filtered)

--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -53,13 +53,13 @@ class RegexFilter(Filter):
                             match = match[0]
                         else:
                             eval_logger.debug(
-                                f"No match in the output in RegexFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(resp)}`, regex: {self.regex}"
+                                f"No match in the output in RegexFilter! Using fallback {self.fallback}, likely rated as incorrect. Response (last 200 characters): `{repr(resp[-200:])}`, regex: {self.regex}."
                             )
                             match = self.fallback
                     match = match.strip()
                 else:
                     eval_logger.debug(
-                        f"No match in the output in RegexFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(resp)}`, regex: {self.regex}"
+                        f"No match in the output in RegexFilter! Using fallback {self.fallback}, likely rated as incorrect. Response (last 200 characters): `{repr(resp[-200:])}`, regex: {self.regex}."
                     )
                     match = self.fallback
                 filtered.append(match)
@@ -105,7 +105,7 @@ class POSFilter(Filter):
                 return pos_tags
             else:
                 eval_logger.debug(
-                    f"No match in the output in POSFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(result)}`"
+                    f"No match in the output in POSFilter! Using fallback {self.fallback}, likely rated as incorrect. Response (last 200 characters): `{repr(result[-200:])}`, regex: {self.regex}."
                 )
 
                 return self.fallback
@@ -248,7 +248,7 @@ class MultiChoiceRegexFilter(RegexFilter):
                         )
                 if not match:
                     eval_logger.debug(
-                        f"No match in the output in MultiChoiceRegexFilter! Using fallback {self.fallback}, likely rated as WRONG. Response: `{repr(resp)}`, regex: {self.regex}"
+                        f"No match in the output in MultiChoiceRegexFilter! Using fallback {self.fallback}, likely rated as incorrect. Response (last 200 characters): `{repr(resp[-200:])}`, regex: {self.regex}."
                     )
                     match = self.fallback
                 filtered.append(match)

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1612,7 +1612,7 @@ class HFLM(TemplateLM):
                     ]
                     if len(think_token_indices) < 1:
                         eval_logger.warning(
-                            f"The token think_end_token={self.think_end_token} was not found in the generated sequence. `max_gen_toks` may be too small for the thinking model. Got think_token_indices={think_token_indices}, generated cont_toks (decoded, last 200 characters): `{repr(self.tokenizer.decode(cont_toks[-200:]))}`."
+                            f"The token think_end_token={self.think_end_token} was not found in the generated sequence. max_gen_toks={max_gen_toks} may be too small for the thinking model. Got think_token_indices={think_token_indices}, generated cont_toks (decoded, last 200 characters): `{repr(self.tokenizer.decode(cont_toks[-200:]))}`."
                         )
 
                     if think_token_indices:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1612,7 +1612,7 @@ class HFLM(TemplateLM):
                     ]
                     if len(think_token_indices) < 1:
                         eval_logger.warning(
-                            f"The token think_end_token={self.think_end_token} was not found in the generated sequence. max_gen_toks={max_gen_toks} may be too small for the thinking model. Got think_token_indices={think_token_indices}, generated cont_toks (decoded, last 200 characters): `{repr(self.tokenizer.decode(cont_toks[-200:]))}`."
+                            f"The token think_end_token={self.think_end_token} was not found in the generated sequence. max_gen_toks={max_gen_toks} may be too small for the thinking model, consider using `--gen_kwargs max_gen_toks=xxx` with a larger value. Got think_token_indices={think_token_indices}, generated cont_toks (decoded, last 200 characters): `{repr(self.tokenizer.decode(cont_toks[-200:]))}`."
                         )
 
                     if think_token_indices:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1594,7 +1594,7 @@ class HFLM(TemplateLM):
 
             if generated_length == max_gen_toks:
                 eval_logger.warning(
-                    f"Generated {generated_length} which is equal to `max_gen_toks`. The end performance may be low simply due to too short allowed generations."
+                    f"Generated {generated_length} tokens which is equal to `max_gen_toks`, an answer may be missing due to a too small `max_gen_toks` budget or bad model performance."
                 )
 
             cont_toks_list = cont.tolist()
@@ -1610,9 +1610,9 @@ class HFLM(TemplateLM):
                         for i, token in enumerate(cont_toks)
                         if token == self.think_end_token
                     ]
-                    if len(think_token_indices) < 2:
+                    if len(think_token_indices) < 1:
                         eval_logger.warning(
-                            f"The token think_end_token={self.think_end_token} was not found. max_gen_toks is likely too small for a thinking model. Got think_token_indices={think_token_indices}, generated cont_toks (decoded): `{repr(self.tokenizer.decode(cont_toks))}`."
+                            f"The token think_end_token={self.think_end_token} was not found in the generated sequence. `max_gen_toks` may be too small for the thinking model. Got think_token_indices={think_token_indices}, generated cont_toks (decoded, last 200 characters): `{repr(self.tokenizer.decode(cont_toks[-200:]))}`."
                         )
 
                     if think_token_indices:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1590,6 +1590,13 @@ class HFLM(TemplateLM):
                 **kwargs,
             )
 
+            generated_length = cont.shape[-1] - context_enc.shape[-1]
+
+            if generated_length == max_gen_toks:
+                eval_logger.warning(
+                    f"Generated {generated_length} which is equal to `max_gen_toks`. The end performance may be low simply due to too short allowed generations."
+                )
+
             cont_toks_list = cont.tolist()
             for cont_toks, context in zip(cont_toks_list, contexts, strict=True):
                 # discard context + left-padding toks if using causal decoder-only LM
@@ -1603,10 +1610,23 @@ class HFLM(TemplateLM):
                         for i, token in enumerate(cont_toks)
                         if token == self.think_end_token
                     ]
+                    if len(think_token_indices) < 2:
+                        eval_logger.warning(
+                            f"The token think_end_token={self.think_end_token} was not found. max_gen_toks is likely too small for a thinking model. Got think_token_indices={think_token_indices}, generated cont_toks (decoded): `{repr(self.tokenizer.decode(cont_toks))}`."
+                        )
+
                     if think_token_indices:
                         cont_toks = cont_toks[think_token_indices[-1] + 1 :]
 
                 s = self.tok_decode(cont_toks)
+
+                for stop_sequence in until:
+                    stop_length = len(stop_sequence)
+
+                    if s[-stop_length:] == stop_sequence:
+                        eval_logger.warning(
+                            f"Sequence generation stopped due to the stop sequence: `{repr(stop_sequence)}`. This may or may not be expected."
+                        )
 
                 # Strip leading whitespace if we removed thinking tokens
                 if isinstance(self.think_end_token, int):

--- a/lm_eval/models/utils.py
+++ b/lm_eval/models/utils.py
@@ -931,6 +931,12 @@ def postprocess_generated_text(
                 # for seq2seq case where self.tok_decode(self.eot_token_id) = ''
                 generation = generation.split(term)[0]
     if think_end_token:
+        if think_end_token not in generation:
+            eval_logger.warning(
+                f"The token think_end_token=`{think_end_token}` was not found in the generated sequence. "
+                "`max_gen_toks` may be too small for the thinking model. "
+                f"Got generated text (last 200 characters): `{repr(generation[-200:])}`."
+            )
         generation = generation.split(think_end_token)[-1].lstrip()
 
     return generation

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -708,6 +708,20 @@ class VLLM(TemplateLM):
                 cont, context, _cache_gen_kwargs, strict=True
             ):
                 generated_text: str = output.outputs[0].text
+
+                if self.think_end_token is not None and self.think_end_token not in generated_text:
+                    eval_logger.warning(
+                        f"Could not find an answer in the generated sequence (sequence end): {repr(generated_text[-50:])}"
+                    )
+
+                for stop_sequence in until:
+                    stop_length = len(stop_sequence)
+
+                    if generated_text[-stop_length:] == stop_sequence:
+                        eval_logger.warning(
+                            f"Sequence generation stopped due to the stop sequence: `{repr(stop_sequence)}`. This may or may not be expected."
+                        )
+
                 # use secondary stop seqs to cut off should-have-been-stopped content post-hoc
                 generated_text = postprocess_generated_text(
                     generated_text, _gen_kwargs.get("until"), self.think_end_token

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -709,11 +709,6 @@ class VLLM(TemplateLM):
             ):
                 generated_text: str = output.outputs[0].text
 
-                if self.think_end_token is not None and self.think_end_token not in generated_text:
-                    eval_logger.warning(
-                            f"The token think_end_token=`{self.think_end_token}` was not found in the generated sequence. `max_gen_toks` may be too small for the thinking model. Generated text (decoded, last 200 characters): `{repr(self.tokenizer.decode(generated_text[-200:]))}`."
-                    )
-
                 for stop_sequence in until:
                     stop_length = len(stop_sequence)
 
@@ -721,6 +716,11 @@ class VLLM(TemplateLM):
                         eval_logger.warning(
                             f"Sequence generation stopped due to the stop sequence: `{repr(stop_sequence)}`. This may or may not be expected."
                         )
+
+                if self.think_end_token is not None and self.think_end_token not in generated_text:
+                    eval_logger.warning(
+                        f"The token think_end_token=`{self.think_end_token}` was not found in the generated sequence. max_gen_toks={max_gen_toks} may be too small for the thinking model. Generated text (decoded, last 200 characters): `{repr(generated_text[-200:])}`."
+                    )
 
                 # use secondary stop seqs to cut off should-have-been-stopped content post-hoc
                 generated_text = postprocess_generated_text(

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -711,7 +711,7 @@ class VLLM(TemplateLM):
 
                 if self.think_end_token is not None and self.think_end_token not in generated_text:
                     eval_logger.warning(
-                        f"Could not find an answer in the generated sequence (sequence end): {repr(generated_text[-50:])}"
+                            f"The token think_end_token=`{self.think_end_token}` was not found in the generated sequence. `max_gen_toks` may be too small for the thinking model. Generated text (decoded, last 200 characters): `{repr(self.tokenizer.decode(generated_text[-200:]))}`."
                     )
 
                 for stop_sequence in until:

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -719,7 +719,7 @@ class VLLM(TemplateLM):
 
                 if self.think_end_token is not None and self.think_end_token not in generated_text:
                     eval_logger.warning(
-                        f"The token think_end_token=`{self.think_end_token}` was not found in the generated sequence. max_gen_toks={max_gen_toks} may be too small for the thinking model. Generated text (decoded, last 200 characters): `{repr(generated_text[-200:])}`."
+                        f"The token think_end_token=`{self.think_end_token}` was not found in the generated sequence. max_gen_toks={max_gen_toks} may be too small for the thinking model, consider using `--gen_kwargs max_gen_toks=xxx` with a larger value. Generated text (decoded, last 200 characters): `{repr(generated_text[-200:])}`."
                     )
 
                 # use secondary stop seqs to cut off should-have-been-stopped content post-hoc


### PR DESCRIPTION
As per title. This PR:

- Adds debug logs in case an answer does not match a given regex, yielding an `[invalid]` answer
- Adds warnings in case `max_gen_toks` is hit in generative tasks.
- Adds warnings in case `think_end_token` is specified but not found in an answer for generative tasks (fixes: https://github.com/EleutherAI/lm-evaluation-harness/issues/3382)
- Adds warnings in case generation finishes due to hitting one of `until`.

These logs are very useful to debug and understand why tasks performance is bad in some cases, for example would likely be useful for & fix https://github.com/EleutherAI/lm-evaluation-harness/issues/2953 https://github.com/EleutherAI/lm-evaluation-harness/issues/3129 https://github.com/EleutherAI/lm-evaluation-harness/issues/3475 https://github.com/EleutherAI/lm-evaluation-harness/issues/3003

Example of logs:

```bash
export MODEL_ID="Qwen/Qwen-8B"

LMEVAL_LOG_LEVEL=DEBUG CUDA_VISIBLE_DEVICES="6" lm_eval \
    --model hf \
    --model_args '{"pretrained":"'"${MODEL_ID}"'","dtype":"auto","enable_thinking": true,"think_end_token":"</think>"}' \
    --device "cuda" \
    --tasks ${TASKS} \
    --apply_chat_template --fewshot_as_multiturn \
    --limit 50 \
    --batch_size 16 &> upstream_hf.log &
```

giving

```
2026-04-06:13:46:04 WARNING  [models.utils:935] The token think_end_token=`</think>` was not found in the generated sequence. `max_gen_toks` may be too small for the thinking model. Got generated text (last 200 characters): `'es by 0.75. So P = 19.50 / 0.75. Let me calculate that. \n\nDividing by 0.75 is the same as multiplying by 4/3, right? Because 1/0.75 is 4/3. So 19.50 * (4/3). Let me do that step by step. 19.50 divided'`.
...
|    Tasks     |Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|--------------|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k_platinum|      3|flexible-extract|     5|exact_match|↑  | 0.16|±  |0.0524|
|              |       |strict-match    |     5|exact_match|↑  | 0.00|±  |0.0000|
```

or

```bash
export MODEL_ID="Qwen/Qwen-8B"

LMEVAL_LOG_LEVEL=DEBUG CUDA_VISIBLE_DEVICES="6" lm_eval \
    --model vllm\
    --model_args '{"pretrained":"'"${MODEL_ID}"'","dtype":"auto","tensor_parallel_size":1,"enable_thinking": true,"gpu_memory_utilization":0.9,"think_end_token":"</think>"}' \
    --device "cuda" \
    --tasks ${TASKS} \
    --apply_chat_template --fewshot_as_multiturn \
    --limit 50 \
    --batch_size 16 &> upstream_vllm.log &
```

giving

```
2026-04-06:13:46:18 WARNING  [models.utils:935] The token think_end_token=`</think>` was not found in the generated sequence. `max_gen_toks` may be too small for the thinking model. Got generated text (last 200 characters): `"o half of (2/3)x - 2. Wait, so she sold half of that amount, which means she has half left after that. So after selling half at the orange house, she has half of (2/3)x - 2 left. And that's equal to 5"`.
...
|    Tasks     |Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|--------------|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k_platinum|      3|flexible-extract|     5|exact_match|↑  |  0.2|±  |0.0571|
|              |       |strict-match    |     5|exact_match|↑  |  0.0|±  |0.0000|
```

Adding a larger `--gen_kwargs max_gen_toks=4096`, we see interesting debug logs regarding the regex:

```bash
2026-04-06:13:54:33 DEBUG    [filters.extraction:61] No match in the output in RegexFilter! Using fallback [invalid], likely rated as incorrect. Response (last 200 characters): `'lue of the house**: $80,000 + 120,000 = 200,000$.  \n\nProfit is calculated as:  \n$$\n\\text{Profit} = \\text{Selling Price} - \\text{Total Cost} = 200,000 - 130,000 = 70,000\n$$\n\n**Answer:** $\\boxed{70000}$'`, regex: re.compile('#### (\\-?[0-9\\.\\,]+)').
2026-04-06:13:54:33 DEBUG    [filters.extraction:61] No match in the output in RegexFilter! Using fallback [invalid], likely rated as incorrect. Response (last 200 characters): `'d speed for remaining distance:**  \n$$\n\\text{Speed} = \\frac{\\text{Remaining distance}}{\\text{Remaining time}} = \\frac{6 \\text{ miles}}{1 \\text{ hour}} = 6 \\text{ mph}\n$$\n\n**Answer:**  \n$$\n\\boxed{6}\n$$'`, regex: re.compile('#### (\\-?[0-9\\.\\,]+)').
2026-04-06:13:54:33 DEBUG    [filters.extraction:61] No match in the output in RegexFilter! Using fallback [invalid], likely rated as incorrect. Response (last 200 characters): `"*Allen's Age**:  \n   $$\n   11 \\text{ parts} \\times 9 = 99 \\text{ years}\n   $$\n\n5. **Allen's Age 10 Years from Now**:  \n   $$\n   99 + 10 = 109 \\text{ years}\n   $$\n\n**Final Answer**:  \n$$\n\\boxed{109}\n$$"`, regex: re.compile('#### (\\-?[0-9\\.\\,]+)').
2026-04-06:13:54:33 DEBUG    [filters.extraction:61] No match in the output in RegexFilter! Using fallback [invalid], likely rated as incorrect. Response (last 200 characters): `'30 $.  \n\nTotal coins:  \n$$\nS + (S + 30) = 110  \n$$  \n$$\n2S + 30 = 110  \n$$  \n$$\n2S = 80  \n$$  \n$$\nS = 40  \n$$  \n\nGold coins:  \n$$\n40 + 30 = 70  \n$$  \n\n**Answer:** Gretchen has $\\boxed{70}$ gold coins.'`, regex: re.compile('#### (\\-?[0-9\\.\\,]+)').
```