### PR TITLE
Fix RACE doc_to_text keeping blank marker and dropping the question body

### DIFF
--- a/lm_eval/tasks/race/README.md
+++ b/lm_eval/tasks/race/README.md
@@ -48,6 +48,11 @@ Homepage: https://www.cs.cmu.edu/~glai1/data/race/
 
 * `race`
 
+### Changelog
+
+- `race` v3.0; 2026-05-04:
+  - PR #3716. Fixed how fill-in-the-blank ("cloze") sub-questions are rendered in the few-shot context. For a question like `"I have  _  ."` with answer `"dog"`, the prompt previously contained ` _  .dog` (the question stem was dropped and the blank marker leaked through); it now contains the intended completed sentence `I have dog`.
+
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:

--- a/lm_eval/tasks/race/preprocess_race.py
+++ b/lm_eval/tasks/race/preprocess_race.py
@@ -25,7 +25,7 @@ def doc_to_text(doc):
     text = "Article: " + doc["article"] + "\n\n"
     for problem in process_ast(doc["problems"])[:-1]:
         if problem["question"][-6:] == "  _  .":
-            text += problem["question"][-5:] + get_answer_option(problem) + "\n"
+            text += problem["question"][:-5] + get_answer_option(problem) + "\n"
         else:
             question = "Question: " + problem["question"] + "\n"
             answer = "Answer: " + get_answer_option(problem) + "\n"

--- a/lm_eval/tasks/race/race.yaml
+++ b/lm_eval/tasks/race/race.yaml
@@ -11,4 +11,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 2.0
+  version: 3.0


### PR DESCRIPTION
## Bug

In \`lm_eval/tasks/race/preprocess_race.py:doc_to_text\`, the cloze branch (questions ending in the 6-char blank marker \`\"  _  .\"\`) is supposed to fill the blank with the gold answer and emit the completed sentence. It does the opposite:

\`\`\`python
if problem[\"question\"][-6:] == \"  _  .\":
    text += problem[\"question\"][-5:] + get_answer_option(problem) + \"\\n\"
\`\`\`

Given a question like \`\"I have  _  .\"\`:

- \`[-6:]\` correctly detects the \`\"  _  .\"\` suffix.
- \`[-5:]\` then takes the **last 5 characters** of the question — i.e. \` _  .\` (the blank marker minus one leading space) — and throws away the entire question body.

So the emitted context becomes \` _  .<answer>\\n\` instead of \`I have <answer>\\n\`.

## Root cause

Slice direction typo: \`[-5:]\` (\"last 5 chars\") was written where \`[:-5]\` (\"everything except the last 5 chars\") was intended. The check length is 6 (the full marker), but the slice that reconstructs the pre-blank prefix drops 5 so that the first of the marker's two leading spaces is preserved as the separator before the inserted answer — a classic pattern for this kind of cloze substitution.

## Why the fix is correct

Switching to \`problem[\"question\"][:-5]\` keeps the question body and exactly one leading space in front of the answer:

- \`\"I have  _  .\"[:-5]\` → \`\"I have \"\`
- \`+ get_answer_option(problem) + \"\\n\"\` → \`\"I have dog\\n\"\`

The detection condition (\`[-6:] == \"  _  .\"\`) is unchanged, so only cloze-style RACE items are affected; the non-cloze \`else\` branch continues to emit the standard \`\"Question: ...\\nAnswer: ...\\n\"\` pair unchanged.