### PR TITLE
fix: correct higher_is_better for TER metric (False, not True)

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -371,7 +371,7 @@ def chrf_fn(items):  # This is a passthrough function
 
 @register_metric(
     metric="ter",
-    higher_is_better=True,
+    higher_is_better=False,
     output_type="generate_until",
     aggregation="ter",
 )


### PR DESCRIPTION
## Bug

The `ter` metric is registered with `higher_is_better=True` in `lm_eval/api/metrics.py`:

```python
@register_metric(
    metric="ter",
    higher_is_better=True,   # wrong
    ...
)
```

## Root cause

TER (Translation Edit Rate) is an *error* metric — it measures the number of word edits required to convert the system output into a reference translation. A lower TER means fewer edits and better translation quality. The codebase's own `ter` aggregation function documents this explicitly:

```python
def ter(items):
    """Translation Error Rate is an error metric for machine translation that
    measures the number of edits required to change a system output into one
    of the references
    ...
    Lower is better
    """
```

`higher_is_better=True` contradicts the docstring and inverts any logic that uses this flag for model comparison or leaderboard ranking (e.g. `make_table`, best-model selection).

## Fix

Change `higher_is_better=True` to `higher_is_better=False` for `ter`, consistent with the aggregation docstring and the metric's definition.