### PR TITLE
[Feature] Add `generation_kwargs` jinja templating

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1359,6 +1359,27 @@ class ConfigurableTask(Task):
                 return utils.apply_template(gen_prefix, doc)
         return None
 
+    def _apply_gen_kwargs_templates(self, gen_kwargs: dict, doc: dict) -> dict:
+        """Apply Jinja2 templating to string values inside gen_kwargs.
+
+        After rendering, any string that is a valid Python literal (e.g. a
+        JSON-encoded list of tool definitions) is parsed with ast.literal_eval
+        so that structured values arrive at the model as native Python objects.
+        """
+        if gen_kwargs is None:
+            return gen_kwargs
+        result = {}
+        for k, v in gen_kwargs.items():
+            if isinstance(v, str):
+                rendered = utils.apply_template(v, doc)
+                try:
+                    result[k] = ast.literal_eval(rendered)
+                except (ValueError, SyntaxError):
+                    result[k] = rendered
+            else:
+                result[k] = v
+        return result
+
     def construct_requests(
         self, doc: dict, ctx: str | list[str], **kwargs
     ) -> list[Instance] | Instance:
@@ -1405,7 +1426,12 @@ class ConfigurableTask(Task):
                 arguments.extend(aux_arguments)
 
         elif self.OUTPUT_TYPE == "generate_until":
-            arguments = (ctx, deepcopy(self.config.generation_kwargs))
+            arguments = (
+                ctx,
+                self._apply_gen_kwargs_templates(
+                    deepcopy(self.config.generation_kwargs), doc
+                ),
+            )
 
         multimodal_arg = {}
         if (

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1428,9 +1428,9 @@ class ConfigurableTask(Task):
         elif self.OUTPUT_TYPE == "generate_until":
             arguments = (
                 ctx,
-                self._apply_gen_kwargs_templates(
-                    deepcopy(self.config.generation_kwargs), doc
-                ),
+                deepcopy(self._apply_gen_kwargs_templates(
+                    self.config.generation_kwargs, doc
+                )),
             )
 
         multimodal_arg = {}

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -579,8 +579,10 @@ class TemplateAPI(TemplateLM):
         *,
         generate: bool = True,
         ctxlens: List[int] = None,
+        gen_kwargs: Optional[list] = None,
         **kwargs,
     ) -> Union[List[List[str]], List[List[Tuple[float, bool]]]]:
+        gen_kwargs = gen_kwargs if gen_kwargs else [None] * len(requests)
         ctxlens = ctxlens if ctxlens else [None] * len(requests)
         conn = TCPConnector(limit=self._concurrent, ssl=self.verify_certificate)
         sem = asyncio.Semaphore(self._concurrent)
@@ -605,13 +607,15 @@ class TemplateAPI(TemplateLM):
                         cache_keys=cache_key,
                         generate=generate,
                         ctxlens=ctxlen,
+                        gen_kwargs=these_gen_kwargs[0],
                         **kwargs,
                     )
                 )
-                for message, cache_key, ctxlen in zip(
+                for message, cache_key, ctxlen, these_gen_kwargs in zip(
                     chunks(requests, n=self._batch_size),
                     chunks(cache_keys, n=self._batch_size),
                     chunks(ctxlens, n=self._batch_size),
+                    chunks(gen_kwargs, n=self._batch_size),
                 )
             ]
 
@@ -792,12 +796,15 @@ class TemplateAPI(TemplateLM):
             for chunk in chunked:
                 contexts, all_gen_kwargs, encodings_list = zip(*chunk)
                 if self.tokenized_requests:
-                    max_gen_toks = all_gen_kwargs[0].get(
-                        "max_gen_toks", self._max_gen_toks
-                    )
-                    max_context_len = self.max_length - max_gen_toks
-
-                    encodings_list = [x[-max_context_len:] for x in encodings_list]
+                    
+                    _encodings_list = list()
+                    for x, these_gen_kwargs in zip(encodings_list, all_gen_kwargs):
+                        max_gen_toks = these_gen_kwargs.get(
+                            "max_gen_toks", self._max_gen_toks
+                        )
+                        max_context_len = self.max_length - max_gen_toks
+                        _encodings_list.append(x[-max_context_len:])
+                    encodings_list = _encodings_list
 
                     if any(
                         len(x) + max_gen_toks > self.max_length for x in encodings_list
@@ -811,9 +818,9 @@ class TemplateAPI(TemplateLM):
                     asyncio.run(
                         self.get_batched_requests(
                             req,
-                            cache_keys=[(ctx, all_gen_kwargs[0]) for ctx in contexts],
+                            cache_keys=[(ctx, these_gen_kwargs) for ctx, these_gen_kwargs in zip(contexts, all_gen_kwargs)],
                             generate=True,
-                            gen_kwargs=copy.deepcopy(all_gen_kwargs[0]),
+                            gen_kwargs=copy.deepcopy(all_gen_kwargs),
                         )
                     )
                 )


### PR DESCRIPTION
Currently the `generation_kwargs` of a task definition are fixed once they are defined, meaning that setting something like:
```yaml
generation_kwargs:
  until: []
  max_gen_toks: 30000
  tools: "[ ... ]"
```

Would define the generation for all samples in the task with the given parameters. However one could be interested in making this variable, specially for things like `tools`. This is why we introduce this PR to enable jinja templating of the `generation_kwargs` fields, using the normal syntax. 

This PR enables the construction of `generation_kwargs` that are modified **per sample**, like:

```yaml
generation_kwargs:
  until: []
  max_gen_toks: 30000
  do_sample: false
  tools: "{{tools}}"
```

During generation, the `tools` field of the request will be filled with the content of the sample's `tools` field, changing from sample to sample.

Changes to the codebase are minimum an enable many other applications besides setting tools dynamically.


----

This PR along with https://github.com/EleutherAI/lm-evaluation-harness/pull/3685 are part of an effort to enable tool-usage and function calling evaluation on the `lm-eval` software. We have modified the [T-Eval dataset](https://huggingface.co/datasets/lovesnowbest/T-Eval) and created a `lm-eval` compatible one: [T-Eval PNYX dataset](https://huggingface.co/datasets/PNYX/T-Eval_pnyx) that includes several tasks for measuring function calls. Tasks are working and we wish to share them.