### PR TITLE
docs: add new model implementation template

### DIFF
--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -24,6 +24,8 @@ touch lm_eval/models/<my_model_filename>.py
 
 **Tip: this filename should not shadow package names! For example, naming your file `anthropic.py` is disallowed since the API's name on pypi is `anthropic`, but naming it `anthropic_llms.py` works with no problems.**
 
+For a copy-pasteable starting point that wires up `Collator`, partial caching, and the optional chat-template hooks, see [`templates/new_template_model/`](../templates/new_template_model). Copy `template.py` into `lm_eval/models/` and follow the `# TODO:` markers.
+
 ## Interface
 
 All models must subclass the `lm_eval.api.model.LM` class.
@@ -183,9 +185,62 @@ class MyCustomLM(LM):
 
 If not implemented for a given model type, the flags `--apply_chat_template` , `--fewshot_as_multiturn`, and `--system_instruction` cannot be used.
 
+## Batching, ordering, and caching
+
+The harness ships with a few small utilities that any local-LM implementation should know about. They live in `lm_eval/models/utils.py`, `lm_eval/utils.py`, and `lm_eval/api/model.py`.
+
+### `Collator` — length-sorted batching
+
+`Collator` takes a list of requests, sorts them by a key you provide (typically descending input length), and yields batches of size `n`. Sorting by length keeps padding minimal and makes the longest example run first, so OOMs are caught early instead of after hours of work.
+
+```python
+from lm_eval.models.utils import Collator
+
+def _len(req):  # req is (context, gen_kwargs)
+    return -len(self.tok_encode(req[0]))
+
+collator = Collator(
+    [r.args for r in requests],
+    sort_fn=_len,
+    group_by="gen_kwargs",  # keep requests with matching generation params together
+)
+for batch in collator.get_batched(n=self.batch_size):
+    ...
+# After processing, restore the harness's expected order:
+return collator.get_original(results)
+```
+
+The `group_by` argument is important for `generate_until`: most backends can't mix different `until` strings or `max_gen_toks` values inside a single forward pass. Setting `group_by="gen_kwargs"` keeps each batch homogeneous.
+
+### `Reorderer` — for simple length-sort cases
+
+`lm_eval.utils.Reorderer` is the lightweight predecessor of `Collator`: it just sorts requests by a key, lets you process them in sorted order, and unsorts the results. Use it when you don't need grouping by gen_kwargs or context-prefix sharing — e.g. for `loglikelihood` where each request is independent.
+
+### Partial caching with `cache_hook`
+
+When the user passes `--use_cache <db_path>`, the harness wraps your model with `CachingLM`, which intercepts the three request methods and short-circuits any request whose hash is already in the SQLite cache. To make sure intermediate progress is also persisted (useful for long evaluations that may be interrupted), call `self.cache_hook.add_partial(...)` after each request:
+
+```python
+self.cache_hook.add_partial("generate_until", (context, gen_kwargs), output)
+```
+
+The first argument is the method name, the second is the request payload (must match what `CachingLM` will hash on the next run), and the third is the result. When `--use_cache` was not set, `add_partial` is a no-op.
+
+## Common pitfalls / FAQ
+
+- **Filename shadows a pypi package.** Don't name your file `anthropic.py`, `openai.py`, etc. Use a suffix like `anthropic_llms.py`.
+- **Forgot to import in `lm_eval/models/__init__.py`.** The `@register_model` decorator runs only when the module is imported. Without the import, `--model <name>` will fail with "not found".
+- **Returning the wrong tuple type.** `loglikelihood` returns `list[tuple[float, bool]]`, `loglikelihood_rolling` returns `list[float]`, `generate_until` returns `list[str]`. Mismatches show up as obscure errors deep in the evaluator.
+- **Off-by-one in loglikelihood indexing.** See the diagram in the [Interface](#interface) section: the final continuation token is *not* fed in. If your accuracy looks off-by-one or stuck at chance, suspect this first.
+- **Mixing `gen_kwargs` inside a batch.** Use `Collator(group_by="gen_kwargs")` so requests with different `until` / `max_gen_toks` don't end up in the same forward pass.
+- **Forgetting `collator.get_original(results)`.** The harness assumes responses are in the same order as the input requests, not in length-sorted order.
+- **Whitespace-only stop strings.** Some backends (Anthropic, certain hosted APIs) reject `"\n\n"` as a stop sequence. Filter `[s for s in until if s and s.strip()]` before sending.
+- **Setting `batch_size="auto"` without auto-detection.** If you accept the string, you also need to either implement auto-batch-size or fall back to a sensible default; otherwise `int("auto")` will crash.
+- **Skipping the smoke test.** Always run `--limit 5 --log_samples` against an existing task (e.g. `sciq` for MCQ, `gsm8k` for generative) before opening the PR — the per-sample log will reveal prompt-formatting bugs that aggregate metrics hide.
+
 ## Other
 
-**Pro tip**: In order to make the Evaluation Harness overestimate total runtimes rather than underestimate it, HuggingFace models come in-built with the ability to provide responses on data points in *descending order by total input length* via `lm_eval.utils.Reorderer`. Take a look at `lm_eval.models.hf_causal.HFLM` to see how this is done, and see if you can implement it in your own model!
+**Pro tip**: In order to make the Evaluation Harness overestimate total runtimes rather than underestimate it, HuggingFace models process data points in *descending order by total input length* via `Collator` / `Reorderer`. Take a look at `lm_eval.models.huggingface.HFLM` to see how this is done, and consider implementing the same pattern in your own model.
 
 ## Conclusion
 

--- a/templates/new_template_model/README.md
+++ b/templates/new_template_model/README.md
@@ -1,0 +1,49 @@
+# New Model Template
+
+A copy-pasteable starting point for adding a new local-LM backend to `lm-evaluation-harness`. For the full walkthrough see [`docs/model_guide.md`](../../docs/model_guide.md).
+
+## How to use
+
+1. Copy `template.py` into `lm_eval/models/<your_model_filename>.py`.
+
+   ```sh
+   cp templates/new_template_model/template.py lm_eval/models/my_model.py
+   ```
+
+2. Pick the right base class:
+   - **Subclassing `lm_eval.api.model.TemplateLM`** is usually what you want. It handles prompt assembly, sliding-window perplexity (`loglikelihood_rolling`), and basic batching for you — you only need to implement tokenization, `_loglikelihood_tokens`, and `generate_until`.
+   - **Subclassing `lm_eval.api.model.LM`** directly is for backends that don't tokenize locally (e.g. remote APIs that take strings). You then have to implement all three request methods yourself.
+   - **Subclassing `lm_eval.models.huggingface.HFLM`** is the easiest path if your model loads via `transformers.AutoModelForCausalLM` (or a close variant). See `lm_eval/models/mistral3.py` for a minimal example.
+
+3. Update the `@register_model("...")` decorator with the CLI name(s) for your model.
+
+4. Import your file from `lm_eval/models/__init__.py` so the registry sees it. Without this step, `--model my-model` will fail with "model not found".
+
+5. Smoke-test on a tiny task before opening the PR:
+
+   ```sh
+   lm_eval --model my-model \
+     --model_args pretrained=<path-or-id> \
+     --tasks sciq \
+     --limit 5 \
+     --output_path results/my-model.json \
+     --log_samples
+   ```
+
+   Verify the per-doc samples in `results/samples_*.jsonl` show real prompts and outputs.
+
+## What the template demonstrates
+
+- **Required interface**: `loglikelihood`, `loglikelihood_rolling`, `generate_until`, plus `eot_token_id`, `max_length`, `max_gen_toks`, `batch_size`.
+- **`Collator` usage**: length-sorted batching with `group_by="gen_kwargs"` so requests sharing the same generation parameters stay together.
+- **Partial caching**: how to call `self.cache_hook.add_partial(...)` so later runs benefit from `--use_cache`.
+- **Optional chat-template hooks**: `tokenizer_name`, `chat_template`, `apply_chat_template`.
+
+## Reference implementations
+
+| Backend | File | Notes |
+|---|---|---|
+| HuggingFace `transformers` | `lm_eval/models/huggingface.py` | Full-featured reference — Collator, Reorderer, partial caching, chat templates, multi-GPU |
+| Minimal HF subclass | `lm_eval/models/mistral3.py` | ~130 lines, shows how to override only what changes |
+| Anthropic API | `lm_eval/models/anthropic_llms.py` | Remote-API style, no local tokenization |
+| OpenAI-compatible | `lm_eval/models/openai_completions.py` | Local & remote completions endpoints |

--- a/templates/new_template_model/template.py
+++ b/templates/new_template_model/template.py
@@ -1,0 +1,220 @@
+"""
+Skeleton for a new local LM implementation.
+
+Copy this file to ``lm_eval/models/<your_model_filename>.py`` and fill in the
+TODOs. See ``docs/model_guide.md`` for the full walkthrough and ``HFLM`` in
+``lm_eval/models/huggingface.py`` for a fully-featured reference.
+
+The two main building blocks used here are:
+
+- ``TemplateLM`` (``lm_eval.api.model.TemplateLM``): provides shared
+  tokenization / scoring boilerplate so subclasses only need to implement
+  ``_loglikelihood_tokens`` and ``generate_until``. Subclass this directly
+  for new local models that don't fit the HuggingFace ``transformers`` flow.
+- ``Collator`` (``lm_eval.models.utils.Collator``): reorders requests by
+  length (descending) and yields batches, so padding stays minimal and the
+  longest example is processed first (catches OOMs early).
+
+This skeleton intentionally omits a full ``loglikelihood_tokens`` implementation
+because that part is highly model-specific. The TODOs mark the only places you
+must touch.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from lm_eval.api.model import TemplateLM
+from lm_eval.models.utils import Collator
+
+
+if TYPE_CHECKING:
+    from lm_eval.api.instance import Instance
+
+
+# IMPORTANT: do not name this module the same as a pypi package you import
+# (e.g. ``anthropic.py`` would shadow the ``anthropic`` SDK). Prefer
+# ``<vendor>_llms.py`` or ``<framework>_lm.py``.
+
+eval_logger = logging.getLogger(__name__)
+
+
+# TODO: uncomment and replace ``my-model`` with the CLI name(s) you want to
+# expose, e.g. ``@register_model("my-model", "my-model-chat")``. Keep this
+# decorator commented out in the template so importing it doesn't pollute the
+# real model registry.
+#
+# from lm_eval.api.registry import register_model
+# @register_model("my-model")
+class MyTemplateLM(TemplateLM):
+    """Replace this docstring with a one-liner describing your model backend.
+
+    Construction kwargs are forwarded from ``--model_args``. Keep the signature
+    close to ``HFLM.__init__`` if you want to share documentation.
+    """
+
+    # Maximum sequence length used when the model config doesn't expose one.
+    _DEFAULT_MAX_LENGTH = 2048
+
+    def __init__(
+        self,
+        pretrained: str,
+        batch_size: int | str = 1,
+        max_length: int | None = None,
+        device: str | None = None,
+        **kwargs,
+    ) -> None:
+        # TODO: load your model + tokenizer here. Store everything you need
+        #       on ``self`` so the request methods can reuse it.
+        super().__init__()
+        self._pretrained = pretrained
+        self._batch_size = batch_size
+        self._max_length = max_length or self._DEFAULT_MAX_LENGTH
+        self._device = device
+
+    # ------------------------------------------------------------------
+    # Properties expected by the harness
+    # ------------------------------------------------------------------
+
+    @property
+    def eot_token_id(self) -> int:
+        # TODO: return the model's end-of-text token id (often
+        # ``self.tokenizer.eos_token_id``). Used by the evaluator for stop logic.
+        raise NotImplementedError
+
+    @property
+    def max_length(self) -> int:
+        return self._max_length
+
+    @property
+    def max_gen_toks(self) -> int:
+        # Default cap for ``generate_until`` when a task does not set
+        # ``max_gen_toks``. 256 is a reasonable starting value.
+        return 256
+
+    @property
+    def batch_size(self) -> int:
+        return (
+            int(self._batch_size)
+            if isinstance(self._batch_size, str)
+            else self._batch_size
+        )
+
+    @property
+    def device(self):
+        return self._device
+
+    # ------------------------------------------------------------------
+    # Tokenization (only required if subclassing TemplateLM)
+    # ------------------------------------------------------------------
+
+    def tok_encode(self, string: str, **kwargs) -> list[int]:
+        # TODO: tokenize ``string`` to a list of ids. Whatever you return here
+        #       is what loglikelihood scoring will operate on.
+        raise NotImplementedError
+
+    def tok_decode(self, tokens: list[int], **kwargs) -> str:
+        # TODO: inverse of ``tok_encode``. Used to render generated outputs.
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Required request methods
+    # ------------------------------------------------------------------
+
+    def loglikelihood(self, requests: list[Instance]) -> list[tuple[float, bool]]:
+        """Score each ``(context, continuation)`` pair.
+
+        Returns a list of ``(logprob, is_greedy)`` tuples in the same order
+        as ``requests``.
+        """
+        # TODO: implement, or subclass ``TemplateLM`` and implement
+        #       ``_loglikelihood_tokens`` instead. The base class will then
+        #       handle prompt construction, batching and ordering for you.
+        raise NotImplementedError
+
+    def loglikelihood_rolling(self, requests: list[Instance]) -> list[float]:
+        """Compute full-sequence log-likelihood for perplexity tasks.
+
+        The base ``TemplateLM`` provides a sliding-window implementation built
+        on ``loglikelihood``; override only if you can do something faster.
+        """
+        raise NotImplementedError
+
+    def generate_until(self, requests: list[Instance]) -> list[str]:
+        """Greedy / sampled generation up to per-request stop strings.
+
+        Each ``Instance.args`` is ``(context: str, gen_kwargs: dict)``, where
+        ``gen_kwargs`` may include ``until``, ``max_gen_toks``, ``temperature``,
+        ``do_sample``, etc.
+        """
+
+        # ------- 1) reorder + batch with Collator -------
+        # Sort by descending input length so padding stays minimal and the
+        # longest example is generated first (catches OOM early).
+        def _sort_key(req: tuple[str, dict]) -> int:
+            ctx, _ = req
+            return -len(self.tok_encode(ctx))
+
+        # ``group_by="gen_kwargs"`` keeps requests with identical generation
+        # parameters in the same batch — important because most backends can't
+        # mix ``until`` strings or ``max_gen_toks`` within a single forward pass.
+        collator = Collator(
+            [req.args for req in requests],
+            sort_fn=_sort_key,
+            group_by="gen_kwargs",
+        )
+
+        results: list[str] = []
+        for batch in collator.get_batched(n=self.batch_size):
+            # ``batch`` is a list of ``(context, gen_kwargs)`` tuples that share
+            # the same gen_kwargs.
+            contexts = [ctx for ctx, _ in batch]
+            gen_kwargs = batch[0][1] if batch else {}
+
+            # TODO: call your model here. Translate ``gen_kwargs`` into the
+            #       generate() arguments expected by your backend (e.g. map
+            #       ``until`` -> stop sequences, ``max_gen_toks`` -> max_new_tokens).
+            outputs: list[str] = self._generate(contexts, gen_kwargs)
+
+            # ------- 2) optional partial caching -------
+            # ``cache_hook.add_partial`` writes the request/response pair into
+            # the SQLite cache (when ``--use_cache`` was set). This lets later
+            # runs short-circuit identical requests without re-hitting the model.
+            for (ctx, gk), out in zip(batch, outputs, strict=True):
+                self.cache_hook.add_partial("generate_until", (ctx, gk), out)
+                results.append(out)
+
+        # ------- 3) restore original order -------
+        # The Collator hands batches back in length-sorted order; the harness
+        # expects responses indexed the same as the input requests.
+        return collator.get_original(results)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _generate(self, contexts: list[str], gen_kwargs: dict) -> list[str]:
+        # TODO: implement model-specific generation here.
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Optional: chat-template support
+    # ------------------------------------------------------------------
+    # Implement these to make ``--apply_chat_template``, ``--system_instruction``
+    # and ``--fewshot_as_multiturn`` work with your model. See
+    # ``HFLM.apply_chat_template`` for a reference.
+
+    @property
+    def tokenizer_name(self) -> str:
+        # Used to fingerprint cached requests across chat templates.
+        raise NotImplementedError
+
+    def chat_template(self, chat_template: bool | str = False) -> str | None:
+        # Return the Jinja chat template string (or "" for no template).
+        return ""
+
+    def apply_chat_template(
+        self, chat_history: list[dict[str, str]], add_generation_prompt: bool = True
+    ) -> str:
+        raise NotImplementedError


### PR DESCRIPTION
Add a model template and expand the model guide with batching, ordering, caching, and implementation pitfalls so new contributors have a clearer starting point.

## Summary
- Add a `templates/new_template_model/` starter template for local model implementations.
- Expand `docs/model_guide.md` with notes on `Collator`, `Reorderer`, partial caching, and common model implementation pitfalls.
- Link the model guide to the new template so contributors have a clearer starting point.
Closes #2358.