### PR TITLE
Fix zeno_visualize discarding tasks intersection result

### DIFF
--- a/scripts/zeno_visualize.py
+++ b/scripts/zeno_visualize.py
@@ -79,7 +79,7 @@ def main():
         old_tasks = tasks.copy()
         task_count = len(tasks)
         model_tasks = set(tasks_for_model(model, args.data_path))
-        tasks.intersection(set(model_tasks))
+        tasks &= set(model_tasks)
 
         if task_count != len(tasks):
             eval_logger.warning(


### PR DESCRIPTION
**Bug:** `tasks.intersection(set(model_tasks))` on line 82 of `scripts/zeno_visualize.py` discards the result — `set.intersection()` is non-mutating and returns a new set without modifying the receiver.

**Root cause:** `set.intersection(other)` returns the intersection as a new set; it does not update `self` in place. The caller must either use `set &= other` (in-place) or reassign the return value.

**Effect:** `tasks` is never narrowed, so:
1. The warning on lines 84-87 (`if task_count != len(tasks)`) can never fire — `len(tasks)` is unchanged.
2. All tasks from the first model are used regardless of whether subsequent models have them, causing `zeno_visualize` to attempt uploading data for tasks that some models never evaluated.

**Fix:** Replace with the in-place form `tasks &= set(model_tasks)`.

Closes #3646