### PR TITLE
Fix GPQA preprocess stripping mathematical bracket expressions

### DIFF
--- a/lm_eval/tasks/gpqa/README.md
+++ b/lm_eval/tasks/gpqa/README.md
@@ -43,6 +43,10 @@ None
 * `gpqa_{main, diamond, extended}_cot_zeroshot`
 * `gpqa_{main, diamond, extended}_cot_n_shot`
 
+### Changelog
+
+* **v2.1** (PR #3735): narrowed the answer-preprocessing regex from `\[.*?\]` to `\[\w+\]`. The previous pattern stripped any bracketed content, which destroyed mathematical expressions like `[ (T_1 - T_2) / (T1*T2)]` in answer choices (e.g. GPQA-Diamond Q171). PR #3735
+
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:

--- a/lm_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/cot_n_shot/_gpqa_cot_n_shot_yaml
@@ -35,4 +35,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 2.0
+  version: 2.1

--- a/lm_eval/tasks/gpqa/cot_n_shot/utils.py
+++ b/lm_eval/tasks/gpqa/cot_n_shot/utils.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import random
 import re
+from typing import TYPE_CHECKING
 
-import datasets
+
+if TYPE_CHECKING:
+    import datasets
 
 
 def preprocess(text):
@@ -9,7 +14,7 @@ def preprocess(text):
         return " "
     text = text.strip()
     text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
+    text = re.sub(r"\[\w+\]", "", text)
     text = text.replace("  ", " ")
     return text
 

--- a/lm_eval/tasks/gpqa/cot_zeroshot/_gpqa_cot_zeroshot_yaml
+++ b/lm_eval/tasks/gpqa/cot_zeroshot/_gpqa_cot_zeroshot_yaml
@@ -35,4 +35,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 2.1

--- a/lm_eval/tasks/gpqa/cot_zeroshot/utils.py
+++ b/lm_eval/tasks/gpqa/cot_zeroshot/utils.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import random
 import re
+from typing import TYPE_CHECKING
 
-import datasets
+
+if TYPE_CHECKING:
+    import datasets
 
 
 def preprocess(text):
@@ -9,7 +14,7 @@ def preprocess(text):
         return " "
     text = text.strip()
     text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
+    text = re.sub(r"\[\w+\]", "", text)
     text = text.replace("  ", " ")
     return text
 

--- a/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/generative/_gpqa_generative_n_shot_yaml
@@ -36,4 +36,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 2.0
+  version: 2.1

--- a/lm_eval/tasks/gpqa/generative/utils.py
+++ b/lm_eval/tasks/gpqa/generative/utils.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import random
 import re
+from typing import TYPE_CHECKING
 
-import datasets
+
+if TYPE_CHECKING:
+    import datasets
 
 
 def preprocess(text):

--- a/lm_eval/tasks/gpqa/generative/utils.py
+++ b/lm_eval/tasks/gpqa/generative/utils.py
@@ -9,7 +9,7 @@ def preprocess(text):
         return " "
     text = text.strip()
     text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
+    text = re.sub(r"\[\w+\]", "", text)
     text = text.replace("  ", " ")
     return text
 

--- a/lm_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
+++ b/lm_eval/tasks/gpqa/n_shot/_gpqa_n_shot_yaml
@@ -18,4 +18,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 2.0
+  version: 2.1

--- a/lm_eval/tasks/gpqa/n_shot/utils.py
+++ b/lm_eval/tasks/gpqa/n_shot/utils.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import random
 import re
+from typing import TYPE_CHECKING
 
-import datasets
+
+if TYPE_CHECKING:
+    import datasets
 
 
 def preprocess(text):
@@ -9,7 +14,7 @@ def preprocess(text):
         return " "
     text = text.strip()
     text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
+    text = re.sub(r"\[\w+\]", "", text)
     text = text.replace("  ", " ")
     return text
 

--- a/lm_eval/tasks/gpqa/zeroshot/_gpqa_zeroshot_yaml
+++ b/lm_eval/tasks/gpqa/zeroshot/_gpqa_zeroshot_yaml
@@ -18,4 +18,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.1

--- a/lm_eval/tasks/gpqa/zeroshot/utils.py
+++ b/lm_eval/tasks/gpqa/zeroshot/utils.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import random
 import re
+from typing import TYPE_CHECKING
 
-import datasets
+
+if TYPE_CHECKING:
+    import datasets
 
 
 def preprocess(text):
@@ -9,7 +14,7 @@ def preprocess(text):
         return " "
     text = text.strip()
     text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
+    text = re.sub(r"\[\w+\]", "", text)
     text = text.replace("  ", " ")
     return text
 


### PR DESCRIPTION
## Bug

`preprocess()` in `lm_eval/tasks/gpqa/generative/utils.py` applies `re.sub("\\[.*?\\]", "", text)` to clean annotation markers from question/answer text.  The non-greedy dot wildcard matches *any* content inside brackets, including valid mathematical notation.  For GPQA-Diamond question 171 the correct answer is:

```
ln(2) = [ (T_1 - T_2) / (T1*T2)]
```

After preprocessing this becomes `ln(2) = ` — the entire right-hand side is stripped, making the answer both wrong and incomparable to other choices.

## Root cause

`\[.*?\]` was borrowed from Wikipedia-cleaning pipelines where all `[…]` markers are editorial artefacts.  GPQA answers are professional exam questions that routinely use bracket notation for mathematical grouping.

## Fix

Restrict the pattern to `\[\w+\]` — only removes markers that consist entirely of word characters (e.g. `[edit]`, `[1]`, `[note]`).  Markers with spaces, operators, or parentheses (i.e. math expressions) are left intact.

The `[title]` case is already handled by the explicit `str.replace` on the line above, so no behaviour changes for that marker.

Closes #2907.