### PR TITLE
Add docs FAQ entry point

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,9 @@ Welcome to the docs for the LM Evaluation Harness!
 ## Table of Contents
 
 * To learn about the public interface of the library, as well as how to evaluate via the command line or as integrated into an external library, see the [Interface](./interface.md).
+* For short answers to common setup and evaluation questions, see the [FAQ](./faq.md).
 * To learn how to add a new library, API, or model type to the library, as well as a quick explainer on the types of ways to evaluate an LM, see the [Model Guide](./model_guide.md).
   * For an extended description of how to extend the library to new model classes served over an API, see the [API Guide](./API_guide.md).
 * For a crash course on adding new tasks to the library, see our [New Task Guide](./new_task_guide.md).
 * To learn more about pushing the limits of task configuration that the Eval Harness supports, see the [Task Configuration Guide](./task_guide.md).
+* For common pitfalls and troubleshooting tips, see the [Common Pitfalls and Troubleshooting Guide](./footguns.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,35 @@
+# Frequently Asked Questions
+
+This page collects short answers to common setup and evaluation questions. For deeper troubleshooting, see the [Common Pitfalls and Troubleshooting Guide](./footguns.md).
+
+## How are evaluation request types implemented?
+
+The harness routes task examples into model request types such as `loglikelihood`, `loglikelihood_rolling`, and `generate_until`. These are implemented by model wrappers that subclass `lm_eval.api.model.LM`.
+
+See the [Model Guide](./model_guide.md#interface) for the method signatures and examples. For a longer treatment of evaluation details, see the paper appendix linked from issue [#1676](https://github.com/EleutherAI/lm-evaluation-harness/issues/1676).
+
+## Why do offline runs try to access Hugging Face?
+
+Some tasks and models resolve datasets, tokenizers, configs, or weights through Hugging Face unless you point the harness at local files or a local cache. If you need offline execution, prepare the relevant dataset/model artifacts ahead of time and pass local paths where supported by the task or model.
+
+For task authoring, see the [New Task Guide](./new_task_guide.md). For model wrappers and tokenizer handling, see the [Model Guide](./model_guide.md).
+
+## How do I use a dataset saved locally?
+
+Use the task configuration fields that identify the dataset path and loading arguments for your task. Local paths are most often handled in YAML task configs, then selected with the normal task name or include path mechanisms.
+
+Start with the [Task Configuration Guide](./task_guide.md) and the [New Task Guide](./new_task_guide.md), then compare against existing task YAMLs under `lm_eval/tasks/`.
+
+## Why do stop sequences or newlines behave unexpectedly in YAML?
+
+YAML quoting changes how escape sequences are interpreted. For example, single quotes preserve the literal characters `\` and `n`, while double quotes can encode an actual newline.
+
+See [Newline Characters in YAML](./footguns.md#newline-characters-in-yaml-n) for concrete examples.
+
+## Which guide should I read first?
+
+- Use the [Interface Guide](./interface.md) to run evaluations from the command line or Python.
+- Use the [New Task Guide](./new_task_guide.md) when adding a task.
+- Use the [Task Configuration Guide](./task_guide.md) when editing YAML task behavior.
+- Use the [Model Guide](./model_guide.md) when adding a model backend.
+- Use the [API Guide](./API_guide.md) for API-served model integrations.


### PR DESCRIPTION
Closes #1676.

## Summary

- adds `docs/faq.md` as a short entry point for common setup and evaluation questions
- covers request types, offline Hugging Face behavior, local datasets, YAML newline pitfalls, and which guide to read first
- links the docs index to the new FAQ and the existing common pitfalls guide

This is intentionally a starter FAQ rather than a comprehensive rewrite. It keeps the answers short and routes readers to the existing guides for details.

## Verification

- checked that relative Markdown links in `docs/faq.md` and `docs/README.md` resolve in the docs tree

## AANA gate

I used AANA as a verifier/correction gate before publishing this PR. The gate was limited to public repository evidence: the issue text, the existing docs tree, this FAQ patch, and the link-check smoke test. It does not certify production readiness, benchmark correctness, compliance, security, or alignment; it only checked that the PR text stays within those evidence limits and avoids broader claims.
