### PR TITLE
fix: bound request cache filename length

### DIFF
--- a/lm_eval/caching/cache.py
+++ b/lm_eval/caching/cache.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import re
 
 import dill
 
@@ -22,12 +23,38 @@ HASH_PREFIX = hashlib.sha256(HASH_INPUT.encode("utf-8")).hexdigest()
 
 FILE_SUFFIX = f".{HASH_PREFIX}.pickle"
 
+# Keep cache file basenames comfortably below common 255-byte filesystem limits.
+# Some request cache keys include model paths or endpoint identifiers, which can be
+# very long. Preserve a readable prefix and append a hash of the full key so cache
+# entries remain stable and unique without overflowing the filesystem limit.
+MAX_CACHE_FILENAME_BYTES = 240
+CACHE_KEY_HASH_LEN = 16
+
+
+def _cache_file_path(file_name: str) -> str:
+    safe_file_name = re.sub(r"[/\\\\]+", "_", file_name)
+    basename = f"{safe_file_name}{FILE_SUFFIX}"
+
+    if len(basename.encode("utf-8")) <= MAX_CACHE_FILENAME_BYTES:
+        return os.path.join(PATH, basename)
+
+    file_name_hash = hashlib.sha256(file_name.encode("utf-8")).hexdigest()[
+        :CACHE_KEY_HASH_LEN
+    ]
+    hashed_suffix = f"-{file_name_hash}{FILE_SUFFIX}"
+    max_prefix_bytes = MAX_CACHE_FILENAME_BYTES - len(hashed_suffix.encode("utf-8"))
+
+    prefix = safe_file_name.encode("utf-8")[:max_prefix_bytes]
+    prefix = prefix.decode("utf-8", errors="ignore").rstrip("-_.") or "cache"
+
+    return os.path.join(PATH, f"{prefix}{hashed_suffix}")
+
 
 def load_from_cache(file_name: str, cache: bool = False):
     if not cache:
         return
     try:
-        path = f"{PATH}/{file_name}{FILE_SUFFIX}"
+        path = _cache_file_path(file_name)
 
         with open(path, "rb") as file:
             cached_task_dict = dill.loads(file.read())
@@ -42,7 +69,7 @@ def save_to_cache(file_name, obj):
     if not os.path.exists(PATH):
         os.mkdir(PATH)
 
-    file_path = f"{PATH}/{file_name}{FILE_SUFFIX}"
+    file_path = _cache_file_path(file_name)
 
     eval_logger.debug(f"Saving {file_path} to cache...")
     with open(file_path, "wb") as file:

--- a/lm_eval/caching/cache.py
+++ b/lm_eval/caching/cache.py
@@ -14,7 +14,7 @@ MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
 OVERRIDE_PATH = os.getenv("LM_HARNESS_CACHE_PATH")
 
 
-PATH = OVERRIDE_PATH if OVERRIDE_PATH else f"{MODULE_DIR}/.cache"
+PATH = OVERRIDE_PATH or f"{MODULE_DIR}/.cache"
 
 # This should be sufficient for uniqueness
 HASH_INPUT = "EleutherAI-lm-evaluation-harness"
@@ -57,12 +57,11 @@ def load_from_cache(file_name: str, cache: bool = False):
         path = _cache_file_path(file_name)
 
         with open(path, "rb") as file:
-            cached_task_dict = dill.loads(file.read())
+            cached_task_dict = dill.loads(file.read())  # noqa: S301
             return cached_task_dict
 
-    except Exception:
-        eval_logger.debug(f"{file_name} is not cached, generating...")
-        pass
+    except Exception:  # noqa: BLE001
+        eval_logger.debug("%s is not cached, generating...", file_name)
 
 
 def save_to_cache(file_name, obj):
@@ -71,7 +70,7 @@ def save_to_cache(file_name, obj):
 
     file_path = _cache_file_path(file_name)
 
-    eval_logger.debug(f"Saving {file_path} to cache...")
+    eval_logger.debug("Saving %s to cache...", file_path)
     with open(file_path, "wb") as file:
         file.write(dill.dumps(obj))
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,28 @@
+import os
+
+from lm_eval.caching import cache
+
+
+def test_long_cache_keys_are_hashed_below_filesystem_limit(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "PATH", str(tmp_path))
+
+    long_model_name = "tokenizer" + "very-long-model-name/" * 30
+    cache_key = f"requests-mmlu-5shot-rank0-world_size1-chat_template-{long_model_name}"
+
+    cache.save_to_cache(cache_key, {"ok": True})
+
+    cache_files = os.listdir(tmp_path)
+    assert len(cache_files) == 1
+    assert len(cache_files[0].encode("utf-8")) <= cache.MAX_CACHE_FILENAME_BYTES
+    assert cache.load_from_cache(cache_key, cache=True) == {"ok": True}
+
+
+def test_short_cache_keys_keep_readable_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "PATH", str(tmp_path))
+
+    cache_key = "requests-sciq-0shot-rank0-world_size1-tokenizergpt2"
+    cache.save_to_cache(cache_key, ["cached"])
+
+    cache_files = os.listdir(tmp_path)
+    assert cache_files == [f"{cache_key}{cache.FILE_SUFFIX}"]
+    assert cache.load_from_cache(cache_key, cache=True) == ["cached"]


### PR DESCRIPTION
## Summary
- hash overlong request cache filenames while preserving a readable prefix
- keep cache filename basenames below common filesystem limits
- add regression coverage for long cache keys and unchanged short-key filenames

## Tests
- `.venv/bin/python -m pytest tests/test_cache.py`
- `.venv/bin/python -m py_compile lm_eval/caching/cache.py tests/test_cache.py`

Fixes #3325
