### PR TITLE
fix(vllm): add ray to [vllm] extras so data-parallel mode works out of the box

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -118,7 +118,8 @@ class VLLM(TemplateLM):
             )
         if self.data_parallel_size > 1 and not find_spec("ray"):
             raise ModuleNotFoundError(
-                "ray is required for data parallelism. Please install ray using `pip install ray`."
+                "ray is required for data parallelism. "
+                "Install it via `pip install 'lm_eval[vllm]'` or `pip install ray>=2.0`."
             )
         self.model_args = {
             "model": pretrained,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ Repository = "https://github.com/EleutherAI/lm-evaluation-harness"
 api = ["requests", "aiohttp", "tenacity", "tqdm", "tiktoken"]
 archiver = ["jsonlines", "zstandard"]
 hf = ["transformers>=4.1","torch>=1.8", "accelerate>=0.26.0", "peft>=0.2.0",]
-vllm = ["vllm>=0.18"]
+vllm = ["vllm>=0.18", "ray>=2.0"]
 gptq = ["auto-gptq[triton]>=0.6.0"]
 gptqmodel = ["gptqmodel>=1.0.9"]
 ipex = ["optimum-intel"]


### PR DESCRIPTION
## Summary

`ray` is used by the vLLM backend's data-parallel path (when `data_parallel_size > 1`), but it was missing from the `[vllm]` optional-dependency group in `pyproject.toml`. As a result, `pip install lm_eval[vllm]` produces an environment that raises `ModuleNotFoundError` at model-init time whenever a user sets `data_parallel_size > 1`, even though nothing in the install command hinted that an extra package was required. Adding `ray>=2.0` to the `vllm` extras closes this gap — users who run `pip install lm_eval[vllm]` will now have ray available for multi-GPU data-parallel evaluation. The error message raised by the `find_spec("ray")` guard is also updated to point to `pip install 'lm_eval[vllm]'` so that re-installing via the extras is the obvious path to resolution.

## Issue

Fixes #3688

## Local verification

```
# Lint on changed files exactly as CI invokes it
$ cd /tmp/lm-evaluation-harness
$ SKIP=no-commit-to-branch,mypy pre-commit run --files lm_eval/models/vllm_causallms.py pyproject.toml
check for added large files..............................................Passed
check python ast.........................................................Passed
fix utf-8 byte order marker..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
don't commit to branch..................................................Skipped
trim trailing whitespace.................................................Passed
fix utf-8 byte order marker..............................................Passed
mixed line ending........................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
codespell................................................................Passed
PyMarkdown...........................................(no files to check)Skipped

# Core unit tests (network-independent subset, same flags as CI)
$ python -m pytest tests/test_misc.py tests/test_metrics.py tests/test_filters.py \
    tests/test_aggregation_pipeline.py tests/test_evaluator_utils.py \
    tests/test_janitor.py tests/test_samplers.py -x --showlocals -s -vv
======================== 122 passed, 1 skipped in 2.93s ========================
=== LOCAL_TEST_PASSED ===
```

## Risk

Adding `ray>=2.0` to the vllm extras installs ray as a transitive dependency for all `lm_eval[vllm]` users, including those who never use data parallelism. Ray is a substantial package, so users with tight environment sizes may see a larger install footprint; they can continue to install vllm alone (`pip install vllm lm_eval`) if they prefer not to pull in ray. No code logic is changed — the only runtime-visible difference is the updated error message wording, which is non-breaking.
