### PR TITLE
fix(vllm): add ray to vllm extras (#3688)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ Repository = "https://github.com/EleutherAI/lm-evaluation-harness"
 # Model backend dependencies
 api = ["requests", "aiohttp", "tenacity", "tqdm", "tiktoken"]
 hf = ["transformers>=4.1","torch>=1.8", "accelerate>=0.26.0", "peft>=0.2.0",]
-vllm = ["vllm>=0.4.2"]
+vllm = ["vllm>=0.4.2", "ray"]
 gptq = ["auto-gptq[triton]>=0.6.0"]
 gptqmodel = ["gptqmodel>=1.0.9"]
 ipex = ["optimum-intel"]


### PR DESCRIPTION
## Summary

`lm_eval/models/vllm_causallms.py` imports `ray` at module level (line 14), but `ray` is missing from the `[vllm]` extras in `pyproject.toml`. vllm itself does not pull `ray` in transitively (absent from `vllm/requirements/cuda.txt` and from vllm's PyPI `requires_dist`), so `pip install lm_eval[vllm]` currently produces an environment that fails on `ImportError: No module named 'ray'` the moment the backend loads.

Fixes #3688

## Changes

- `pyproject.toml`: add `"ray"` to the `vllm` extras entry

## Testing

- `pip install -e '.[vllm]'` now pulls ray, and `python -c "import lm_eval.models.vllm_causallms"` succeeds in a clean environment

## Notes

The three ray call sites (`@ray.remote`, `ray.get`, `ray.shutdown`) sit inside the `data_parallel_size > 1 and not self.V1` branch, so ray is technically only needed for multi-GPU data-parallel runs. A follow-up could lazy-import ray if the added install footprint becomes a concern, but that is out of scope for this fix. This PR keeps the existing import contract and only corrects the packaging metadata to match it.