### PR TITLE
fix(vllm): fix dp with ray. remove mp distribution; pin vllm >=0.18

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: mixed-line-ending
         args: [ --fix=lf ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.12
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/README.md
+++ b/README.md
@@ -431,6 +431,9 @@ lm_eval --model vllm \
 
 To use vllm, do `pip install "lm_eval[vllm]"`. For a full list of supported vLLM configurations, please reference our [vLLM integration](https://github.com/EleutherAI/lm-evaluation-harness/blob/e74ec966556253fbe3d8ecba9de675c77c075bce/lm_eval/models/vllm_causallms.py) and the vLLM documentation.
 
+> [!Note]
+> `data_parallel_size>1` dispatches each replica as a separate [ray](https://github.com/ray-project/ray) actor and requires `pip install ray`. Each actor reserves `tensor_parallel_size` GPUs (default 1).
+
 vLLM occasionally differs in output from Huggingface. We treat Huggingface as the reference implementation and provide a [script](./scripts/model_comparator.py) for checking the validity of vllm results against HF.
 
 > [!Tip]

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -111,7 +111,7 @@ class VLLM(TemplateLM):
         self.truncation_side = truncation_side
         self.data_parallel_size = int(data_parallel_size)
         if self.data_parallel_size > 1 and not find_spec("ray"):
-            raise ImportError(
+            raise ModuleNotFoundError(
                 "ray is required for data parallelism. Please install ray using `pip install ray`."
             )
         self.model_args = {
@@ -384,7 +384,7 @@ class VLLM(TemplateLM):
             # correctly; without it the inner LLM sees 0 devices and asserts
             # in gpu_worker.init_device.
             @ray.remote(num_gpus=self.tensor_parallel_size)
-            def dp_worker(
+            def dp_replica(
                 model_args: dict,
                 sampling_params: list[SamplingParams],
                 requests: list[list[int]],
@@ -426,7 +426,7 @@ class VLLM(TemplateLM):
                 (self.model_args, sp, req, self.lora_request)
                 for req, sp in zip(requests, sampling_params, strict=True)  # type: ignore
             )
-            object_refs = [dp_worker.remote(*x) for x in inputs]
+            object_refs = [dp_replica.remote(*x) for x in inputs]
             results = ray.get(object_refs)
             # Invoke ray.shutdown() to prevent hang-ups if subsequent calls required.
             ray.shutdown()

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-import gc
 import logging
 import os
 from importlib.metadata import version
 from importlib.util import find_spec
-from multiprocessing import Process, Queue
-from queue import Empty
-from time import sleep
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import jinja2
-import ray
 from more_itertools import distribute
 from packaging.version import parse as parse_version
 from tqdm import tqdm
@@ -50,76 +45,12 @@ try:
 except ModuleNotFoundError:
     from vllm.transformers_utils.tokenizer import get_tokenizer
 
-try:
-    # Moved since vllm-project/vllm#27164
-    from vllm.utils.network_utils import get_open_port  # type: ignore
-except ModuleNotFoundError:
-    from vllm.utils import get_open_port
-
-
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase
 
     from lm_eval.api.instance import Instance
 
 eval_logger = logging.getLogger(__name__)
-
-
-def _vllm_mp_worker(
-    model_args: dict,
-    sampling_params: list[SamplingParams],
-    requests: list[list[int]],
-    lora_request: LoRARequest,
-    result_queue: Queue,
-    dp_size: int,
-    local_dp_rank: int,
-    dp_master_port: int,
-    dp_master_ip: str = "127.0.0.1",
-) -> None:
-    """
-    Worker process for vLLM multiprocessing.
-    Initializes a vLLM engine, processes requests, and puts results or errors
-    onto the result_queue.
-    """
-
-    if not requests:
-        result_queue.put((local_dp_rank, []))
-        return None
-
-    os.environ["VLLM_DP_RANK"] = os.environ["VLLM_DP_RANK_LOCAL"] = str(local_dp_rank)
-    os.environ["VLLM_DP_SIZE"] = str(dp_size)
-    os.environ["VLLM_DP_MASTER_IP"] = str(dp_master_ip)
-    os.environ["VLLM_DP_MASTER_PORT"] = str(dp_master_port)
-
-    llm = None
-    try:
-        llm = LLM(**model_args)
-        res = llm.generate(
-            [TokensPrompt(prompt_token_ids=request) for request in requests],
-            sampling_params=sampling_params,
-            lora_request=lora_request,
-        )
-        # Give engines time to pause their processing loops before exiting."
-        sleep(1)
-        result_queue.put((local_dp_rank, res))
-
-    except Exception as e:
-        error_message = f"Worker {local_dp_rank} failed during generation: {type(e).__name__}: {str(e)}"
-        eval_logger.error(error_message, exc_info=True)
-        result_queue.put((local_dp_rank, {"error": error_message}))
-
-    finally:
-        if llm is not None:
-            try:
-                del llm
-                gc.collect()
-            except Exception as e_cleanup:
-                eval_logger.warning(
-                    f"Worker {local_dp_rank} encountered an error during LLM cleanup: {type(e_cleanup).__name__}: {str(e_cleanup)}",
-                    exc_info=True,
-                )
-
-    return None
 
 
 @register_model("vllm")
@@ -141,7 +72,6 @@ class VLLM(TemplateLM):
         tensor_parallel_size: int = 1,
         quantization: str | None = None,
         max_gen_toks: int = 256,
-        swap_space: int = 4,
         batch_size: str | int = "auto",
         max_batch_size=None,
         max_length: int | None = None,
@@ -166,18 +96,24 @@ class VLLM(TemplateLM):
                 "attempted to use 'vllm' LM type, but package `vllm` is not installed. "
                 "Please install vllm via `pip install lm-eval[vllm]` or `pip install -e .[vllm]`"
             )
+        if "swap_space" in kwargs:
+            eval_logger.warning("swap_space is no longer supported by vLLM; ignoring.")
+            kwargs.pop("swap_space")
 
         assert max_length is None or max_model_len is None, (
             "Either max_length or max_model_len may be provided, but not both"
         )
         kwargs.pop("device", None)
         self.think_end_token = think_end_token
-        self.V1 = os.environ.get("VLLM_USE_V1", "1") != "0"
         self._max_length = max_model_len if max_model_len is not None else max_length
         self.tensor_parallel_size = int(tensor_parallel_size)
         # truncation strategy for inputs exceeding max length
         self.truncation_side = truncation_side
         self.data_parallel_size = int(data_parallel_size)
+        if self.data_parallel_size > 1 and not find_spec("ray"):
+            raise ImportError(
+                "ray is required for data parallelism. Please install ray using `pip install ray`."
+            )
         self.model_args = {
             "model": pretrained,
             "gpu_memory_utilization": float(gpu_memory_utilization),
@@ -190,7 +126,6 @@ class VLLM(TemplateLM):
             "tensor_parallel_size": int(tensor_parallel_size),
             "max_model_len": int(self._max_length) if self._max_length else None,
             "max_num_seqs": kwargs.get("max_num_seqs", max_batch_size),
-            "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
             "enable_lora": bool(lora_local_path),
@@ -205,13 +140,10 @@ class VLLM(TemplateLM):
         if self.data_parallel_size <= 1:
             self.model = LLM(**self.model_args)  # type: ignore[invalid-argument-type]
         else:
+            # note: DP is always dispatched through ray actors; the mp data-parallel
+            # path was dropped upstream for dense models.
             eval_logger.warning(
                 "You might experience occasional issues with model weight downloading when data_parallel is in use. To ensure stable performance, run with data_parallel_size=1 until the weights are downloaded and cached."
-            )
-            self.model_args["distributed_executor_backend"] = (
-                "ray"
-                if not self.V1
-                else self.model_args.get("distributed_executor_backend", None)
             )
             self.batch_size = "auto"
             eval_logger.info("Manual batching is not compatible with data parallelism.")
@@ -278,7 +210,8 @@ class VLLM(TemplateLM):
         self.custom_prefix_token_id = prefix_token_id
         if prefix_token_id is not None:
             eval_logger.info(
-                f"Loglikelihood prefix token id used in evaluation: {self.prefix_token_id}"
+                "Loglikelihood prefix token id used in evaluation: %s",
+                self.prefix_token_id,
             )
 
         self._max_gen_toks = max_gen_toks
@@ -329,9 +262,7 @@ class VLLM(TemplateLM):
     def apply_chat_template(
         self, chat_history: list[dict[str, str]], add_generation_prompt: bool = True
     ) -> str:
-        """
-        Method to apply a chat template to a list of chat history between user and model.
-        """
+        """Method to apply a chat template to a list of chat history between user and model."""
         try:
             chat_templated = self.tokenizer.apply_chat_template(
                 chat_history,
@@ -446,17 +377,38 @@ class VLLM(TemplateLM):
             sampling_params = cast(
                 "list[SamplingParams]", [sampling_params] * len(requests)
             )
-        if self.data_parallel_size > 1 and not self.V1:
-            # vLLM hangs if resources are set in ray.remote
-            # also seems to only work with decorator and not with ray.remote() fn
-            # see https://github.com/vllm-project/vllm/issues/973
-            @ray.remote
-            def run_inference_one_model(
+        if self.data_parallel_size > 1:
+            import ray
+
+            # num_gpus reserves GPUs per actor so ray sets CUDA_VISIBLE_DEVICES
+            # correctly; without it the inner LLM sees 0 devices and asserts
+            # in gpu_worker.init_device.
+            @ray.remote(num_gpus=self.tensor_parallel_size)
+            def dp_worker(
                 model_args: dict,
                 sampling_params: list[SamplingParams],
                 requests: list[list[int]],
                 lora_request: LoRARequest,
             ):
+                # inner LLM must not itself use ray — nested placement groups
+                # deadlock on V1. Let vLLM auto-pick (uni for TP=1, mp for TP>1).
+                model_args = {
+                    k: v
+                    for k, v in model_args.items()
+                    if k != "distributed_executor_backend"
+                }
+                # ray propagates driver env vars into actors. VLLM_DP_* can
+                # leak in from EngineArgs/chat-template resolution on the
+                # driver and make the inner LLM (DP=1) compute a nonzero
+                # DP-adjusted local_rank → AssertionError in gpu_worker.
+                for _k in (
+                    "VLLM_DP_RANK",
+                    "VLLM_DP_RANK_LOCAL",
+                    "VLLM_DP_SIZE",
+                    "VLLM_DP_MASTER_IP",
+                    "VLLM_DP_MASTER_PORT",
+                ):
+                    os.environ.pop(_k, None)
                 llm = LLM(**model_args)
                 return llm.generate(
                     [TokensPrompt(prompt_token_ids=request) for request in requests],
@@ -474,85 +426,12 @@ class VLLM(TemplateLM):
                 (self.model_args, sp, req, self.lora_request)
                 for req, sp in zip(requests, sampling_params, strict=True)  # type: ignore
             )
-            object_refs = [run_inference_one_model.remote(*x) for x in inputs]
+            object_refs = [dp_worker.remote(*x) for x in inputs]
             results = ray.get(object_refs)
             # Invoke ray.shutdown() to prevent hang-ups if subsequent calls required.
             ray.shutdown()
             # flatten results
             return undistribute(results)
-        elif self.data_parallel_size > 1:
-            # based on https://github.com/vllm-project/vllm/blob/a04720bc36401d831cb048c3917b9e58173d9c1d/examples/offline_inference/data_parallel.py
-            dp_size = self.data_parallel_size
-            dp_master_ip = os.environ.get("VLLM_DP_MASTER_IP", "127.0.0.1")
-            dp_master_port = os.environ.get("VLLM_DP_MASTER_PORT") or get_open_port()
-
-            requests = (list(x) for x in distribute(self.data_parallel_size, requests))  # type: ignore
-            sampling_params = (
-                list(sp) for sp in distribute(self.data_parallel_size, sampling_params)
-            )  # type: ignore
-            procs, resq = [], Queue()
-            # We use Process as it is non-daemonic
-            try:
-                for rank, (req, sp) in enumerate(
-                    zip(requests, sampling_params, strict=True)  # type: ignore[invalid-argument-type]
-                ):  # type:ignore[invalid-argument-type]
-                    proc = Process(
-                        target=_vllm_mp_worker,
-                        args=(
-                            self.model_args.copy(),
-                            sp,
-                            req,
-                            self.lora_request,
-                            resq,
-                            dp_size,
-                            rank,
-                            dp_master_port,
-                            dp_master_ip,
-                        ),
-                    )
-                    proc.start()
-                    procs.append(proc)
-
-                # Collect results
-                rank_res = {}
-                while len(rank_res) < len(procs):
-                    try:
-                        rank, result = resq.get(timeout=30)
-                        if isinstance(result, dict) and "error" in result:
-                            raise RuntimeError(result["error"])
-                        rank_res[rank] = result
-                    except Empty:
-                        dead_procs = [
-                            idx
-                            for idx, p in enumerate(procs)
-                            if not p.is_alive() and idx not in rank_res
-                        ]
-                        if dead_procs:
-                            raise RuntimeError(
-                                f"Worker processes {dead_procs} died unexpectedly"
-                            ) from None
-                        continue
-
-                results = [rank_res[i] for i in range(len(procs))]
-                return undistribute(results)
-
-            # cleanup
-            finally:
-                try:
-                    resq.close()
-                    resq.join_thread()
-                except Exception:
-                    eval_logger.debug(
-                        "Failed to close vllm DP results queue", exc_info=True
-                    )
-                for proc in procs:
-                    proc.join(timeout=10)
-                    if proc.is_alive():
-                        proc.terminate()
-                        proc.join(timeout=5)
-                        if proc.is_alive():
-                            proc.kill()
-
         else:
             outputs = self.model.generate(
                 [TokensPrompt(prompt_token_ids=request) for request in requests],
@@ -770,7 +649,9 @@ class VLLM(TemplateLM):
             for _, context_enc, continuation_enc in chunk:
                 if (full_length := len(context_enc + continuation_enc)) > max_cxt_len:
                     eval_logger.warning(
-                        f"Context length {full_length} exceeds max length ({max_cxt_len}). Truncating context."
+                        "Context length %s exceeds max length (%s). Truncating context.",
+                        full_length,
+                        max_cxt_len,
                     )
                 inp = (context_enc + continuation_enc)[-max_cxt_len:]
                 ctxlen = len(context_enc) - max(
@@ -818,7 +699,6 @@ class VLLM(TemplateLM):
             is_greedy: bool
                 Whether argmax matches given continuation exactly
         """
-
         # The first entry of prompt_logprobs is None because the model has no previous tokens to condition on.
         continuation_logprobs_dicts = outputs.prompt_logprobs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ Repository = "https://github.com/EleutherAI/lm-evaluation-harness"
 # Model backend dependencies
 api = ["requests", "aiohttp", "tenacity", "tqdm", "tiktoken"]
 hf = ["transformers>=4.1","torch>=1.8", "accelerate>=0.26.0", "peft>=0.2.0",]
-vllm = ["vllm>=0.4.2"]
+vllm = ["vllm>=0.18"]
 gptq = ["auto-gptq[triton]>=0.6.0"]
 gptqmodel = ["gptqmodel>=1.0.9"]
 ipex = ["optimum-intel"]


### PR DESCRIPTION
Summary                                                                                                                                                                            
                                                            
  - Removed the multiprocessing path. vLLM had dropped offline mp-based data parallelism for dense models.
  - Fixed the ray DP path to work:
    - `@ray.remote(num_gpus=tensor_parallel_size)` — without a GPU reservation, each actor saw device_count == 0 and tripped gpu_worker.init_device.                                   
    - Do not pass `distributed_executor_backend` inside the actor so the inner LLM auto-picks uni/mp instead of creating a nested ray placement group (which deadlocks against the outer     
  actor's reservation).                                                                                                                                                              
    - Clear VLLM_DP_* env vars inside the actor. Ray propagates driver env, and these leaked in. Also so not pass `distributed_executor_backend` inside the actor so the inner LLM auto-picks `uni`/`mp`.                                                                            
  - Drop `swap_space` from the model args, as vllm > 0.18 no longer supports it.