### PR TITLE
Fix fewshot_examples crashing with ValueError when training set is smaller than k

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -240,7 +240,7 @@ class Task(abc.ABC):
         if self._training_docs is None:
             self._training_docs = list(self.training_docs())
 
-        return rnd.sample(self._training_docs, k)
+        return rnd.sample(self._training_docs, min(k, len(self._training_docs)))
 
     def doc_to_decontamination_query(self, doc):
         raise NotImplementedError(


### PR DESCRIPTION
## Bug

`fewshot_examples` calls `rnd.sample(self._training_docs, k)` unconditionally:

```python
def fewshot_examples(self, k, rnd):
    if self._training_docs is None:
        self._training_docs = list(self.training_docs())
    return rnd.sample(self._training_docs, k)
```

`random.sample(population, k)` raises `ValueError: Sample larger than population or is negative` when `k > len(population)`. If a task's training set has fewer documents than the requested number of few-shot examples (e.g., 3 training docs, `num_fewshot=5`), the evaluation crashes.

## Root cause

No guard exists between `k` and `len(self._training_docs)`. Tasks with small training sets or custom datasets that do not have enough examples trigger the crash at runtime.

## Why the fix is correct

`min(k, len(self._training_docs))` caps the sample to what is available, returning as many few-shot examples as possible without crashing. The caller builds the few-shot prompt from whatever is returned, so fewer examples produces a valid (if shorter) prompt rather than an exception. This mirrors the logic already used in the else-branch of `fewshot_context` (`rnd.sample(self._fewshot_docs, num_fewshot + 1)`), which would have the same failure mode if the validation docs list were small.