### PR TITLE
fix(metrics): use numpy median to handle even-length arrays correctly

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -38,7 +38,7 @@ def mean(arr):
 
 @register_aggregation("median")
 def median(arr):
-    return sorted(arr)[len(arr) // 2]
+    return float(np.median(arr))
 
 
 # Certain metrics must be calculated across all documents in a benchmark.


### PR DESCRIPTION
### Bug

The ` median ` aggregation in ` lm_eval/api/metrics.py ` returns the upper of the two middle elements for even-length inputs, rather than their arithmetic mean:

```python
@register_aggregation(\"median\")
def median(arr):
    return sorted(arr)[len(arr) // 2]
```

For ` arr = [1, 2, 3, 4] ` this returns ` 3 `, whereas the median of that sample is ` 2.5 `.

### Root cause

` len(arr) // 2 ` indexes a single element regardless of parity. For odd-length inputs this is the true middle element and is correct; for even-length inputs the median is the mean of ` sorted(arr)[n // 2 - 1] ` and ` sorted(arr)[n // 2] `, which the current code doesn't compute.

### Why the fix is correct

` numpy.median ` follows the standard definition: it returns the middle element for odd ` n ` and the arithmetic mean of the two middle elements for even ` n `. Wrapping with ` float(...) ` preserves the existing return type for downstream callers (` bootstrap_stderr `, ` sample_stddev `, etc., which subtract and square the values via ` mean `).

The aggregation registry name is ` median `; matching the mathematical definition is the expected behavior, and ` numpy ` is already imported in this file.