### PR TITLE
fix: SQuAD2 fewshot TypeError — missing optional args in doc_to_text/doc_to_target

### DIFF
--- a/lm_eval/tasks/squadv2/task.py
+++ b/lm_eval/tasks/squadv2/task.py
@@ -77,7 +77,7 @@ class SQuAD2(ConfigurableTask):
     def validation_docs(self):
         return self.dataset["validation"]
 
-    def doc_to_text(self, doc):
+    def doc_to_text(self, doc, doc_to_text=None):
         return (
             "Title: "
             + doc["title"]
@@ -97,7 +97,7 @@ class SQuAD2(ConfigurableTask):
     def doc_to_decontamination_query(self, doc):
         return doc["context"]
 
-    def doc_to_target(self, doc):
+    def doc_to_target(self, doc, doc_to_target=None):
         answer_list = doc["answers"]["text"]
         if len(answer_list) > 0:
             answer = answer_list[0]

--- a/lm_eval/tasks/unitxt/task.py
+++ b/lm_eval/tasks/unitxt/task.py
@@ -97,13 +97,13 @@ class Unitxt(ConfigurableTask):
     def test_docs(self):
         return self.dataset["test"]
 
-    def doc_to_text(self, doc):
+    def doc_to_text(self, doc, doc_to_text=None):
         return doc["source"]
 
     def should_decontaminate(self):
         return False
 
-    def doc_to_target(self, doc):
+    def doc_to_target(self, doc, doc_to_target=None):
         return doc["target"]
 
     def get_arguments(self, doc, ctx):
@@ -206,7 +206,7 @@ def extract_images(text, instance):
 class UnitxtMultiModal(Unitxt):
     MULTIMODAL = True
 
-    def doc_to_text(self, doc):
+    def doc_to_text(self, doc, doc_to_text=None):
         return re.sub(images_regex, "<image>", doc["source"])
 
     def doc_to_image(self, doc):


### PR DESCRIPTION
## Bug

Running SQuAD v2 with `num_fewshot > 0` raises:

```
TypeError: SQuAD2.doc_to_text() takes 2 positional arguments but 3 were given
```

## Cause

`ConfigurableTask.fewshot_context()` (line 984 of `task.py`) calls:

```python
self.doc_to_text(fs_doc, self.fewshot_cfg.doc_to_text)
```

But `SQuAD2` overrides `doc_to_text(self, doc)` without the optional second argument that the parent `ConfigurableTask.doc_to_text(self, doc, doc_to_text=None)` accepts. Same issue with `doc_to_target`.

## Fix

Add the optional `doc_to_text=None` and `doc_to_target=None` parameters to match the parent signature.