### PR TITLE
Fix: Allow batch_size > 1 for LocalChatCompletion

### DIFF
--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -166,11 +166,7 @@ class LocalChatCompletion(LocalCompletionsAPI):
             auth_token=auth_token,
             **kwargs,
         )
-        if self._batch_size > 1:
-            eval_logger.warning(
-                "Chat completions does not support batching. Defaulting to batch size 1."
-            )
-            self._batch_size = 1
+
 
     def _create_payload(
         self,


### PR DESCRIPTION
Bug: `LocalChatCompletion` previously forced `batch_size` to 1 because chat completions historically did not support batching. However, local OpenAI-compatible endpoints like vLLM do support batching for chat completions, making this restriction an unnecessary bottleneck. Root cause: The constructor explicitly warned and overrode any `batch_size > 1`. Why fix is correct: Removing this hardcoded override allows users to leverage batching with local chat completion endpoints, significantly improving evaluation speed when the backend supports it.