### PR TITLE
Handle dict-returning metrics on multi_target tasks (mirror single-target path)

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1612,6 +1612,7 @@ class ConfigurableTask(Task):
                         )[metric]
                         result_score = 1.0 if scores > 0.0 else 0.0
                     else:
+                        dict_scores: dict = {}
                         for gold_option in gold:
                             try:
                                 result_score = self._metric_fn_list[metric](
@@ -1626,9 +1627,41 @@ class ConfigurableTask(Task):
                                     [gold_option, result]
                                 )
                             if isinstance(result_score, dict):
-                                # TODO: this handles the case where HF evaluate returns a dict.
-                                result_score = result_score[metric]
+                                # HF evaluate metrics (e.g. ``bertscore``) return
+                                # a dict whose keys are sub-metrics and may NOT
+                                # contain ``metric``. Preserve legacy behaviour
+                                # when ``metric`` is one of the keys; otherwise
+                                # accumulate per-key scores so all sub-metrics
+                                # surface (mirroring the single-target path
+                                # below). Fixes #1302.
+                                if metric in result_score:
+                                    result_score = result_score[metric]
+                                else:
+                                    for k, v in result_score.items():
+                                        dict_scores.setdefault(k, []).append(v)
+                                    continue
                             scores.append(result_score)
+                        if dict_scores:
+                            for k, vals in dict_scores.items():
+                                # ``any`` over per-gold sub-metric values; mirror
+                                # the boolean-collapse semantics already used
+                                # below for non-dict multiple_target results.
+                                result_dict[k] = 1.0 if any(vals) else 0.0
+                                if (
+                                    metric in self._aggregation_list
+                                    and k not in self._aggregation_list
+                                ):
+                                    self._aggregation_list[k] = self._aggregation_list[
+                                        metric
+                                    ]
+                                if (
+                                    metric in self._higher_is_better
+                                    and k not in self._higher_is_better
+                                ):
+                                    self._higher_is_better[k] = self._higher_is_better[
+                                        metric
+                                    ]
+                            continue
                         result_score = 1.0 if any(scores) else 0.0
                 else:
                     try:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -214,10 +214,87 @@ def test_dict_metric_uses_custom_aggregation():
     assert agg_metrics["pass@3,none"] == 1.5
 
 
+def _make_multi_target_task(metric_fn, metric_name="bertscore"):
+    """Build a generate_until + multiple_target task with a custom metric."""
+    config = {
+        "task": "test_multi_target_dict",
+        "output_type": "generate_until",
+        "metric_list": [
+            {"metric": metric_name, "aggregation": "mean", "higher_is_better": True}
+        ],
+        "doc_to_text": "{{q}}",
+        "doc_to_target": "{{a}}",
+        "target_delimiter": " ",
+    }
+    task = MockConfigurableTask()
+    task._config = TaskConfig(**config)
+    task.OUTPUT_TYPE = "generate_until"
+    task.multiple_target = 1
+    task._metric_fn_list = {metric_name: metric_fn}
+    task._metric_fn_kwargs = {metric_name: {}}
+    task._aggregation_list = {metric_name: None}
+    task._higher_is_better = {metric_name: True}
+    task.doc_to_choice = lambda doc: None
+    return task
+
+
+def test_multi_target_hf_dict_metric_no_keyerror():
+    """Regression test for #1302: HF-evaluate-style metrics on multiple_target
+    tasks must not raise KeyError when the returned dict's keys don't match
+    the metric's registered name (e.g. ``bertscore`` returns precision/recall/f1).
+    """
+
+    def hf_like(references, predictions, **kwargs):
+        # mimic huggingface/evaluate `bertscore.compute(...)` shape
+        return {
+            "precision": [0.8],
+            "recall": [0.7],
+            "f1": [0.75],
+            "hashcode": "bert-base",
+        }
+
+    task = _make_multi_target_task(hf_like, metric_name="bertscore")
+    task.doc_to_target = lambda doc: ["alpha", "beta"]
+
+    # No KeyError, all sub-metric keys surface in the result dict.
+    result = task.process_results({"q": "?", "a": "alpha"}, ["alpha"])
+
+    assert "precision" in result, f"missing 'precision' in {result}"
+    assert "recall" in result, f"missing 'recall' in {result}"
+    assert "f1" in result, f"missing 'f1' in {result}"
+    # the bare metric name must NOT appear (no such key in returned dict)
+    assert "bertscore" not in result
+
+    # aggregation/higher_is_better registered for sub-keys
+    assert "precision" in task._higher_is_better
+    assert task._higher_is_better["precision"] is True
+
+
+def test_multi_target_dict_metric_with_matching_key_legacy():
+    """Backwards compatibility: when the dict DOES contain the metric name as
+    a key (e.g. ``{"exact_match": 0.0}``), the legacy single-value extraction
+    behaviour is preserved — score is still ``1.0 if any(scores) else 0.0``.
+    """
+
+    def returns_metric_keyed_dict(references, predictions, **kwargs):
+        # gold "alpha" matches result "alpha" -> 1.0 ; gold "beta" -> 0.0
+        match = 1.0 if references[0] == predictions[0] else 0.0
+        return {"my_metric": match, "extra_info": "ignored"}
+
+    task = _make_multi_target_task(returns_metric_keyed_dict, metric_name="my_metric")
+    task.doc_to_target = lambda doc: ["alpha", "beta"]
+    result = task.process_results({"q": "?", "a": "alpha"}, ["alpha"])
+    assert "my_metric" in result, f"missing 'my_metric' in {result}"
+    # any(gold_alpha=1.0, gold_beta=0.0) -> 1.0
+    assert result["my_metric"] == 1.0
+
+
 if __name__ == "__main__":
     test_acc_mutual_info_slicing()
     test_acc_mutual_info_different_predictions()
     test_acc_mutual_info_without_metric()
     test_bootstrap_internal_no_mp()
     test_dict_metric_uses_custom_aggregation()
+    test_multi_target_hf_dict_metric_no_keyerror()
+    test_multi_target_dict_metric_with_matching_key_legacy()
     print("All tests passed!")


### PR DESCRIPTION
## Summary

Fixes #1302. HF-evaluate-style metrics that return dicts (e.g. `bertscore` returning `{precision, recall, f1, hashcode}`) crash `ConfigurableTask.process_results()` with `KeyError` on `multiple_target` tasks.

`lm_eval/api/task.py` line 1630 inside the `multiple_target` branch unconditionally executed `result_score = result_score[metric]` when the metric returned a dict. HF metrics name their sub-metrics by what they compute (`precision` / `recall` / `f1`), not by the registered metric name (`bertscore`). The sibling single-target path at L1642–1655 already handled this correctly — the multi-target path was inconsistent.

## Fix

Mirror the single-target path. If the returned dict contains `metric` as a key, preserve legacy extraction. Otherwise, accumulate per-key scores across gold options into `dict_scores`, then expand every sub-metric into `result_dict` with `any`-collapse semantics (consistent with non-dict multi-target behaviour). Propagate aggregation and higher-is-better hints. ~35 LOC of production change.

## Test

`tests/test_metrics.py`:
- `test_multi_target_hf_dict_metric_no_keyerror` — reproduces #1302 with a bertscore-shaped dict.
- `test_multi_target_dict_metric_with_matching_key_legacy` — pins backwards compat when the dict already contains the metric key.

TDD RED → GREEN. `pytest tests/test_metrics.py` 7/7 pass. `pytest tests/test_metrics.py tests/test_evaluator_utils.py tests/test_misc.py tests/test_aggregation_pipeline.py tests/test_registry.py` → 118/118 pass.

## Risk notes

- Triggered only when `multiple_target=True` AND metric returns a dict AND that dict does not contain the metric name as a key. Prior behaviour was an exception, so no working callers depended on the old behaviour in this branch.
- `any`-collapse on sub-metrics matches the existing scalar multi-target convention. A more semantic per-sub-metric aggregation (mean, etc.) is a separate behaviour change.

Refs #1302