### PR TITLE
fix(vllm): disallow data_parallel with enable_expert_parallel

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -109,6 +109,13 @@ class VLLM(TemplateLM):
         # truncation strategy for inputs exceeding max length
         self.truncation_side = truncation_side
         self.data_parallel_size = int(data_parallel_size)
+        if self.data_parallel_size > 1 and kwargs.get("enable_expert_parallel", False):
+            raise ValueError(
+                "data_parallel_size > 1 is not supported with enable_expert_parallel=True. "
+                "lm-eval dispatches data parallelism through independent Ray workers, which "
+                "does not provide a single coordinated MoE expert-parallel engine. "
+                "Use tensor_parallel_size > 1 with data_parallel_size=1 instead."
+            )
         if self.data_parallel_size > 1 and not find_spec("ray"):
             raise ModuleNotFoundError(
                 "ray is required for data parallelism. Please install ray using `pip install ray`."

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -7,6 +7,32 @@ from lm_eval.api.instance import Instance
 
 
 task_manager = tasks.TaskManager()
+
+
+class TestVLLMValidation:
+    """Tests for VLLM constructor validation."""
+
+    vllm = pytest.importorskip("vllm")
+
+    def test_data_parallel_with_expert_parallel_raises(self):
+        """data_parallel_size > 1 with enable_expert_parallel=True must raise."""
+        from lm_eval.models.vllm_causallms import VLLM
+
+        with (
+            patch.multiple(
+                "lm_eval.models.vllm_causallms",
+                find_spec=lambda name: None if name == "ray" else MagicMock(),
+                LLM=MagicMock(),
+                get_tokenizer=MagicMock(return_value=MagicMock()),
+            ),
+            patch("transformers.AutoConfig.from_pretrained", MagicMock()),
+            pytest.raises(ValueError, match=r"data_parallel_size > 1.*expert_parallel"),
+        ):
+            VLLM(
+                pretrained="mock-model",
+                data_parallel_size=2,
+                enable_expert_parallel=True,
+            )
 
 
 @pytest.mark.skip(reason="requires CUDA")


### PR DESCRIPTION
Fixes #3712

  When `data_parallel_size > 1` and `enable_expert_parallel=True` are used together, evaluation produces very low accuracy (~5% instead of ~85%). This happens because lm-eval dispatches DP via independent Ray workers, each creating its own vLLM instance - there's no coordinated MoE expert-parallel engine across workers.

  This PR fails fast with a clear error message instead of silently producing garbage results. Users should `use tensor_parallel_size > 1` with `data_parallel_size=1` for MoE models.