### PR TITLE
fix(hendrycks_math): extract \boxed{} from model response in process_results

### DIFF
--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -17,13 +17,23 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
 
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     retval = 0
-    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
-    if len(indices) <= 1:
-        answer = results[0]
-    else:
-        answer = results[0][indices[0] + 1 : indices[-1]]
+    response = results[0]
 
-    if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
+    # Try to extract answer from \boxed{} first, then fall back to $...$ extraction
+    boxed = last_boxed_only_string(response)
+    if boxed is not None:
+        try:
+            answer = remove_boxed(boxed)
+        except (AssertionError, IndexError):
+            answer = response
+    else:
+        indices = [pos for pos, char in enumerate(response) if char == "$"]
+        if len(indices) <= 1:
+            answer = response
+        else:
+            answer = response[indices[0] + 1 : indices[-1]]
+
+    if is_equiv(answer, doc["answer"]):
         retval = 1
 
     results = {


### PR DESCRIPTION
## Summary

Fixes #3643.

`process_results` was applying `last_boxed_only_string` / `remove_boxed` only to the ground-truth answer, not to the model's response. Instruct models routinely wrap their final answer in `\boxed{}`, so a response like `The answer is $\boxed{\frac{1}{2}}$` was being compared as the literal string `\boxed{\frac{1}{2}}` against `\frac{1}{2}`, scoring 0 even when correct.

**Changes:**
- Port the same `\boxed{}` extraction pattern already used in `lm_eval/tasks/aime/utils.py`: try `last_boxed_only_string` + `remove_boxed` on the response first, fall back to `$...$` extraction if no boxed expression is found
- Use the pre-computed `doc["answer"]` field (already set by `process_docs`) instead of re-extracting from `doc["solution"]`

## Test plan

- [x] `process_results(doc, [r"The answer is $\boxed{2}$."])` → `exact_match: 1` (was `0`)
- [x] `process_results(doc, [r"The answer is \boxed{2}."])` → `exact_match: 1` (was `0`)
- [x] `process_results(doc, [r"\boxed{3}"])` → `exact_match: 0` (still `0`)
- [x] `$...$`-only responses continue to work as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)