### PR TITLE
Fix DummyLM.generate_until printing context as gen_kwargs

### DIFF
--- a/lm_eval/models/dummy.py
+++ b/lm_eval/models/dummy.py
@@ -37,7 +37,7 @@ class DummyLM(LM):
             res.append("lol")
             if self.write_out:
                 print(request.arguments[0])
-                print(f"gen_kwargs: {request.arguments[0]}")
+                print(f"gen_kwargs: {request.arguments[1]}")
             assert request.arguments[0].strip() != ""
 
         return res


### PR DESCRIPTION
## Bug

\`DummyLM.generate_until\` in \`lm_eval/models/dummy.py\` prints request arguments under \`write_out=True\`:

\`\`\`python
print(request.arguments[0])
print(f\"gen_kwargs: {request.arguments[0]}\")
\`\`\`

## Root cause

Per \`LM.generate_until\`'s docstring in \`lm_eval/api/model.py\`, each \`Instance.args\` is a \`(context, gen_kwargs)\` tuple. \`request.arguments[1]\` is the gen_kwargs dict; \`request.arguments[0]\` is the context. The label says \"gen_kwargs:\" but the index is still 0, so the context is printed twice — once unlabeled and once mislabeled as \"gen_kwargs:\". The sibling \`loglikelihood\` write-out indexes correctly (\`[0]\` for context, \`[1]\` for continuation).

## Fix

Use \`request.arguments[1]\` for the gen_kwargs print so the labeled value matches the label.