### PR TITLE
[fix] Disambiguate cache entries for repeated generate_until requests (#3046)

### DIFF
--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -23,6 +23,8 @@ class Instance:
     task_name: Optional[str] = None
     doc_id: Optional[int] = None
     repeats: Optional[int] = None
+    repeat_idx: int = 0
+    is_padding: bool = False
 
     def __post_init__(self) -> None:
         # unpack metadata field

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -232,6 +232,25 @@ def hash_args(attr: str, args: Iterable[Any]) -> str:
     return hashlib.sha256(dat.encode("utf-8")).hexdigest()
 
 
+def _is_sampling_gen_kwargs(gen_kwargs: Any) -> bool:
+    # do_sample=False is not decisive: openai_completions drops it before
+    # dispatch but forwards temperature. top_k<2 degenerates to greedy.
+    if not isinstance(gen_kwargs, dict):
+        return False
+    if gen_kwargs.get("do_sample") is True:
+        return True
+    temperature = gen_kwargs.get("temperature")
+    if temperature is not None and temperature > 0:
+        return True
+    top_p = gen_kwargs.get("top_p")
+    if top_p is not None and top_p < 1.0:
+        return True
+    top_k = gen_kwargs.get("top_k")
+    if top_k is not None and top_k > 1:
+        return True
+    return False
+
+
 class CacheHook:
     def __init__(self, cachinglm: Optional["CachingLM"]) -> None:
         if cachinglm is None:
@@ -243,6 +262,16 @@ class CacheHook:
     def add_partial(self, attr: str, req: Iterable[Any], res: Any) -> None:
         if self.dbdict is None:
             return
+        # skip sampled generate_until writes -- never read back. deterministic
+        # repeats>1 still writes args-only rows here; the wrapper reads under
+        # repeat-aware keys, so those rows are harmless orphans.
+        if attr == "generate_until":
+            try:
+                gen_kwargs = req[1] if len(req) > 1 else None  # type: ignore[index]
+            except TypeError:
+                gen_kwargs = None
+            if _is_sampling_gen_kwargs(gen_kwargs):
+                return
         hsh = hash_args(attr, req)
         self.dbdict[hsh] = res
 
@@ -273,18 +302,24 @@ class CachingLM:
             return lm_attr
 
         def _fn(requests: list["Instance"]) -> list["Instance"]:
-            res = []
-            remaining_reqs = []
+            res: list[Any] = []
+            remaining_reqs: list["Instance"] = []
+            # key for each remaining req; None => don't cache this result
+            remaining_keys: list[Optional[str]] = []
             warned = False
-            # figure out which ones are cached and which ones are new
+            occurrence: dict[str, int] = {}
+
             eval_logger.info(
                 f"Loading '{attr}' responses from cache '{self.cache_db}' where possible..."
             )
             for req in tqdm(requests, desc="Checking cached requests"):
-                hsh = hash_args(attr, req.args)
-                if attr == "generate_until" and req.args[1].get("do_sample", False):
-                    # when we are doing non-greedy generation, don't use the cache
-                    # (else every "randomly sampled" generation would be identical for repeats > 1).
+                if getattr(req, "is_padding", False):
+                    res.append(None)
+                    remaining_reqs.append(req)
+                    remaining_keys.append(None)
+                    continue
+
+                if attr == "generate_until" and _is_sampling_gen_kwargs(req.args[1]):
                     if not warned:
                         eval_logger.warning(
                             f"Arguments to lm.generate_until() '{req.args[1]}' include non-deterministic sampling. Caching will not be performed for such requests."
@@ -292,7 +327,11 @@ class CachingLM:
                         warned = True
                     res.append(None)
                     remaining_reqs.append(req)
-                elif hsh in self.dbdict:
+                    remaining_keys.append(None)
+                    continue
+
+                hsh = self._cache_key(attr, req, occurrence)
+                if hsh in self.dbdict:
                     ob = self.dbdict[hsh]
 
                     assert ob is not None
@@ -301,28 +340,59 @@ class CachingLM:
                 else:
                     res.append(None)
                     remaining_reqs.append(req)
+                    remaining_keys.append(hsh)
             eval_logger.info(
                 f"Cached requests: {len(requests) - len(remaining_reqs)}, Requests remaining: {len(remaining_reqs)}"
             )
-            # actually run the LM on the requests that do not have cached results
             rem_res = getattr(self.lm, attr)(remaining_reqs) if remaining_reqs else []
 
-            # stick the new ones back into the list and also cache any of the new ones
             resptr = 0
-            for req, r in zip(remaining_reqs, rem_res, strict=True):
+            for req, r, hsh in zip(
+                remaining_reqs, rem_res, remaining_keys, strict=True
+            ):
                 while res[resptr] is not None:
                     resptr += 1
 
                 res[resptr] = r
 
-                # caching
-                hsh = hash_args(attr, req.args)
-                self.dbdict[hsh] = r
+                if hsh is not None:
+                    self.dbdict[hsh] = r
             self.dbdict.commit()
 
             return res
 
         return _fn
+
+    @staticmethod
+    def _cache_key(
+        attr: str, req: "Instance", occurrence: dict[str, int]
+    ) -> str:
+        # Legacy args-only key for:
+        #   - non-generate_until requests (deterministic, no repeats>1 uses)
+        #   - single-sample generate_until (keeps pre-existing caches valid)
+        if attr != "generate_until":
+            return hash_args(attr, req.args)
+
+        repeats = req.repeats if req.repeats is not None else 1
+        if repeats <= 1 and req.repeat_idx == 0:
+            return hash_args(attr, req.args)
+
+        if req.task_name is not None and req.doc_id is not None:
+            extras: list[Any] = [
+                req.task_name,
+                req.doc_id,
+                req.idx,
+                req.repeat_idx,
+            ]
+        else:
+            # no task metadata: count duplicates within this call instead.
+            # two logical reqs with identical args get conflated here.
+            counter_key = json.dumps([attr, list(req.args)], default=str)
+            slot = occurrence.get(counter_key, 0)
+            occurrence[counter_key] = slot + 1
+            extras = [slot]
+
+        return hash_args(attr, list(req.args) + extras)
 
     def get_cache_hook(self) -> "CacheHook":
         return CacheHook(self)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import itertools
 import json
 import logging
@@ -573,20 +574,27 @@ def evaluate(
     # execute each type of request
     for reqtype, reqs in requests.items():
         eval_logger.info(f"Running {reqtype} requests")
-        # create `K` copies of each request `req` based off `K = req.repeats`
+        # shallow-copy K clones per req; resps stays shared with the original
         cloned_reqs = []
         for req in reqs:
-            cloned_reqs.extend([req] * req.repeats)
+            for i in range(req.repeats):
+                cloned_reqs.append(dataclasses.replace(req, repeat_idx=i))
 
         if (lm.world_size > 1) and (padding_requests[reqtype] > 0):
+            pad_req = reqs[-1]
             for _ in range(padding_requests[reqtype]):
-                cloned_reqs.extend([req] * req.repeats)
+                for i in range(pad_req.repeats):
+                    cloned_reqs.append(
+                        dataclasses.replace(pad_req, repeat_idx=i, is_padding=True)
+                    )
 
         # run requests through model
         resps = getattr(lm, reqtype)(cloned_reqs)
 
         # put responses from model into a list of length K for each request.
         for x, req in zip(resps, cloned_reqs, strict=True):
+            if req.is_padding:
+                continue
             req.resps.append(x)
 
         if lm.world_size > 1:

--- a/tests/test_caching_lm.py
+++ b/tests/test_caching_lm.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+from typing import Any
+
+import pytest
+
+from lm_eval.api.instance import Instance
+from lm_eval.api.model import LM, CachingLM, hash_args
+
+
+class _StubLM(LM):
+    def __init__(self) -> None:
+        super().__init__()
+        self.counter = 0
+
+    def loglikelihood(self, requests):
+        raise NotImplementedError
+
+    def loglikelihood_rolling(self, requests):
+        raise NotImplementedError
+
+    def generate_until(self, requests):
+        out = []
+        for _ in requests:
+            out.append(f"gen_{self.counter}")
+            self.counter += 1
+        return out
+
+
+def _make_req(
+    context: str,
+    gen_kwargs: dict,
+    *,
+    task_name: str | None = "t",
+    doc_id: int | None = 0,
+    idx: int = 0,
+    repeats: int = 1,
+) -> Instance:
+    return Instance(
+        request_type="generate_until",
+        doc={},
+        arguments=(context, gen_kwargs),
+        idx=idx,
+        metadata=(task_name, doc_id, repeats),
+    )
+
+
+def _cloned(req: Instance) -> list[Instance]:
+    return [dataclasses.replace(req, repeat_idx=i) for i in range(req.repeats)]
+
+
+def test_deterministic_repeats_cache_k_distinct_outputs(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    parent = _make_req("ctx", {"temperature": 0}, doc_id=42, repeats=4)
+    clones = _cloned(parent)
+
+    lm1 = _StubLM()
+    r1 = CachingLM(lm1, cache_db).generate_until(clones)
+    assert r1 == ["gen_0", "gen_1", "gen_2", "gen_3"]
+    assert lm1.counter == 4
+
+    lm2 = _StubLM()
+    r2 = CachingLM(lm2, cache_db).generate_until(clones)
+    assert r2 == r1
+    assert lm2.counter == 0
+
+
+def test_repeats_one_preserves_legacy_key_shape(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    req = _make_req("ctx", {"temperature": 0}, repeats=1)
+
+    wrapped = CachingLM(_StubLM(), cache_db)
+    wrapped.generate_until([req])
+
+    legacy_key = hash_args("generate_until", req.args)
+    assert legacy_key in wrapped.dbdict
+    assert wrapped.dbdict[legacy_key] == "gen_0"
+
+
+@pytest.mark.parametrize(
+    "gen_kwargs",
+    [
+        {"do_sample": True},
+        {"temperature": 0.7},
+        {"top_p": 0.9},
+        {"top_k": 50},
+    ],
+)
+def test_sampling_bypasses_cache_lookup_and_post_write(tmp_path, gen_kwargs):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    parent = _make_req("ctx", gen_kwargs, repeats=3)
+    clones = _cloned(parent)
+
+    lm1 = _StubLM()
+    wrapped1 = CachingLM(lm1, cache_db)
+    assert wrapped1.generate_until(clones) == ["gen_0", "gen_1", "gen_2"]
+    # stub doesn't call add_partial; what we're pinning is that the wrapper
+    # itself never writes on the sampling path
+    assert len(wrapped1.dbdict) == 0
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == [
+        "gen_0",
+        "gen_1",
+        "gen_2",
+    ]
+    assert lm2.counter == 3
+
+
+def test_partial_writes_preserve_crash_resumability_for_repeats_one(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+
+    class CrashingLM(_StubLM):
+        def __init__(self, crash_after: int):
+            super().__init__()
+            self.crash_after = crash_after
+
+        def generate_until(self, requests):
+            out = []
+            for req in requests:
+                if self.counter >= self.crash_after:
+                    raise RuntimeError("simulated API failure")
+                out.append(f"gen_{self.counter}")
+                self.cache_hook.add_partial("generate_until", req.args, out[-1])
+                self.counter += 1
+            return out
+
+    reqs = [
+        _make_req("ctx-a", {"temperature": 0}, doc_id=0, repeats=1),
+        _make_req("ctx-b", {"temperature": 0}, doc_id=1, repeats=1),
+        _make_req("ctx-c", {"temperature": 0}, doc_id=2, repeats=1),
+    ]
+
+    wrapped1 = CachingLM(CrashingLM(crash_after=2), cache_db)
+    with pytest.raises(RuntimeError):
+        wrapped1.generate_until(reqs)
+    assert len(wrapped1.dbdict) == 2
+
+    lm2 = _StubLM()
+    r2 = CachingLM(lm2, cache_db).generate_until(reqs)
+    assert r2 == ["gen_0", "gen_1", "gen_0"]
+    assert lm2.counter == 1
+
+
+def test_do_sample_false_alone_is_greedy_and_cached(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    clones = _cloned(_make_req("ctx", {"do_sample": False}, repeats=2))
+
+    r1 = CachingLM(_StubLM(), cache_db).generate_until(clones)
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == r1
+    assert lm2.counter == 0
+
+
+def test_do_sample_false_with_temperature_still_bypasses_cache(tmp_path):
+    # API backends drop do_sample and forward temperature; must not replay.
+    cache_db = os.path.join(tmp_path, "cache.db")
+    clones = _cloned(
+        _make_req("ctx", {"do_sample": False, "temperature": 0.7}, repeats=2)
+    )
+
+    wrapped1 = CachingLM(_StubLM(), cache_db)
+    assert wrapped1.generate_until(clones) == ["gen_0", "gen_1"]
+    assert len(wrapped1.dbdict) == 0
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == ["gen_0", "gen_1"]
+    assert lm2.counter == 2
+
+
+def test_explicit_temperature_zero_is_greedy_and_cached(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    clones = _cloned(_make_req("ctx", {"temperature": 0}, repeats=2))
+
+    r1 = CachingLM(_StubLM(), cache_db).generate_until(clones)
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == r1
+    assert lm2.counter == 0
+
+
+def test_repeat_idx_triggers_new_key_even_when_repeats_unset(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    base = Instance(
+        request_type="generate_until",
+        doc={},
+        arguments=("ctx", {"temperature": 0}),
+        idx=0,
+    )
+    clones = [dataclasses.replace(base, repeat_idx=i) for i in range(3)]
+
+    wrapped1 = CachingLM(_StubLM(), cache_db)
+    r1 = wrapped1.generate_until(clones)
+    assert r1 == ["gen_0", "gen_1", "gen_2"]
+    assert len(wrapped1.dbdict) == 3
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == r1
+    assert lm2.counter == 0
+
+
+def test_missing_metadata_falls_back_to_occurrence_counter(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    clones = _cloned(
+        _make_req(
+            "ctx",
+            {"temperature": 0},
+            task_name=None,
+            doc_id=None,
+            repeats=3,
+        )
+    )
+
+    r1 = CachingLM(_StubLM(), cache_db).generate_until(clones)
+    assert r1 == ["gen_0", "gen_1", "gen_2"]
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == r1
+    assert lm2.counter == 0
+
+
+def test_add_partial_skips_writes_on_sampled_generate_until(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+
+    class EmittingLM(_StubLM):
+        def generate_until(self, requests):
+            out = []
+            for req in requests:
+                text = f"gen_{self.counter}"
+                out.append(text)
+                self.cache_hook.add_partial("generate_until", req.args, text)
+                self.counter += 1
+            return out
+
+    clones = _cloned(_make_req("ctx", {"temperature": 0.7}, repeats=3))
+    wrapped = CachingLM(EmittingLM(), cache_db)
+    wrapped.generate_until(clones)
+    assert len(wrapped.dbdict) == 0
+
+
+def test_loglikelihood_repeats_not_fragmented(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+
+    class LLStubLM(_StubLM):
+        def loglikelihood(self, requests):
+            out = []
+            for _ in requests:
+                out.append((float(self.counter), True))
+                self.counter += 1
+            return out
+
+    base = Instance(
+        request_type="loglikelihood",
+        doc={},
+        arguments=("ctx", "cont"),
+        idx=0,
+        metadata=("t", 0, 3),
+    )
+    clones = [dataclasses.replace(base, repeat_idx=i) for i in range(3)]
+
+    wrapped = CachingLM(LLStubLM(), cache_db)
+    wrapped.loglikelihood(clones)
+    assert list(wrapped.dbdict.keys()) == [hash_args("loglikelihood", base.args)]
+
+
+@pytest.mark.parametrize(
+    "gen_kwargs",
+    [{"top_k": 0}, {"top_k": 1}, {"top_k": 1, "temperature": 0}],
+)
+def test_top_k_le_one_is_not_sampling(tmp_path, gen_kwargs):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    clones = _cloned(_make_req("ctx", gen_kwargs, repeats=2))
+
+    r1 = CachingLM(_StubLM(), cache_db).generate_until(clones)
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == r1
+    assert lm2.counter == 0
+
+
+def test_ddp_padding_duplicates_do_not_poison_real_slots(tmp_path):
+    cache_db = os.path.join(tmp_path, "cache.db")
+    parent = _make_req("ctx-last", {"temperature": 0}, doc_id=7, repeats=3)
+    clones = _cloned(parent)
+    padding = [dataclasses.replace(c, is_padding=True) for c in _cloned(parent)]
+
+    CachingLM(_StubLM(), cache_db).generate_until(clones + padding)
+
+    lm2 = _StubLM()
+    assert CachingLM(lm2, cache_db).generate_until(clones) == [
+        "gen_0",
+        "gen_1",
+        "gen_2",
+    ]
+    assert lm2.counter == 0
+
+
+def test_padding_resps_do_not_contaminate_real_request():
+    # resps is shared between clones and padding via shallow copy; the
+    # evaluator-side append skip keeps downstream filters seeing K entries,
+    # not K + numpad*K.
+    real = _make_req("ctx", {"temperature": 0}, doc_id=0, repeats=2)
+    clones = _cloned(real)
+    padding = [dataclasses.replace(c, is_padding=True) for c in _cloned(real)]
+
+    # resps is the same list object on every clone and on the original
+    assert all(c.resps is real.resps for c in clones + padding)
+
+    for i, req in enumerate(clones + padding):
+        if req.is_padding:
+            continue
+        req.resps.append(f"gen_{i}")
+
+    assert real.resps == ["gen_0", "gen_1"]


### PR DESCRIPTION
## Summary

Fixes #3046. Cloned `generate_until` requests created by `repeats > 1` were aliased by reference in `evaluator.py`, so all K siblings hashed to one cache key and overwrote each other. On a cached re-run every slot returned the same value, silently collapsing pass@k, self-consistency, and `humaneval_64`-style evaluations into `repeats=1`.

- Clones now carry a distinct `repeat_idx` (`dataclasses.replace`); `.resps` stays shared so the existing aggregation pattern works unchanged.
- `CachingLM` keys `generate_until` on `(args, task_name, doc_id, idx, repeat_idx)` when `repeats > 1` or `repeat_idx > 0`; everything else (`loglikelihood`, single-sample `generate_until`) keeps the legacy args-only key, so pre-existing SQLite caches remain valid.
- Sampling detection broadened: `do_sample=True`, `temperature > 0`, `top_p < 1`, or `top_k > 1` bypasses cache on both lookup and `add_partial` writes. `do_sample=False` is not treated as authoritative because API backends drop it and forward `temperature`.
- DDP/FSDP batch padding clones are flagged `is_padding=True`; they skip the cache and skip the `resps` append so downstream filters see exactly K entries per real request.

## Known limitation

Per-slot crash resumability is not available for deterministic `repeats > 1` runs: backends call `add_partial` with `(context, gen_kwargs)` only, so they can't disambiguate sibling slots. Closing this gap would require threading `repeat_idx` through every backend's Collator path; out of scope for #3046.

## Cache invalidation

Caches produced before this patch for `repeats > 1` tasks are now orphaned under the new key shape. Users should clear their cache directory after upgrade. `repeats == 1` caches stay valid.

## Test plan

- [x] `tests/test_caching_lm.py` - 19 new tests: deterministic K-slot caching, legacy key shape preservation, sampling bypass (4 variants), `do_sample=False` + `temperature` interaction, `top_k <= 1` is greedy, crash resumability via `add_partial`, repeat_idx without repeats, metadata-missing occurrence-counter fallback, `add_partial` skip on sampled runs, `loglikelihood` not fragmented, DDP padding isolation, shared `.resps` non-contamination.
- [x] `tests/test_evaluator_utils.py`, `tests/test_misc.py`, `tests/test_registry.py` - 99 related existing tests still pass.