### PR TITLE
Fix infinite loop in ruler qa generate_samples when used_docs cannot shrink

### DIFF
--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -181,6 +181,8 @@ def generate_samples(
             except:  # noqa: E722
                 if used_docs > incremental:
                     used_docs -= incremental
+                else:
+                    raise
 
         if remove_newline_tab:
             input_text = " ".join(


### PR DESCRIPTION
## Bug

The retry loop in `lm_eval/tasks/ruler/qa_utils.py:173` spins forever whenever `used_docs` lands at or below `incremental` and a sample still fails to satisfy `length <= max_seq_length`:

```python
while True:
    try:
        input_text, answer = generate_input_output(index + pre_samples, used_docs, qas=qas, docs=docs)
        length = len(tokenizer(input_text).input_ids) + tokens_to_generate
        assert length <= max_seq_length, f"{length} exceeds max_seq_length."
        break
    except:  # noqa: E722
        if used_docs > incremental:
            used_docs -= incremental
        # nothing happens if used_docs <= incremental
```

With the broad `except:` swallowing the assertion/ValueError and `used_docs` not changing, every iteration reproduces the same failure. This is the hang reported in #2963 when `max_seq_lengths < 4096` (the outer sizing loop at lines 149-165 can land on `num_docs == 0`, which then makes `generate_input_output` call `random.sample(curr_more, -1)` — a `ValueError` that is caught, but with `used_docs == 0 <= incremental`, the `-= incremental` branch never runs).

## Root cause

Missing termination for the "can't reduce doc count further" case in the `except` branch. PR #3372 added this guard for `prepare_niah.py`; `qa_utils.py` has the same loop structure and the same bug.

## Fix

Re-raise the original exception once `used_docs` can no longer be reduced, so the caller sees the underlying `AssertionError` / `ValueError` (e.g., "{length} exceeds max_seq_length.") instead of a hang. Two-line structural change; the success path and the "decrement and retry" path are unchanged.