### PR TITLE
fix for keyerror while running humaneval_infilling 

### DIFF
--- a/lm_eval/tasks/humaneval_infilling/random_span_infilling_light.yaml
+++ b/lm_eval/tasks/humaneval_infilling/random_span_infilling_light.yaml
@@ -1,3 +1,3 @@
 include: multi_line_infilling.yaml
-task: humaneval_single_line_infilling_light
+task: humaneval_random_span_infilling_light
 dataset_name: HumanEval-RandomSpanInfillingLight


### PR DESCRIPTION
Hi there! While running the `humaneval_infilling` task, I got the keyerror that `humaneval_random_span_infilling_light` subtask was not in the list. On inspecting the `random_span_infilling_light.yaml` I found that the task name was set to `humaneval_single_line_infilling_light` instead of `humaneval_random_span_infilling_light`. This PR fixes that. 

 