### PR TITLE
fix(mmlu_pro_plus): sync fixes from `mmlu_pro`

### DIFF
--- a/lm_eval/tasks/mmlu-pro-plus/README.md
+++ b/lm_eval/tasks/mmlu-pro-plus/README.md
@@ -68,3 +68,7 @@ If other tasks on this dataset are already supported:
 * [x] Have you noted which, if any, published evaluation setups are matched by this variant?
 
 ### Changelog
+
+* (tasks, group) 2026-05-04 -- (version 1.0 --> version 1.1)
+  * fix fewshot answers being rendered in user turns instead of assistant turns under `--apply_chat_template` (mirrors mmlu_pro #3693).
+  * trimmed whitespace from options (mirrors mmlu_pro #3500).

--- a/lm_eval/tasks/mmlu-pro-plus/_default_template_yaml
+++ b/lm_eval/tasks/mmlu-pro-plus/_default_template_yaml
@@ -4,7 +4,7 @@ fewshot_split: validation
 fewshot_config:
   sampler: first_n
   doc_to_text: !function utils.fewshot_to_text
-  doc_to_target: ""
+  doc_to_target: !function utils.fewshot_to_target
 output_type: generate_until
 doc_to_text: !function utils.doc_to_text
 doc_to_target: answer
@@ -30,4 +30,4 @@ metric_list:
     ignore_case: true
     ignore_punctuation: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/mmlu-pro-plus/utils.py
+++ b/lm_eval/tasks/mmlu-pro-plus/utils.py
@@ -28,7 +28,7 @@ def format_cot_example(example, including_answer=True):
     prompt += question + "\n"
     prompt += "Options:\n"
     for i, opt in enumerate(options):
-        prompt += "{}. {}\n".format(choices[i], opt)
+        prompt += f"{choices[i]}. {opt.strip()}\n"
     if including_answer:
         cot_content = example["cot_content"].replace(
             "A: Let's think step by step.", "Answer: Let's think step by step."
@@ -39,8 +39,14 @@ def format_cot_example(example, including_answer=True):
     return prompt
 
 
+def format_cot_target(example, including_answer=True):
+    cot_content = example["cot_content"].replace("A: Let's think step by step. ", "")
+    return cot_content
+
+
 doc_to_text = partial(format_cot_example, including_answer=False)
-fewshot_to_text = partial(format_cot_example, including_answer=True)
+fewshot_to_text = partial(format_cot_example, including_answer=False)
+fewshot_to_target = partial(format_cot_target, including_answer=True)
 
 
 def process_docs(dataset, subject):


### PR DESCRIPTION
`mmlu_pro_plus` was forked from `mmlu_pro` and has drifted out of sync. This ports two the fixes:                                                                    
                                                                                                                                                                                     
  - Fewshot answers were rendered in the user turn instead of the assistant turn under `--apply_chat_template`. #3693.                                                       
  - Option strings weren't whitespace-trimmed, biasing the choice-letter regex extractor. #3500.              