### PR TITLE
Guard vLLM tok_encode against prefix_token_id being None

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -382,7 +382,11 @@ class VLLM(TemplateLM):
             return []
 
         _string: list[str] = [string] if isinstance(string, str) else string
-        _bos_token = self.tokenizer.decode(self.prefix_token_id)
+        _bos_token = (
+            self.tokenizer.decode(self.prefix_token_id)
+            if self.prefix_token_id is not None
+            else None
+        )
 
         special_tokens_kwargs = {
             **kwargs,


### PR DESCRIPTION
Closes #3683.

## Bug

Running the vLLM backend against a tokenizer that has no BOS and no EOS token (e.g. `Qwen/Qwen-1_8B-Chat` and others in the Qwen series) crashes in `tok_encode` before the first request is issued:

```
TypeError: argument 'tokens': 'NoneType' object cannot be converted to 'Sequence'
```

## Root cause

`VLLM.prefix_token_id` (`lm_eval/models/vllm_causallms.py` L300–L306) falls back from `custom_prefix_token_id` to `tokenizer.bos_token_id` to `tokenizer.eos_token_id`. If all three are `None`, the property returns `None`.

`tok_encode` unconditionally calls `self.tokenizer.decode(self.prefix_token_id)` (L385), and the vLLM tokenizer raises the `TypeError` above when handed `None` instead of a sequence of ints.

## Fix

Only decode when `prefix_token_id` is set; otherwise leave `_bos_token` as `None`.

## Why the fix is correct

- When `prefix_token_id` is a valid int, behavior is unchanged — same call, same result.
- When it is `None`, the only consumer of `_bos_token` is `has_bos_prefix(s, _bos_token)` (L395). That helper already short-circuits to `False` on `None` (`lm_eval/models/utils.py` L939–L941), which is the correct classification here: if the tokenizer has no BOS there is no BOS to detect, so every string takes the `strs_not` branch and is encoded with the default `add_special_tokens` kwargs. Passing the empty string `\"\"` would be wrong because `str.startswith(\"\")` is always `True`, so this preserves the original semantics.
- The change is local to the `None` case and does not touch any other code path.