### PR TITLE
fix: truncate sanitized model name to avoid filename too long error

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -293,11 +293,16 @@ def get_file_datetime(filename: str) -> str:
     return filename[filename.rfind("_") + 1 :].replace(".jsonl", "")
 
 
-def sanitize_model_name(model_name: str) -> str:
+def sanitize_model_name(model_name: str, max_length: int = 200) -> str:
     """
     Given the model name, returns a sanitized version of it.
+
+    Truncates to ``max_length`` characters to avoid ``OSError: [Errno 36]
+    File name too long`` when model_args contains long local paths or many
+    key=value pairs.
     """
-    return re.sub(r"[\"<>:/|\\?*\[\]]+", "__", model_name)
+    sanitized = re.sub(r"[\"<>:/|\\?*\[\]]+", "__", model_name)
+    return sanitized[:max_length]
 
 
 def sanitize_task_name(task_name: str) -> str:


### PR DESCRIPTION
## Why are these changes needed?

  When --model_args contains long local paths or many key=value pairs, the
  sanitized model name used as a directory name can exceed the OS limit
  (255 chars on Linux/Mac), causing OSError: [Errno 36] File name too long.

  Added a max_length=200 parameter to sanitize_model_name() that truncates
  the result before it hits the filesystem limit.

  ## Related issue number

  Closes #1454

  ## Checks
  - [ ] I've included any doc changes needed
  - [ ] I've added tests (if relevant)
  - [x] I've made sure all auto checks have passed

