### PR TITLE
Fix median aggregation returning arbitrary element instead of median

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -38,7 +38,7 @@ def mean(arr):
 
 @register_aggregation("median")
 def median(arr):
-    return arr[len(arr) // 2]
+    return sorted(arr)[len(arr) // 2]
 
 
 # Certain metrics must be calculated across all documents in a benchmark.


### PR DESCRIPTION
## Summary

The `median()` aggregation function indexes into the unsorted input array:

```python
def median(arr):
    return arr[len(arr) // 2]
```

This returns whichever element happened to land at the middle index by evaluation order, not the actual statistical median. For example, `median([10, 1, 20, 5, 15])` returns `20` (element at index 2) instead of `10`.

Any task using `aggregation: median` in its YAML config silently gets a wrong score.

**Fix:** Sort before indexing: `sorted(arr)[len(arr) // 2]`.

## Test plan

- [x] Verified `[10, 1, 20, 5, 15][5 // 2]` returns 20 (wrong), `sorted(...)[5 // 2]` returns 10 (correct)
- [ ] Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)