### PR TITLE
Fix infinite loop in ruler vt/cwe generate_samples when noise/word count hits floor

### DIFF
--- a/lm_eval/tasks/ruler/cwe_utils.py
+++ b/lm_eval/tasks/ruler/cwe_utils.py
@@ -140,6 +140,8 @@ def sys_word_pair_random(
             except:  # noqa: E722
                 if used_words > incremental:
                     used_words -= incremental
+                else:
+                    break
 
         if remove_newline_tab:
             input_text = " ".join(

--- a/lm_eval/tasks/ruler/vt_utils.py
+++ b/lm_eval/tasks/ruler/vt_utils.py
@@ -186,6 +186,8 @@ def sys_vartrack_w_noise_random(
             except:  # noqa: E722
                 if used_noises > incremental:
                     used_noises -= incremental
+                else:
+                    break
 
         if add_fewshot and (icl_example is not None):
             # insert icl_example between model template and input


### PR DESCRIPTION
## Bug

The `while True` retry loops in `vt_utils.py` and `cwe_utils.py` share the
same defect already fixed in `qa_utils.py` (PR #3713): the loop spins
forever when `max_seq_length` is smaller than the minimum possible example
(e.g. 2048 instead of the typical 4096).

**`vt_utils.py` (`used_noises`):**
```python
except:  # noqa: E722
    if used_noises > incremental:
        used_noises -= incremental
    # nothing when used_noises <= incremental → infinite loop
```

**`cwe_utils.py` (`used_words`):**
```python
except:  # noqa: E722
    if used_words > incremental:
        used_words -= incremental
    # same gap
```

## Root cause

The guard `> incremental` prevents the counter from going negative, but
leaves no exit path once it reaches `incremental`. The loop retries with
the same unchanged counter indefinitely.

## Fix

Add `else: break` in both files, identical to the fix already applied to
`qa_utils.py` in #3713. When the counter can no longer shrink, exit the
loop; the last generated example (which may slightly exceed the target
length) is accepted rather than hanging forever.

Fixes #2963