### PR TITLE
fix(vllm): guard against None prefix_token_id in tok_encode

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -375,7 +375,7 @@ class VLLM(TemplateLM):
             return []
 
         _string: list[str] = [string] if isinstance(string, str) else string
-        _bos_token = self.tokenizer.decode(self.prefix_token_id)
+        _bos_token = self.tokenizer.decode(self.prefix_token_id) if self.prefix_token_id is not None else ""
 
         special_tokens_kwargs = {
             **kwargs,


### PR DESCRIPTION
  PR Title:
  fix(vllm): handle None prefix_token_id to support models without BOS token (e.g. Qwen)

  PR Body:
  ## Problem
  When using the vLLM backend with models that have no BOS token
  (`bos_token_id=None`, e.g. Qwen series), `tok_encode` unconditionally calls
  `self.tokenizer.decode(self.prefix_token_id)`, which raises:

      TypeError: argument 'tokens': 'NoneType' object cannot be converted to 'Sequence'

  This makes Qwen models completely unusable with the vLLM backend.

  ## Fix
  Add a None guard so `_bos_token` falls back to an empty string when
  `prefix_token_id` is None.

  ## Testing
  Verified on `Qwen/Qwen-1_8B-Chat` with vLLM 0.18.0 and lm-eval 0.4.11.
  Ran MMLU + C-Eval evaluation successfully after this fix.

  Closes #3683