### PR TITLE
cache prompt template renders for doc_to_text/target/choice (#1286)

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -677,6 +677,11 @@ class ConfigurableTask(Task):
         self._aggregation_list = {}
         self._higher_is_better = {}
 
+        # Cache rendered prompt outputs (doc_to_text / doc_to_target / doc_to_choice)
+        # so that few-shot rendering doesn't redo Jinja template work for the same
+        # (doc, template) pair across repeated samplings. See issue #1286.
+        self._render_cache: dict = {}
+
         if self.config.metric_list is None:
             # TODO: handle this in TaskConfig.__post_init__ ?
             _metric_list = DEFAULT_METRIC_REGISTRY[self.config.output_type]
@@ -1205,6 +1210,16 @@ class ConfigurableTask(Task):
         else:
             doc_to_text = self.config.doc_to_text
 
+        cache = getattr(self, "_render_cache", None)
+        cache_key = ("text", id(doc), id(doc_to_text)) if cache is not None else None
+        if cache_key is not None and cache_key in cache:
+            return cache[cache_key]
+        result = self._doc_to_text_render(doc, doc_to_text)
+        if cache_key is not None:
+            cache[cache_key] = result
+        return result
+
+    def _doc_to_text_render(self, doc, doc_to_text):
         if isinstance(doc_to_text, int):
             return doc_to_text
         elif isinstance(doc_to_text, str):
@@ -1241,6 +1256,16 @@ class ConfigurableTask(Task):
         else:
             doc_to_target = self.config.doc_to_target
 
+        cache = getattr(self, "_render_cache", None)
+        cache_key = ("target", id(doc), id(doc_to_target)) if cache is not None else None
+        if cache_key is not None and cache_key in cache:
+            return cache[cache_key]
+        result = self._doc_to_target_render(doc, doc_to_target)
+        if cache_key is not None:
+            cache[cache_key] = result
+        return result
+
+    def _doc_to_target_render(self, doc: Mapping, doc_to_target) -> int | str | list:
         if isinstance(doc_to_target, int):
             return doc_to_target
         elif isinstance(doc_to_target, str):
@@ -1289,6 +1314,16 @@ class ConfigurableTask(Task):
         else:
             doc_to_choice = self.config.doc_to_choice
 
+        cache = getattr(self, "_render_cache", None)
+        cache_key = ("choice", id(doc), id(doc_to_choice)) if cache is not None else None
+        if cache_key is not None and cache_key in cache:
+            return cache[cache_key]
+        result = self._doc_to_choice_render(doc, doc_to_choice)
+        if cache_key is not None:
+            cache[cache_key] = result
+        return result
+
+    def _doc_to_choice_render(self, doc: Any, doc_to_choice) -> list[str]:
         if isinstance(doc_to_choice, str):
             if doc_to_choice in self.features:
                 return doc[doc_to_choice]

--- a/tests/test_render_cache.py
+++ b/tests/test_render_cache.py
@@ -1,0 +1,106 @@
+"""Tests for the render cache on ConfigurableTask.doc_to_text / doc_to_target /
+doc_to_choice.
+
+The cache key is `(kind, id(doc), id(template))`. A repeat call with the same
+doc and same template should hit cache on the second invocation; different
+docs or different templates should not collide.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from lm_eval.api.task import ConfigurableTask
+
+
+def _make_task():
+    """Build a minimal ConfigurableTask instance without running __init__.
+
+    We only need the cache wrapper logic to be exercised; the underlying
+    `_doc_to_*_render` helpers are stubbed so we can count calls.
+    """
+    task = ConfigurableTask.__new__(ConfigurableTask)
+    task._render_cache = {}
+    task.prompt = None
+
+    cfg = Mock()
+    cfg.doc_to_text = "{{q}}"
+    cfg.doc_to_target = "{{a}}"
+    cfg.doc_to_choice = "{{c}}"
+    task.config = cfg
+    task._config = cfg
+    task.features = []
+
+    return task
+
+
+def test_doc_to_text_hits_cache_on_repeat_doc():
+    task = _make_task()
+    task._doc_to_text_render = Mock(return_value="rendered")
+
+    doc = {"q": "test"}
+    r1 = task.doc_to_text(doc)
+    r2 = task.doc_to_text(doc)
+
+    assert r1 == r2 == "rendered"
+    assert task._doc_to_text_render.call_count == 1, (
+        "second call with the same doc should hit cache"
+    )
+
+
+def test_doc_to_text_different_docs_dont_collide():
+    task = _make_task()
+    task._doc_to_text_render = Mock(side_effect=lambda doc, _: f"rendered:{doc['q']}")
+
+    doc_a = {"q": "first"}
+    doc_b = {"q": "second"}
+    r_a1 = task.doc_to_text(doc_a)
+    r_b = task.doc_to_text(doc_b)
+    r_a2 = task.doc_to_text(doc_a)  # cache hit for doc_a
+
+    assert r_a1 == "rendered:first"
+    assert r_b == "rendered:second"
+    assert r_a2 == "rendered:first"
+    # 2 unique docs => 2 renders, third call hits cache
+    assert task._doc_to_text_render.call_count == 2
+
+
+def test_doc_to_target_hits_cache_on_repeat_doc():
+    task = _make_task()
+    task._doc_to_target_render = Mock(return_value="answer")
+
+    doc = {"a": "test"}
+    r1 = task.doc_to_target(doc)
+    r2 = task.doc_to_target(doc)
+
+    assert r1 == r2 == "answer"
+    assert task._doc_to_target_render.call_count == 1
+
+
+def test_doc_to_choice_hits_cache_on_repeat_doc():
+    task = _make_task()
+    task.config.doc_to_choice = "{{c}}"  # not None, so we hit the else branch
+    task._doc_to_choice_render = Mock(return_value=["a", "b"])
+
+    doc = {"c": "test"}
+    r1 = task.doc_to_choice(doc)
+    r2 = task.doc_to_choice(doc)
+
+    assert r1 == r2 == ["a", "b"]
+    assert task._doc_to_choice_render.call_count == 1
+
+
+def test_falls_through_when_render_cache_missing():
+    """A subclass that bypasses ConfigurableTask.__init__ won't have
+    `_render_cache`; the wrapper should still work, just without caching."""
+    task = _make_task()
+    del task._render_cache
+    task._doc_to_text_render = Mock(return_value="rendered")
+
+    doc = {"q": "test"}
+    r1 = task.doc_to_text(doc)
+    r2 = task.doc_to_text(doc)
+
+    assert r1 == r2 == "rendered"
+    # Without a cache, both calls render fresh.
+    assert task._doc_to_text_render.call_count == 2


### PR DESCRIPTION
fix #1286 (Change 1)

Per @haileyschoelkopf's note in the issue: caching `doc_to_text` / `doc_to_target` / `doc_to_choice` results so that the same `(doc, template)` pair isn't re-rendered repeatedly. Scope is Change 1 only; Change 2 (HF `dataset.map()` based cross-run caching) deferred because of the silent stale-cache risk the issue body calls out.

### Approach

- adds `self._render_cache: dict = {}` to `ConfigurableTask.__init__`.
- splits each of `doc_to_text` / `doc_to_target` / `doc_to_choice` into a thin cache-checking wrapper plus a private `_*_render` helper that contains the original body. cache key is `(kind, id(doc), id(template))`.
- if `_render_cache` is missing (e.g. on a `Task` subclass that bypasses `ConfigurableTask.__init__`), the wrappers fall through to direct computation. no behaviour regression.

### Where it lands

- in `fewshot_context()` the sampler often pulls the same few-shot doc for many test docs. previously each pull re-ran the Jinja template through `utils.apply_template`. now the first pull renders, the rest hit cache.
- multiple-input tasks (Winogrande etc) call `doc_to_*` repeatedly on the same test doc. those benefit too.

### Cache lifetime

- per-Task-instance dict. cleared when the task is reinitialised.
- bounded by O(num_unique_docs * 3 kinds * num_unique_templates). typical scale is < 1M entries. happy to swap to `functools.lru_cache` if you'd rather have an explicit maxsize.

### Tested

- the new file parses cleanly and existing call sites are untouched.
- I haven't run the project test suite locally. happy to chase a green CI here if anything trips.