### PR TITLE
Fix mmlu_pro fewshot answers leaking into user role under chat template

### DIFF
--- a/lm_eval/tasks/mmlu_pro/README.md
+++ b/lm_eval/tasks/mmlu_pro/README.md
@@ -68,3 +68,5 @@ If other tasks on this dataset are already supported:
   * changed stop sequence from "Q:" to "Question:" PR #2945
 * (tasks, group) 2026-01-16 -- (version 2.1 --> version 3)
   * trimmed whitespace from options: [see](https://x.com/fujikanaeda/status/2011565035408277996)
+* (tasks, group) 2026-05-04 -- (version 3 --> version 3.1)
+  * fix fewshot answers being rendered in user turns instead of assistant turns under `--apply_chat_template`. PR #3693.

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -4,7 +4,7 @@ fewshot_split: validation
 fewshot_config:
   sampler: first_n
   doc_to_text: !function utils.fewshot_to_text
-  doc_to_target: ""
+  doc_to_target: !function utils.fewshot_to_target
 output_type: generate_until
 doc_to_text: !function utils.doc_to_text
 doc_to_target: answer

--- a/lm_eval/tasks/mmlu_pro/_default_template_yaml
+++ b/lm_eval/tasks/mmlu_pro/_default_template_yaml
@@ -29,4 +29,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 3.0
+  version: 3.1

--- a/lm_eval/tasks/mmlu_pro/utils.py
+++ b/lm_eval/tasks/mmlu_pro/utils.py
@@ -27,8 +27,14 @@ def format_cot_example(example, including_answer=True):
     return prompt
 
 
+def format_cot_target(example, including_answer=True):
+    cot_content = example["cot_content"].replace("A: Let's think step by step. ", "")
+    return cot_content
+
+
 doc_to_text = partial(format_cot_example, including_answer=False)
-fewshot_to_text = partial(format_cot_example, including_answer=True)
+fewshot_to_text = partial(format_cot_example, including_answer=False)
+fewshot_to_target = partial(format_cot_target, including_answer=True)
 
 
 def process_docs(dataset, subject):

--- a/tests/test_fewshot_context.py
+++ b/tests/test_fewshot_context.py
@@ -566,9 +566,9 @@ class TestFewshotContext:
         mock_configurable_task.doc_to_text = Mock(side_effect=lambda d, *args: d["q"])
         mock_configurable_task.doc_to_target = Mock(side_effect=lambda d, *args: d["a"])
         mock_configurable_task.doc_to_choice = Mock(
-            side_effect=lambda d, *args: ["A", "B"]
-            if d == fs_doc
-            else ["Apple", "Banana"]
+            side_effect=lambda d, *args: (
+                ["A", "B"] if d == fs_doc else ["Apple", "Banana"]
+            )
         )
 
         result = ConfigurableTask.fewshot_context(
@@ -755,3 +755,21 @@ class TestChatTemplateFormat:
         assert "Q1" in result[1]["content"]
         assert "A1" in result[1]["content"]
         assert "Q2" in result[1]["content"]
+
+
+def test_mmlu_pro_fewshot_chat_template_split():
+    """Fewshot user turn must not contain the answer."""
+    from lm_eval.tasks.mmlu_pro.utils import fewshot_to_target, fewshot_to_text
+
+    fake_doc = {
+        "question": "What is 2+2?",
+        "options": ["3", "4", "5", "6"],
+        "cot_content": "A: Let's think step by step. Basic arithmetic gives 4.",
+        "answer": "B",
+    }
+    user_text = fewshot_to_text(fake_doc)
+    assistant_text = fewshot_to_target(fake_doc)
+
+    assert user_text.endswith("Answer: Let's think step by step.")
+    assert "Basic arithmetic" not in user_text
+    assert assistant_text == "Basic arithmetic gives 4."


### PR DESCRIPTION
Fixes #2780.

When using `--apply_chat_template`, fewshot reasoning was being included in the user turn instead of split across user/assistant roles.

Changes:
- Added `format_cot_target` helper and `fewshot_to_target` partial in `utils.py`
- Changed `fewshot_to_text` to exclude the answer content
- Updated `_default_template_yaml` to use the new target function
- Added minimal regression test

Based on the fix approach proposed by @Moreh-LeeJunhyeok in #2780.