### PR TITLE
add scripts/export_attestation.py (#3749)

### DIFF
--- a/scripts/attestation.schema.json
+++ b/scripts/attestation.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "lm-evaluation-harness attestation bundle",
+  "type": "object",
+  "required": [
+    "harness_attestation_version",
+    "model_id",
+    "tasks",
+    "results",
+    "results_sha256",
+    "outputs_sha256",
+    "meta"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "harness_attestation_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "model_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tasks": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["task_id", "metric", "filter", "value", "stderr"],
+        "additionalProperties": false,
+        "properties": {
+          "task_id": { "type": "string" },
+          "metric": { "type": "string" },
+          "filter": { "type": "string" },
+          "value": {
+            "type": "string",
+            "pattern": "^-?(0\\.0|[1-9][0-9]*\\.[0-9]+|[0-9]+(\\.[0-9]+)?e-?[0-9]+)$"
+          },
+          "stderr": {
+            "oneOf": [
+              { "type": "null" },
+              {
+                "type": "string",
+                "pattern": "^-?(0\\.0|[1-9][0-9]*\\.[0-9]+|[0-9]+(\\.[0-9]+)?e-?[0-9]+)$"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "results_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "outputs_sha256": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      ]
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "git_hash": { "type": ["string", "null"] },
+        "versions": { "type": "object" },
+        "n_shot": { "type": "object" },
+        "date": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/scripts/export_attestation.py
+++ b/scripts/export_attestation.py
@@ -16,9 +16,12 @@ import json
 import math
 import sys
 import unicodedata
-from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 ATTESTATION_VERSION = 1
@@ -44,8 +47,7 @@ def _format_float(x: float) -> str:
     s = repr(float(x))
     if "e" in s:
         mantissa, _, exp = s.partition("e")
-        if exp.startswith("+"):
-            exp = exp[1:]
+        exp = exp.removeprefix("+")
         sign = "-" if exp.startswith("-") else ""
         digits = exp.lstrip("+-").lstrip("0") or "0"
         s = f"{mantissa}e{sign}{digits}"
@@ -136,13 +138,15 @@ def extract_results(doc: dict) -> list[dict]:
             stderr_str = _format_metric_value(
                 metrics.get(f"{metric}_stderr,{filter_key}")
             )
-            entries.append({
-                "task_id": task_id,
-                "metric": metric,
-                "filter": filter_key,
-                "value": value_str,
-                "stderr": stderr_str,
-            })
+            entries.append(
+                {
+                    "task_id": task_id,
+                    "metric": metric,
+                    "filter": filter_key,
+                    "value": value_str,
+                    "stderr": stderr_str,
+                }
+            )
     entries.sort(key=lambda e: (e["task_id"], e["metric"], e["filter"]))
     return entries
 
@@ -224,12 +228,16 @@ def compute_outputs_sha256(samples_paths: list[Path]) -> str:
                     f"filter={r.get('filter', '')!r}"
                 )
             seen.add(key)
-            h.update(canonical_encode({
-                "task_id": task_id,
-                "doc_id": r["doc_id"],
-                "filter": r.get("filter", ""),
-                "filtered_resps": r["filtered_resps"],
-            }))
+            h.update(
+                canonical_encode(
+                    {
+                        "task_id": task_id,
+                        "doc_id": r["doc_id"],
+                        "filter": r.get("filter", ""),
+                        "filtered_resps": r["filtered_resps"],
+                    }
+                )
+            )
             h.update(b"\n")
     return h.hexdigest()
 
@@ -247,7 +255,8 @@ def discover_pair(input_dir: Path) -> tuple[Path, list[Path]]:
 def pair_samples_for_results(results_path: Path) -> list[Path]:
     date_id = _date_id(results_path.name)
     return sorted(
-        p for p in results_path.parent.glob("samples_*.jsonl")
+        p
+        for p in results_path.parent.glob("samples_*.jsonl")
         if _date_id(p.name) == date_id
     )
 
@@ -295,22 +304,31 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     src = p.add_mutually_exclusive_group(required=True)
     src.add_argument(
-        "--input_dir", type=Path,
+        "--input_dir",
+        type=Path,
         help="Directory containing results_*.json (and samples_*.jsonl).",
     )
     src.add_argument(
-        "--results", type=Path, help="Explicit results_*.json file.",
+        "--results",
+        type=Path,
+        help="Explicit results_*.json file.",
     )
     p.add_argument(
-        "--samples", nargs="+", type=Path, default=None,
+        "--samples",
+        nargs="+",
+        type=Path,
+        default=None,
         help="Explicit sample files; only valid with --results.",
     )
     p.add_argument(
-        "--output", type=Path, default=None,
+        "--output",
+        type=Path,
+        default=None,
         help="Where to write the bundle. Default: stdout.",
     )
     p.add_argument(
-        "--no_samples", action="store_true",
+        "--no_samples",
+        action="store_true",
         help="Skip outputs hashing.",
     )
     return p.parse_args(argv)
@@ -328,7 +346,8 @@ def main(argv: list[str] | None = None) -> int:
         else:
             results_path = args.results
             samples_paths = (
-                list(args.samples) if args.samples is not None
+                list(args.samples)
+                if args.samples is not None
                 else pair_samples_for_results(results_path)
             )
         bundle = build_attestation(

--- a/scripts/export_attestation.py
+++ b/scripts/export_attestation.py
@@ -1,0 +1,351 @@
+"""Export an attestation bundle from lm-evaluation-harness output.
+
+Reads --output_path / --log_samples artifacts and emits a JSON document
+containing SHA256 digests of the headline scores and per-sample outputs.
+See attestation.schema.json for the bundle shape and canonical encoding rules.
+
+Stdlib-only. The bundle provides integrity, not authenticity; sign it
+separately if you need authentication.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+import unicodedata
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+
+ATTESTATION_VERSION = 1
+
+
+class AttestationError(Exception):
+    exit_code = 1
+
+
+class ResultsError(AttestationError):
+    exit_code = 3
+
+
+class SamplesError(AttestationError):
+    exit_code = 4
+
+
+def _format_float(x: float) -> str:
+    if not math.isfinite(x):
+        raise ValueError(f"non-finite float not allowed: {x!r}")
+    if x == 0.0:
+        return "0.0"
+    s = repr(float(x))
+    if "e" in s:
+        mantissa, _, exp = s.partition("e")
+        if exp.startswith("+"):
+            exp = exp[1:]
+        sign = "-" if exp.startswith("-") else ""
+        digits = exp.lstrip("+-").lstrip("0") or "0"
+        s = f"{mantissa}e{sign}{digits}"
+    return s
+
+
+def _canonicalize(obj: Any) -> Any:
+    if obj is None or isinstance(obj, bool):
+        return obj
+    if isinstance(obj, int):
+        return obj
+    if isinstance(obj, float):
+        return _format_float(obj)
+    if isinstance(obj, str):
+        return unicodedata.normalize("NFC", obj)
+    if isinstance(obj, (list, tuple)):
+        return [_canonicalize(x) for x in obj]
+    if isinstance(obj, dict):
+        out: dict[str, Any] = {}
+        for k, v in obj.items():
+            if not isinstance(k, str):
+                raise TypeError(f"dict keys must be strings; got {type(k).__name__}")
+            out[unicodedata.normalize("NFC", k)] = _canonicalize(v)
+        return out
+    raise TypeError(f"unsupported type: {type(obj).__name__}")
+
+
+def canonical_encode(obj: Any) -> bytes:
+    return json.dumps(
+        _canonicalize(obj),
+        sort_keys=True,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def derive_model_id(doc: dict) -> str:
+    source = doc.get("model_source")
+    name = doc.get("model_name")
+    if source and name:
+        return f"{source}/{name}"
+
+    config = doc.get("config") or {}
+    raw_source = config.get("model")
+    raw_args = config.get("model_args")
+    if raw_source and raw_args:
+        for prefix in ("peft", "delta", "pretrained", "model", "path", "engine"):
+            if isinstance(raw_args, dict):
+                value = raw_args.get(prefix)
+                if isinstance(value, str) and value.strip():
+                    return f"{raw_source}/{value.strip()}"
+            if isinstance(raw_args, str) and f"{prefix}=" in raw_args:
+                tail = raw_args.split(f"{prefix}=", 1)[1]
+                value = tail.split(",", 1)[0].strip()
+                if value:
+                    return f"{raw_source}/{value}"
+        return str(raw_source)
+    return raw_source or name or "unknown"
+
+
+def _format_metric_value(value: Any) -> str | None:
+    if not _is_number(value):
+        return None
+    return _format_float(float(value))
+
+
+def extract_results(doc: dict) -> list[dict]:
+    entries: list[dict] = []
+    for task_id, metrics in (doc.get("results") or {}).items():
+        if not isinstance(metrics, dict):
+            continue
+        for key, value in metrics.items():
+            metric, sep, filter_key = key.partition(",")
+            if not sep or metric.endswith("_stderr"):
+                continue
+            value_str = _format_metric_value(value)
+            if value_str is None:
+                continue
+            stderr_str = _format_metric_value(
+                metrics.get(f"{metric}_stderr,{filter_key}")
+            )
+            entries.append({
+                "task_id": task_id,
+                "metric": metric,
+                "filter": filter_key,
+                "value": value_str,
+                "stderr": stderr_str,
+            })
+    entries.sort(key=lambda e: (e["task_id"], e["metric"], e["filter"]))
+    return entries
+
+
+def derive_tasks(entries: list[dict]) -> list[str]:
+    return sorted({e["task_id"] for e in entries})
+
+
+def derive_meta(doc: dict) -> dict:
+    return {
+        "git_hash": doc.get("git_hash"),
+        "versions": doc.get("versions") or {},
+        "n_shot": doc.get("n-shot") or {},
+        "date": doc.get("date"),
+    }
+
+
+def _date_id(name: str) -> str:
+    stem = name
+    for ext in (".jsonl", ".json"):
+        if stem.endswith(ext):
+            stem = stem[: -len(ext)]
+            break
+    return stem.rsplit("_", 1)[-1]
+
+
+def _task_from_samples_name(name: str) -> str:
+    stem = name
+    for ext in (".jsonl", ".json"):
+        if stem.endswith(ext):
+            stem = stem[: -len(ext)]
+            break
+    parts = stem.split("_", 1)
+    if len(parts) < 2:
+        raise SamplesError(f"unrecognised samples filename: {name}")
+    return parts[1].rsplit("_", 1)[0]
+
+
+def iter_sample_records(samples_paths: list[Path]) -> Iterator[tuple[str, dict]]:
+    for p in samples_paths:
+        task_id = _task_from_samples_name(p.name)
+        try:
+            f = p.open(encoding="utf-8")
+        except FileNotFoundError as e:
+            raise SamplesError(f"samples file not found: {p}") from e
+        except OSError as e:
+            raise SamplesError(f"could not read {p}: {e}") from e
+        with f:
+            for line_no, raw in enumerate(f, 1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError as e:
+                    raise SamplesError(f"{p}:{line_no}: {e}") from e
+                yield task_id, record
+
+
+def compute_outputs_sha256(samples_paths: list[Path]) -> str:
+    by_task: dict[str, list[dict]] = {}
+    for task_id, record in iter_sample_records(samples_paths):
+        by_task.setdefault(task_id, []).append(record)
+
+    h = hashlib.sha256()
+    for task_id in sorted(by_task):
+        records = by_task[task_id]
+        records.sort(key=lambda r: (r.get("doc_id"), r.get("filter", "")))
+        seen: set[tuple] = set()
+        for r in records:
+            if "doc_id" not in r or "filtered_resps" not in r:
+                raise SamplesError(
+                    f"sample for task {task_id!r} missing doc_id/filtered_resps"
+                )
+            key = (r["doc_id"], r.get("filter", ""))
+            if key in seen:
+                raise SamplesError(
+                    f"collision in task {task_id!r}: doc_id={r['doc_id']!r}, "
+                    f"filter={r.get('filter', '')!r}"
+                )
+            seen.add(key)
+            h.update(canonical_encode({
+                "task_id": task_id,
+                "doc_id": r["doc_id"],
+                "filter": r.get("filter", ""),
+                "filtered_resps": r["filtered_resps"],
+            }))
+            h.update(b"\n")
+    return h.hexdigest()
+
+
+def discover_pair(input_dir: Path) -> tuple[Path, list[Path]]:
+    if not input_dir.is_dir():
+        raise ResultsError(f"not a directory: {input_dir}")
+    results_files = list(input_dir.glob("results_*.json"))
+    if not results_files:
+        raise ResultsError(f"no results_*.json in {input_dir}")
+    latest = max(results_files, key=lambda p: _date_id(p.name))
+    return latest, pair_samples_for_results(latest)
+
+
+def pair_samples_for_results(results_path: Path) -> list[Path]:
+    date_id = _date_id(results_path.name)
+    return sorted(
+        p for p in results_path.parent.glob("samples_*.jsonl")
+        if _date_id(p.name) == date_id
+    )
+
+
+def build_attestation(
+    results_path: Path,
+    samples_paths: list[Path] | None,
+    *,
+    include_outputs: bool = True,
+) -> dict:
+    try:
+        doc = json.loads(results_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise ResultsError(str(e)) from e
+    except json.JSONDecodeError as e:
+        raise ResultsError(f"{results_path}: {e}") from e
+
+    entries = extract_results(doc)
+    if not entries:
+        raise ResultsError(f"no scalar metric entries in {results_path}")
+
+    model_id = derive_model_id(doc)
+    tasks = derive_tasks(entries)
+    claim = {"model_id": model_id, "tasks": tasks, "results": entries}
+
+    if include_outputs and samples_paths:
+        outputs_sha = compute_outputs_sha256(samples_paths)
+    else:
+        outputs_sha = None
+
+    return {
+        "harness_attestation_version": ATTESTATION_VERSION,
+        "model_id": model_id,
+        "tasks": tasks,
+        "results": entries,
+        "results_sha256": sha256_hex(canonical_encode(claim)),
+        "outputs_sha256": outputs_sha,
+        "meta": derive_meta(doc),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Export an attestation bundle from lm-evaluation-harness output."
+    )
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--input_dir", type=Path,
+        help="Directory containing results_*.json (and samples_*.jsonl).",
+    )
+    src.add_argument(
+        "--results", type=Path, help="Explicit results_*.json file.",
+    )
+    p.add_argument(
+        "--samples", nargs="+", type=Path, default=None,
+        help="Explicit sample files; only valid with --results.",
+    )
+    p.add_argument(
+        "--output", type=Path, default=None,
+        help="Where to write the bundle. Default: stdout.",
+    )
+    p.add_argument(
+        "--no_samples", action="store_true",
+        help="Skip outputs hashing.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.samples is not None and args.results is None:
+        print("--samples requires --results", file=sys.stderr)
+        return 2
+
+    try:
+        if args.input_dir is not None:
+            results_path, samples_paths = discover_pair(args.input_dir)
+        else:
+            results_path = args.results
+            samples_paths = (
+                list(args.samples) if args.samples is not None
+                else pair_samples_for_results(results_path)
+            )
+        bundle = build_attestation(
+            results_path, samples_paths, include_outputs=not args.no_samples
+        )
+    except AttestationError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return e.exit_code
+
+    output = json.dumps(bundle, indent=2, ensure_ascii=False) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        sys.stdout.write(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_export_attestation.py
+++ b/tests/scripts/test_export_attestation.py
@@ -1,0 +1,733 @@
+"""Tests for scripts/export_attestation.py. Stdlib-only."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+from scripts.export_attestation import (
+    ATTESTATION_VERSION,
+    AttestationError,
+    ResultsError,
+    SamplesError,
+    _format_float,
+    build_attestation,
+    canonical_encode,
+    compute_outputs_sha256,
+    derive_meta,
+    derive_model_id,
+    derive_tasks,
+    discover_pair,
+    extract_results,
+    main,
+    pair_samples_for_results,
+    sha256_hex,
+)
+
+
+DATE_ID = "2024-01-01T00-00-00.000000"
+RESULTS_HASH = "f1070dd00dedbe06a9ccf354eacc3ea40ae6636de117378e96114aacaf948522"
+OUTPUTS_HASH = "67d91f2214d6f512947e562697905cf4af96717121a302794c8256b0c6aa0e6d"
+
+
+def _make_results_doc(model_source="hf", model_name="EleutherAI/pythia-70m"):
+    return {
+        "model_source": model_source,
+        "model_name": model_name,
+        "model_name_sanitized": model_name.replace("/", "__"),
+        "results": {
+            "arc_easy": {
+                "name": "arc_easy",
+                "alias": "arc_easy",
+                "sample_len": 2,
+                "acc,none": 0.5,
+                "acc_stderr,none": 0.1,
+                "acc_norm,none": 0.75,
+                "acc_norm_stderr,none": "N/A",
+            },
+            "hellaswag": {
+                "name": "hellaswag",
+                "alias": "hellaswag",
+                "sample_len": 2,
+                "acc,none": 0.25,
+                "acc_stderr,none": 0.05,
+            },
+        },
+        "configs": {"arc_easy": {}, "hellaswag": {}},
+        "versions": {"arc_easy": "1.0", "hellaswag": "1.0"},
+        "n-shot": {"arc_easy": 0, "hellaswag": 0},
+        "config": {"model": "hf", "model_args": "pretrained=EleutherAI/pythia-70m"},
+        "git_hash": "abcd1234",
+        "date": "2024-01-01T00:00:00",
+    }
+
+
+def _make_sample(doc_id, filtered_resps, filter_key="none"):
+    return {
+        "doc_id": doc_id,
+        "doc": {"question": f"q{doc_id}"},
+        "target": "A",
+        "arguments": {"gen_args_0": {"arg_0": "ctx"}},
+        "resps": filtered_resps,
+        "filtered_resps": filtered_resps,
+        "filter": filter_key,
+        "metrics": ["acc"],
+        "doc_hash": "h" * 64,
+        "prompt_hash": "p" * 64,
+        "target_hash": "t" * 64,
+    }
+
+
+def _write_fixture(tmp_path, with_samples=True):
+    model_dir = tmp_path / "EleutherAI__pythia-70m"
+    model_dir.mkdir()
+    results_path = model_dir / f"results_{DATE_ID}.json"
+    results_path.write_text(json.dumps(_make_results_doc()), encoding="utf-8")
+
+    if with_samples:
+        for task_id, samples in [
+            ("arc_easy", [_make_sample(0, ["A"]), _make_sample(1, ["B"])]),
+            ("hellaswag", [_make_sample(0, ["X"]), _make_sample(1, ["Y"])]),
+        ]:
+            p = model_dir / f"samples_{task_id}_{DATE_ID}.jsonl"
+            with p.open("w", encoding="utf-8") as f:
+                for s in samples:
+                    f.write(json.dumps(s) + "\n")
+    return model_dir
+
+
+# A reference encoder that does not use json.dumps. Used to verify that the
+# canonical encoding produces the same bytes when implemented from scratch.
+
+def _hand_format_float(x):
+    if not math.isfinite(x):
+        raise ValueError("non-finite")
+    if x == 0.0:
+        return "0.0"
+    s = repr(float(x))
+    if "e" in s:
+        mantissa, _, exp = s.partition("e")
+        if exp.startswith("+"):
+            exp = exp[1:]
+        sign = "-" if exp.startswith("-") else ""
+        digits = exp.lstrip("+-").lstrip("0") or "0"
+        s = f"{mantissa}e{sign}{digits}"
+    return s
+
+
+def _hand_canonicalize(obj):
+    if obj is None or isinstance(obj, bool):
+        return obj
+    if isinstance(obj, int):
+        return obj
+    if isinstance(obj, float):
+        return _hand_format_float(obj)
+    if isinstance(obj, str):
+        return unicodedata.normalize("NFC", obj)
+    if isinstance(obj, list):
+        return [_hand_canonicalize(x) for x in obj]
+    if isinstance(obj, dict):
+        return {
+            unicodedata.normalize("NFC", k): _hand_canonicalize(v)
+            for k, v in obj.items()
+        }
+    raise TypeError(type(obj).__name__)
+
+
+def _hand_encode_str(s):
+    out = ['"']
+    for ch in s:
+        cp = ord(ch)
+        if ch == '"':
+            out.append('\\"')
+        elif ch == "\\":
+            out.append("\\\\")
+        elif ch == "\b":
+            out.append("\\b")
+        elif ch == "\f":
+            out.append("\\f")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ch == "\t":
+            out.append("\\t")
+        elif cp < 0x20 or cp >= 0x7F:
+            if cp <= 0xFFFF:
+                out.append(f"\\u{cp:04x}")
+            else:
+                cp -= 0x10000
+                high = 0xD800 + (cp >> 10)
+                low = 0xDC00 + (cp & 0x3FF)
+                out.append(f"\\u{high:04x}\\u{low:04x}")
+        else:
+            out.append(ch)
+    out.append('"')
+    return "".join(out)
+
+
+def _hand_encode(obj):
+    if obj is None:
+        return "null"
+    if obj is True:
+        return "true"
+    if obj is False:
+        return "false"
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, str):
+        return _hand_encode_str(obj)
+    if isinstance(obj, list):
+        return "[" + ",".join(_hand_encode(x) for x in obj) + "]"
+    if isinstance(obj, dict):
+        items = sorted(obj.items())
+        return "{" + ",".join(
+            f"{_hand_encode_str(k)}:{_hand_encode(v)}" for k, v in items
+        ) + "}"
+    raise TypeError(type(obj).__name__)
+
+
+def hand_canonical_encode(obj):
+    return _hand_encode(_hand_canonicalize(obj)).encode("utf-8")
+
+
+@pytest.mark.parametrize("value, expected", [
+    (0.0, "0.0"),
+    (-0.0, "0.0"),
+    (1.0, "1.0"),
+    (0.5, "0.5"),
+    (-3.14, "-3.14"),
+    (1e10, "10000000000.0"),
+    (1e16, "1e16"),
+    (1e-10, "1e-10"),
+    (5e-324, "5e-324"),
+    (-2.5e100, "-2.5e100"),
+])
+def test_format_float(value, expected):
+    assert _format_float(value) == expected
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_format_float_rejects_non_finite(value):
+    with pytest.raises(ValueError):
+        _format_float(value)
+
+
+class TestCanonicalEncoding:
+    def test_sort_keys_and_separators(self):
+        assert canonical_encode({"b": 2, "a": 1}) == b'{"a":1,"b":2}'
+
+    def test_nested_sort_keys(self):
+        assert canonical_encode({"outer": {"z": 1, "a": 2}}) == b'{"outer":{"a":2,"z":1}}'
+
+    def test_floats_stringified(self):
+        assert canonical_encode({"x": 0.5}) == b'{"x":"0.5"}'
+
+    def test_disallows_nan(self):
+        with pytest.raises(ValueError):
+            canonical_encode({"x": float("nan")})
+
+    def test_disallows_infinity(self):
+        with pytest.raises(ValueError):
+            canonical_encode({"x": float("inf")})
+
+    def test_unicode_escaped(self):
+        encoded = canonical_encode({"x": "café"})
+        assert encoded == b'{"x":"caf\\u00e9"}'
+
+    def test_nfc_normalizes_input(self):
+        nfc = "café"
+        nfd = "café"
+        assert nfc != nfd
+        assert canonical_encode({"x": nfc}) == canonical_encode({"x": nfd})
+
+    def test_nfc_normalizes_dict_keys(self):
+        nfc = "café"
+        nfd = "café"
+        assert canonical_encode({nfc: 1}) == canonical_encode({nfd: 1})
+
+    def test_compact_no_whitespace(self):
+        assert b" " not in canonical_encode([1, 2, {"a": 3}])
+
+    def test_rejects_unsupported_types(self):
+        with pytest.raises(TypeError):
+            canonical_encode({"x": object()})
+
+    def test_dict_keys_must_be_strings(self):
+        with pytest.raises(TypeError, match="dict keys"):
+            canonical_encode({1: "value"})
+
+
+class TestResultsExtraction:
+    def test_extracts_metric_filter_value_stderr(self):
+        entries = extract_results(_make_results_doc())
+        keys = {(e["task_id"], e["metric"], e["filter"]) for e in entries}
+        assert keys == {
+            ("arc_easy", "acc", "none"),
+            ("arc_easy", "acc_norm", "none"),
+            ("hellaswag", "acc", "none"),
+        }
+
+    def test_skips_alias_name_sample_len(self):
+        for e in extract_results(_make_results_doc()):
+            assert e["metric"] not in {"name", "alias", "sample_len"}
+
+    def test_handles_na_stderr(self):
+        entries = extract_results(_make_results_doc())
+        acc_norm = next(
+            e for e in entries if e["task_id"] == "arc_easy" and e["metric"] == "acc_norm"
+        )
+        assert acc_norm["stderr"] is None
+
+    def test_value_is_canonical_string(self):
+        entries = extract_results(_make_results_doc())
+        acc = next(
+            e for e in entries if e["task_id"] == "arc_easy" and e["metric"] == "acc"
+        )
+        assert acc["value"] == "0.5"
+        assert acc["stderr"] == "0.1"
+
+    def test_skips_non_scalar_value(self):
+        doc = _make_results_doc()
+        doc["results"]["arc_easy"]["text_metric,none"] = "some string"
+        metrics = {(e["task_id"], e["metric"]) for e in extract_results(doc)}
+        assert ("arc_easy", "text_metric") not in metrics
+
+    def test_skips_bool_value(self):
+        doc = _make_results_doc()
+        doc["results"]["arc_easy"]["bool_metric,none"] = True
+        metrics = {(e["task_id"], e["metric"]) for e in extract_results(doc)}
+        assert ("arc_easy", "bool_metric") not in metrics
+
+    def test_sort_order_stable(self):
+        doc = _make_results_doc()
+        rev = {
+            "model_source": doc["model_source"],
+            "model_name": doc["model_name"],
+            "results": {
+                k: dict(reversed(list(v.items())))
+                for k, v in reversed(list(doc["results"].items()))
+            },
+        }
+        assert extract_results(doc) == extract_results(rev)
+
+
+class TestDeriveModelId:
+    def test_uses_top_level_fields(self):
+        doc = {"model_source": "hf", "model_name": "EleutherAI/pythia-70m"}
+        assert derive_model_id(doc) == "hf/EleutherAI/pythia-70m"
+
+    def test_falls_back_to_config_string(self):
+        doc = {"config": {"model": "vllm", "model_args": "pretrained=foo/bar,dtype=auto"}}
+        assert derive_model_id(doc) == "vllm/foo/bar"
+
+    def test_falls_back_to_config_dict(self):
+        doc = {"config": {"model": "vllm", "model_args": {"pretrained": "foo/bar"}}}
+        assert derive_model_id(doc) == "vllm/foo/bar"
+
+    def test_unknown_when_nothing_present(self):
+        assert derive_model_id({}) == "unknown"
+
+    def test_peft_takes_precedence(self):
+        doc = {"config": {"model": "hf", "model_args": "pretrained=base/model,peft=adapter/lora"}}
+        assert derive_model_id(doc) == "hf/adapter/lora"
+
+    def test_delta_takes_precedence(self):
+        doc = {"config": {"model": "hf", "model_args": {"pretrained": "base/model", "delta": "tweaked/model"}}}
+        assert derive_model_id(doc) == "hf/tweaked/model"
+
+    def test_strips_whitespace(self):
+        doc = {"config": {"model": "hf", "model_args": "pretrained= foo/bar ,dtype=auto"}}
+        assert derive_model_id(doc) == "hf/foo/bar"
+
+    def test_empty_value_falls_through(self):
+        doc = {"config": {"model": "hf", "model_args": "pretrained=,model=actual/name"}}
+        assert derive_model_id(doc) == "hf/actual/name"
+
+    def test_empty_dict_value_falls_through(self):
+        doc = {"config": {"model": "hf", "model_args": {"pretrained": "", "model": "actual/name"}}}
+        assert derive_model_id(doc) == "hf/actual/name"
+
+
+def test_derive_meta():
+    meta = derive_meta(_make_results_doc())
+    assert meta == {
+        "git_hash": "abcd1234",
+        "versions": {"arc_easy": "1.0", "hellaswag": "1.0"},
+        "n_shot": {"arc_easy": 0, "hellaswag": 0},
+        "date": "2024-01-01T00:00:00",
+    }
+
+
+def test_derive_tasks_sorted_unique():
+    entries = [
+        {"task_id": "z", "metric": "m", "filter": "none", "value": "0.0", "stderr": None},
+        {"task_id": "a", "metric": "m", "filter": "none", "value": "0.0", "stderr": None},
+        {"task_id": "a", "metric": "n", "filter": "none", "value": "0.0", "stderr": None},
+    ]
+    assert derive_tasks(entries) == ["a", "z"]
+
+
+class TestOutputsHash:
+    def test_filtered_resps_only(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        samples_paths = sorted(model_dir.glob("samples_*.jsonl"))
+        before = compute_outputs_sha256(samples_paths)
+
+        # mutate fields that should NOT affect the digest
+        for p in samples_paths:
+            mutated = []
+            for line in p.read_text(encoding="utf-8").splitlines():
+                rec = json.loads(line)
+                rec["resps"] = ["DIFFERENT"]
+                rec["doc"] = {"question": "totally different"}
+                rec["target"] = "Z"
+                rec["arguments"] = {"gen_args_0": {"arg_0": "x"}}
+                mutated.append(json.dumps(rec))
+            p.write_text("\n".join(mutated) + "\n", encoding="utf-8")
+
+        assert before == compute_outputs_sha256(samples_paths)
+
+    def test_filtered_resps_change_diverges(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        samples_paths = sorted(model_dir.glob("samples_*.jsonl"))
+        before = compute_outputs_sha256(samples_paths)
+
+        target = next(p for p in samples_paths if "arc_easy" in p.name)
+        lines = target.read_text(encoding="utf-8").splitlines()
+        rec = json.loads(lines[0])
+        rec["filtered_resps"] = ["CHANGED"]
+        lines[0] = json.dumps(rec)
+        target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        assert before != compute_outputs_sha256(samples_paths)
+
+    def test_doc_id_ordering_invariant(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        samples_paths = sorted(model_dir.glob("samples_*.jsonl"))
+        before = compute_outputs_sha256(samples_paths)
+
+        for p in samples_paths:
+            lines = p.read_text(encoding="utf-8").splitlines()
+            p.write_text("\n".join(reversed(lines)) + "\n", encoding="utf-8")
+
+        assert before == compute_outputs_sha256(samples_paths)
+
+    def test_collision_raises(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        target = model_dir / f"samples_arc_easy_{DATE_ID}.jsonl"
+        rec = _make_sample(0, ["A"])
+        target.write_text(json.dumps(rec) + "\n" + json.dumps(rec) + "\n", encoding="utf-8")
+        with pytest.raises(SamplesError, match="collision"):
+            compute_outputs_sha256([target])
+
+    def test_missing_required_keys(self, tmp_path):
+        target = tmp_path / f"samples_x_{DATE_ID}.jsonl"
+        target.write_text(json.dumps({"doc_id": 0}) + "\n", encoding="utf-8")
+        with pytest.raises(SamplesError, match="missing"):
+            compute_outputs_sha256([target])
+
+    def test_missing_samples_file(self, tmp_path):
+        with pytest.raises(SamplesError, match="not found"):
+            compute_outputs_sha256([tmp_path / f"samples_x_{DATE_ID}.jsonl"])
+
+    def test_malformed_json(self, tmp_path):
+        target = tmp_path / f"samples_x_{DATE_ID}.jsonl"
+        target.write_text("{not json}\n", encoding="utf-8")
+        with pytest.raises(SamplesError):
+            compute_outputs_sha256([target])
+
+
+class TestDiscoverPair:
+    def test_pairs_by_date_id(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        assert results_path.name == f"results_{DATE_ID}.json"
+        assert len(samples_paths) == 2
+        assert all(DATE_ID in p.name for p in samples_paths)
+
+    def test_picks_latest_results(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        older = model_dir / "results_2023-01-01T00-00-00.000000.json"
+        older.write_text(json.dumps(_make_results_doc()), encoding="utf-8")
+        results_path, _ = discover_pair(model_dir)
+        assert DATE_ID in results_path.name
+
+    def test_missing_dir(self, tmp_path):
+        with pytest.raises(ResultsError, match="not a directory"):
+            discover_pair(tmp_path / "does_not_exist")
+
+    def test_empty_dir(self, tmp_path):
+        with pytest.raises(ResultsError, match="no results_"):
+            discover_pair(tmp_path)
+
+    def test_pair_samples_skips_unrelated(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path = model_dir / f"results_{DATE_ID}.json"
+        other = model_dir / "samples_arc_easy_1999-01-01T00-00-00.000000.jsonl"
+        other.write_text(json.dumps(_make_sample(0, ["A"])) + "\n", encoding="utf-8")
+        paths = pair_samples_for_results(results_path)
+        assert other not in paths
+
+
+class TestBuildAttestation:
+    def test_full_bundle(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths)
+        assert bundle["harness_attestation_version"] == ATTESTATION_VERSION
+        assert bundle["model_id"] == "hf/EleutherAI/pythia-70m"
+        assert bundle["tasks"] == ["arc_easy", "hellaswag"]
+        assert len(bundle["results"]) == 3
+        assert len(bundle["results_sha256"]) == 64
+        assert bundle["outputs_sha256"] is not None
+        assert bundle["meta"]["git_hash"] == "abcd1234"
+
+    def test_results_entries_are_strings(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths)
+        for entry in bundle["results"]:
+            assert isinstance(entry["value"], str)
+            assert entry["stderr"] is None or isinstance(entry["stderr"], str)
+
+    def test_no_samples_yields_null(self, tmp_path):
+        model_dir = _write_fixture(tmp_path, with_samples=False)
+        results_path = model_dir / f"results_{DATE_ID}.json"
+        bundle = build_attestation(results_path, samples_paths=[])
+        assert bundle["outputs_sha256"] is None
+        assert bundle["results_sha256"] is not None
+
+    def test_include_outputs_false(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths, include_outputs=False)
+        assert bundle["outputs_sha256"] is None
+
+    def test_meta_changes_dont_affect_results_sha(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle_a = build_attestation(results_path, samples_paths)
+
+        doc = json.loads(results_path.read_text(encoding="utf-8"))
+        doc["git_hash"] = "deadbeef"
+        doc["date"] = "2099-12-31T00:00:00"
+        results_path.write_text(json.dumps(doc), encoding="utf-8")
+
+        bundle_b = build_attestation(results_path, samples_paths)
+        assert bundle_a["results_sha256"] == bundle_b["results_sha256"]
+        assert bundle_a["meta"]["git_hash"] != bundle_b["meta"]["git_hash"]
+
+    def test_empty_results_raises(self, tmp_path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        results_path = model_dir / f"results_{DATE_ID}.json"
+        results_path.write_text(
+            json.dumps({"model_source": "hf", "model_name": "x", "results": {}}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ResultsError, match="no scalar"):
+            build_attestation(results_path, [])
+
+    def test_missing_results_file_raises(self, tmp_path):
+        with pytest.raises(ResultsError):
+            build_attestation(tmp_path / "missing.json", None)
+
+
+class TestCLI:
+    def test_input_dir_to_stdout(self, tmp_path, capsys):
+        model_dir = _write_fixture(tmp_path)
+        rc = main(["--input_dir", str(model_dir)])
+        assert rc == 0
+        bundle = json.loads(capsys.readouterr().out)
+        assert bundle["model_id"] == "hf/EleutherAI/pythia-70m"
+        assert bundle["outputs_sha256"] is not None
+
+    def test_results_to_output_file(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path = model_dir / f"results_{DATE_ID}.json"
+        out_path = tmp_path / "bundle.json"
+        rc = main(["--results", str(results_path), "--output", str(out_path)])
+        assert rc == 0
+        bundle = json.loads(out_path.read_text(encoding="utf-8"))
+        assert bundle["model_id"] == "hf/EleutherAI/pythia-70m"
+
+    def test_no_samples_flag(self, tmp_path, capsys):
+        model_dir = _write_fixture(tmp_path)
+        rc = main(["--input_dir", str(model_dir), "--no_samples"])
+        assert rc == 0
+        bundle = json.loads(capsys.readouterr().out)
+        assert bundle["outputs_sha256"] is None
+
+    def test_missing_input_dir(self, tmp_path, capsys):
+        rc = main(["--input_dir", str(tmp_path / "nope")])
+        assert rc == 3
+        assert "error" in capsys.readouterr().err
+
+    def test_mutex_input_dir_and_results(self, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            main(["--input_dir", str(tmp_path), "--results", str(tmp_path / "x.json")])
+        assert exc.value.code == 2
+
+    def test_one_of_required(self):
+        with pytest.raises(SystemExit) as exc:
+            main([])
+        assert exc.value.code == 2
+
+    def test_samples_without_results(self, tmp_path, capsys):
+        rc = main(["--input_dir", str(tmp_path), "--samples", str(tmp_path / "s.jsonl")])
+        assert rc == 2
+        assert "--samples requires --results" in capsys.readouterr().err
+
+    def test_subprocess_invocation(self, tmp_path):
+        # End-to-end: catches packaging issues that in-process calls miss.
+        model_dir = _write_fixture(tmp_path)
+        repo_root = Path(__file__).resolve().parents[2]
+        script = repo_root / "scripts" / "export_attestation.py"
+        result = subprocess.run(
+            [sys.executable, str(script), "--input_dir", str(model_dir)],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        bundle = json.loads(result.stdout)
+        assert bundle["results_sha256"] == RESULTS_HASH
+        assert bundle["outputs_sha256"] == OUTPUTS_HASH
+
+
+def test_schema_file_exists_and_parses():
+    schema_path = Path(__file__).resolve().parents[2] / "scripts" / "attestation.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    assert schema["type"] == "object"
+    assert "harness_attestation_version" in schema["required"]
+
+
+class TestCanonicalSpec:
+    # The "recompute via stdlib json" tests catch parameter drift in
+    # canonical_encode. The hand-canonical tests are the real cross-impl check
+    # because they don't go through json.dumps at all.
+
+    def test_results_sha_recompute_via_stdlib(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths)
+        claim = {
+            "model_id": bundle["model_id"],
+            "tasks": bundle["tasks"],
+            "results": bundle["results"],
+        }
+        canonical = json.dumps(
+            claim, sort_keys=True, ensure_ascii=True,
+            allow_nan=False, separators=(",", ":"),
+        ).encode("utf-8")
+        assert hashlib.sha256(canonical).hexdigest() == bundle["results_sha256"]
+
+    def test_outputs_sha_recompute_via_stdlib(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths)
+
+        by_task = {}
+        for p in samples_paths:
+            stem = p.name[: -len(".jsonl")]
+            task_id = stem.split("_", 1)[1].rsplit("_", 1)[0]
+            for line in p.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    by_task.setdefault(task_id, []).append(json.loads(line))
+
+        h = hashlib.sha256()
+        for task_id in sorted(by_task):
+            for r in sorted(by_task[task_id], key=lambda r: (r["doc_id"], r.get("filter", ""))):
+                payload = json.dumps(
+                    {
+                        "task_id": task_id,
+                        "doc_id": r["doc_id"],
+                        "filter": r.get("filter", ""),
+                        "filtered_resps": r["filtered_resps"],
+                    },
+                    sort_keys=True, ensure_ascii=True,
+                    allow_nan=False, separators=(",", ":"),
+                ).encode("utf-8")
+                h.update(payload)
+                h.update(b"\n")
+        assert h.hexdigest() == bundle["outputs_sha256"]
+
+    def test_hand_canonical_matches_for_tiny_input(self):
+        claim = {
+            "model_id": "hf/x",
+            "tasks": ["t"],
+            "results": [
+                {"task_id": "t", "metric": "acc", "filter": "none",
+                 "value": "0.5", "stderr": "0.1"},
+            ],
+        }
+        assert hand_canonical_encode(claim) == canonical_encode(claim)
+
+    def test_hand_canonical_matches_for_realistic_fixture(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths)
+        claim = {
+            "model_id": bundle["model_id"],
+            "tasks": bundle["tasks"],
+            "results": bundle["results"],
+        }
+        hand = hand_canonical_encode(claim)
+        assert hand == canonical_encode(claim)
+        assert hashlib.sha256(hand).hexdigest() == bundle["results_sha256"]
+
+    def test_hand_canonical_handles_nfc_and_floats(self):
+        obj = {
+            "name": "café",  # NFD; should normalize to NFC
+            "values": [1.0, 1e16, -0.0, 0.1],
+        }
+        assert hand_canonical_encode(obj) == canonical_encode(obj)
+
+    def test_canonical_byte_form_is_stable(self):
+        claim = {
+            "model_id": "hf/x",
+            "tasks": ["t"],
+            "results": [
+                {"task_id": "t", "metric": "acc", "filter": "none",
+                 "value": "0.5", "stderr": "0.1"},
+            ],
+        }
+        assert canonical_encode(claim) == (
+            b'{"model_id":"hf/x",'
+            b'"results":[{"filter":"none","metric":"acc","stderr":"0.1",'
+            b'"task_id":"t","value":"0.5"}],'
+            b'"tasks":["t"]}'
+        )
+
+    def test_results_hash_golden(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths)
+        assert bundle["results_sha256"] == RESULTS_HASH
+
+    def test_outputs_hash_golden(self, tmp_path):
+        model_dir = _write_fixture(tmp_path)
+        results_path, samples_paths = discover_pair(model_dir)
+        bundle = build_attestation(results_path, samples_paths)
+        assert bundle["outputs_sha256"] == OUTPUTS_HASH
+
+
+def test_exit_codes():
+    assert ResultsError.exit_code == 3
+    assert SamplesError.exit_code == 4
+    assert issubclass(ResultsError, AttestationError)
+    assert issubclass(SamplesError, AttestationError)
+
+
+def test_sha256_hex_helper():
+    assert sha256_hex(b"") == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/scripts/test_export_attestation.py
+++ b/tests/scripts/test_export_attestation.py
@@ -106,6 +106,7 @@ def _write_fixture(tmp_path, with_samples=True):
 # A reference encoder that does not use json.dumps. Used to verify that the
 # canonical encoding produces the same bytes when implemented from scratch.
 
+
 def _hand_format_float(x):
     if not math.isfinite(x):
         raise ValueError("non-finite")
@@ -114,8 +115,7 @@ def _hand_format_float(x):
     s = repr(float(x))
     if "e" in s:
         mantissa, _, exp = s.partition("e")
-        if exp.startswith("+"):
-            exp = exp[1:]
+        exp = exp.removeprefix("+")
         sign = "-" if exp.startswith("-") else ""
         digits = exp.lstrip("+-").lstrip("0") or "0"
         s = f"{mantissa}e{sign}{digits}"
@@ -188,9 +188,11 @@ def _hand_encode(obj):
         return "[" + ",".join(_hand_encode(x) for x in obj) + "]"
     if isinstance(obj, dict):
         items = sorted(obj.items())
-        return "{" + ",".join(
-            f"{_hand_encode_str(k)}:{_hand_encode(v)}" for k, v in items
-        ) + "}"
+        return (
+            "{"
+            + ",".join(f"{_hand_encode_str(k)}:{_hand_encode(v)}" for k, v in items)
+            + "}"
+        )
     raise TypeError(type(obj).__name__)
 
 
@@ -198,18 +200,21 @@ def hand_canonical_encode(obj):
     return _hand_encode(_hand_canonicalize(obj)).encode("utf-8")
 
 
-@pytest.mark.parametrize("value, expected", [
-    (0.0, "0.0"),
-    (-0.0, "0.0"),
-    (1.0, "1.0"),
-    (0.5, "0.5"),
-    (-3.14, "-3.14"),
-    (1e10, "10000000000.0"),
-    (1e16, "1e16"),
-    (1e-10, "1e-10"),
-    (5e-324, "5e-324"),
-    (-2.5e100, "-2.5e100"),
-])
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0.0, "0.0"),
+        (-0.0, "0.0"),
+        (1.0, "1.0"),
+        (0.5, "0.5"),
+        (-3.14, "-3.14"),
+        (1e10, "10000000000.0"),
+        (1e16, "1e16"),
+        (1e-10, "1e-10"),
+        (5e-324, "5e-324"),
+        (-2.5e100, "-2.5e100"),
+    ],
+)
 def test_format_float(value, expected):
     assert _format_float(value) == expected
 
@@ -225,7 +230,9 @@ class TestCanonicalEncoding:
         assert canonical_encode({"b": 2, "a": 1}) == b'{"a":1,"b":2}'
 
     def test_nested_sort_keys(self):
-        assert canonical_encode({"outer": {"z": 1, "a": 2}}) == b'{"outer":{"a":2,"z":1}}'
+        assert (
+            canonical_encode({"outer": {"z": 1, "a": 2}}) == b'{"outer":{"a":2,"z":1}}'
+        )
 
     def test_floats_stringified(self):
         assert canonical_encode({"x": 0.5}) == b'{"x":"0.5"}'
@@ -239,18 +246,18 @@ class TestCanonicalEncoding:
             canonical_encode({"x": float("inf")})
 
     def test_unicode_escaped(self):
-        encoded = canonical_encode({"x": "café"})
-        assert encoded == b'{"x":"caf\\u00e9"}'
+        encoded = canonical_encode({"x": "über"})
+        assert encoded == b'{"x":"\\u00fcber"}'
 
     def test_nfc_normalizes_input(self):
-        nfc = "café"
-        nfd = "café"
+        nfc = "über"
+        nfd = "über"
         assert nfc != nfd
         assert canonical_encode({"x": nfc}) == canonical_encode({"x": nfd})
 
     def test_nfc_normalizes_dict_keys(self):
-        nfc = "café"
-        nfd = "café"
+        nfc = "über"
+        nfd = "über"
         assert canonical_encode({nfc: 1}) == canonical_encode({nfd: 1})
 
     def test_compact_no_whitespace(self):
@@ -282,7 +289,9 @@ class TestResultsExtraction:
     def test_handles_na_stderr(self):
         entries = extract_results(_make_results_doc())
         acc_norm = next(
-            e for e in entries if e["task_id"] == "arc_easy" and e["metric"] == "acc_norm"
+            e
+            for e in entries
+            if e["task_id"] == "arc_easy" and e["metric"] == "acc_norm"
         )
         assert acc_norm["stderr"] is None
 
@@ -325,7 +334,9 @@ class TestDeriveModelId:
         assert derive_model_id(doc) == "hf/EleutherAI/pythia-70m"
 
     def test_falls_back_to_config_string(self):
-        doc = {"config": {"model": "vllm", "model_args": "pretrained=foo/bar,dtype=auto"}}
+        doc = {
+            "config": {"model": "vllm", "model_args": "pretrained=foo/bar,dtype=auto"}
+        }
         assert derive_model_id(doc) == "vllm/foo/bar"
 
     def test_falls_back_to_config_dict(self):
@@ -336,15 +347,27 @@ class TestDeriveModelId:
         assert derive_model_id({}) == "unknown"
 
     def test_peft_takes_precedence(self):
-        doc = {"config": {"model": "hf", "model_args": "pretrained=base/model,peft=adapter/lora"}}
+        doc = {
+            "config": {
+                "model": "hf",
+                "model_args": "pretrained=base/model,peft=adapter/lora",
+            }
+        }
         assert derive_model_id(doc) == "hf/adapter/lora"
 
     def test_delta_takes_precedence(self):
-        doc = {"config": {"model": "hf", "model_args": {"pretrained": "base/model", "delta": "tweaked/model"}}}
+        doc = {
+            "config": {
+                "model": "hf",
+                "model_args": {"pretrained": "base/model", "delta": "tweaked/model"},
+            }
+        }
         assert derive_model_id(doc) == "hf/tweaked/model"
 
     def test_strips_whitespace(self):
-        doc = {"config": {"model": "hf", "model_args": "pretrained= foo/bar ,dtype=auto"}}
+        doc = {
+            "config": {"model": "hf", "model_args": "pretrained= foo/bar ,dtype=auto"}
+        }
         assert derive_model_id(doc) == "hf/foo/bar"
 
     def test_empty_value_falls_through(self):
@@ -352,7 +375,12 @@ class TestDeriveModelId:
         assert derive_model_id(doc) == "hf/actual/name"
 
     def test_empty_dict_value_falls_through(self):
-        doc = {"config": {"model": "hf", "model_args": {"pretrained": "", "model": "actual/name"}}}
+        doc = {
+            "config": {
+                "model": "hf",
+                "model_args": {"pretrained": "", "model": "actual/name"},
+            }
+        }
         assert derive_model_id(doc) == "hf/actual/name"
 
 
@@ -368,9 +396,27 @@ def test_derive_meta():
 
 def test_derive_tasks_sorted_unique():
     entries = [
-        {"task_id": "z", "metric": "m", "filter": "none", "value": "0.0", "stderr": None},
-        {"task_id": "a", "metric": "m", "filter": "none", "value": "0.0", "stderr": None},
-        {"task_id": "a", "metric": "n", "filter": "none", "value": "0.0", "stderr": None},
+        {
+            "task_id": "z",
+            "metric": "m",
+            "filter": "none",
+            "value": "0.0",
+            "stderr": None,
+        },
+        {
+            "task_id": "a",
+            "metric": "m",
+            "filter": "none",
+            "value": "0.0",
+            "stderr": None,
+        },
+        {
+            "task_id": "a",
+            "metric": "n",
+            "filter": "none",
+            "value": "0.0",
+            "stderr": None,
+        },
     ]
     assert derive_tasks(entries) == ["a", "z"]
 
@@ -424,7 +470,9 @@ class TestOutputsHash:
         model_dir = _write_fixture(tmp_path)
         target = model_dir / f"samples_arc_easy_{DATE_ID}.jsonl"
         rec = _make_sample(0, ["A"])
-        target.write_text(json.dumps(rec) + "\n" + json.dumps(rec) + "\n", encoding="utf-8")
+        target.write_text(
+            json.dumps(rec) + "\n" + json.dumps(rec) + "\n", encoding="utf-8"
+        )
         with pytest.raises(SamplesError, match="collision"):
             compute_outputs_sha256([target])
 
@@ -582,7 +630,9 @@ class TestCLI:
         assert exc.value.code == 2
 
     def test_samples_without_results(self, tmp_path, capsys):
-        rc = main(["--input_dir", str(tmp_path), "--samples", str(tmp_path / "s.jsonl")])
+        rc = main(
+            ["--input_dir", str(tmp_path), "--samples", str(tmp_path / "s.jsonl")]
+        )
         assert rc == 2
         assert "--samples requires --results" in capsys.readouterr().err
 
@@ -591,9 +641,11 @@ class TestCLI:
         model_dir = _write_fixture(tmp_path)
         repo_root = Path(__file__).resolve().parents[2]
         script = repo_root / "scripts" / "export_attestation.py"
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             [sys.executable, str(script), "--input_dir", str(model_dir)],
-            capture_output=True, text=True, check=False,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         assert result.returncode == 0, result.stderr
         bundle = json.loads(result.stdout)
@@ -602,7 +654,9 @@ class TestCLI:
 
 
 def test_schema_file_exists_and_parses():
-    schema_path = Path(__file__).resolve().parents[2] / "scripts" / "attestation.schema.json"
+    schema_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "attestation.schema.json"
+    )
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     assert schema["type"] == "object"
     assert "harness_attestation_version" in schema["required"]
@@ -623,8 +677,11 @@ class TestCanonicalSpec:
             "results": bundle["results"],
         }
         canonical = json.dumps(
-            claim, sort_keys=True, ensure_ascii=True,
-            allow_nan=False, separators=(",", ":"),
+            claim,
+            sort_keys=True,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
         ).encode("utf-8")
         assert hashlib.sha256(canonical).hexdigest() == bundle["results_sha256"]
 
@@ -643,7 +700,9 @@ class TestCanonicalSpec:
 
         h = hashlib.sha256()
         for task_id in sorted(by_task):
-            for r in sorted(by_task[task_id], key=lambda r: (r["doc_id"], r.get("filter", ""))):
+            for r in sorted(
+                by_task[task_id], key=lambda r: (r["doc_id"], r.get("filter", ""))
+            ):
                 payload = json.dumps(
                     {
                         "task_id": task_id,
@@ -651,8 +710,10 @@ class TestCanonicalSpec:
                         "filter": r.get("filter", ""),
                         "filtered_resps": r["filtered_resps"],
                     },
-                    sort_keys=True, ensure_ascii=True,
-                    allow_nan=False, separators=(",", ":"),
+                    sort_keys=True,
+                    ensure_ascii=True,
+                    allow_nan=False,
+                    separators=(",", ":"),
                 ).encode("utf-8")
                 h.update(payload)
                 h.update(b"\n")
@@ -663,8 +724,13 @@ class TestCanonicalSpec:
             "model_id": "hf/x",
             "tasks": ["t"],
             "results": [
-                {"task_id": "t", "metric": "acc", "filter": "none",
-                 "value": "0.5", "stderr": "0.1"},
+                {
+                    "task_id": "t",
+                    "metric": "acc",
+                    "filter": "none",
+                    "value": "0.5",
+                    "stderr": "0.1",
+                },
             ],
         }
         assert hand_canonical_encode(claim) == canonical_encode(claim)
@@ -684,7 +750,7 @@ class TestCanonicalSpec:
 
     def test_hand_canonical_handles_nfc_and_floats(self):
         obj = {
-            "name": "café",  # NFD; should normalize to NFC
+            "name": "über",  # NFD; should normalize to NFC
             "values": [1.0, 1e16, -0.0, 0.1],
         }
         assert hand_canonical_encode(obj) == canonical_encode(obj)
@@ -694,8 +760,13 @@ class TestCanonicalSpec:
             "model_id": "hf/x",
             "tasks": ["t"],
             "results": [
-                {"task_id": "t", "metric": "acc", "filter": "none",
-                 "value": "0.5", "stderr": "0.1"},
+                {
+                    "task_id": "t",
+                    "metric": "acc",
+                    "filter": "none",
+                    "value": "0.5",
+                    "stderr": "0.1",
+                },
             ],
         }
         assert canonical_encode(claim) == (
@@ -726,7 +797,10 @@ def test_exit_codes():
 
 
 def test_sha256_hex_helper():
-    assert sha256_hex(b"") == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    assert (
+        sha256_hex(b"")
+        == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3749.                                                                                                                                                                                
   
  Adds a post-processor over `--output_path`/`--log_samples` artifacts that emits a small JSON fingerprint bundle with two SHA256 digests:                                                     
                                                         
  - `results_sha256` over canonical `{model_id, tasks, results}`. Matches across reruns that hit identical scores.                                                                             
  - `outputs_sha256` over per-sample `filtered_resps`. Catches divergent outputs that aggregate to the same score.
                                                                                                                                                                                               
  ### Deviations from the issue's example schema
                                                                                                                                                                                               
  1. **Decimal-string encoding for numeric values.** Python's `repr(1e10)` is `"10000000000.0"`; Go's `json.Marshal` gives `"10000000000"`. JSON numbers aren't actually portable across       
  language implementations, so `value` and `stderr` are encoded as decimal strings. The exact format is documented in the script docstring and in `attestation.schema.json`.
                                                                                                                                                                                               
  2. **`filter` field on each results entry.** Tasks with multiple filter passes (`strict-match`, `flexible-extract`, `none`) would otherwise collide on `(task_id, metric)`.                  
  
  3. **`meta` block outside the hash.** `git_hash`, `date`, `versions`, `n_shot` go in `meta`. This lets two reruns on different commits still compare equal when their scores match.          
                                                         
  ### Threat model                                                                                                                                                                             
                                                         
  Bundle is integrity-only. Anyone can hand-edit `meta` without invalidating `results_sha256`. Sign separately if you need authenticity.                                                       
  
  ### Usage                                                                                                                                                                                    
                                                         
  ```bash
  python scripts/export_attestation.py --input_dir <output_path>/<model>/
  python scripts/export_attestation.py --results <path/results_*.json>                                                                                                                         
  ```
                                                                                                                                                                                               
  ### Testing                                            

  80 tests, all passing. Covers canonical encoding, hash stability, CLI paths, and edge cases (NaN/Infinity, NFC normalization, missing files, doc_id collisions). Includes a hand-rolled canonical encoder that does not use `json.dumps`, which validates that a third-party verifier could reproduce the bundle bytes from the spec alone.
                                                                                                                                                                                               
  Stdlib-only. No changes under `lm_eval/`.