### PR TITLE
fix(mgsm): migrate dataset_path from juletxara/mgsm to jbross-ibm-research/mgsm

### DIFF
--- a/lm_eval/tasks/mgsm/direct/direct_yaml
+++ b/lm_eval/tasks/mgsm/direct/direct_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 tag: mgsm_direct
-dataset_path: juletxara/mgsm
+dataset_path: jbross-ibm-research/mgsm
 dataset_name: null  # Overridden by language-specific config.
 output_type: generate_until
 training_split: train

--- a/lm_eval/tasks/mgsm/en_cot/cot_yaml
+++ b/lm_eval/tasks/mgsm/en_cot/cot_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 tag: mgsm_cot_native
-dataset_path: juletxara/mgsm
+dataset_path: jbross-ibm-research/mgsm
 dataset_name: null  # Overridden by language-specific config.
 output_type: generate_until
 training_split: train

--- a/lm_eval/tasks/mgsm/native_cot/cot_yaml
+++ b/lm_eval/tasks/mgsm/native_cot/cot_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 tag: mgsm_cot_native
-dataset_path: juletxara/mgsm
+dataset_path: jbross-ibm-research/mgsm
 dataset_name: null  # Overridden by language-specific config.
 output_type: generate_until
 training_split: train


### PR DESCRIPTION
## Problem

All three `mgsm` task variants (`direct`, `en_cot`, `native_cot`) fail to load with modern versions of the `datasets` library (>= 2.11.0):

```
RuntimeError: Dataset scripts are no longer supported, but found mgsm.py
```

The current `dataset_path: juletxara/mgsm` relies on a legacy `mgsm.py` loading script, which HuggingFace Datasets has deprecated and now blocks entirely.

## Fix

Replace with `jbross-ibm-research/mgsm`, a script-less mirror of the same dataset with identical splits (`train`, `test`) and schema (`question`, `answer`, `answer_number`, `equation_solution`).

The change touches only the 3 base YAML files (`direct_yaml`, `en_cot/cot_yaml`, `native_cot/cot_yaml`) — all 33 language-specific configs inherit `dataset_path` from these via `include:`, so no per-language changes are needed.

## Files changed

- `lm_eval/tasks/mgsm/direct/direct_yaml`
- `lm_eval/tasks/mgsm/en_cot/cot_yaml`
- `lm_eval/tasks/mgsm/native_cot/cot_yaml`

Fixes #3390