### PR TITLE
fix(noreval/noridiom): use absolute module paths for !function imports (#3624)

### DIFF
--- a/lm_eval/tasks/noreval/noridiom/_noridiom_yaml
+++ b/lm_eval/tasks/noreval/noridiom/_noridiom_yaml
@@ -5,7 +5,7 @@ test_split: test
 num_fewshot: 0
 output_type: generate_until
 doc_to_target: completion
-process_results: !function utils.process_results
+process_results: !function lm_eval.tasks.noreval.noridiom.utils.process_results
 generation_kwargs:
   until:
     - "\n"

--- a/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p0.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p0.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nno
 task: noridiom_nno_p0
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nn
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nn
 doc_to_text: "Fullfør dette uttrykket: {{idiom_start}}"

--- a/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p1.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p1.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nno
 task: noridiom_nno_p1
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nn
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nn
 doc_to_text: "Skriv fortsetjinga av idiomet {{idiom_start}}"

--- a/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p2.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p2.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nno
 task: noridiom_nno_p2
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nn
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nn
 doc_to_text: "Korleis fortset uttrykket \"{{idiom_start}}\"?"

--- a/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p3.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p3.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nno
 task: noridiom_nno_p3
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nn
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nn
 doc_to_text: "Fullfør vendinga: {{idiom_start}}"

--- a/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p4.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p4.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nno
 task: noridiom_nno_p4
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nn
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nn
 doc_to_text: "{{idiom_start}}"

--- a/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p0.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p0.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nob
 task: noridiom_nob_p0
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nb
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nb
 doc_to_text: "Fullfør dette uttrykket: {{idiom_start}}"

--- a/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p1.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p1.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nob
 task: noridiom_nob_p1
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nb
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nb
 doc_to_text: "Skriv fortsettelsen av idiomet {{idiom_start}}"

--- a/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p2.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p2.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nob
 task: noridiom_nob_p2
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nb
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nb
 doc_to_text: "Hvordan fortsetter uttrykket \"{{idiom_start}}\"?"

--- a/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p3.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p3.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nob
 task: noridiom_nob_p3
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nb
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nb
 doc_to_text: "Fullfør vendingen \"{{idiom_start}}\""

--- a/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p4.yaml
+++ b/lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p4.yaml
@@ -1,5 +1,5 @@
 tag: noridiom_nob
 task: noridiom_nob_p4
 include: ../_noridiom_yaml
-process_docs: !function ../utils.filter_dataset_nb
+process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nb
 doc_to_text: "{{idiom_start}}"


### PR DESCRIPTION
## Summary

Fixes #3624.

Replace relative `!function ../utils.X` (and `!function utils.X` in the parent `_noridiom_yaml`) with the absolute module path `lm_eval.tasks.noreval.noridiom.utils.X` across all 11 noridiom YAML configurations.

## Why

As reported in #3624, relative `!function` imports in the noridiom task YAMLs can fail to resolve in containerized deployments (Singularity, Docker with non-standard `WORKDIR`, etc.) where the working directory or module-path search behaves differently from a typical dev install. Absolute module paths resolve consistently regardless of how the harness is invoked.

## Change pattern

```diff
- process_docs: !function ../utils.filter_dataset_nb
+ process_docs: !function lm_eval.tasks.noreval.noridiom.utils.filter_dataset_nb
```

```diff
- process_results: !function utils.process_results
+ process_results: !function lm_eval.tasks.noreval.noridiom.utils.process_results
```

## Modified files (11)

- `lm_eval/tasks/noreval/noridiom/_noridiom_yaml` — `process_results`
- `lm_eval/tasks/noreval/noridiom/nob/noridiom_nob_p{0..4}.yaml` (5 files) — `process_docs`
- `lm_eval/tasks/noreval/noridiom/nno/noridiom_nno_p{0..4}.yaml` (5 files) — `process_docs`

The reporter's listed scope was 10 files (the `nob/` + `nno/` task YAMLs); I also included `_noridiom_yaml` for consistency since it has the same kind of relative `!function utils.X` reference. Happy to drop that one if you'd prefer to keep this PR strictly to the reporter's scope.

No Python code changes; task behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)