### PR TITLE
Fix french_bench_topic_based_nli doc_to_decontamination_query pointing at nonexistent 'texte' field

### DIFF
--- a/lm_eval/tasks/french_bench/french_bench_topic_based_nli.yaml
+++ b/lm_eval/tasks/french_bench/french_bench_topic_based_nli.yaml
@@ -13,7 +13,7 @@ doc_to_text: "\nAvis Client: {{text}}\n\nA propos du thème \"{{topic}}\", l'avi
 doc_to_choice: ['positif', 'négatif', 'neutre']
 doc_to_target: "{{['positif', 'negatif', 'neutre'].index(polarity)}}"
 should_decontaminate: true
-doc_to_decontamination_query: texte
+doc_to_decontamination_query: text
 metric_list:
   - metric: acc
     aggregation: mean


### PR DESCRIPTION
## Bug

`lm_eval/tasks/french_bench/french_bench_topic_based_nli.yaml` defines the task against the `manu/topic_based_nli_test` dataset and formats the prompt using `{{text}}` and `{{topic}}`:

```yaml
doc_to_text: "\nAvis Client: {{text}}\n\nA propos du thème \"{{topic}}\", l'avis client est"
doc_to_choice: ['positif', 'négatif', 'neutre']
doc_to_target: "{{['positif', 'negatif', 'neutre'].index(polarity)}}"
```

So the dataset records expose `text`, `topic`, and `polarity`. The decontamination section, however, references a nonexistent French variant:

```yaml
should_decontaminate: true
doc_to_decontamination_query: texte
```

No record in this dataset has a top-level `texte` attribute — the yaml itself confirms the field is `text` three lines above. Jinja resolves `texte` to an empty string, so every example is checked for contamination against `""` instead of its customer review, silently reducing decontamination for this task to a no-op.

## Root cause

Same class of bug as #3718 (`headqa` → `query` vs `qtext`): someone wrote the French word for the field name instead of the actual dataset field. Harmless in isolation, but `should_decontaminate: true` promises decontamination that never actually runs.

## Why the fix is correct

Strip the trailing `e` so it matches the field used by `doc_to_text` above:

```diff
 should_decontaminate: true
-doc_to_decontamination_query: texte
+doc_to_decontamination_query: text
```

- Consistent with `doc_to_text: "...{{text}}..."` in the same file.
- Consistent with the repo convention (every other `doc_to_decontamination_query` names the real dataset field carrying the query text — `piqa: goal`, `triviaqa: question`, `winogrande: sentence`, etc.).
- Single-character edit, no other changes.