### PR TITLE
fix(api): chat payload leaking top-level text type

### DIFF
--- a/lm_eval/models/anthropic_llms.py
+++ b/lm_eval/models/anthropic_llms.py
@@ -326,10 +326,11 @@ class AnthropicChat(LocalCompletionsAPI):
 
         cleaned_messages = []
         for msg in messages:
+            msg_type = msg.get("type", "text")
             cleaned_msg = {
                 "role": msg["role"],
                 "content": [
-                    {"type": msg["type"], msg["type"]: msg["content"]},
+                    {"type": msg_type, msg_type: msg["content"]},
                 ],
             }
             cleaned_messages.append(cleaned_msg)

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -87,8 +87,8 @@ def create_image_prompt(
         }
         images.append(img_dict)
 
-    # chat is in format of list[dict["role": "user"/"system", "content": str, "type": "text"],...]
-    # with images, we need "content" to be a list of dicts with "type" and "text"/"image_url"
+    # With images, we need "content" to be a list of dicts with
+    # "type" and "text"/"image_url".
     # currently we do not support few-shots so only one user message
     # text content also has <image> placeholders, which apparently is not necessary for API class (confirm)
 
@@ -97,7 +97,7 @@ def create_image_prompt(
     else:
         text_content = {"type": "text", "text": chat[-1]["content"]}
         chat[-1]["content"] = images + [text_content]
-    chat[-1].pop("type")
+    chat[-1].pop("type", None)
     return chat
 
 
@@ -342,12 +342,7 @@ class TemplateAPI(TemplateLM):
             return chat_history
         else:
             # bit of a hack. We'll load back before sending to the API
-            return JsonChatStr(
-                json.dumps(
-                    [{**item, "type": "text"} for item in chat_history],
-                    ensure_ascii=False,
-                )
-            )
+            return JsonChatStr(json.dumps(chat_history, ensure_ascii=False))
 
     @cached_property
     def eot_token_id(self) -> Optional[int]:

--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from lm_eval.models.api_models import create_image_prompt
 from lm_eval.models.openai_completions import LocalCompletionsAPI
 
 
@@ -159,6 +161,57 @@ def test_model_tokenized_call_usage(
         assert "json" in kwargs
         assert kwargs["json"] == expected_payload
         assert result == {"result": "success"}
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [
+        pytest.param(
+            "LocalChatCompletion",
+            id="local-chat-completions",
+        ),
+        pytest.param(
+            "OpenAIChatCompletion",
+            id="openai-chat-completions",
+        ),
+    ],
+)
+def test_chat_template_payload_does_not_add_top_level_type(model_cls):
+    from lm_eval.models import openai_completions
+
+    model = getattr(openai_completions, model_cls)(
+        base_url="http://test-url.com",
+        model="test-model",
+    )
+    chat = [{"role": "user", "content": "Reply with one word: hello"}]
+
+    messages = model.create_message((model.apply_chat_template(chat),))
+    payload = model._create_payload(messages, generate=True, gen_kwargs={})
+
+    assert payload["messages"] == chat
+    assert "type" not in payload["messages"][0]
+
+
+@pytest.mark.parametrize("include_legacy_type", [False, True])
+def test_create_image_prompt_uses_content_parts_without_top_level_type(
+    include_legacy_type,
+):
+    class DummyImage:
+        def save(self, buf, format):
+            buf.write(b"image-bytes")
+
+    chat = [{"role": "user", "content": "Describe this image"}]
+    if include_legacy_type:
+        chat[0]["type"] = "text"
+
+    messages = create_image_prompt([DummyImage()], json.loads(json.dumps(chat)))
+
+    assert "type" not in messages[-1]
+    assert messages[-1]["content"][0]["type"] == "image_url"
+    assert messages[-1]["content"][1] == {
+        "type": "text",
+        "text": "Describe this image",
+    }
 
 
 class DummyAsyncContextManager:

--- a/tests/models/test_litellm.py
+++ b/tests/models/test_litellm.py
@@ -28,7 +28,7 @@ OPENAI_CHAT_RESPONSE = {
 def _chat_messages(content="Hi"):
     """Wrap chat messages as JsonChatStr — the format generate_until uses."""
     return (
-        JsonChatStr(json.dumps([{"role": "user", "content": content, "type": "text"}])),
+        JsonChatStr(json.dumps([{"role": "user", "content": content}])),
     )
 
 
@@ -108,9 +108,7 @@ def test_model_call(litellm_model):
     litellm_model._litellm.completion.assert_called_once()
     call_kwargs = litellm_model._litellm.completion.call_args[1]
     assert call_kwargs["model"] == "gpt-4o-mini"
-    assert call_kwargs["messages"] == [
-        {"role": "user", "content": "Hi", "type": "text"}
-    ]
+    assert call_kwargs["messages"] == [{"role": "user", "content": "Hi"}]
     assert result == OPENAI_CHAT_RESPONSE
 
 


### PR DESCRIPTION
## Summary

Fixes the non-tokenized API chat path so text-only chat messages are sent in the standard OpenAI-compatible shape:

```json
{"role": "user", "content": "..."}
```

instead of leaking an internal top-level text marker:

```json
{"role": "user", "content": "...", "type": "text"}
```

The leaked top-level type field is rejected by stricter OpenAI-compatible backends for Mistral models. Typed text is still used where it belongs:
inside multimodal content parts.

## Details

TemplateAPI.apply_chat_template() was wrapping non-tokenized API chat messages in JsonChatStr, but also added type: "text" to each message.
create_message() later deserializes that value unchanged, and the OpenAI-compatible chat payload builders pass it through directly as messages.

This changes the text-only path to serialize chat_history unchanged. For multimodal requests, create_image_prompt() still converts string content
into OpenAI-style content parts such as:

```json
[
	{"type": "image_url", "image_url": {"url": "..."}},
	{"type": "text", "text": "..."}
]
```

It also tolerates legacy/internal messages that still contain a top-level type.

## Reproduction

A strict Mistral-compatible endpoint rejects the extra top-level type:

```bash
curl -sS "$BASE_URL" \
	-H "Content-Type: application/json" \
	-H "Authorization: Bearer $API_KEY" \
	-d '{
		"model": "mistralai/Mistral-Medium-3.5-128B",
		"messages": [
			{"role": "user", "content": "Reply with one word: hello", "type": "text"}
		],
		"max_tokens": 10
	}'
```
Response:
```json
{
	"error": {
		"message": "1 validation error for UserMessage\ntype\n  Extra inputs are not permitted ...",
		"type": "BadRequestError",
		"code": 400
	}
}
```
The same request without top-level type succeeds:
```bash
curl -sS "$BASE_URL" \
	-H "Content-Type: application/json" \
	-H "Authorization: Bearer $API_KEY" \
	-d '{
		"model": "mistralai/Mistral-Medium-3.5-128B",
		"messages": [
			{"role": "user", "content": "Reply with one word: hello"}
		],
		"max_tokens": 10
	}'
```
mistral-common’s OpenAI conversion also emits text-only user messages as {"role": "user", "content": "..."} and only uses typed structures inside
content chunks for multimodal content:
https://mistralai.github.io/mistral-common/code_reference/mistral_common/protocol/instruct/messages/

## Tests

- Added coverage that local-chat-completions and openai-chat-completions no longer add top-level type.
- Added coverage that multimodal image prompts still use content parts and remove/tolerate top-level type.
- Updated LiteLLM chat tests to expect the clean message shape.

