### PR TITLE
Allow --include_path / --include_module to import external LM subclasses (#1457)

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -118,7 +118,12 @@ lm-eval run --config my_config.yaml --tasks mmlu
 
 | Argument | Description |
 |----------|-------------|
-| `--include_path` | Additional directory containing external task YAML files. |
+| `--include_path` | Directory of external task YAML files, or a single `.py` file to import (for custom `@register_model` / `@register_metric` classes). Pointing at a `.py` file also runs YAML discovery in its parent directory. |
+| `--include_module` | Dotted module path(s) to import before evaluation, e.g. `--include_module my_pkg.my_lms`. Use this when the custom model lives inside an installed package. |
+
+To use an externally-defined model, decorate an `LM` subclass with `@register_model("my-alias")` and point `--include_path` at the `.py` file (or `--include_module` at its dotted path), then pass `--model my-alias`.
+
+Single-file `--include_path` does not modify `sys.path`. The file can import installed packages normally but cannot import sibling `.py` files; `from helpers import X` will fail with an `ImportError` pointing at `--include_module`. Ship multi-file code as a package and use `--include_module` instead.
 
 ### Logging and Tracking
 

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -102,6 +102,24 @@ Using this decorator results in the class being added to an accounting of the us
 
 **Tip: be sure to import your model in `lm_eval/models/__init__.py!`**
 
+### Using an externally-defined model without editing `lm-eval`
+
+To register a custom model from outside the repo, pass its location on the CLI:
+
+```bash
+# Single .py file with @register_model classes
+lm_eval run --model my-alias --include_path ./my_lms/fake_lm.py --tasks hellaswag
+
+# Installed Python package
+lm_eval run --model my-alias --include_module my_pkg.my_lms --tasks hellaswag
+```
+
+Both flags run before model lookup. `@register_metric` and `@register_filter` decorators in the same file also register.
+
+When `--include_path` is a directory, only YAML task discovery runs. When it is a `.py` file, that file is imported and YAML discovery runs on its parent directory.
+
+`sys.path` is not modified for single-file imports, so sibling imports (`from helpers import X`) will fail. Use `--include_module` for multi-file code.
+
 ## Testing
 
 We also recommend that new model contributions be accompanied by short tests of their 3 core functionalities, at minimum. To see an example of such tests, look at https://github.com/EleutherAI/lm-evaluation-harness/blob/35bdecd379c0cefad6897e67db892f4a6026a128/tests/test_ggml.py .

--- a/lm_eval/_cli/ls.py
+++ b/lm_eval/_cli/ls.py
@@ -60,14 +60,28 @@ class List(SubCommand):
             type=str,
             default=None,
             metavar="DIR",
-            help="Additional path to include if there are external tasks.",
+            help="Directory of external tasks, or a single .py file to import.",
+        )
+        self._parser.add_argument(
+            "--include_module",
+            type=str,
+            nargs="+",
+            default=None,
+            metavar="DOTTED",
+            help="Dotted module path(s) to import before listing.",
         )
 
     def _execute(self, args: argparse.Namespace) -> None:
         """Execute the list command."""
+        from lm_eval._include import import_user_modules, task_discovery_path
         from lm_eval.tasks import TaskManager
 
-        task_manager = TaskManager(include_path=args.include_path)
+        import_user_modules(
+            include_path=args.include_path,
+            include_module=getattr(args, "include_module", None),
+        )
+
+        task_manager = TaskManager(include_path=task_discovery_path(args.include_path))
 
         if args.what == "tasks":
             print(task_manager.list_all_tasks())

--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -239,7 +239,18 @@ class Run(SubCommand):
             type=str,
             default=None,
             metavar="<path>",
-            help="Additional directory for external tasks",
+            help=(
+                "Directory of external task YAML files, or a single .py file "
+                "to import (for custom @register_model/@register_metric)."
+            ),
+        )
+        task_group.add_argument(
+            "--include_module",
+            type=str,
+            nargs="+",
+            default=None,
+            metavar="<dotted.path>",
+            help="Dotted module path(s) to import before evaluation.",
         )
 
         # Logging and Tracking

--- a/lm_eval/_cli/validate.py
+++ b/lm_eval/_cli/validate.py
@@ -89,14 +89,28 @@ class Validate(SubCommand):
             type=str,
             default=None,
             metavar="DIR",
-            help="Additional path to include if there are external tasks.",
+            help="Directory of external tasks, or a single .py file to import.",
+        )
+        self._parser.add_argument(
+            "--include_module",
+            type=str,
+            nargs="+",
+            default=None,
+            metavar="DOTTED",
+            help="Dotted module path(s) to import before validation.",
         )
 
     def _execute(self, args: argparse.Namespace) -> None:
         """Execute the validate command."""
+        from lm_eval._include import import_user_modules, task_discovery_path
         from lm_eval.tasks import TaskManager
 
-        task_manager = TaskManager(include_path=args.include_path)
+        import_user_modules(
+            include_path=args.include_path,
+            include_module=getattr(args, "include_module", None),
+        )
+
+        task_manager = TaskManager(include_path=task_discovery_path(args.include_path))
         task_list = args.tasks.split(",")
 
         print(f"Validating tasks: {task_list}")

--- a/lm_eval/_include.py
+++ b/lm_eval/_include.py
@@ -1,0 +1,126 @@
+"""Runtime imports for user-supplied models/metrics/filters.
+
+A .py file passed via `--include_path` is imported under a synthetic module
+name. `sys.path` is not modified, so sibling imports from that file will
+fail. Users with multi-file code should ship a package and use
+`--include_module`.
+
+Directories passed via `--include_path` are not touched here; they remain
+YAML task-discovery roots.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+
+eval_logger = logging.getLogger(__name__)
+
+_imported_paths: set[Path] = set()
+_imported_modules: set[str] = set()
+
+
+def _already_loaded(resolved: Path) -> bool:
+    """Return True if a module whose __file__ equals resolved is in sys.modules."""
+    for mod in list(sys.modules.values()):
+        mod_file = getattr(mod, "__file__", None)
+        if not mod_file:
+            continue
+        try:
+            if Path(mod_file).resolve() == resolved:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _import_file(path: Path) -> None:
+    """Import the given .py file. Idempotent across repeated calls."""
+    resolved = path.resolve()
+    if resolved in _imported_paths:
+        return
+    if _already_loaded(resolved):
+        _imported_paths.add(resolved)
+        return
+
+    suffix = hashlib.sha1(str(resolved).encode(), usedforsecurity=False).hexdigest()[:8]
+    mod_name = f"lm_eval_user_{resolved.stem}_{suffix}"
+    spec = importlib.util.spec_from_file_location(mod_name, resolved)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not build import spec for {resolved}")
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except ModuleNotFoundError as err:
+        raise ImportError(
+            f"Failed to import user module {resolved}: {err}. "
+            "Sibling .py imports are not supported; package the module "
+            "and use --include_module."
+        ) from err
+    except Exception as err:
+        raise ImportError(f"Failed to import user module {resolved}: {err}") from err
+
+    _imported_paths.add(resolved)
+    eval_logger.info("Imported user module from %s", resolved)
+
+
+def task_discovery_path(include_path: str | Path | None) -> str | None:
+    """Map an --include_path value to the YAML task-discovery root.
+
+    For a .py file, returns its parent directory so YAML tasks next to
+    the file are still discovered. Directories and None pass through.
+    """
+    if include_path is None:
+        return None
+    p = Path(include_path)
+    if p.is_file() and p.suffix == ".py":
+        return str(p.parent)
+    return str(include_path)
+
+
+def import_user_modules(
+    include_path: str | Path | None = None,
+    include_module: str | list[str] | None = None,
+) -> None:
+    """Import user-supplied Python so @register_* decorators run.
+
+    include_path: only acted on when it points at a .py file. Other values
+    (directories, non-.py files, missing paths) are skipped; TaskManager
+    handles YAML discovery for directories.
+
+    include_module: one or more dotted names passed to importlib.
+    """
+    if include_path:
+        path = Path(include_path)
+        if path.is_file() and path.suffix == ".py":
+            _import_file(path)
+        elif path.exists() and not path.is_dir():
+            eval_logger.warning(
+                "--include_path %s: not a .py file and not a directory; "
+                "skipped for Python import.",
+                path,
+            )
+
+    if include_module:
+        names = (
+            [include_module]
+            if isinstance(include_module, str)
+            else list(include_module)
+        )
+        for name in names:
+            if name in _imported_modules:
+                continue
+            try:
+                importlib.import_module(name)
+            except Exception as err:
+                raise ImportError(
+                    f"Failed to import user module '{name}': {err}"
+                ) from err
+            _imported_modules.add(name)
+            eval_logger.info("Imported user module '%s'", name)

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -146,7 +146,12 @@ class EvaluatorConfig:
 
     # External tasks and generation
     include_path: str | None = field(
-        default=None, metadata={"help": "Additional dir path for external tasks"}
+        default=None,
+        metadata={"help": "Directory for external tasks or a .py file to import"},
+    )
+    include_module: list[str] | None = field(
+        default=None,
+        metadata={"help": "Dotted module path(s) to import before evaluation"},
     )
     gen_kwargs: dict = field(
         default_factory=dict,
@@ -267,6 +272,10 @@ class EvaluatorConfig:
 
     def _configure(self):
         """Validate configuration and preprocess fields after creation."""
+        from lm_eval._include import import_user_modules
+
+        import_user_modules(self.include_path, self.include_module)
+
         self._validate_arguments()._process_arguments()._set_trust_remote_code()
 
         return self
@@ -345,15 +354,15 @@ class EvaluatorConfig:
         import glob
         import itertools
 
+        from lm_eval._include import task_discovery_path
         from lm_eval.tasks import TaskManager
         from lm_eval.tasks._yaml_loader import load_yaml
 
         # if metadata manually passed use that:
         self.metadata = metadata or self.metadata
 
-        # Create task manager with metadata
         task_manager = TaskManager(
-            include_path=self.include_path,
+            include_path=task_discovery_path(self.include_path),
             metadata=self.metadata or {},
         )
 

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -1,0 +1,314 @@
+"""Tests for lm_eval._include and the --include_path / --include_module CLI flags."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import lm_eval.models  # noqa: F401 — load built-ins before registering fakes
+from lm_eval import _include
+from lm_eval.api.registry import get_model, model_registry
+
+
+_USER_LM_SRC = textwrap.dedent(
+    """
+    from lm_eval.api.model import LM
+    from lm_eval.api.registry import register_model
+
+
+    @register_model("{alias}")
+    class FakeUserLM(LM):
+        def __init__(self, **kwargs):
+            super().__init__()
+
+        def loglikelihood(self, requests):
+            return []
+
+        def loglikelihood_rolling(self, requests):
+            return []
+
+        def generate_until(self, requests):
+            return []
+    """
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_include_caches():
+    _include._imported_paths.clear()
+    _include._imported_modules.clear()
+    try:
+        yield
+    finally:
+        _include._imported_paths.clear()
+        _include._imported_modules.clear()
+        for name in list(sys.modules):
+            if name.startswith(("lm_eval_user_", "issue1457_pkg")):
+                sys.modules.pop(name, None)
+
+
+def _write_user_lm(tmp_path: Path, alias: str, filename: str = "my_lm.py") -> Path:
+    f = tmp_path / filename
+    f.write_text(_USER_LM_SRC.format(alias=alias))
+    return f
+
+
+def test_include_path_single_file(tmp_path: Path):
+    alias = "issue1457-from-file"
+    py_file = _write_user_lm(tmp_path, alias)
+
+    assert alias not in model_registry
+    _include.import_user_modules(include_path=py_file)
+    assert alias in model_registry
+    assert get_model(alias).__name__ == "FakeUserLM"
+
+
+def test_include_path_directory_is_not_auto_imported(tmp_path: Path):
+    alias = "issue1457-dir-must-stay-lazy"
+    _write_user_lm(tmp_path, alias)
+
+    _include.import_user_modules(include_path=tmp_path)
+    assert alias not in model_registry
+
+
+def test_include_path_does_not_mutate_sys_path_or_shadow_modules(tmp_path: Path):
+    (tmp_path / "packaging.py").write_text("SENTINEL = 'user-decoy'")
+    alias = "issue1457-no-global-leak"
+    py_file = _write_user_lm(tmp_path, alias)
+
+    sys_path_before = list(sys.path)
+    _include.import_user_modules(include_path=py_file)
+
+    assert list(sys.path) == sys_path_before
+    assert str(tmp_path) not in sys.path
+
+    for name, mod in list(sys.modules.items()):
+        if name.startswith("lm_eval_user_"):
+            continue
+        f = getattr(mod, "__file__", None)
+        if not f:
+            continue
+        try:
+            resolved = str(Path(f).resolve())
+        except OSError:
+            continue
+        assert str(tmp_path.resolve()) not in resolved, (
+            f"sys.modules['{name}'] was loaded from user dir {f}"
+        )
+
+
+def test_sibling_import_fails_cleanly(tmp_path: Path):
+    (tmp_path / "helpers.py").write_text("SENTINEL = 'ok'")
+    main = tmp_path / "main.py"
+    main.write_text("from helpers import SENTINEL  # noqa: F401\n")
+
+    with pytest.raises(ImportError) as exc_info:
+        _include.import_user_modules(include_path=main)
+
+    msg = str(exc_info.value)
+    assert "main.py" in msg
+    assert "--include_module" in msg
+
+
+def test_reimport_is_noop(tmp_path: Path):
+    alias = "issue1457-reimport"
+    py_file = _write_user_lm(tmp_path, alias)
+
+    _include.import_user_modules(include_path=py_file)
+    _include.import_user_modules(include_path=py_file)
+    assert alias in model_registry
+
+
+def test_broken_user_file_raises_with_path(tmp_path: Path):
+    bad = tmp_path / "broken.py"
+    bad.write_text("this is not valid python :::")
+
+    with pytest.raises(ImportError) as exc_info:
+        _include.import_user_modules(include_path=bad)
+
+    assert "broken.py" in str(exc_info.value)
+
+
+def test_include_module_dotted_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pkg = tmp_path / "issue1457_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "lms.py").write_text(_USER_LM_SRC.format(alias="issue1457-from-module"))
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in list(sys.modules):
+        if name.startswith("issue1457_pkg"):
+            sys.modules.pop(name)
+
+    _include.import_user_modules(include_module="issue1457_pkg.lms")
+    assert "issue1457-from-module" in model_registry
+
+
+def test_nonexistent_include_path_is_ignored(tmp_path: Path):
+    _include.import_user_modules(include_path=tmp_path / "does-not-exist")
+
+
+def test_non_py_existing_file_warns_and_skips(tmp_path, caplog):
+    odd = tmp_path / "my_lm.pyc"
+    odd.write_text("not python")
+
+    with caplog.at_level("WARNING", logger="lm_eval._include"):
+        _include.import_user_modules(include_path=odd)
+
+    assert any("my_lm.pyc" in r.getMessage() for r in caplog.records)
+
+
+def test_module_then_same_file_no_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    pkg = tmp_path / "issue1457_pkg"
+    pkg.mkdir()
+    alias = "issue1457-module-then-file"
+    (pkg / "__init__.py").write_text(_USER_LM_SRC.format(alias=alias))
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _include.import_user_modules(include_module="issue1457_pkg")
+    assert alias in model_registry
+
+    _include.import_user_modules(include_path=pkg / "__init__.py")
+    assert alias in model_registry
+
+
+def test_configure_triggers_import_for_py_file(tmp_path: Path):
+    from lm_eval.config.evaluate_config import EvaluatorConfig
+
+    alias = "issue1457-via-config"
+    py_file = _write_user_lm(tmp_path, alias)
+
+    EvaluatorConfig(
+        model="dummy",
+        tasks=["hellaswag"],
+        include_path=str(py_file),
+    )._configure()
+
+    assert alias in model_registry
+    assert get_model(alias).__name__ == "FakeUserLM"
+
+
+def test_task_discovery_path_splits_py_file_from_yaml_root():
+    assert _include.task_discovery_path(None) is None
+    assert _include.task_discovery_path("./some_dir") == "./some_dir"
+    assert _include.task_discovery_path(Path(__file__)) == str(Path(__file__).parent)
+
+
+def test_configure_does_not_import_directory_py_files(tmp_path: Path):
+    from lm_eval.config.evaluate_config import EvaluatorConfig
+
+    alias = "issue1457-dir-via-config"
+    _write_user_lm(tmp_path, alias)
+
+    EvaluatorConfig(
+        model="dummy",
+        tasks=["hellaswag"],
+        include_path=str(tmp_path),
+    )._configure()
+
+    assert alias not in model_registry
+
+
+def test_register_metric_and_filter_via_include_path(tmp_path: Path):
+    from lm_eval.api.registry import (
+        filter_registry,
+        get_aggregation,
+        metric_registry,
+    )
+
+    py_file = tmp_path / "extras.py"
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            from lm_eval.api.filter import Filter
+            from lm_eval.api.registry import (
+                register_aggregation,
+                register_filter,
+                register_metric,
+            )
+
+            @register_aggregation("issue1457-agg")
+            def my_agg(items):
+                return sum(items) / max(len(items), 1)
+
+            @register_metric(
+                metric="issue1457-metric",
+                higher_is_better=True,
+                aggregation="issue1457-agg",
+            )
+            def my_metric(items):
+                return sum(1 for i in items if i)
+
+            @register_filter("issue1457-filter")
+            class MyFilter(Filter):
+                def apply(self, resps, docs):
+                    return resps
+            """
+        )
+    )
+
+    _include.import_user_modules(include_path=py_file)
+
+    assert "issue1457-metric" in metric_registry
+    assert "issue1457-filter" in filter_registry
+    assert get_aggregation("issue1457-agg")([1, 1, 0, 1]) == 0.75
+
+
+def test_cli_run_parses_include_module_multi(tmp_path: Path):
+    import argparse
+
+    from lm_eval._cli.run import Run
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    Run.create(subparsers)
+
+    args = parser.parse_args(
+        [
+            "run",
+            "--model",
+            "dummy",
+            "--tasks",
+            "hellaswag",
+            "--include_path",
+            str(tmp_path / "x.py"),
+            "--include_module",
+            "pkg_a",
+            "pkg_b.sub",
+        ]
+    )
+    assert args.include_path == str(tmp_path / "x.py")
+    assert args.include_module == ["pkg_a", "pkg_b.sub"]
+
+
+def test_cli_ls_accepts_include_module():
+    import argparse
+
+    from lm_eval._cli.ls import List
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    List.create(subparsers)
+
+    args = parser.parse_args(["ls", "tasks", "--include_module", "foo.bar"])
+    assert args.include_module == ["foo.bar"]
+
+
+def test_cli_validate_accepts_include_module():
+    import argparse
+
+    from lm_eval._cli.validate import Validate
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    Validate.create(subparsers)
+
+    args = parser.parse_args(
+        ["validate", "--tasks", "foo", "--include_module", "foo.bar"]
+    )
+    assert args.include_module == ["foo.bar"]


### PR DESCRIPTION
Closes #1457.

Currently, using a custom `LM` subclass with the CLI requires editing `lm_eval/__main__.py` or dropping to `simple_evaluate()`. This PR mirrors the external-task include flow for models:

- `--include_path` now also accepts a single `.py` file. When it does, YAML discovery still runs in the file's parent directory.
- New `--include_module DOTTED [DOTTED ...]` imports installed packages. Wired into `run`, `ls`, and `validate` so custom metrics/filters also resolve during validation.

### Notes

`sys.path` is not modified for single-file imports. That means the user file can import installed packages normally but cannot import sibling `.py` files; attempting `from helpers import X` raises an `ImportError` pointing at `--include_module`. Keeping `sys.path` untouched avoids a local `packaging.py` shadowing the real package and avoids name collisions across multiple includes. For multi-file code, ship a package and use `--include_module`.

Directories passed to `--include_path` keep their existing YAML-only behavior. The helper is idempotent and skips paths/modules already loaded, so `--include_module pkg` followed by `--include_path pkg/__init__.py` does not collide. A path that exists but is not a directory or `.py` now warns instead of being silently dropped.

### Tests

`tests/test_include.py` covers: single-file include, directory no-op, `sys.path`/`sys.modules` non-mutation, sibling-import failure, reimport idempotence, multi-value `--include_module`, module-then-same-file round-trip, broken file surfacing the path, non-`.py` warning, CLI wiring for all three subcommands, `@register_metric` / `@register_filter` propagation, and `task_discovery_path`. 183/183 pass across the adjacent suite (`test_registry`, `test_task_manager`, `test_cli_subcommands`, `test_misc`). `ruff check` and `ruff format --check` clean.

### Docs

- `docs/interface.md`: `--include_path` / `--include_module` rows and note.
- `docs/model_guide.md`: section on registering external models.