### PR TITLE
fix(task): only raise ValueError on rank 0 when no docs found in distributed eval

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -372,7 +372,7 @@ class Task(abc.ABC):
 
         self._instances = flattened_instances
 
-        if len(self._instances) == 0:
+        if len(self._instances) == 0 and rank == 0:
             raise ValueError("task.build_requests() did not find any docs!")
 
         if cache_requests and (not cached_instances or rewrite_requests_cache):


### PR DESCRIPTION
## Bug

When running distributed evaluation with `world_size > num_docs`, ranks with index ≥ num_docs receive an empty doc iterator from `islice(raw_iterator, rank, limit, world_size)`. These ranks legitimately have zero instances — not a task misconfiguration — yet the unconditional guard on [line 375 of `lm_eval/api/task.py`](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/api/task.py#L375) raises `ValueError: task.build_requests() did not find any docs!` and kills the entire run.

## Root cause

```python
# Before — fires on every rank that gets no docs
if len(self._instances) == 0:
    raise ValueError("task.build_requests() did not find any docs!")
```

Rank 0 always receives at least one document when the task is non-empty (it takes indices 0, world_size, 2·world_size, …), so an empty `_instances` on rank 0 is the correct signal that the task truly has no documents. Higher ranks receiving zero documents is a normal outcome of the modular distribution.

## Fix

```python
# After — only fires on rank 0, where an empty task is genuinely erroneous
if len(self._instances) == 0 and rank == 0:
    raise ValueError("task.build_requests() did not find any docs!")
```

`rank` is already a parameter of `build_all_requests()`, so no additional plumbing is required. The change is a single token addition.

Fixes #3511.