### PR TITLE
fix(huggingface): skip Hub SHA lookup for pre-initialized PreTrainedModel

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1762,7 +1762,14 @@ class HFLM(TemplateLM):
             else:
                 return ""
 
-        def get_model_sha(pretrained: str, revision: str) -> str:
+        def get_model_sha(pretrained, revision: str) -> str:
+            # HFLM.pretrained can be a HF Hub id / local path (str) OR a
+            # pre-initialized transformers.PreTrainedModel (see __init__ docstring).
+            # HfApi().model_info only accepts a repo_id string; passing a model
+            # object raises and triggers a spurious "Failed to get model SHA"
+            # warning for every pre-initialized-model run (see #3431).
+            if not isinstance(pretrained, str):
+                return ""
             try:
                 model_info = HfApi().model_info(repo_id=pretrained, revision=revision)
                 return model_info.sha

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -164,3 +164,18 @@ class Test_HFLM:
                 self.LM.loglikelihood(self.MULTIPLE_CH)
             assert "arc_easy" in str(exc_info.value)
             assert "enable_thinking=True" in str(exc_info.value)
+
+    def test_get_model_info_skips_hub_call_for_pretrained_model(self) -> None:
+        # Regression for #3431: when a user passes a pre-initialized
+        # transformers.PreTrainedModel as `pretrained`, HFLM previously called
+        # HfApi().model_info(repo_id=<model_object>), which raises and emits a
+        # spurious "Failed to get model SHA" warning on every run.
+        # The fix short-circuits when `self.pretrained` is not a str, so the
+        # Hub call must not happen and `model_sha` must be the empty string.
+        with (
+            patch.object(self.LM, "pretrained", self.LM._model),
+            patch("lm_eval.models.huggingface.HfApi") as mock_hf_api,
+        ):
+            info = self.LM.get_model_info()
+            mock_hf_api.assert_not_called()
+        assert info["model_sha"] == ""


### PR DESCRIPTION
## Summary

Fixes #3431.

`HFLM.get_model_info()` always emits a spurious `Failed to get model SHA for ...` warning whenever the user passes a pre-initialized `transformers.PreTrainedModel` as `pretrained` (a supported call path documented in [`huggingface.py:118-122`](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/models/huggingface.py#L118-L122)). The inner `get_model_sha` helper calls `HfApi().model_info(repo_id=self.pretrained, ...)`, which only accepts a string — passing a model object raises every time and is silently swallowed in the `except`.

The fix short-circuits when `self.pretrained` is not a string: there is no Hub SHA to fetch for a pre-initialized model. No behavior change for the string code paths.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# Setup once
git clone https://github.com/EleutherAI/lm-evaluation-harness.git /tmp/lm-eval-3431 && cd /tmp/lm-eval-3431
python -m venv .venv && source .venv/bin/activate
pip install -e ".[hf]" >/dev/null 2>&1

cat > /tmp/repro_3431.py <<'PY'
import logging, warnings
logging.basicConfig(level=logging.DEBUG)
from transformers import AutoModelForCausalLM, AutoTokenizer
from lm_eval.models.huggingface import HFLM

tok = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
mdl = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
lm = HFLM(pretrained=mdl, tokenizer=tok, device="cpu")
info = lm.get_model_info()
print("model_sha:", repr(info["model_sha"]))
PY

# BEFORE — Expected: at least one "Failed to get model SHA for ..." debug line
git checkout main
python /tmp/repro_3431.py 2>&1 | grep -E "Failed to get model SHA|model_sha"

# AFTER — Expected: no "Failed to get model SHA" line, model_sha: ''
git checkout fix/3431-model-sha-pretrained-model
python /tmp/repro_3431.py 2>&1 | grep -E "Failed to get model SHA|model_sha"
```

## What I ran locally

```
pytest tests/models/test_huggingface.py::Test_HFLM::test_get_model_info_skips_hub_call_for_pretrained_model -v
```

The new regression test fails on `main` (HfApi is called because the helper goes through the `try` branch and only catches the exception after) and passes on this branch (HfApi is not called at all).

## Edge cases

| Case | Behavior on main | Behavior on this branch |
|---|---|---|
| `pretrained="EleutherAI/pythia-70m"` (str, valid Hub id) | Hub call → real SHA | Hub call → real SHA (unchanged) |
| `pretrained="/local/path"` (str, local path) | Hub call → 404 → empty + warning | Hub call → 404 → empty + warning (unchanged) |
| `pretrained=AutoModelForCausalLM.from_pretrained(...)` (PreTrainedModel) | Hub call raises → empty + warning every run | Skipped → empty, no warning |
| `peft="adapter/repo"` (str) | Hub call → real SHA | Hub call → real SHA (unchanged) |
| `delta=None` | No call | No call (unchanged) |

## Notes

- The change is in the local `get_model_sha` closure inside `HFLM.get_model_info`; no public API changes.
- Type annotation widened from `pretrained: str` to `pretrained` since `HFLM.pretrained` is documented to accept `str | PreTrainedModel`.
- Added a 4-line comment in the source pointing at #3431 so reviewers reading the diff cold see the why immediately.

---
*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against `lm_eval/models/huggingface.py` and `tests/models/test_huggingface.py`. The reproducer block above is the one I used during development; reviewers can paste it verbatim.*
