### PR TITLE
Fix DummyLM.generate_until write_out printing context as gen_kwargs

### DIFF
--- a/lm_eval/models/dummy.py
+++ b/lm_eval/models/dummy.py
@@ -37,7 +37,7 @@ class DummyLM(LM):
             res.append("lol")
             if self.write_out:
                 print(request.arguments[0])
-                print(f"gen_kwargs: {request.arguments[0]}")
+                print(f"gen_kwargs: {request.arguments[1]}")
             assert request.arguments[0].strip() != ""
 
         return res


### PR DESCRIPTION
### Bug
When `DummyLM(write_out=True)`, `generate_until` prints `request.arguments[0]` twice in the write-out branch, with the second print labeled `gen_kwargs:`, so the logged gen_kwargs is actually the context.

https://github.com/EleutherAI/lm-evaluation-harness/blob/b5b9b9c/lm_eval/models/dummy.py#L36-L41

```python
for request in tqdm(requests, disable=disable_tqdm):
    res.append("lol")
    if self.write_out:
        print(request.arguments[0])
        print(f"gen_kwargs: {request.arguments[0]}")
    assert request.arguments[0].strip() != ""
```

### Root cause
Copy-paste: per `LM.generate_until`'s docstring, `Instance.args` is a `(context, gen_kwargs)` tuple, and other backends like `megatron_lm.py` and `winml.py` unpack it as `context, gen_kwargs = request.args`. The second print should use index `[1]`.

### Fix
Change `request.arguments[0]` to `request.arguments[1]` in the `gen_kwargs:` print so the labeled value matches the label. No behavior change unless `write_out=True`.