### PR TITLE
[Feature] Load task `doc` as chat-template

### DIFF
--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -101,6 +101,12 @@ class Run(SubCommand):
             help="Apply chat template to prompts (optional template name)",
         )
         model_group.add_argument(
+            "--doc_as_chat_template",
+            action="store_true",
+            default=False,
+            help="Interpret doc_to_text output as JSON chat history (list of message dicts).",
+        )
+        model_group.add_argument(
             "--limit",
             "-L",
             type=float,
@@ -402,6 +408,7 @@ class Run(SubCommand):
             evaluation_tracker=evaluation_tracker,
             system_instruction=cfg.system_instruction,
             apply_chat_template=cfg.apply_chat_template,
+            doc_as_chat_template=cfg.doc_as_chat_template,
             fewshot_as_multiturn=cfg.fewshot_as_multiturn,
             gen_kwargs=cfg.gen_kwargs,
             task_manager=task_manager,

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import ast
+import json
 import logging
 import random
 import re
@@ -276,6 +277,7 @@ class Task(abc.ABC):
         rewrite_requests_cache: bool = False,
         system_instruction: str | None = None,
         apply_chat_template: bool = False,
+        doc_as_chat_template: bool = False,
         fewshot_as_multiturn: bool = False,
         chat_template: Callable | None = None,
         tokenizer_name: str = "",
@@ -287,6 +289,7 @@ class Task(abc.ABC):
 
         cache_key = f"requests-{self._config.task}-{self.config.num_fewshot}shot-rank{rank}-world_size{world_size}"
         cache_key += "-chat_template" if apply_chat_template else ""
+        cache_key += "-doc_as_chat_template" if doc_as_chat_template else ""
         cache_key += "-fewshot_as_multiturn" if fewshot_as_multiturn else ""
         cache_key += (
             f"-system_prompt_hash{utils.hash_string(system_instruction)}"
@@ -341,6 +344,7 @@ class Task(abc.ABC):
                 else self.config.num_fewshot,
                 system_instruction=system_instruction,
                 apply_chat_template=apply_chat_template,
+                doc_as_chat_template=doc_as_chat_template,
                 fewshot_as_multiturn=fewshot_as_multiturn,
                 chat_template=chat_template,
                 gen_prefix=self.doc_to_prefix(doc),
@@ -936,6 +940,7 @@ class ConfigurableTask(Task):
         num_fewshot: int,
         system_instruction: str | None = None,
         apply_chat_template: bool = False,
+        doc_as_chat_template: bool = False,
         fewshot_as_multiturn: bool = False,
         chat_template: Callable[..., str] | None = None,
         gen_prefix: str | None = None,
@@ -965,79 +970,96 @@ class ConfigurableTask(Task):
                 multiple-input tasks (e.g., Winogrande where each choice becomes a
                 separate context).
         """
-        messages = []
+
         chat_template = (
-            partial(chat_template, add_generation_prompt=not gen_prefix)
-            if chat_template
-            else None
-        )
-        description = self.resolve_field(doc, self.config.description) or ""
-        system_prompt = maybe_delimit(
-            system_instruction, description, self.config.fewshot_delimiter
-        )
-        if system_prompt:
-            messages.append(Message("system", system_prompt))
-
-        if num_fewshot > 0:
-            for fs_doc in self.sampler.sample(
-                n=num_fewshot,
-                eval_doc=doc
-                if self.fewshot_cfg.split == self.config.test_split
-                else None,
-            ):
-                q, c, a = (
-                    self.doc_to_text(fs_doc, self.fewshot_cfg.doc_to_text),
-                    self.doc_to_choice(fs_doc, self.fewshot_cfg.doc_to_choice)
-                    if self.fewshot_cfg.doc_to_choice
-                    else None,
-                    self.doc_to_target(fs_doc, self.fewshot_cfg.doc_to_target),
-                )
-                _gen_prefix = self.resolve_field(doc, self.fewshot_cfg.gen_prefix)
-                # for multiple inputs, q: int, c: list[str], target: str
-                # TODO: fix this hacky way of handling multiple inputs
-                if self.multiple_input:
-                    q = cast("str", c[q])  # type: ignore
-                    c = None
-                # TODO: fix types
-                messages += self.build_qa_turn(
-                    q=q,
-                    c=c,
-                    a=a,
-                    gen_prefix=_gen_prefix,
-                    tgt_delim=self.fewshot_cfg.target_delimiter,
-                    few_delim=self.fewshot_cfg.fewshot_delimiter,
-                )
-
-        q, c, a = (
-            self.doc_to_text(doc),
-            self.doc_to_choice(doc) if self.config.doc_to_choice else None,
-            self.doc_to_target(doc),
-        )
-        if self.multiple_input:
-            assert isinstance(c, list), "multiple inputs require choices to be a list"
-            return self.multiple_input_context(
-                messages,
-                gen_prefix,
-                c,
-                chat_template=chat_template if apply_chat_template else None,
-                fewshot_as_multiturn=fewshot_as_multiturn,
+                partial(chat_template, add_generation_prompt=not gen_prefix)
+                if chat_template
+                else None
             )
-        messages += self.build_qa_turn(
-            q=q,
-            c=c,
-            gen_prefix=gen_prefix,
-            tgt_delim=self.config.target_delimiter,
-            few_delim="",
-        )
-        if apply_chat_template and chat_template:
-            res = (
-                [m.to_dict() for m in messages]
-                if fewshot_as_multiturn
-                else multiturn_to_singleturn(messages)
-            )
+        
+        if doc_as_chat_template:
+            # The doc is a chat template, use it
+            try:
+                res = json.loads(self.doc_to_text(doc))
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"Failed to parse doc_to_text output as JSON with --doc_as_chat_template: {e}"
+                ) from e
+
+            # Apply template
             res = chat_template(res)
+
         else:
-            res = "".join(m.to_text() for m in messages)
+            # Contruct the correct data format for the doc
+            messages = []
+            
+            description = self.resolve_field(doc, self.config.description) or ""
+            system_prompt = maybe_delimit(
+                system_instruction, description, self.config.fewshot_delimiter
+            )
+            if system_prompt:
+                messages.append(Message("system", system_prompt))
+
+            if num_fewshot > 0:
+                for fs_doc in self.sampler.sample(
+                    n=num_fewshot,
+                    eval_doc=doc
+                    if self.fewshot_cfg.split == self.config.test_split
+                    else None,
+                ):
+                    q, c, a = (
+                        self.doc_to_text(fs_doc, self.fewshot_cfg.doc_to_text),
+                        self.doc_to_choice(fs_doc, self.fewshot_cfg.doc_to_choice)
+                        if self.fewshot_cfg.doc_to_choice
+                        else None,
+                        self.doc_to_target(fs_doc, self.fewshot_cfg.doc_to_target),
+                    )
+                    _gen_prefix = self.resolve_field(doc, self.fewshot_cfg.gen_prefix)
+                    # for multiple inputs, q: int, c: list[str], target: str
+                    # TODO: fix this hacky way of handling multiple inputs
+                    if self.multiple_input:
+                        q = cast("str", c[q])  # type: ignore
+                        c = None
+                    # TODO: fix types
+                    messages += self.build_qa_turn(
+                        q=q,
+                        c=c,
+                        a=a,
+                        gen_prefix=_gen_prefix,
+                        tgt_delim=self.fewshot_cfg.target_delimiter,
+                        few_delim=self.fewshot_cfg.fewshot_delimiter,
+                    )
+
+            q, c, a = (
+                self.doc_to_text(doc),
+                self.doc_to_choice(doc) if self.config.doc_to_choice else None,
+                self.doc_to_target(doc),
+            )
+            if self.multiple_input:
+                assert isinstance(c, list), "multiple inputs require choices to be a list"
+                return self.multiple_input_context(
+                    messages,
+                    gen_prefix,
+                    c,
+                    chat_template=chat_template if apply_chat_template else None,
+                    fewshot_as_multiturn=fewshot_as_multiturn,
+                )
+            messages += self.build_qa_turn(
+                q=q,
+                c=c,
+                gen_prefix=gen_prefix,
+                tgt_delim=self.config.target_delimiter,
+                few_delim="",
+            )
+            if apply_chat_template and chat_template:
+                res = (
+                    [m.to_dict() for m in messages]
+                    if fewshot_as_multiturn
+                    else multiturn_to_singleturn(messages)
+                )
+                res = chat_template(res)
+            else:
+                res = "".join(m.to_text() for m in messages)
 
         return res
 

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -132,6 +132,12 @@ class EvaluatorConfig:
             "help": "Apply chat template to prompt. Either True, or a string identifying the tokenizer template."
         },
     )
+    doc_as_chat_template: bool = field(
+        default=False,
+        metadata={
+            "help": "Interpret doc_to_text output as JSON chat history (list of message dicts)."
+        },
+    )
     fewshot_as_multiturn: bool | None = field(
         default=None,
         metadata={
@@ -291,6 +297,14 @@ class EvaluatorConfig:
         if (self.log_samples or self.predict_only) and not self.output_path:
             raise ValueError(
                 "Specify --output_path if providing --log_samples or --predict_only"
+            )
+
+        # doc_as_chat_template and apply_chat_template are mutually exclusive
+        if self.doc_as_chat_template and self.apply_chat_template:
+            raise ValueError(
+                "Cannot use both --doc_as_chat_template and --apply_chat_template. "
+                "--doc_as_chat_template directly parses JSON chat history, "
+                "--apply_chat_template applies the \"role\"/\"content\" fields and (optionally) tokenizer templates."
             )
 
         # Handle fewshot_as_multiturn logic:

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -72,6 +72,7 @@ def simple_evaluate(
     evaluation_tracker: EvaluationTracker | None = None,
     system_instruction: str | None = None,
     apply_chat_template: bool | str = False,
+    doc_as_chat_template: bool = False,
     fewshot_as_multiturn: bool = True,
     gen_kwargs: str | dict[str, str | float | int] | None = None,
     task_manager: TaskManager | None = None,
@@ -360,6 +361,7 @@ def simple_evaluate(
         log_samples=True if predict_only else log_samples,
         system_instruction=system_instruction,
         apply_chat_template=apply_chat_template,
+        doc_as_chat_template=doc_as_chat_template,
         fewshot_as_multiturn=fewshot_as_multiturn,
         verbosity=verbosity,
         confirm_run_unsafe_code=confirm_run_unsafe_code,
@@ -423,6 +425,7 @@ def evaluate(
     log_samples: bool = True,
     system_instruction: str | None = None,
     apply_chat_template: bool | str = False,
+    doc_as_chat_template: bool | str = False,
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
     confirm_run_unsafe_code: bool = False,
@@ -533,9 +536,10 @@ def evaluate(
             rewrite_requests_cache=rewrite_requests_cache,
             system_instruction=system_instruction,
             apply_chat_template=bool(apply_chat_template),
+            doc_as_chat_template=doc_as_chat_template,
             fewshot_as_multiturn=fewshot_as_multiturn,
             chat_template=getattr(lm, "apply_chat_template", None)
-            if apply_chat_template
+            if (apply_chat_template or doc_as_chat_template)
             else None,
             tokenizer_name=getattr(lm, "tokenizer_name", "")
             if apply_chat_template
@@ -586,6 +590,10 @@ def evaluate(
         resps = getattr(lm, reqtype)(cloned_reqs)
 
         # put responses from model into a list of length K for each request.
+        # If the model returns tuples with content and optional fields like
+        # tool_calls/reasoning, unpack them: store the text content in resps
+        # (preserving the expected str contract) and store additional fields
+        # separately on the Instance.
         for x, req in zip(resps, cloned_reqs, strict=True):
             req.resps.append(x)
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -590,10 +590,6 @@ def evaluate(
         resps = getattr(lm, reqtype)(cloned_reqs)
 
         # put responses from model into a list of length K for each request.
-        # If the model returns tuples with content and optional fields like
-        # tool_calls/reasoning, unpack them: store the text content in resps
-        # (preserving the expected str contract) and store additional fields
-        # separately on the Instance.
         for x, req in zip(resps, cloned_reqs, strict=True):
             req.resps.append(x)
 


### PR DESCRIPTION
Currently there is no way to control the construction of a chat-template request when working with `ConfigurableTask`. Two main drawbacks exist in current handling of the chat template:
- **Cannot set custom chat history**:  In order to do this one must resort to abusing the `fewshots`, by passing custom examples that actually contain the chat history. However this fixes the chat lengths of all samples and make actual fewshots even more complex to add.
- **Cannot set a per-doc system prompt**: The system prompt is currently fixed per-task, which might not be popper in some cases (i.e. tool-calling or instruction following tasks where the system provides per-doc context). There is no way to have a per-doc system prompt, not even abusing other mechanics.

This PR includes a new CLI flag: 
`--doc_as_chat_template`

which will by-pass the construction of the chat template using the Message class and simply parse the chat template from the content of the doc_to_text into a valid JSON and then dump that as a dict to later apply the chat_template() function.
Clean and gives the task creator full control on the template received by the backend.

Again, checks wont pass due to lint...