### PR TITLE
Fix BigBench multiple-choice crash on mixed-format tasks

### DIFF
--- a/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
@@ -5,6 +5,7 @@ dataset_kwargs:
   # subtask_name: null
 output_type: multiple_choice
 test_split: default
+process_docs: !function utils.filter_multiple_choice
 doc_to_text: inputs
 doc_to_target: "{{multiple_choice_targets.index(targets[0])}}"
 doc_to_choice: "{{multiple_choice_targets}}"

--- a/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
@@ -5,6 +5,7 @@ dataset_kwargs:
   # subtask_name: null
 output_type: multiple_choice
 test_split: default
+process_docs: !function utils.filter_multiple_choice
 doc_to_text: inputs
 doc_to_target: "{{multiple_choice_scores.index(1)}}"
 doc_to_choice: "{{multiple_choice_targets}}"

--- a/lm_eval/tasks/bigbench/utils.py
+++ b/lm_eval/tasks/bigbench/utils.py
@@ -1,0 +1,9 @@
+def filter_multiple_choice(dataset):
+    """Filter out examples that have no multiple-choice targets.
+
+    Some BigBench tasks (e.g. kanji_ascii) contain a mix of multiple-choice
+    and free-form examples in the same split.  The multiple-choice task
+    variant crashes when it encounters rows with an empty
+    ``multiple_choice_targets`` list, so we drop them here.
+    """
+    return dataset.filter(lambda doc: len(doc["multiple_choice_targets"]) > 0)


### PR DESCRIPTION
## Bug

BigBench multiple-choice tasks crash with `ValueError` on subtasks that contain a mix of multiple-choice and free-form examples in the same dataset split (e.g. `kanji_ascii`).

The Jinja template `{{multiple_choice_targets.index(targets[0])}}` raises `ValueError: 'u' is not in list` (or similar) when it encounters a row where `multiple_choice_targets` is an empty list.

## Root cause

`generate_tasks.py` decides whether a subtask qualifies as multiple-choice by checking only the **first** example. Subtasks like `kanji_ascii` have multiple-choice examples at the start but free-form examples later (index 188+), where `multiple_choice_targets` and `multiple_choice_scores` are both `[]`.

## Fix

Add a `process_docs` filter to both multiple-choice template YAMLs that drops rows with empty `multiple_choice_targets` before evaluation. This follows the same pattern used by other tasks in the repo (e.g. `crows_pairs`, `bbq`).

Three files changed:
- **New** `lm_eval/tasks/bigbench/utils.py` — one filter function
- **Modified** `multiple_choice_template_a_yaml` — added `process_docs` line
- **Modified** `multiple_choice_template_b_yaml` — added `process_docs` line

Fixes #3636