### PR TITLE
fix: don't pass task stop sequences to vLLM for reasoning models

### DIFF
--- a/lm_eval/models/utils.py
+++ b/lm_eval/models/utils.py
@@ -923,6 +923,10 @@ def postprocess_generated_text(
     Returns:
         str: The processed generation - text before stop sequences and after thinking sections.
     """
+    # Strip thinking content first so stop sequences apply to the response,
+    # not to the reasoning trace (which often contains \n\n etc.)
+    if think_end_token:
+        generation = generation.split(think_end_token)[-1].lstrip()
     if stop:
         stop = [stop] if isinstance(stop, str) else stop
         for term in stop:
@@ -930,8 +934,6 @@ def postprocess_generated_text(
                 # ignore '' separator,
                 # for seq2seq case where self.tok_decode(self.eot_token_id) = ''
                 generation = generation.split(term)[0]
-    if think_end_token:
-        generation = generation.split(think_end_token)[-1].lstrip()
 
     return generation
 

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -708,9 +708,21 @@ class VLLM(TemplateLM):
                 )
                 context_encoding_truncated.append(toks)
 
-                sampling_params.append(
-                    SamplingParams(max_tokens=max_gen_toks, stop=until, **kwargs)
-                )
+                # When a reasoning model is active, task-level stop sequences
+                # (e.g. the fewshot delimiter "\n\n") should not go to vLLM —
+                # they often exist inside <think> blocks and cause it to truncate
+                # before any response is produced.  Only EOS should be passed
+                # to vLLM; task stops are applied in postprocess_generated_text
+                # after thinking content is stripped.
+                if self.think_end_token:
+                    eos_only = [s for s in until if s == eos]
+                    sampling_params.append(
+                        SamplingParams(max_tokens=max_gen_toks, stop=eos_only, **kwargs)
+                    )
+                else:
+                    sampling_params.append(
+                        SamplingParams(max_tokens=max_gen_toks, stop=until, **kwargs)
+                    )
                 _cache_gen_kwargs.append(
                     kwargs | {"until": until, "max_gen_toks": max_gen_toks}
                 )


### PR DESCRIPTION
When think_end_token is set, task-level stop sequences like "\n\n" (the fewshot delimiter default) fire inside <think> blocks and truncate generation before any response is produced.

Two changes:

1. vllm_causallms.py: When think_end_token is set, only pass EOS to vLLM's SamplingParams. Task stop sequences remain in the cached gen_kwargs for post-processing.
2. utils.py: Reorder postprocess_generated_text to strip thinking content before applying stop sequences, so stops match the actual response rather than the reasoning trace.

Non-reasoning models are unaffected — the code path only diverges when think_end_token is set.

Scope

This affects all generate_until tasks. 17 tasks in the repo don't specify explicit until in their generation_kwargs and inherit the
fewshot delimiter (typically "\n\n") as a stop sequence. Any reasoning model evaluated on these tasks may produce truncated or empty output without this fix.

Test results

Tested with Kimi-K2.5 (MoE, reasoning_parser=kimi_k2) on JSONSchemaBench (generate_until task, default until: ["\n\n"] from fewshot delimiter, max_model_len=65536, max_gen_toks=32768):

  ┌────────────────────┬─────────┬───────────┬─────────┐
  │                                                    │ JS-Easy           │ JS-Medium          │ JS-Hard          │
  ├────────────────────┼─────────┼───────────┼─────────┤
  │ Before (unpatched)                    │ 0.00                │ 0.00                     │ 0.00                │
  ├────────────────────┼─────────┼───────────┼─────────┤
  │ After (patched)                           │ 0.99                │ 0.96                     │ 0.88                │
  └────────────────────┴─────────┴───────────┴─────────┘

Before: all 1,531 samples scored 0.0 on both json_validity and schema_compliance — generation was truncated inside <think> blocks before any JSON was produced. Total eval time 778s (near-immediate truncation per sample).

After: real scores, 34 min eval time with full thinking traces and JSON output.