### PR TITLE
Fix dataset_path for truthfulqa_gen

### DIFF
--- a/lm_eval/tasks/truthfulqa/truthfulqa_gen.yaml
+++ b/lm_eval/tasks/truthfulqa/truthfulqa_gen.yaml
@@ -1,7 +1,7 @@
 tag:
   - truthfulqa
 task: truthfulqa_gen
-dataset_path: truthful_qa
+dataset_path: truthfulqa/truthful_qa
 dataset_name: generation
 output_type: generate_until
 training_split: null


### PR DESCRIPTION
The path for the dataset `dataset_path` was not set properly for the generation task `truthfulqa_gen`.