### PR TITLE
[Feature] `tool_calls` and `reasoning`: Tracking and evaluation

### DIFF
--- a/lm_eval/api/filter.py
+++ b/lm_eval/api/filter.py
@@ -28,6 +28,17 @@ class Filter(ABC):
         [<filtered resps for instance 0>, <filtered resps for instance 1>]
         """
         return resps
+    
+
+    def apply_wkwargs(self, resps: Union[List, Iterable], docs: List[dict], **kwargs) -> Iterable:
+        """
+        Same behaviour as `apply` but with the added parsing of keyword arguments, for backward compatibility.
+
+        This function is intended to be used when the model response (or part of it) is produced, for example, in the 
+        `tool_calls` or `reasoning` field of a chat generation request.
+        By default this will fallback to normal apply, ignoring any additional argument.
+        """
+        return self.apply(resps, docs)
 
 
 @dataclass
@@ -43,14 +54,38 @@ class FilterEnsemble:
     filters: List[Callable[[], Filter]]
 
     def apply(self, instances: List[Instance]) -> None:
-        resps, docs = zip(*((inst.resps, inst.doc) for inst in instances))
-        resps, docs = list(resps), list(docs)
+        # Unpack instances
+        resps = [inst.resps for inst in instances]
+        docs = [inst.doc for inst in instances]
+        tool_calls, has_tools = self.get_tool_calls(resps, instances)
 
         for f in self.filters:
             # apply filters in sequence
-            resps = f().apply(resps, docs)
+            if has_tools:
+                resps = f().apply_wkwargs(resps, docs, tool_calls=tool_calls)
+            else:
+                resps = f().apply(resps, docs)
 
         # add the end results after filtering to filtered_requests of their respective source instances.
         # has key `self.name`: each FilterEnsemble applied in a given run should use a different name.
         for inst, resp in zip(instances, resps):
             inst.filtered_resps[self.name] = resp
+
+    def get_tool_calls(self, resps: List[str], instances: List[Instance]) -> List[dict]:
+         # Check if tool_calls are actually populated (non-empty)
+        has_tool_calls = any(inst.tool_calls for inst in instances)
+
+        if has_tool_calls:
+            tool_calls = [inst.tool_calls for inst in instances]
+            # Verify all tool_calls lists have same length as resps
+            if all(len(tc) == len(resp) for tc, resp in zip(tool_calls, resps)):
+                # Valid: tool_calls are present and aligned
+                pass
+            else:
+                # Mismatch: fall back to None padding
+                tool_calls = [[None] * len(resp) for resp in resps]
+        else:
+            # No tool_calls present, patch with Nones
+            tool_calls = [[None] * len(resp) for resp in resps]
+
+        return tool_calls, has_tool_calls

--- a/lm_eval/api/filter.py
+++ b/lm_eval/api/filter.py
@@ -28,13 +28,14 @@ class Filter(ABC):
         [<filtered resps for instance 0>, <filtered resps for instance 1>]
         """
         return resps
-    
 
-    def apply_wkwargs(self, resps: Union[List, Iterable], docs: List[dict], **kwargs) -> Iterable:
+    def apply_wkwargs(
+        self, resps: Union[List, Iterable], docs: List[dict], **kwargs
+    ) -> Iterable:
         """
         Same behaviour as `apply` but with the added parsing of keyword arguments, for backward compatibility.
 
-        This function is intended to be used when the model response (or part of it) is produced, for example, in the 
+        This function is intended to be used when the model response (or part of it) is produced, for example, in the
         `tool_calls` or `reasoning` field of a chat generation request.
         By default this will fallback to normal apply, ignoring any additional argument.
         """
@@ -58,11 +59,18 @@ class FilterEnsemble:
         resps = [inst.resps for inst in instances]
         docs = [inst.doc for inst in instances]
         tool_calls, has_tools = self.get_tool_calls(resps, instances)
+        reasoning, has_reasoning = self.get_reasoning(resps, instances)
 
         for f in self.filters:
-            # apply filters in sequence
+            # apply filters in sequence - pass kwargs conditionally based on what's available
+            kwargs = {}
             if has_tools:
-                resps = f().apply_wkwargs(resps, docs, tool_calls=tool_calls)
+                kwargs["tool_calls"] = tool_calls
+            if has_reasoning:
+                kwargs["reasoning"] = reasoning
+
+            if kwargs:
+                resps = f().apply_wkwargs(resps, docs, **kwargs)
             else:
                 resps = f().apply(resps, docs)
 
@@ -71,8 +79,8 @@ class FilterEnsemble:
         for inst, resp in zip(instances, resps):
             inst.filtered_resps[self.name] = resp
 
-    def get_tool_calls(self, resps: List[str], instances: List[Instance]) -> List[dict]:
-         # Check if tool_calls are actually populated (non-empty)
+    def get_tool_calls(self, resps: List[str], instances: List[Instance]) -> tuple:
+        # Check if tool_calls are actually populated (non-empty)
         has_tool_calls = any(inst.tool_calls for inst in instances)
 
         if has_tool_calls:
@@ -89,3 +97,22 @@ class FilterEnsemble:
             tool_calls = [[None] * len(resp) for resp in resps]
 
         return tool_calls, has_tool_calls
+
+    def get_reasoning(self, resps: List[str], instances: List[Instance]) -> tuple:
+        # Check if reasoning is actually populated (non-empty)
+        has_reasoning = any(inst.reasoning for inst in instances)
+
+        if has_reasoning:
+            reasoning = [inst.reasoning for inst in instances]
+            # Verify all reasoning lists have same length as resps
+            if all(len(r) == len(resp) for r, resp in zip(reasoning, resps)):
+                # Valid: reasoning is present and aligned
+                pass
+            else:
+                # Mismatch: fall back to None padding
+                reasoning = [[None] * len(resp) for resp in resps]
+        else:
+            # No reasoning present, patch with Nones
+            reasoning = [[None] * len(resp) for resp in resps]
+
+        return reasoning, has_reasoning

--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Literal, Optional, Tuple
+from typing import List, Literal, Optional, Tuple
 
 
 OutputType = Literal[
@@ -18,6 +18,7 @@ class Instance:
     )
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
+    tool_calls: List[Optional[List[dict]]] = field(default_factory=list)
 
     # initialized after init
     task_name: Optional[str] = None

--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -19,6 +19,7 @@ class Instance:
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
     tool_calls: List[Optional[List[dict]]] = field(default_factory=list)
+    reasoning: List[Optional[str]] = field(default_factory=list)
 
     # initialized after init
     task_name: Optional[str] = None

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -586,8 +586,16 @@ def evaluate(
         resps = getattr(lm, reqtype)(cloned_reqs)
 
         # put responses from model into a list of length K for each request.
+        # If the model returns (content, tool_calls) tuples (e.g. LocalChatCompletion),
+        # unpack them: store the text content in resps (preserving the expected str contract)
+        # and store tool_calls separately on the Instance for use in custom tasks.
         for x, req in zip(resps, cloned_reqs, strict=True):
-            req.resps.append(x)
+            if isinstance(x, tuple) and len(x) == 2:
+                content, tool_calls = x
+                req.resps.append(content)
+                req.tool_calls.append(tool_calls)
+            else:
+                req.resps.append(x)
 
         if lm.world_size > 1:
             lm.barrier()
@@ -636,6 +644,7 @@ def evaluate(
                         "filtered_resps": [
                             req.filtered_resps[filter_key] for req in requests
                         ],
+                        "tool_calls": [req.tool_calls for req in requests],
                         "filter": filter_key,
                         "metrics": list(metrics.keys()),
                         "doc_hash": hash_string(

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -586,14 +586,18 @@ def evaluate(
         resps = getattr(lm, reqtype)(cloned_reqs)
 
         # put responses from model into a list of length K for each request.
-        # If the model returns (content, tool_calls) tuples (e.g. LocalChatCompletion),
-        # unpack them: store the text content in resps (preserving the expected str contract)
-        # and store tool_calls separately on the Instance for use in custom tasks.
+        # If the model returns tuples with content and optional fields like 
+        # tool_calls/reasoning, unpack them: store the text content in resps 
+        # (preserving the expected str contract) and store additional fields 
+        # separately on the Instance.
         for x, req in zip(resps, cloned_reqs, strict=True):
-            if isinstance(x, tuple) and len(x) == 2:
-                content, tool_calls = x
+            if isinstance(x, tuple) and len(x) >= 2:
+                content = x[0]
+                tool_calls = x[1] if len(x) > 1 else None
+                reasoning = x[2] if len(x) > 2 else None
                 req.resps.append(content)
                 req.tool_calls.append(tool_calls)
+                req.reasoning.append(reasoning)
             else:
                 req.resps.append(x)
 
@@ -645,6 +649,7 @@ def evaluate(
                             req.filtered_resps[filter_key] for req in requests
                         ],
                         "tool_calls": [req.tool_calls for req in requests],
+                        "reasoning": [req.reasoning for req in requests],
                         "filter": filter_key,
                         "metrics": list(metrics.keys()),
                         "doc_hash": hash_string(

--- a/lm_eval/filters/custom.py
+++ b/lm_eval/filters/custom.py
@@ -9,9 +9,13 @@ class CustomFilter(Filter):
     """
 
     def __init__(self, **kwargs) -> None:
-        self.filter_fn = kwargs.pop("filter_fn")
+        self.filter_fn = kwargs.pop("filter_fn", super().apply)
+        self.filter_wkwargs_fn = kwargs.pop("filter_wkwargs_fn", super().apply_wkwargs)
 
         super().__init__(**kwargs)
 
     def apply(self, resps, docs):
         return self.filter_fn(resps, docs)
+
+    def apply_wkwargs(self, resps, docs, **kwargs):
+        return self.filter_wkwargs_fn(resps, docs, **kwargs)

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -223,11 +223,12 @@ class LocalChatCompletion(LocalCompletionsAPI):
                         msg.get("reasoning", None),
                     )
             except Exception as e:
-                # account for cases that generation is blocked by content filter,
-                # which is common for Azure OpenAI Service,
-                # not sure if need to account for multiple choices
-                eval_logger.warning(f"Could not parse generations: {e}")
-                tmp = [("", None, None)]
+                # This point is only reached if the backend returned 200 but the
+                # payload is not OpenAI API compatible. We cannot safely assume
+                # this means that the model refused to answer, we must throw an
+                # error so the user inspects the issue.
+                eval_logger.error(f"Could not parse generations: {e}")
+                raise e
             res = res + tmp
         return res
 

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -220,13 +220,14 @@ class LocalChatCompletion(LocalCompletionsAPI):
                     tmp[choices["index"]] = (
                         msg.get("content"),
                         msg.get("tool_calls", None),
+                        msg.get("reasoning", None),
                     )
             except Exception as e:
                 # account for cases that generation is blocked by content filter,
                 # which is common for Azure OpenAI Service,
                 # not sure if need to account for multiple choices
                 eval_logger.warning(f"Could not parse generations: {e}")
-                tmp = [("", None)]
+                tmp = [("", None, None)]
             res = res + tmp
         return res
 

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -208,7 +208,7 @@ class LocalChatCompletion(LocalCompletionsAPI):
         }
 
     @staticmethod
-    def parse_generations(outputs: Union[Dict, List[Dict]], **kwargs) -> List[str]:
+    def parse_generations(outputs: Union[Dict, List[Dict]], **kwargs) -> List[tuple]:
         res = []
         if not isinstance(outputs, list):
             outputs = [outputs]
@@ -216,13 +216,17 @@ class LocalChatCompletion(LocalCompletionsAPI):
             try:
                 tmp = [None] * len(out["choices"])
                 for choices in out["choices"]:
-                    tmp[choices["index"]] = choices["message"]["content"]
+                    msg = choices["message"]
+                    tmp[choices["index"]] = (
+                        msg.get("content"),
+                        msg.get("tool_calls", None),
+                    )
             except Exception as e:
                 # account for cases that generation is blocked by content filter,
                 # which is common for Azure OpenAI Service,
                 # not sure if need to account for multiple choices
                 eval_logger.warning(f"Could not parse generations: {e}")
-                tmp = [""]
+                tmp = [("", None)]
             res = res + tmp
         return res
 

--- a/lm_eval/result_schema.py
+++ b/lm_eval/result_schema.py
@@ -193,6 +193,11 @@ class SampleResult(TypedDict, extra_items=float):
     Generation: ``list[str]``.
     Multiple-choice: ``list[list[str]]`` — per-choice ``[log_prob, is_greedy]``."""
 
+    tool_calls: NotRequired[list[list[dict | None]]]
+    """Tool calls made by the model (if any).  Per-request × repeats.
+    Only present for models that support tool calling.
+    Each entry is either a list of tool call dicts or None if no tool was called."""
+
     filter: str
     """Name of the filter applied (e.g. ``"none"``, ``"strict-match"``)."""
 

--- a/lm_eval/result_schema.py
+++ b/lm_eval/result_schema.py
@@ -198,6 +198,11 @@ class SampleResult(TypedDict, extra_items=float):
     Only present for models that support tool calling.
     Each entry is either a list of tool call dicts or None if no tool was called."""
 
+    reasoning: NotRequired[list[list[str | None]]]
+    """Reasoning text from the model (if any).  Per-request × repeats.
+    Only present for models that support reasoning output.
+    Each entry is either a reasoning string or None if no reasoning was provided."""
+
     filter: str
     """Name of the filter applied (e.g. ``"none"``, ``"strict-match"``)."""
 


### PR DESCRIPTION
This PR adds support for tracking and filtering evaluation results based on model reasoning and tool call data.

Currently the `tool_calls` and `reasoning` fields of the generated answers are discarded, however they can be useful for evaluation some specific behavior of Language Models when they are used with `chat-templates`. For example, one would want to know if a model is using the tools provided correctly and calling the tools using the correct format without having to re-write the whole parsing step (something normally solved by the backend), additionally one might be interested in observing (and evaluating) the reasoning trace of a thinking model in addition to the final response.

To make this possible we contribute with the following:
* We add `tool_calls` and `reasoning` fields to the `Instance` class (as optional), to track generations.
* We add these to the result schema to keep it tidy.
* We modify the evaluator (keeping it backward compatible) to accept a tupple (responses, tool_calls, reasoning) and log them properly.
* We include an example modification for the client we normally use, the `LocalChatCompletion` of `lm_eval/models/openai_completions.py`. This can be extended to other models later.
* Finally we modify the `Filter(ABC)` class to include a new method: `apply_wkwargs`, a version of `apply` that accepts `kwargs` and include the handling of the `tool_calls`  and `reasoning` optional parameters. The reason to surface the traces here is to keep the evaluation function tidy. One might want to do a simple `exact-match` evaluation but with content coming from the `tool_calls` or the `resps` field, or a combination of both. Surfacing traces at this point (using custom filters) offers the most versatility to the user that can prepare the `filtered_resps` in a way that makes it compatible with existent comparison methods or create custom structures that can be handled by other custom evaluation methods. Using `kwargs` instead of fixed parameters also enables the function to be used with potentially new fields in the future, without needing to modify this any further (the basic `apply` function signature was not modified to keep everything backward compatible).

With this PR it is possible to define a filter like:

```yaml
filter_list:
  - name: "tool_call_extract"
    filter:
      - function: "custom"
        filter_wkwargs_fn: !function utils.build_predictions_call_with_tools
```

That will respond to a signature like:
```python
def build_predictions_call_with_tools(
        resps: list[list[str]], docs: list[dict], tool_calls: list[list[dict]], reasoning: list[list[str]] = None, **kwargs,
) -> list[list[str]]:
```


----

This PR along with https://github.com/EleutherAI/lm-evaluation-harness/pull/3684 are part of an effort to enable tool-usage and function calling evaluation on the `lm-eval` software. We have modified the [T-Eval dataset](https://huggingface.co/datasets/lovesnowbest/T-Eval) and created a `lm-eval` compatible one: [T-Eval PNYX dataset](https://huggingface.co/datasets/PNYX/T-Eval_pnyx) that includes several tasks for measuring function calls. Tasks are working and we wish to share them.