### PR TITLE
Fix headqa doc_to_decontamination_query pointing at nonexistent 'query' field

### DIFF
--- a/lm_eval/tasks/headqa/headqa_en.yaml
+++ b/lm_eval/tasks/headqa/headqa_en.yaml
@@ -10,7 +10,7 @@ doc_to_text: "Question: {{qtext}}\nAnswer:"
 doc_to_target: "{{ra - 1}}"
 doc_to_choice: "{{answers|map(attribute='atext')|list}}" # this will be cast to an int.
 should_decontaminate: true
-doc_to_decontamination_query: query
+doc_to_decontamination_query: qtext
 metric_list:
   - metric: acc
     aggregation: mean


### PR DESCRIPTION
## Bug

`lm_eval/tasks/headqa/headqa_en.yaml` is defined against the `EleutherAI/headqa` dataset, whose records expose the question as `qtext` (the other fields used here are `ra` for the correct-answer index and `answers[].atext` for the options). The rest of the YAML targets those fields consistently:

```yaml
doc_to_text:   "Question: {{qtext}}\nAnswer:"
doc_to_target: "{{ra - 1}}"
doc_to_choice: "{{answers|map(attribute='atext')|list}}"
```

The decontamination section, however, references a nonexistent field name:

```yaml
should_decontaminate: true
doc_to_decontamination_query: query
```

No headqa record has a top-level `query` attribute, so the Jinja evaluation resolves `query` to an empty string and every headqa example gets checked for contamination against `""` rather than its actual question. This silently reduces headqa decontamination to a no-op — including for `headqa_es.yaml`, which inherits this file via `include:`.

## Root cause

Copy-paste / wrong field name for this dataset. Every other `doc_to_decontamination_query` in the repo names the real dataset field carrying the query text (e.g. `piqa` → `goal`, `triviaqa` → `question`, `winogrande` → `sentence`, `wsc273` → `text`, `spanish_bench/openbookqa_es` → `question_stem`).

## Why the fix is correct

The headqa question field is `qtext` — the same field `doc_to_text` above uses — so switching to it makes decontamination actually compare against the question text:

```diff
 should_decontaminate: true
-doc_to_decontamination_query: query
+doc_to_decontamination_query: qtext
```

Single-field rename. No other YAML changes, and the Spanish sibling inherits the fix automatically.