### PR TITLE
[Feat] Add native Tensor Parallelism support for HF backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,24 @@ To learn more about model parallelism and how to use it with the `accelerate` li
 
 **Note: we do not currently support multi-node evaluations natively, and advise using either an externally hosted server to run inference requests against, or creating a custom integration with your distributed framework [as is done for the GPT-NeoX library](https://github.com/EleutherAI/gpt-neox/blob/main/eval_tasks/eval_adapter.py).**
 
+#### Tensor Parallelism (native PyTorch)
+
+For models that support PyTorch's native Tensor Parallelism (via DTensor), you can shard model weights across GPUs without `accelerate`'s device-map by passing `tp_plan=auto` in `--model_args`. Launch with `torchrun` or `accelerate launch`:
+
+```bash
+torchrun --nproc-per-node=4 -m lm_eval \
+    --model hf \
+    --model_args pretrained=google/gemma-4-31B-it,tp_plan=auto \
+    --tasks lambada_openai,arc_easy \
+    --batch_size 16
+```
+
+**Constraints:**
+
+- `tp_plan` and `parallelize=True` are mutually exclusive — use one or the other.
+- The number of key-value heads in the model must be divisible by `--nproc-per-node` (the TP degree).
+- Requires PyTorch >= 2.4 and a `transformers` version that exposes a TP plan for the model (v4.47+).
+
 ### Steered Hugging Face `transformers` models
 
 To evaluate a Hugging Face `transformers` model with steering vectors applied, specify the model type as `steered` and provide the path to either a PyTorch file containing pre-defined steering vectors, or a CSV file that specifies how to derive steering vectors from pretrained `sparsify` or `sae_lens` models (you will need to install the corresponding optional dependency for this method).

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import json
 import logging
+import os
 import random
 import time
 from collections import defaultdict
@@ -269,15 +270,21 @@ def simple_evaluate(
         eval_logger.info("Using pre-initialized model")
         lm = model
 
+    # Under TP launchers (torchrun) every rank reports lm.rank==0; fall back to
+    # LOCAL_RANK so each process gets its own cache db and only LOCAL_RANK==0
+    # performs final result aggregation / I/O.
+    cache_rank = lm.rank or int(os.environ.get("LOCAL_RANK", "0"))
     if use_cache is not None:
-        eval_logger.info(f"Using cache at {use_cache + '_rank' + str(lm.rank) + '.db'}")
+        eval_logger.info(
+            f"Using cache at {use_cache + '_rank' + str(cache_rank) + '.db'}"
+        )
         lm = lm_eval.api.model.CachingLM(
             lm,
             use_cache
             # each rank receives a different cache db.
             # necessary to avoid multiple writes to cache at once
             + "_rank"
-            + str(lm.rank)
+            + str(cache_rank)
             + ".db",
         )
 
@@ -367,7 +374,10 @@ def simple_evaluate(
     if verbosity is not None:
         setup_logging(verbosity=verbosity)
 
-    if lm.rank == 0:
+    # `lm.rank == 0` covers DP / single-process; `LOCAL_RANK == 0` covers TP
+    # (torchrun), where every rank reports rank==0 but only one process should
+    # build/return results so callers don't duplicate file writes.
+    if lm.rank == 0 and int(os.environ.get("LOCAL_RANK", "0")) == 0:
         if isinstance(model, str):
             model_name = model
         elif hasattr(model, "config") and hasattr(model.config, "_name_or_path"):

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -97,6 +97,9 @@ class HFLM(TemplateLM):
         max_memory_per_gpu: int | str | None = None,
         max_cpu_memory: int | str | None = None,
         offload_folder: str | os.PathLike | None = "./offload",
+        # Tensor Parallelism options
+        tp_plan: str | dict | None = None,
+        tp_size: int | None = None,
         # PEFT, delta weights and quantization options
         peft: str | None = None,
         delta: str | None = None,
@@ -179,6 +182,15 @@ class HFLM(TemplateLM):
             offload_folder: Directory for disk offloading when the model does
                 not fit in GPU and CPU memory combined. Only used when
                 ``parallelize=True``.
+            tp_plan: Tensor parallelism plan for distributing model weights
+                across multiple GPUs using PyTorch's DTensor. Set to
+                ``"auto"`` to use the model's predefined TP plan. Mutually
+                exclusive with ``parallelize``. Requires launching with
+                ``torchrun`` or ``accelerate launch``.
+            tp_size: Number of devices to use for tensor parallelism. If
+                ``None``, defaults to the total number of processes launched
+                by ``torchrun`` (i.e. ``WORLD_SIZE``). Must be ≤
+                ``--nproc-per-node``.
             peft: Path or HuggingFace Hub ID of a PEFT (LoRA, etc.) adapter to
                 load on top of the base model.
             delta: Path or HuggingFace Hub ID of delta weights to apply to the
@@ -211,6 +223,9 @@ class HFLM(TemplateLM):
             assert not parallelize, (
                 "`parallelize=True` is not compatible with passing pre-initialized model to `pretrained`"
             )
+            assert tp_plan is None, (
+                "`tp_plan` is not compatible with passing pre-initialized model to `pretrained`"
+            )
             self._model = pretrained
             self._device = self._model.device
             self._config = self._model.config
@@ -221,27 +236,43 @@ class HFLM(TemplateLM):
             assert isinstance(pretrained, str)
             assert isinstance(batch_size, (int, str))
 
-            accelerator_kwargs = InitProcessGroupKwargs(timeout=timedelta(weeks=52))
-            accelerator = Accelerator(kwargs_handlers=[accelerator_kwargs])
-            if accelerator.num_processes > 1:
-                self.accelerator = accelerator
+            if tp_plan is not None and parallelize:
+                raise ValueError(
+                    "`tp_plan` and `parallelize=True` are mutually exclusive. Choose either one for parallelization."
+                )
 
-            # Detect device count based on accelerator device type
-            device_type = accelerator.device.type
-            if "cuda" in device_type:
-                gpus = torch.cuda.device_count()
-            elif "npu" in device_type:
-                gpus = torch.npu.device_count()
-            elif "xpu" in device_type:
-                gpus = torch.xpu.device_count()
-            elif "hpu" in device_type:
-                gpus = torch.hpu.device_count()
+            if tp_plan is not None:
+                # TP mode: skip Accelerator entirely, let transformers handle
+                # distribution via torchrun + device_mesh.
+                device_type = torch._C._get_accelerator().type
+                local_rank = int(os.environ.get("LOCAL_RANK", 0))
+                self._device = torch.device(f"{device_type}:{local_rank}")
+                gpus = 0  # prevent later model.to(device) calls
+
             else:
-                # Fallback to CUDA count for compatibility
-                gpus = torch.cuda.device_count()
+                accelerator_kwargs = InitProcessGroupKwargs(timeout=timedelta(weeks=52))
+                accelerator = Accelerator(kwargs_handlers=[accelerator_kwargs])
+                if accelerator.num_processes > 1:
+                    self.accelerator = accelerator
 
-            # using one process with no model parallelism
-            if not (parallelize or accelerator.num_processes > 1):
+                # Detect device count based on accelerator device type
+                device_type = accelerator.device.type
+                if "cuda" in device_type:
+                    gpus = torch.cuda.device_count()
+                elif "npu" in device_type:
+                    gpus = torch.npu.device_count()
+                elif "xpu" in device_type:
+                    gpus = torch.xpu.device_count()
+                elif "hpu" in device_type:
+                    gpus = torch.hpu.device_count()
+                else:
+                    # Fallback to CUDA count for compatibility
+                    gpus = torch.cuda.device_count()
+
+            # Determine if we are in single device mode (no model parallelism)
+            single_device = not parallelize and tp_plan is None and not getattr(self, 'accelerator', None)
+
+            if single_device:
                 # use user-passed device
                 device_list = set(
                     ["cuda", "cpu"]
@@ -268,6 +299,9 @@ class HFLM(TemplateLM):
                         if torch.cuda.is_available()
                         else torch.device("cpu")
                     )
+            elif tp_plan is not None:
+                # Device already set above during TP init
+                pass
             else:  # Parallelism managed by accelerate
                 if device != "cuda":
                     eval_logger.info(
@@ -322,6 +356,8 @@ class HFLM(TemplateLM):
                 dtype=dtype,
                 trust_remote_code=trust_remote_code,
                 parallelize=parallelize,
+                tp_plan=tp_plan,
+                tp_size=tp_size,
                 gpus=gpus,
                 max_memory_per_gpu=max_memory_per_gpu,
                 max_cpu_memory=max_cpu_memory,
@@ -385,7 +421,7 @@ class HFLM(TemplateLM):
 
         if isinstance(pretrained, str):
             if (gpus >= 1 or str(self.device) == "mps") and not (
-                parallelize or autogptq or hasattr(self, "accelerator")
+                parallelize or tp_plan is not None or autogptq or hasattr(self, "accelerator")
             ):
                 # TODO: can remove this whole snippet except in the mps case, perhaps?
                 # place model onto device requested manually,
@@ -397,8 +433,13 @@ class HFLM(TemplateLM):
                     eval_logger.debug(
                         "Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes` or `device_map` is provided. If the desired GPU is being used, this message is safe to ignore."
                     )
+            # TP mode: all ranks run the same eval loop, no data splitting.
+            # From lm-eval's perspective, this is a single model.
+            if tp_plan is not None:
+                self._rank = 0
+                self._world_size = 1
             # multigpu data-parallel support when launched with accelerate
-            if gpus > 1:
+            elif gpus > 1:
                 if accelerator.num_processes > 1:
                     if parallelize:
                         eval_logger.warning(
@@ -698,6 +739,9 @@ class HFLM(TemplateLM):
         max_memory_per_gpu: int | str | None = None,
         max_cpu_memory: int | str | None = None,
         offload_folder: str | None = "./offload",
+        # Tensor Parallelism options
+        tp_plan: str | dict | None = None,
+        tp_size: int | None = None,
         # PEFT, delta weights and quantization options
         peft: str | None = None,
         delta: str | None = None,
@@ -721,16 +765,22 @@ class HFLM(TemplateLM):
 
         model_kwargs = kwargs or {}
 
-        model_kwargs.update(
-            self._get_accelerate_args(
-                parallelize=parallelize,
-                device_map=kwargs.get("device_map"),
-                max_memory_per_gpu=max_memory_per_gpu,
-                max_cpu_memory=max_cpu_memory,
-                offload_folder=offload_folder,
-                gpus=gpus,
+        if tp_plan is not None:
+            # TP mode: tp_plan and device_map are mutually exclusive in transformers
+            model_kwargs["tp_plan"] = tp_plan
+            if tp_size is not None:
+                model_kwargs["tp_size"] = int(tp_size)
+        else:
+            model_kwargs.update(
+                self._get_accelerate_args(
+                    parallelize=parallelize,
+                    device_map=kwargs.get("device_map"),
+                    max_memory_per_gpu=max_memory_per_gpu,
+                    max_cpu_memory=max_cpu_memory,
+                    offload_folder=offload_folder,
+                    gpus=gpus,
+                )
             )
-        )
 
         if not autogptq and not gptqmodel:
             if model_kwargs.get("load_in_4bit"):

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -99,7 +99,6 @@ class HFLM(TemplateLM):
         offload_folder: str | os.PathLike | None = "./offload",
         # Tensor Parallelism options
         tp_plan: str | dict | None = None,
-        tp_size: int | None = None,
         # PEFT, delta weights and quantization options
         peft: str | None = None,
         delta: str | None = None,
@@ -186,11 +185,8 @@ class HFLM(TemplateLM):
                 across multiple GPUs using PyTorch's DTensor. Set to
                 ``"auto"`` to use the model's predefined TP plan. Mutually
                 exclusive with ``parallelize``. Requires launching with
-                ``torchrun`` or ``accelerate launch``.
-            tp_size: Number of devices to use for tensor parallelism. If
-                ``None``, defaults to the total number of processes launched
-                by ``torchrun`` (i.e. ``WORLD_SIZE``). Must be ≤
-                ``--nproc-per-node``.
+                ``torchrun`` or ``accelerate launch``. The number of
+                processes (``--nproc-per-node``) determines the TP degree.
             peft: Path or HuggingFace Hub ID of a PEFT (LoRA, etc.) adapter to
                 load on top of the base model.
             delta: Path or HuggingFace Hub ID of delta weights to apply to the
@@ -357,7 +353,6 @@ class HFLM(TemplateLM):
                 trust_remote_code=trust_remote_code,
                 parallelize=parallelize,
                 tp_plan=tp_plan,
-                tp_size=tp_size,
                 gpus=gpus,
                 max_memory_per_gpu=max_memory_per_gpu,
                 max_cpu_memory=max_cpu_memory,
@@ -741,7 +736,6 @@ class HFLM(TemplateLM):
         offload_folder: str | None = "./offload",
         # Tensor Parallelism options
         tp_plan: str | dict | None = None,
-        tp_size: int | None = None,
         # PEFT, delta weights and quantization options
         peft: str | None = None,
         delta: str | None = None,
@@ -768,8 +762,6 @@ class HFLM(TemplateLM):
         if tp_plan is not None:
             # TP mode: tp_plan and device_map are mutually exclusive in transformers
             model_kwargs["tp_plan"] = tp_plan
-            if tp_size is not None:
-                model_kwargs["tp_size"] = int(tp_size)
         else:
             model_kwargs.update(
                 self._get_accelerate_args(

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -232,12 +232,11 @@ class HFLM(TemplateLM):
             assert isinstance(pretrained, str)
             assert isinstance(batch_size, (int, str))
 
-            if tp_plan is not None and parallelize:
-                raise ValueError(
-                    "`tp_plan` and `parallelize=True` are mutually exclusive. Choose either one for parallelization."
-                )
-
             if tp_plan is not None:
+                if parallelize:
+                    raise ValueError(
+                        "`tp_plan` and `parallelize=True` are mutually exclusive. Choose either one for parallelization."
+                    )
                 # TP mode: skip Accelerator entirely, let transformers handle
                 # distribution via torchrun + device_mesh.
                 device_type = torch._C._get_accelerator().type
@@ -266,7 +265,11 @@ class HFLM(TemplateLM):
                     gpus = torch.cuda.device_count()
 
             # Determine if we are in single device mode (no model parallelism)
-            single_device = not parallelize and tp_plan is None and not getattr(self, 'accelerator', None)
+            single_device = (
+                not parallelize
+                and tp_plan is None
+                and not getattr(self, "accelerator", None)
+            )
 
             if single_device:
                 # use user-passed device
@@ -319,6 +322,19 @@ class HFLM(TemplateLM):
                 gguf_file=gguf_file,
                 subfolder=subfolder,
             )
+            if tp_plan:
+                world = int(os.environ.get("WORLD_SIZE", "1"))
+                n_kv = getattr(
+                    self._config,
+                    "num_key_value_heads",
+                    getattr(self._config, "num_attention_heads", world),
+                )
+                if n_kv % world != 0:
+                    raise ValueError(
+                        f"tp_plan requires num_key_value_heads ({n_kv}) to be divisible by "
+                        f"WORLD_SIZE ({world}). Re-launch with --nproc-per-node "
+                        f"set to a divisor of {n_kv}."
+                    )
 
             # determine which of 'causal' and 'seq2seq' backends to use for HF models
         self._get_backend(
@@ -416,7 +432,10 @@ class HFLM(TemplateLM):
 
         if isinstance(pretrained, str):
             if (gpus >= 1 or str(self.device) == "mps") and not (
-                parallelize or tp_plan is not None or autogptq or hasattr(self, "accelerator")
+                parallelize
+                or tp_plan is not None
+                or autogptq
+                or hasattr(self, "accelerator")
             ):
                 # TODO: can remove this whole snippet except in the mps case, perhaps?
                 # place model onto device requested manually,


### PR DESCRIPTION
Using TP to accelerate `lm_eval` for HF.

**Usage:**
With `torchrun`:
```
torchrun --nproc-per-node=4 -m lm_eval \
    --model hf \
    --model_args pretrained=google/gemma-4-31B-it,max_length=4096,add_bos_token=True,tp_plan=auto \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size 16 \
    --output_path ./GSM8K/31B
```
Or with `accelerate launch`:
```
accelerate launch --num_processes=4 -m lm_eval \
    --model hf \
    --model_args pretrained=google/gemma-4-31B-it,max_length=4096,add_bos_token=True,tp_plan=auto \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size 16 \
    --output_path ./GSM8K/31B
```