### PR TITLE
Add MolecularIQ chemistry reasoning benchmark task

### DIFF
--- a/lm_eval/tasks/moleculariq/README.md
+++ b/lm_eval/tasks/moleculariq/README.md
@@ -1,0 +1,164 @@
+# MolecularIQ Benchmark Task
+
+MolecularIQ is a fully symbolically verifiable benchmark for assessing reasoning over molecular structures.
+It covers three task types -- feature counting, index-based attribution, and constrained generation -- across
+six categories of symbolically verifiable molecular features (graph topology, chemistry-typed topology,
+composition, chemical perception, functional groups, and synthesis/fragmentation) and three orthogonal
+complexity axes (SMILES representation format, molecular complexity, and multitask load).
+
+**Paper**: [MolecularIQ: Characterizing Chemical Reasoning Capabilities Through Symbolic Verification on Molecular Graphs](https://arxiv.org/abs/2601.15279)
+
+**Leaderboard**: [https://huggingface.co/spaces/ml-jku/molecularIQ_leaderboard](https://huggingface.co/spaces/ml-jku/molecularIQ_leaderboard)
+
+**Code**: [https://github.com/ml-jku/moleculariq](https://github.com/ml-jku/moleculariq)
+
+## Dataset
+
+- **Dataset**: `ml-jku/moleculariq-v0.0`
+- **Split**: test (5,111 questions from 849 unique molecules)
+
+## Task Types
+
+The benchmark includes three reasoning task types:
+
+1. **Feature Counting** (1,800 questions): Establishes baseline comprehension of molecular graphs.
+   - `single_count`: Single property counting (e.g., "How many rotatable bonds?")
+   - `multi_count`: Multiple property counting in one question
+
+2. **Index-based Attribution** (1,740 questions): Requires models to ground answers in specific atoms/bonds/substructures.
+   - `single_index`: Single index identification (e.g., "Which atoms are part of the Murcko scaffold?")
+   - `multi_index`: Multiple index identification
+
+3. **Constrained Generation** (1,571 questions): Generating molecules that satisfy given constraints.
+   - `single_constraint_generation`: Single constraint
+   - `multi_constraint_generation`: Multiple constraints
+
+## Molecular Feature Categories
+
+- **Graph Topology**: Rings, fused rings, bridgehead atoms, ring size extremes, linear termini, branch points
+- **Chemistry-typed Topology**: Aromatic vs. aliphatic rings, heterocycles, saturation, sp3 carbon hybridization, longest carbon chains, stereochemical descriptors
+- **Composition**: Carbon, hetero, halogen, heavy, hydrogen atom counts, molecular formula
+- **Chemical Perception**: Hydrogen bond donors/acceptors, rotatable bonds, oxidation states
+- **Functional Groups**: Alcohols, amines, carboxylic acids, and other standard functional groups
+- **Synthesis/Fragmentation**: BRICS fragmentation, template-based reaction prediction, Murcko scaffold extraction
+
+## Complexity Axes
+
+- **Molecular Complexity** (Bertz index): Simple (0-250), Medium (250-1000), Complex (1000+)
+- **Multitask Load**: 1, 2, 3, or 5 simultaneous sub-tasks per question
+- **SMILES Representation**: Canonical, kekulized, randomized, ring-number enumerated
+
+## Metrics
+
+- **pass_at_1**: Accuracy on first attempt
+- **pass_at_3**: Any correct answer in first 3 attempts
+- **avg_accuracy**: Average accuracy across all attempts
+
+Scoring uses a binary symbolic verifier; per-instance accuracy is the mean over independent rollouts.
+
+## Available Tasks
+
+| Task | Description |
+|------|-------------|
+| `moleculariq_pass_at_k` | Raw question only - use with `--system_instruction` or chat models |
+| `moleculariq_inline` | Question with inline prompt (instructions + answer format) |
+
+## Usage
+
+### Basic Usage (Raw Question)
+
+For chat models or when using `--system_instruction`:
+
+```bash
+lm_eval --model vllm \
+    --model_args pretrained=your-model-name \
+    --tasks moleculariq_pass_at_k \
+    --batch_size auto
+```
+
+### With Inline Prompt
+
+For models that need explicit instructions in the prompt:
+
+```bash
+lm_eval --model vllm \
+    --model_args pretrained=your-model-name \
+    --tasks moleculariq_inline \
+    --batch_size auto
+```
+
+### Quick Test (Limited Samples)
+
+```bash
+lm_eval --model vllm \
+    --model_args pretrained=facebook/opt-125m \
+    --tasks moleculariq_pass_at_k \
+    --limit 10 \
+    --batch_size auto
+```
+
+## Directory Structure
+
+```
+moleculariq/
+├── __init__.py                    # Package init
+├── moleculariq_pass_at_k.yaml     # Task with raw question only
+├── moleculariq_inline.yaml        # Task with inline prompt
+├── task_processor.py              # Processing hooks (uses moleculariq_core)
+├── extractors.py                  # Answer extraction functions
+└── README.md
+```
+
+## Dependencies
+
+- `moleculariq_core`: Core library for molecular reasoning and reward computation
+- `rdkit`: Chemistry toolkit (dependency of moleculariq_core)
+- `datasets`: For loading the HuggingFace dataset
+
+Install dependencies:
+```bash
+pip install moleculariq-core rdkit
+```
+
+## Answer Format
+
+Models should return answers in JSON format within answer tags:
+
+```
+<answer>{"property_name": value}</answer>
+```
+
+For count tasks:
+```
+<answer>{"ring_count": 2}</answer>
+```
+
+For index tasks:
+```
+<answer>{"carbon_indices": [0, 1, 3]}</answer>
+```
+
+For constraint generation:
+```
+<answer>{"smiles": "CCO"}</answer>
+```
+
+## Atom Indexing Convention
+
+Atoms are indexed from 0 to N-1, reading the SMILES string left to right, counting only heavy atoms (non-hydrogen). Examples:
+
+- `"CCO"`: C(0), C(1), O(2)
+- `"CC(C)O"`: C(0), C(1), C(2), O(3)
+- `"CC(=O)N"`: C(0), C(1), O(2), N(3)
+
+## Citation
+
+```bibtex
+@inproceedings{bartmann2026moleculariq,
+  title={Molecular{IQ}: Characterizing Chemical Reasoning Capabilities Through Symbolic Verification on Molecular Graphs},
+  author={Christoph Bartmann and Johannes Schimunek and Mykyta Ielanskyi and Philipp Seidl and G{\"u}nter Klambauer and Sohvi Luukkonen},
+  booktitle={The Fourteenth International Conference on Learning Representations},
+  year={2026},
+  url={https://openreview.net/forum?id=RqwEzZqMFv}
+}
+```

--- a/lm_eval/tasks/moleculariq/__init__.py
+++ b/lm_eval/tasks/moleculariq/__init__.py
@@ -1,0 +1,1 @@
+"""MolecularIQ benchmark task for lm-evaluation-harness."""

--- a/lm_eval/tasks/moleculariq/extractors.py
+++ b/lm_eval/tasks/moleculariq/extractors.py
@@ -1,0 +1,388 @@
+"""
+Extraction functions for MolecularIQ chemistry tasks.
+Unified extraction using <answer></answer> tags.
+"""
+
+import ast
+import json
+import re
+
+
+def extract_moleculariq_answer(response: str) -> str | int | float | dict | list | None:
+    """
+    Unified extraction function for MolecularIQ.
+
+    Handles multiple common formats in priority order:
+    1. Strip thinking blocks (</think>)
+    2. <answer>...</answer> tags (standard format)
+    3. JSON objects/arrays via extract_answer_only logic
+    4. Fallback to general extraction patterns
+
+    Args:
+        response: Raw model response string
+
+    Returns:
+        Extracted answer (string, number, dict, or list), or None if extraction failed
+    """
+    if not response or not isinstance(response, str):
+        return None
+
+    # Step 1: Strip thinking blocks to get the answer portion
+    content = response.strip()
+    if "</think>" in content:
+        content = content.split("</think>")[-1].strip()
+
+    # Step 2: Check for <answer></answer> tags (standard format)
+    if "<answer>" in content and "</answer>" in content:
+        answer = content.split("<answer>")[-1].split("</answer>")[0].strip()
+        return answer
+
+    # Step 3: Fall back to JSON/dict detection via extract_answer_only
+    json_answer = extract_answer_only(content)
+    if json_answer is not None:
+        return json_answer
+
+    # Step 4: Fall back to general extraction patterns (boxed, bold, etc.)
+    return extract_general_answer(response)
+
+
+def extract_general_answer(response):
+    """
+    Simplified answer extraction for chemistry CoT traces and cleanup.
+    """
+    # Handle thinking mode
+    if "</think>" in response:
+        content = response.split("</think>")[-1].strip()
+    else:
+        content = response.strip()
+
+    answer = None
+
+    if "<answer>" in content and "</answer>" in content:
+        answer = content.split("<answer>")[-1].split("</answer>")[0].strip()
+    else:
+        # Check for boxed or bold answers
+        answer = extract_last_formatted_answer(content)
+
+    if answer is not None:
+        cleaned = clean_extracted_answer(answer)
+        if cleaned is not None:
+            return convert_to_appropriate_type(cleaned)
+
+    # Fallback: try other patterns
+    return extract_fallback_patterns(content)
+
+
+def extract_last_formatted_answer(content):
+    r"""
+    Extract the last formatted answer from the content.
+    Looks for **content**, \\boxed{content}, and (content) patterns.
+    """
+    all_matches = []
+
+    # Find positions of bold matches **content**
+    for match in re.finditer(r"\*\*(.+?)\*\*", content):
+        all_matches.append((match.start(), match.group(1)))
+
+    # Find positions of boxed matches \\boxed{content}
+    pattern = r"\\boxed\{"
+    for match in re.finditer(pattern, content):
+        start = match.end()
+        brace_count = 1
+        end = start
+
+        while end < len(content) and brace_count > 0:
+            if content[end] == "{":
+                brace_count += 1
+            elif content[end] == "}":
+                brace_count -= 1
+            end += 1
+
+        if brace_count == 0:
+            extracted = content[start : end - 1]
+            all_matches.append((match.start(), extracted))
+
+    if all_matches:
+        all_matches.sort(key=lambda x: x[0])
+        last_answer = all_matches[-1][1].strip()
+        return last_answer
+
+    return None
+
+
+def extract_fallback_patterns(content):
+    """Fallback extraction methods."""
+    # Content in quotes
+    quoted = re.findall(r'"([^"]+)"', content)
+    if quoted:
+        return clean_extracted_answer(quoted[-1])
+
+    single_quoted = re.findall(r"'([^']+)'", content)
+    if single_quoted:
+        return clean_extracted_answer(single_quoted[-1])
+
+    # Numbers with units
+    numbers_with_units = re.findall(r"([0-9.]+(?:\.[0-9]+)?)\s*([a-zA-Z]+)", content)
+    if numbers_with_units:
+        return f"{numbers_with_units[-1][0]} {numbers_with_units[-1][1]}"
+
+    # Just numbers
+    numbers = re.findall(r"([0-9.]+(?:\.[0-9]+)?)", content)
+    if numbers:
+        return numbers[-1]
+
+    return None
+
+
+def remove_latex_commands(text):
+    r"""Remove LaTeX commands like \\text{}, \\mathrm{}, \\mathbf{}."""
+    if not text:
+        return text
+
+    latex_commands = ["text", "mathrm", "mathbf"]
+    result = text
+
+    for cmd in latex_commands:
+        pattern = rf"\\{cmd}\{{"
+
+        while True:
+            match = re.search(pattern, result)
+            if not match:
+                break
+
+            start = match.end()
+            brace_count = 1
+            end = start
+
+            while end < len(result) and brace_count > 0:
+                if result[end] == "{":
+                    brace_count += 1
+                elif result[end] == "}":
+                    brace_count -= 1
+                end += 1
+
+            if brace_count == 0:
+                before = result[: match.start()]
+                content = result[start : end - 1]
+                after = result[end:]
+                result = before + content + after
+            else:
+                break
+
+    return result
+
+
+def clean_extracted_answer(answer):
+    """Clean extracted answers."""
+    if not answer:
+        return None
+
+    answer = answer.strip()
+
+    # Remove common artifacts
+    answer = re.sub(r"^\$+|\$+$", "", answer)
+    answer = re.sub(r"^\[|\]$", "", answer)
+    answer = re.sub(r"[.,;:]+$", "", answer)
+
+    if not answer.startswith(("\\text{", "\\mathrm{", "\\mathbf{")):
+        answer = re.sub(r"^\{|\}$", "", answer)
+
+    answer = remove_latex_commands(answer)
+    answer = normalize_sub_super_scripts(answer)
+    answer = remove_chemistry_units(answer)
+
+    return answer.strip()
+
+
+def remove_chemistry_units(answer):
+    """Remove common chemistry units from numerical answers."""
+    if not answer:
+        return answer
+
+    unit_pattern = (
+        r"^([+-]?(?:\d+\.?\d*|\d*\.\d+)(?:[eE][+-]?\d+)?)\s*(?:"
+        + r"Å²|Å\^2|A²|A\^2|"
+        + r"g/mol|Da|kDa|amu|"
+        + r"logP|cLogP|"
+        + r"mol/L|mmol/L|"
+        + r"kJ/mol|kcal/mol|"
+        + r"°C|°F|"
+        + r"mmHg|"
+        + r"μM|μL|μg|μm|μs|μA|"
+        + r"uM|uL|ug|um|us|uA|"
+        + r"mM|mL|mg|mm|ms|mV|mA|"
+        + r"nM|nm|ns|"
+        + r"pM|Pa|"
+        + r"kPa|kDa|kJ|kg|km|kHz|"
+        + r"MPa|MHz|"
+        + r"GHz|THz|"
+        + r"eV|"
+        + r"atm|bar|torr|"
+        + r"cal|kcal|"
+        + r"min|hr|hours|"
+        + r"percent|units|"
+        + r"M|L|K|J|V|A|C|F|g|m|s|h|%"
+        + r")(?:\s*[.,;:]?)*$"
+    )
+
+    match = re.search(unit_pattern, answer, re.IGNORECASE | re.UNICODE)
+    if match:
+        return match.group(1)
+
+    return answer
+
+
+def convert_to_appropriate_type(answer):
+    """Convert answer to appropriate type (int, float, or string)."""
+    if not answer:
+        return answer
+
+    answer_str = str(answer).strip()
+
+    # Try integer first
+    try:
+        if "." not in answer_str:
+            return int(answer_str)
+    except ValueError:
+        pass
+
+    # Try float
+    try:
+        return float(answer_str)
+    except ValueError:
+        pass
+
+    try:
+        return ast.literal_eval(answer_str)
+    except (ValueError, SyntaxError):
+        pass
+
+    return answer_str
+
+
+def normalize_sub_super_scripts(text):
+    """Normalize Unicode subscript and superscript digits to standard digits."""
+    subscripts = str.maketrans("₀₁₂₃₄₅₆₇₈₉₊₋", "0123456789+-")
+    superscripts = str.maketrans("⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻", "0123456789+-")
+    return text.translate(subscripts).translate(superscripts)
+
+
+def extract_answer_only(response):
+    """
+    Enhanced extraction function that extracts content in the following priority:
+    1. Content between <answer></answer> tags (highest priority)
+    2. Valid JSON objects or arrays
+    3. Python dictionary/list formats
+    """
+    if not response or not isinstance(response, str):
+        return None
+
+    # Priority 1: Check for answer tags
+    if "<answer>" in response and "</answer>" in response:
+        answer = response.split("<answer>")[-1].split("</answer>")[0]
+        return answer
+
+    # Priority 2 & 3: Find and validate JSON/dict/list/tuple structures
+    candidates = []
+
+    def find_balanced_structures(text):
+        """Find all balanced bracket/brace structures in text."""
+        structures = []
+        stack = {"[": [], "{": [], "(": []}
+        reverse_matching = {"]": "[", "}": "{", ")": "("}
+
+        i = 0
+        while i < len(text):
+            char = text[i]
+
+            if char == '"':
+                i += 1
+                while i < len(text):
+                    if text[i] == '"' and (i == 0 or text[i - 1] != "\\"):
+                        break
+                    i += 1
+                i += 1
+                continue
+            elif char == "'":
+                if i > 0 and text[i - 1] in ["{", "[", ":", ",", " ", "("]:
+                    j = i + 1
+                    found_close = False
+                    while j < len(text) and j < i + 1000:
+                        if (
+                            text[j] == "'"
+                            and (j == 0 or text[j - 1] != "\\")
+                            and j + 1 < len(text)
+                            and text[j + 1] in ["}", "]", ":", ",", " ", ")"]
+                        ):
+                            found_close = True
+                            break
+                        j += 1
+
+                    if found_close:
+                        i = j + 1
+                        continue
+
+            if char in stack:
+                stack[char].append(i)
+            elif char in reverse_matching:
+                opener = reverse_matching[char]
+                if stack[opener]:
+                    start = stack[opener].pop()
+                    complete_structure = text[start : i + 1]
+                    structures.append((start, complete_structure))
+
+            i += 1
+
+        return structures
+
+    structures = find_balanced_structures(response)
+
+    # Filter out nested structures
+    filtered_structures = []
+    for i, (start1, struct1) in enumerate(structures):
+        is_nested = False
+        for j, (start2, struct2) in enumerate(structures):
+            if i != j:
+                end1 = start1 + len(struct1)
+                end2 = start2 + len(struct2)
+                if start2 <= start1 and end2 >= end1 and len(struct2) > len(struct1):
+                    is_nested = True
+                    break
+        if not is_nested:
+            filtered_structures.append((start1, struct1))
+
+    for start_pos, candidate in filtered_structures:
+        if candidate.startswith("{"):
+            structure_type = "dict"
+        elif candidate.startswith("["):
+            structure_type = "list"
+        elif candidate.startswith("("):
+            structure_type = "tuple"
+        else:
+            continue
+
+        if structure_type in ["dict", "list"]:
+            try:
+                json.loads(candidate)
+                candidates.append((start_pos, candidate, "json"))
+                continue
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        try:
+            ast.literal_eval(candidate)
+            candidates.append((start_pos, candidate, "python"))
+        except (ValueError, SyntaxError, TypeError):
+            if (
+                structure_type == "dict"
+                and ":" in candidate
+                and '"' not in candidate
+                and "'" not in candidate
+            ):
+                candidates.append((start_pos, candidate, "simple_dict"))
+
+    if candidates:
+        candidates.sort(key=lambda x: x[0])
+        return candidates[-1][1]
+
+    return None

--- a/lm_eval/tasks/moleculariq/moleculariq_inline.yaml
+++ b/lm_eval/tasks/moleculariq/moleculariq_inline.yaml
@@ -1,0 +1,36 @@
+tag:
+  - chemistry
+  - moleculariq
+task: moleculariq_inline
+dataset_path: ml-jku/moleculariq-v0.0
+dataset_name: default
+process_docs: !function task_processor.process_docs
+output_type: generate_until
+test_split: test
+doc_to_text: !function task_processor.doc_to_text_inline
+doc_to_target: target
+process_results: !function task_processor.process_results_pass_at_k
+repeats: 3
+generation_kwargs:
+  max_gen_toks: 32768
+  until: []
+  do_sample: true
+
+filter_list:
+  - name: "all"
+    filter: []
+metric_list:
+  - metric: pass_at_1
+    aggregation: mean
+    higher_is_better: true
+  - metric: pass_at_3
+    aggregation: mean
+    higher_is_better: true
+  - metric: avg_accuracy
+    aggregation: mean
+    higher_is_better: true
+  - metric: extracted_answers
+    aggregation: bypass
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/moleculariq/moleculariq_pass_at_k.yaml
+++ b/lm_eval/tasks/moleculariq/moleculariq_pass_at_k.yaml
@@ -1,0 +1,70 @@
+tag:
+  - chemistry
+  - moleculariq
+task: moleculariq_pass_at_k
+description: |
+  You are an expert chemist. Answer molecular property, understanding, structural analysis and molecular generation questions precisely and accurately.
+
+  CRITICAL: Only content within <answer></answer> tags will be extracted. ALWAYS return JSON format.
+
+  KEY REQUIREMENT: Use EXACT key names from the question. Never modify or invent keys.
+
+  INDEXING: Atoms are indexed from 0 to the end of the SMILES string from left to right. Only heavy atoms (skip [H], include [2H]/[3H]).
+  Examples:
+      - "CCO": C(0), C(1), O(2)
+      - "CC(C)O": C(0), C(1), C(2), O(3)
+      - "CC(=O)N": C(0), C(1), O(2), N(3)
+
+  ABSENT FEATURES: Use 0 for counts, [] for indices. Never null or omit.
+
+  ALWAYS USE JSON with EXACT keys from the question:
+
+  Single count (key from question: "alcohol_count"):
+  <answer>{"alcohol_count": 2}</answer>
+  <answer>{"alcohol_count": 0}</answer>  (if absent)
+
+  Single index (key from question: "ketone_indices"):
+  <answer>{"ketone_indices": [5]}</answer>
+  <answer>{"ketone_indices": []}</answer>  (if absent)
+
+  Multiple properties (keys from question: "ring_count", "halogen_indices"):
+  <answer>{"ring_count": 2, "halogen_indices": [3, 7]}</answer>
+  <answer>{"ring_count": 0, "halogen_indices": []}</answer>  (if all absent)
+
+  Constraint generation:
+  <answer>{"smiles": "CC(O)C"}</answer>
+
+  Include ALL requested properties. Never null or omit.
+dataset_path: ml-jku/moleculariq-v0.0
+dataset_name: default
+process_docs: !function task_processor.process_docs
+output_type: generate_until
+test_split: test
+doc_to_text: !function task_processor.doc_to_text
+doc_to_target: target
+process_results: !function task_processor.process_results_pass_at_k
+repeats: 3
+generation_kwargs:
+  max_tokens: 32768
+  until: []
+  do_sample: true
+  temperature: 0.7
+
+filter_list:
+  - name: "all"
+    filter: []
+metric_list:
+  - metric: pass_at_1
+    aggregation: mean
+    higher_is_better: true
+  - metric: pass_at_3
+    aggregation: mean
+    higher_is_better: true
+  - metric: avg_accuracy
+    aggregation: mean
+    higher_is_better: true
+  - metric: extracted_answers
+    aggregation: bypass
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/moleculariq/task_processor.py
+++ b/lm_eval/tasks/moleculariq/task_processor.py
@@ -1,0 +1,239 @@
+"""
+Task processor for MolecularIQ benchmark.
+Contains the specific hooks: process_docs, doc_to_text, and process_results.
+"""
+
+import statistics
+from collections import defaultdict
+from typing import Any
+
+import datasets
+from moleculariq_core import evaluate_answer
+from tqdm import tqdm
+
+from lm_eval.tasks.moleculariq.extractors import extract_moleculariq_answer
+
+
+class MolecularIQProcessor:
+    """Processor for the MolecularIQ benchmark."""
+
+    def __init__(self):
+        """Initialize the MolecularIQ processor."""
+        self.extraction_function = extract_moleculariq_answer
+
+    def doc_to_text(self, doc: dict) -> str:
+        """Convert document to input text for the model."""
+        return doc.get("question", "")
+
+    def process_docs(self, docs):
+        """Process documents for MolecularIQ task."""
+        if hasattr(docs, "__len__") and len(docs) > 10:
+            print(f"Processing {len(docs)} MolecularIQ documents...")
+        return docs
+
+
+# Create processor instance for use by the task
+processor = MolecularIQProcessor()
+
+
+# Inline prompt for models that need explicit instructions
+INLINE_PROMPT = """You are an expert chemist. Answer the following chemistry question.
+Provide your final answer inside <answer></answer> tags in JSON format.
+
+Question: {question}
+
+Answer:"""
+
+
+# Export the hook functions for the YAML configuration
+def doc_to_text(doc: dict) -> str:
+    return processor.doc_to_text(doc)
+
+
+def doc_to_text_inline(doc: dict) -> str:
+    """Convert document to input text with inline prompt for models needing explicit instructions."""
+    question = doc.get("question", "")
+    return INLINE_PROMPT.format(question=question)
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    return processor.process_docs(dataset)
+
+
+def process_results(doc: dict, results: list[str]) -> dict[str, Any]:
+    """Process results using direct evaluation with MolecularIQ rewards."""
+    metrics = defaultdict(list)
+
+    # Handle nested list results
+    if isinstance(results[0], list):
+        results = results[0]
+
+    # Validate results format
+    if not (isinstance(results, list) and isinstance(results[0], str)):
+        raise TypeError(f"Results must be a list of strings, got {type(results[0])}!")
+
+    per_category_rewards = defaultdict(list)
+
+    # Progress bar for processing results
+    result_iterator = tqdm(
+        enumerate(results, start=1),
+        total=len(results),
+        desc="Evaluating MolecularIQ responses",
+        unit="response",
+        leave=False,
+    )
+
+    for i, result in result_iterator:
+        if not isinstance(result, str):
+            raise TypeError(f"Result must be string, got {type(result)}!")
+
+        # Update progress bar description with current response number
+        result_iterator.set_postfix({"Response": f"{i}/{len(results)}"})
+
+        # Get reward using direct evaluation
+        eval_result = moleculariq_bencheval(doc=doc, answer=result)
+
+        # Extract category and reward
+        category = eval_result.get("task_type", "unknown")
+        reward = eval_result.get("reward", 0)
+
+        per_category_rewards[category].append(reward)
+        metrics["extracted_answers"].append(eval_result.get("extracted_answer", ""))
+
+    # Calculate category averages
+    for category, rewards in sorted(per_category_rewards.items()):
+        if rewards:  # Avoid division by zero
+            avg_reward = statistics.mean(rewards)
+            metrics[category] = avg_reward
+
+    return dict(metrics)
+
+
+def process_results_pass_at_k(doc: dict, results: list[str]) -> dict[str, Any]:
+    """
+    Process results for Pass@k evaluation.
+
+    Pass@k means: does the model get the correct answer in at least one of k attempts?
+    For k attempts, if any attempt is correct, the problem gets a score of 1, otherwise 0.
+    """
+    metrics = defaultdict(list)
+
+    # Handle nested list results
+    if isinstance(results[0], list):
+        results = results[0]
+
+    # Validate results format
+    if not (isinstance(results, list) and isinstance(results[0], str)):
+        raise TypeError(f"Results must be a list of strings, got {type(results[0])}!")
+
+    # Evaluate all results for this document
+    eval_results = []
+    all_rewards = []
+
+    # Progress bar for Pass@k evaluation
+    result_iterator = tqdm(
+        results, desc="Pass@k MolecularIQ evaluation", unit="attempt", leave=False
+    )
+
+    for i, result in enumerate(result_iterator, 1):
+        if not isinstance(result, str):
+            raise TypeError(f"Result must be string, got {type(result)}!")
+
+        # Update progress bar with current attempt info
+        result_iterator.set_postfix({"Attempt": f"{i}/{len(results)}"})
+
+        # Get evaluation using direct evaluation
+        eval_result = moleculariq_bencheval(doc=doc, answer=result)
+        eval_results.append(eval_result)
+        all_rewards.append(eval_result.get("reward", 0))
+
+        # Store extracted answers for debugging
+        metrics["extracted_answers"].append(eval_result.get("extracted_answer", ""))
+
+    # Calculate Pass@k metrics
+    num_attempts = len(all_rewards)
+
+    # Pass@1: first attempt correct
+    metrics["pass_at_1"] = float(all_rewards[0] > 0) if num_attempts > 0 else 0.0
+
+    # Pass@3: any of first 3 attempts correct
+    if num_attempts >= 3:
+        metrics["pass_at_3"] = float(any(reward > 0 for reward in all_rewards[:3]))
+    elif num_attempts > 0:
+        # If fewer than 3 attempts, use all available
+        metrics["pass_at_3"] = float(any(reward > 0 for reward in all_rewards))
+    else:
+        metrics["pass_at_3"] = 0.0
+
+    # Average accuracy across all attempts (traditional metric for comparison)
+    metrics["avg_accuracy"] = statistics.mean(all_rewards) if all_rewards else 0.0
+
+    # Category-specific metrics
+    task_type = doc.get("task_type", "unknown")
+    supercategory = doc.get("supercategory", "unknown")
+
+    # Task type specific metrics
+    metrics[f"{task_type}_avg_accuracy"] = metrics["avg_accuracy"]
+
+    # Supercategory specific metrics
+    if supercategory and supercategory != "unknown":
+        metrics[f"{supercategory}_avg_accuracy"] = metrics["avg_accuracy"]
+
+    return dict(metrics)
+
+
+def moleculariq_bencheval(doc: dict, answer: str) -> dict[str, Any]:
+    """
+    Evaluate a MolecularIQ answer using the appropriate reward function.
+
+    Args:
+        doc: Document containing task data including task_type and target
+        answer: Model's text answer
+
+    Returns:
+        Dict with evaluation results including reward and extracted answer
+    """
+    # Extract task information
+    task_type = doc.get("task_type", "")
+    supercategory = doc.get("supercategory", "")
+
+    extracted_answer = processor.extraction_function(answer)
+
+    # Normalize task type for constraint tasks
+    task_type_norm = task_type
+    if (
+        "single_constraint_generation" in task_type
+        or "multi_constraint_generation" in task_type
+    ):
+        task_type_norm = "constraint_generation"
+
+    # For constraint tasks, use the constraints field
+    if "constraint" in task_type.lower() or "generation" in task_type.lower():
+        constraints = doc.get("constraints") or doc.get("constraint")
+        reward = evaluate_answer(
+            task_type=task_type_norm,
+            predicted=extracted_answer,
+            constraints=constraints,
+            return_details=False,
+        )
+    else:
+        # For other tasks, pass the target directly
+        target = doc.get("target")
+        reward = evaluate_answer(
+            task_type=task_type_norm,
+            predicted=extracted_answer,
+            target=target,
+            return_details=False,
+        )
+
+    # Ensure reward is a float
+    if isinstance(reward, dict):
+        reward = reward.get("reward", 0.0)
+    reward = float(reward)
+
+    return {
+        "task_type": task_type,
+        "reward": reward,
+        "extracted_answer": extracted_answer,
+        "supercategory": supercategory,
+    }


### PR DESCRIPTION
MolecularIQ is a fully symbolically verifiable benchmark for assessing chemical reasoning capabilities of LLMs over molecular graphs. It covers three task types (feature counting, index-based attribution, constrained generation) across six categories of molecular features and three complexity axes.

- Dataset: ml-jku/moleculariq-v0.0 (5,111 questions, 849 molecules)
- Metrics: pass@1, pass@3, avg_accuracy (3 rollouts per instance)
- Two task variants: moleculariq_pass_at_k (raw question, for chat models with --system_instruction) and moleculariq_inline (instructions embedded in prompt, for non-chat models)
- Symbolic verification via moleculariq-core ensures exact evaluation

Paper: https://arxiv.org/abs/2601.15279 (ICLR 2026)
Leaderboard: https://huggingface.co/spaces/ml-jku/molecularIQ_leaderboard
Code: https://github.com/ml-jku/moleculariq