### PR TITLE
Add Trackio logger with per-sample Trace logging

### DIFF
--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -282,6 +282,14 @@ class Run(SubCommand):
             help="Weights & Biases config arguments key=val key2=val2",
         )
         logging_group.add_argument(
+            "--trackio_args",
+            default=None,
+            nargs="+",
+            action=MergeDictAction,
+            metavar="<args>",
+            help="Trackio init arguments key=val key2=val2 (e.g. project=my-evals)",
+        )
+        logging_group.add_argument(
             "--hf_hub_log_args",
             default=None,
             nargs="+",
@@ -347,12 +355,14 @@ class Run(SubCommand):
         cfg = EvaluatorConfig.from_cli(args)
 
         from lm_eval import simple_evaluate
-        from lm_eval.loggers import EvaluationTracker, WandbLogger
+        from lm_eval.loggers import EvaluationTracker, TrackioLogger, WandbLogger
         from lm_eval.utils import handle_non_serializable, make_table
 
         # Set up logging
         if cfg.wandb_args:
             wandb_logger = WandbLogger(cfg.wandb_args, cfg.wandb_config_args)
+        if cfg.trackio_args:
+            trackio_logger = TrackioLogger(cfg.trackio_args)
 
         # Set up evaluation tracker
         if cfg.output_path:
@@ -438,6 +448,16 @@ class Run(SubCommand):
                 except Exception as e:
                     eval_logger.info(f"Logging to W&B failed: {e}")
 
+            # Trackio logging
+            if cfg.trackio_args:
+                try:
+                    trackio_logger.post_init(results)
+                    trackio_logger.log_eval_result()
+                    if cfg.log_samples:
+                        trackio_logger.log_eval_samples(samples)
+                except Exception as e:
+                    eval_logger.info(f"Logging to Trackio failed: {e}")
+
             # Save results
             evaluation_tracker.save_results_aggregated(
                 results=results, samples=samples if cfg.log_samples else None
@@ -468,3 +488,6 @@ class Run(SubCommand):
 
             if cfg.wandb_args:
                 wandb_logger.run.finish()
+
+            if cfg.trackio_args:
+                trackio_logger.finish()

--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -384,8 +384,8 @@ class Run(SubCommand):
 
         # Log task selection (tasks already processed in config)
         if cfg.include_path is not None:
-            eval_logger.info(f"Including path: {cfg.include_path}")
-        eval_logger.info(f"Selected Tasks: {cfg.tasks}")
+            eval_logger.info("Including path: %s", cfg.include_path)
+        eval_logger.info("Selected Tasks: %s", cfg.tasks)
 
         # Run evaluation
         results = simple_evaluate(
@@ -445,8 +445,8 @@ class Run(SubCommand):
                     wandb_logger.log_eval_result()
                     if cfg.log_samples:
                         wandb_logger.log_eval_samples(samples)
-                except Exception as e:
-                    eval_logger.info(f"Logging to W&B failed: {e}")
+                except Exception as e:  # noqa: BLE001
+                    eval_logger.info("Logging to W&B failed: %s", e)
 
             # Trackio logging
             if cfg.trackio_args:
@@ -455,8 +455,8 @@ class Run(SubCommand):
                     trackio_logger.log_eval_result()
                     if cfg.log_samples:
                         trackio_logger.log_eval_samples(samples)
-                except Exception as e:
-                    eval_logger.info(f"Logging to Trackio failed: {e}")
+                except Exception as e:  # noqa: BLE001
+                    eval_logger.info("Logging to Trackio failed: %s", e)
 
             # Save results
             evaluation_tracker.save_results_aggregated(
@@ -464,7 +464,7 @@ class Run(SubCommand):
             )
 
             if cfg.log_samples:
-                for task_name, _ in results["configs"].items():
+                for task_name in results["configs"]:
                     evaluation_tracker.save_results_samples(
                         task_name=task_name, samples=samples[task_name]
                     )

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import json
 import logging
 import textwrap
-from argparse import Namespace
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -12,6 +13,8 @@ from lm_eval.utils import simple_parse_args_string
 
 
 if TYPE_CHECKING:
+    from argparse import Namespace
+
     from lm_eval.tasks import TaskManager
 
 eval_logger = logging.getLogger(__name__)
@@ -168,6 +171,9 @@ class EvaluatorConfig:
     hf_hub_log_args: dict = field(
         default_factory=dict, metadata={"help": "Arguments for HF Hub logging"}
     )
+    trackio_args: dict = field(
+        default_factory=dict, metadata={"help": "Arguments for trackio logging"}
+    )
 
     # Reproducibility
     seed: list = field(
@@ -193,10 +199,10 @@ class EvaluatorConfig:
     )
 
     @classmethod
-    def from_cli(cls, namespace: Namespace) -> "EvaluatorConfig":
-        """
-        Build an EvaluationConfig by merging with simple precedence:
-        CLI args > YAML config > built-in defaults
+    def from_cli(cls, namespace: Namespace) -> EvaluatorConfig:
+        """Build an EvaluationConfig by merging with a simple precedence.
+
+        CLI args > YAML config > built-in defaults.
         """
         # Start with built-in defaults
         config = asdict(cls())
@@ -221,16 +227,16 @@ class EvaluatorConfig:
         if used_config:
             cli_args.pop("config", None)
             eval_logger.info(
-                f"CLI args {cli_args} will override yaml"
+                "CLI args %s will override yaml", cli_args
             ) if cli_args else None
             print(textwrap.dedent(f"""{instance}"""))
 
         return instance
 
     @classmethod
-    def from_config(cls, config_path: str | Path) -> "EvaluatorConfig":
-        """
-        Build an EvaluationConfig from a YAML config file.
+    def from_config(cls, config_path: str | Path) -> EvaluatorConfig:
+        """Build an EvaluationConfig from a YAML config file.
+
         Merges with built-in defaults and validates.
         """
         # Load YAML config
@@ -252,7 +258,7 @@ class EvaluatorConfig:
             raise ValueError(f"Could not read config file {_config_path}: {e}") from e
 
         if not isinstance(yaml_data, dict):
-            raise ValueError(
+            raise TypeError(
                 f"YAML root must be a mapping in {_config_path.resolve()}, got {type(yaml_data).__name__}"
             )
 
@@ -333,7 +339,7 @@ class EvaluatorConfig:
 
         return self
 
-    def process_tasks(self, metadata: dict | None = None) -> "TaskManager":
+    def process_tasks(self, metadata: dict | None = None) -> TaskManager:
         """Process and validate tasks, return resolved task names.
 
         Handles:
@@ -383,7 +389,7 @@ class EvaluatorConfig:
         match_dict = dict.fromkeys(task_list)  # deduplicate file paths
 
         # Match each task
-        for task in match_dict.keys():
+        for task in match_dict:
             if not task.endswith(".yaml"):
                 # Standard task name - match via task manager
                 matches = task_manager.match_tasks([task])

--- a/lm_eval/loggers/__init__.py
+++ b/lm_eval/loggers/__init__.py
@@ -1,2 +1,3 @@
 from .evaluation_tracker import EvaluationTracker
+from .trackio_logger import TrackioLogger
 from .wandb_logger import WandbLogger

--- a/lm_eval/loggers/trackio_logger.py
+++ b/lm_eval/loggers/trackio_logger.py
@@ -1,0 +1,164 @@
+import copy
+import logging
+from typing import Any, Dict, List
+
+from lm_eval.loggers.utils import _handle_non_serializable, remove_none_pattern  # noqa: F401
+
+
+logger = logging.getLogger(__name__)
+
+
+def _sample_to_trace(trackio_module, sample: Dict[str, Any], task_name: str, output_type: str):
+    """Build a trackio.Trace from a single eval sample.
+
+    Picks the most natural prompt/response pair for each task output_type and
+    attaches the gold target plus any computed metrics as metadata so the
+    Trackio dashboard surfaces everything alongside the conversation.
+    """
+    prompt = ""
+    response = ""
+
+    args = sample.get("arguments") or {}
+    if output_type == "loglikelihood":
+        first = args.get("arg_0", {}) if isinstance(args, dict) else (args[0] if args else {})
+        prompt = first.get("arg_0", "") if isinstance(first, dict) else (first[0] if first else "")
+        filt = sample.get("filtered_resps")
+        if filt:
+            logprob, is_greedy = filt[0] if isinstance(filt[0], (list, tuple)) else (filt[0], None)
+            response = (
+                f"continuation log-prob: {logprob}"
+                + (f"\n\ngreedy={bool(is_greedy)}" if is_greedy is not None else "")
+            )
+    elif output_type == "multiple_choice":
+        first = args.get("arg_0", {}) if isinstance(args, dict) else (args[0] if args else {})
+        prompt = first.get("arg_0", "") if isinstance(first, dict) else (first[0] if first else "")
+        filt = sample.get("filtered_resps") or []
+        try:
+            import numpy as np
+
+            choice_idx = int(np.argmax([n[0] if isinstance(n, (list, tuple)) else n for n in filt]))
+            response = f"selected choice {choice_idx}"
+        except Exception:
+            response = str(filt)
+    else:
+        first = args.get("arg_0", {}) if isinstance(args, dict) else (args[0] if args else {})
+        prompt = first.get("arg_0", "") if isinstance(first, dict) else (first[0] if first else "")
+        filt = sample.get("filtered_resps") or sample.get("resps") or []
+        if filt:
+            response = filt[0] if isinstance(filt[0], str) else str(filt[0])
+
+    metadata: Dict[str, Any] = {
+        "task": task_name,
+        "doc_id": sample.get("doc_id"),
+        "target": sample.get("target"),
+        "filter": sample.get("filter"),
+        "output_type": output_type,
+    }
+    for metric_name in sample.get("metrics", []) or []:
+        if metric_name in sample:
+            metadata[metric_name] = sample[metric_name]
+
+    return trackio_module.Trace(
+        messages=[
+            {"role": "user", "content": str(prompt)},
+            {"role": "assistant", "content": str(response)},
+        ],
+        metadata=metadata,
+    )
+
+
+class TrackioLogger:
+    def __init__(self, init_args: Dict[str, Any] = None) -> None:
+        """Logs lm-evaluation-harness results to Trackio.
+
+        Trackio (https://github.com/gradio-app/trackio) is a lightweight,
+        local-first experiment tracker with a wandb-compatible API plus a
+        first-class Trace primitive for conversational/eval samples.
+
+        Args:
+            init_args: kwargs forwarded to ``trackio.init``. Supports
+                ``project``, ``name``, ``group``, ``space_id``, ``config``,
+                and a ``step`` key consumed locally for default log step.
+
+        Usage from the CLI: ``--trackio_args project=my-evals``.
+
+        Programmatic usage::
+
+            trackio_logger.post_init(results)
+            trackio_logger.log_eval_result()
+            trackio_logger.log_eval_samples(samples)
+        """
+        try:
+            import trackio
+        except ImportError as e:
+            raise ImportError(
+                "trackio is not installed. Install it with `pip install trackio` "
+                "or `pip install lm_eval[trackio]`."
+            ) from e
+
+        self._trackio = trackio
+        self.trackio_args: Dict[str, Any] = dict(init_args or {})
+        self.step = self.trackio_args.pop("step", None)
+        if "project" not in self.trackio_args:
+            self.trackio_args["project"] = "lm-eval-harness"
+        self.run = trackio.init(**self.trackio_args)
+
+    def post_init(self, results: Dict[str, Any]) -> None:
+        self.results: Dict[str, Any] = copy.deepcopy(results)
+        self.task_names: List[str] = list(results.get("results", {}).keys())
+        self.group_names: List[str] = list(results.get("groups", {}).keys())
+        self.task_configs: Dict[str, Any] = self.results.get("configs", {})
+
+    def _flatten_results_for_log(self) -> Dict[str, Any]:
+        """Flatten nested {task: {metric: value}} into {task/metric: value} scalars."""
+        flat: Dict[str, Any] = {}
+        for task_name, metrics in self.results.get("results", {}).items():
+            if not isinstance(metrics, dict):
+                continue
+            for k, v in metrics.items():
+                key, _ = remove_none_pattern(k)
+                if isinstance(v, (int, float)):
+                    flat[f"{task_name}/{key}"] = v
+        return flat
+
+    def log_eval_result(self) -> None:
+        """Log aggregate eval metrics + run config to Trackio."""
+        try:
+            self._trackio.config.update(
+                {
+                    "task_configs": self.task_configs,
+                    "cli_configs": self.results.get("config", {}),
+                }
+            )
+        except Exception as e:
+            logger.warning(f"Failed to update Trackio config: {e}")
+
+        flat = self._flatten_results_for_log()
+        if flat:
+            self._trackio.log(flat, step=self.step)
+
+    def log_eval_samples(self, samples: Dict[str, List[Dict[str, Any]]]) -> None:
+        """Log per-sample eval data as Trackio Traces.
+
+        Each sample becomes one ``trackio.Trace`` whose messages capture the
+        prompt and (filtered) model response, with the gold target plus all
+        per-sample metric values attached as metadata.
+        """
+        for task_name in self.task_names:
+            if task_name in self.group_names or task_name not in samples:
+                continue
+            task_cfg = self.task_configs.get(task_name, {}) or {}
+            output_type = task_cfg.get("output_type", "generate_until")
+            for idx, sample in enumerate(samples[task_name]):
+                try:
+                    trace = _sample_to_trace(self._trackio, sample, task_name, output_type)
+                except Exception as e:
+                    logger.warning(f"Failed to build trace for sample {idx} of {task_name}: {e}")
+                    continue
+                self._trackio.log({f"{task_name}/sample": trace}, step=self.step)
+
+    def finish(self) -> None:
+        try:
+            self._trackio.finish()
+        except Exception as e:
+            logger.warning(f"Trackio finish raised: {e}")

--- a/lm_eval/loggers/trackio_logger.py
+++ b/lm_eval/loggers/trackio_logger.py
@@ -1,14 +1,19 @@
 import copy
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
-from lm_eval.loggers.utils import _handle_non_serializable, remove_none_pattern  # noqa: F401
+from lm_eval.loggers.utils import (  # noqa: F401
+    _handle_non_serializable,
+    remove_none_pattern,
+)
 
 
 logger = logging.getLogger(__name__)
 
 
-def _sample_to_trace(trackio_module, sample: Dict[str, Any], task_name: str, output_type: str):
+def _sample_to_trace(
+    trackio_module, sample: dict[str, Any], task_name: str, output_type: str
+):
     """Build a trackio.Trace from a single eval sample.
 
     Picks the most natural prompt/response pair for each task output_type and
@@ -20,34 +25,61 @@ def _sample_to_trace(trackio_module, sample: Dict[str, Any], task_name: str, out
 
     args = sample.get("arguments") or {}
     if output_type == "loglikelihood":
-        first = args.get("arg_0", {}) if isinstance(args, dict) else (args[0] if args else {})
-        prompt = first.get("arg_0", "") if isinstance(first, dict) else (first[0] if first else "")
+        first = (
+            args.get("arg_0", {})
+            if isinstance(args, dict)
+            else (args[0] if args else {})
+        )
+        prompt = (
+            first.get("arg_0", "")
+            if isinstance(first, dict)
+            else (first[0] if first else "")
+        )
         filt = sample.get("filtered_resps")
         if filt:
-            logprob, is_greedy = filt[0] if isinstance(filt[0], (list, tuple)) else (filt[0], None)
-            response = (
-                f"continuation log-prob: {logprob}"
-                + (f"\n\ngreedy={bool(is_greedy)}" if is_greedy is not None else "")
+            logprob, is_greedy = (
+                filt[0] if isinstance(filt[0], (list, tuple)) else (filt[0], None)
+            )
+            response = f"continuation log-prob: {logprob}" + (
+                f"\n\ngreedy={bool(is_greedy)}" if is_greedy is not None else ""
             )
     elif output_type == "multiple_choice":
-        first = args.get("arg_0", {}) if isinstance(args, dict) else (args[0] if args else {})
-        prompt = first.get("arg_0", "") if isinstance(first, dict) else (first[0] if first else "")
+        first = (
+            args.get("arg_0", {})
+            if isinstance(args, dict)
+            else (args[0] if args else {})
+        )
+        prompt = (
+            first.get("arg_0", "")
+            if isinstance(first, dict)
+            else (first[0] if first else "")
+        )
         filt = sample.get("filtered_resps") or []
         try:
             import numpy as np
 
-            choice_idx = int(np.argmax([n[0] if isinstance(n, (list, tuple)) else n for n in filt]))
+            choice_idx = int(
+                np.argmax([n[0] if isinstance(n, (list, tuple)) else n for n in filt])
+            )
             response = f"selected choice {choice_idx}"
-        except Exception:
+        except Exception:  # noqa: BLE001
             response = str(filt)
     else:
-        first = args.get("arg_0", {}) if isinstance(args, dict) else (args[0] if args else {})
-        prompt = first.get("arg_0", "") if isinstance(first, dict) else (first[0] if first else "")
+        first = (
+            args.get("arg_0", {})
+            if isinstance(args, dict)
+            else (args[0] if args else {})
+        )
+        prompt = (
+            first.get("arg_0", "")
+            if isinstance(first, dict)
+            else (first[0] if first else "")
+        )
         filt = sample.get("filtered_resps") or sample.get("resps") or []
         if filt:
             response = filt[0] if isinstance(filt[0], str) else str(filt[0])
 
-    metadata: Dict[str, Any] = {
+    metadata: dict[str, Any] = {
         "task": task_name,
         "doc_id": sample.get("doc_id"),
         "target": sample.get("target"),
@@ -68,7 +100,7 @@ def _sample_to_trace(trackio_module, sample: Dict[str, Any], task_name: str, out
 
 
 class TrackioLogger:
-    def __init__(self, init_args: Dict[str, Any] = None) -> None:
+    def __init__(self, init_args: dict[str, Any] | None = None) -> None:
         """Logs lm-evaluation-harness results to Trackio.
 
         Trackio (https://github.com/gradio-app/trackio) is a lightweight,
@@ -97,21 +129,21 @@ class TrackioLogger:
             ) from e
 
         self._trackio = trackio
-        self.trackio_args: Dict[str, Any] = dict(init_args or {})
+        self.trackio_args: dict[str, Any] = dict(init_args or {})
         self.step = self.trackio_args.pop("step", None)
         if "project" not in self.trackio_args:
             self.trackio_args["project"] = "lm-eval-harness"
         self.run = trackio.init(**self.trackio_args)
 
-    def post_init(self, results: Dict[str, Any]) -> None:
-        self.results: Dict[str, Any] = copy.deepcopy(results)
-        self.task_names: List[str] = list(results.get("results", {}).keys())
-        self.group_names: List[str] = list(results.get("groups", {}).keys())
-        self.task_configs: Dict[str, Any] = self.results.get("configs", {})
+    def post_init(self, results: dict[str, Any]) -> None:
+        self.results: dict[str, Any] = copy.deepcopy(results)
+        self.task_names: list[str] = list(results.get("results", {}).keys())
+        self.group_names: list[str] = list(results.get("groups", {}).keys())
+        self.task_configs: dict[str, Any] = self.results.get("configs", {})
 
-    def _flatten_results_for_log(self) -> Dict[str, Any]:
+    def _flatten_results_for_log(self) -> dict[str, Any]:
         """Flatten nested {task: {metric: value}} into {task/metric: value} scalars."""
-        flat: Dict[str, Any] = {}
+        flat: dict[str, Any] = {}
         for task_name, metrics in self.results.get("results", {}).items():
             if not isinstance(metrics, dict):
                 continue
@@ -130,14 +162,14 @@ class TrackioLogger:
                     "cli_configs": self.results.get("config", {}),
                 }
             )
-        except Exception as e:
-            logger.warning(f"Failed to update Trackio config: {e}")
+        except Exception:
+            logger.exception("Failed to update Trackio config")
 
         flat = self._flatten_results_for_log()
         if flat:
             self._trackio.log(flat, step=self.step)
 
-    def log_eval_samples(self, samples: Dict[str, List[Dict[str, Any]]]) -> None:
+    def log_eval_samples(self, samples: dict[str, list[dict[str, Any]]]) -> None:
         """Log per-sample eval data as Trackio Traces.
 
         Each sample becomes one ``trackio.Trace`` whose messages capture the
@@ -151,14 +183,18 @@ class TrackioLogger:
             output_type = task_cfg.get("output_type", "generate_until")
             for idx, sample in enumerate(samples[task_name]):
                 try:
-                    trace = _sample_to_trace(self._trackio, sample, task_name, output_type)
-                except Exception as e:
-                    logger.warning(f"Failed to build trace for sample {idx} of {task_name}: {e}")
+                    trace = _sample_to_trace(
+                        self._trackio, sample, task_name, output_type
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to build trace for sample %s of %s", idx, task_name
+                    )
                     continue
                 self._trackio.log({f"{task_name}/sample": trace}, step=self.step)
 
     def finish(self) -> None:
         try:
             self._trackio.finish()
-        except Exception as e:
-            logger.warning(f"Trackio finish raised: {e}")
+        except Exception:
+            logger.exception("Trackio finish raised")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ ruler = ["nltk", "wonderwords", "scipy"]
 sentencepiece = ["sentencepiece>=0.1.98"]
 discrim_eval = ["statsmodels==0.14.4"]
 unitxt = ["unitxt==1.22.0"]
+trackio = ["trackio>=0.23.0"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
 tasks = [

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -258,6 +258,7 @@ class TestRunCommand:
         # Mock configuration
         mock_cfg_instance = MagicMock()
         mock_cfg_instance.wandb_args = None
+        mock_cfg_instance.trackio_args = None
         mock_cfg_instance.output_path = None
         mock_cfg_instance.hf_hub_log_args = {}
         mock_cfg_instance.include_path = None
@@ -374,7 +375,7 @@ class TestValidateCommand:
 
 
 class TestEvaluatorConfigTaskLoading:
-    """Test EvaluatorConfig task loading"""
+    """Test EvaluatorConfig task loading."""
 
     @patch("lm_eval.tasks.TaskManager")
     def test_process_tasks_comma_separated_in_list(self, mock_task_manager):
@@ -808,7 +809,7 @@ class TestMergeDictAction:
         assert args.args == {"outer": {"inner": "value"}}
 
     def test_empty_values(self):
-        """Test that empty values result in None"""
+        """Test that empty values result in None."""
         parser = argparse.ArgumentParser()
         parser.add_argument("--args", nargs="*", action=MergeDictAction)
 


### PR DESCRIPTION
Adds a `TrackioLogger` mirroring `WandbLogger`'s lifecycle (`post_init` / `log_eval_result` / `log_eval_samples`) and registered in the same place. The key benefit is logging each eval sample as a [`trackio.Trace`](https://github.com/gradio-app/trackio), prompt and (filtered) model response as `messages`, with the gold target plus per-sample metric values attached as metadata, so that sample inspection can happen directly in the Trackio dashboard rather than a downloaded JSON artifact.

[Trackio](https://github.com/gradio-app/trackio) is a lightweight, local-first experiment tracker with a wandb-compatible API. Local SQLite by default; can optionally sync to a Hugging Face Space.

```bash
lm_eval --model hf --model_args pretrained=Qwen/Qwen2.5-0.5B \\
    --tasks hellaswag \\
    --trackio_args project=lm-eval-harness \\
    --log_samples
```

## Changes
- New `lm_eval/loggers/trackio_logger.py` with the same lifecycle as `WandbLogger`. Per-sample logging shapes the prompt/response correctly per task `output_type` (`loglikelihood`, `multiple_choice`, `loglikelihood_rolling`, `generate_until`).
- Registered in `lm_eval/loggers/__init__.py`.
- New `--trackio_args key=val ...` CLI flag in `lm_eval/_cli/run.py`, wired into the eval loop alongside `--wandb_args`.
- New `trackio` optional extra in `pyproject.toml` (`pip install lm_eval[trackio]`).
