### PR TITLE
fix(anthropic): restore default stop sequence when until filters to empty

### DIFF
--- a/lm_eval/models/anthropic_llms.py
+++ b/lm_eval/models/anthropic_llms.py
@@ -344,6 +344,8 @@ class AnthropicChat(LocalCompletionsAPI):
 
         # Filter out empty or whitespace-only stop sequences for Anthropic API
         stop = [s for s in stop if s and s.strip()]
+        if not stop:
+            stop = [eos] if eos else ["\n\nHuman:"]
 
         out = {
             "messages": cleaned_messages,


### PR DESCRIPTION
## Bug
`AnthropicChat` requests fail when task `generation_kwargs.until` is whitespace-only (e.g. `"\n\n"`), leaving no valid `stop_sequences` after filtering (#2412).

## Root cause
We strip whitespace-only stop strings for the Anthropic API, but when that removes every entry the payload sends `stop_sequences: []` instead of falling back to the model default (`eos`, typically `"\n\nHuman:"`).

## Why this fix is correct
After filtering, if `stop` is empty we restore `[eos]` (or `["\n\nHuman:"]`), matching the pre-filter default used when `until` is absent. Non-whitespace stops are unchanged.

Fixes #2412

Made with [Cursor](https://cursor.com)