### PR TITLE
Add make_table regression coverage

### DIFF
--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -131,14 +131,16 @@ class WandbLogger:
 
             table = wandb.Table(columns=columns)
             results = copy.deepcopy(self.results)
+            versions = results.get("versions", {})
+            n_shot = results.get("n-shot", {})
 
             for k, dic in results.get(key).items():
                 if k in self.group_names and not key == "groups":
                     continue
-                version = results.get("versions").get(k)
+                version = versions.get(k)
                 if version == "N/A":
                     version = None
-                n = results.get("n-shot").get(k)
+                n = n_shot.get(k)
 
                 for (mf), v in dic.items():
                     m, _, f = mf.partition(",")

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -499,6 +499,7 @@ def make_table(result_dict, column: str = "results", sort_results: bool = False)
 
     # Build depth map and hierarchical key ordering from group_subtasks
     group_subtasks = result_dict.get("group_subtasks", {})
+    n_shot = result_dict.get("n-shot", {})
     depth_map, hierarchical_keys = _build_hierarchy_info(
         group_subtasks, set(result_dict[column].keys())
     )
@@ -513,7 +514,7 @@ def make_table(result_dict, column: str = "results", sort_results: bool = False)
     for k in keys:
         dic = dict(result_dict[column][k])  # copy — don't mutate original
         version = result_dict["versions"].get(k, "    N/A")
-        n = str(result_dict.get("n-shot", " ").get(k, " "))
+        n = str(n_shot.get(k, " "))
         higher_is_better = result_dict.get("higher_is_better", {}).get(k, {})
 
         display_name = dic.pop("alias", k)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,5 +1,7 @@
 import os
 import re
+import sys
+import types
 
 import pytest
 
@@ -163,3 +165,106 @@ def test_printed_results(
                 if t1_s or t2_s:
                     assert t1_s == t2_s
                 #     assert t1_s == t2_s
+
+
+class _FakeMarkdownTableWriter:
+    instances = []
+
+    def __init__(self):
+        self.headers = []
+        self.value_matrix = []
+        type(self).instances.append(self)
+
+    def dumps(self):
+        return repr(self.value_matrix)
+
+
+class _FakeLatexTableWriter(_FakeMarkdownTableWriter):
+    pass
+
+
+@pytest.fixture
+def fake_pytablewriter(monkeypatch):
+    _FakeMarkdownTableWriter.instances.clear()
+    _FakeLatexTableWriter.instances.clear()
+    monkeypatch.setitem(
+        sys.modules,
+        "pytablewriter",
+        types.SimpleNamespace(
+            MarkdownTableWriter=_FakeMarkdownTableWriter,
+            LatexTableWriter=_FakeLatexTableWriter,
+        ),
+    )
+
+
+def test_make_table_regression_preserves_hierarchy_and_metadata(fake_pytablewriter):
+    result_dict = {
+        "results": {
+            "parent": {
+                "alias": "Parent",
+                "name": "ignore-me",
+                "sample_len": 123,
+                "sample_count": {"acc,none": 123},
+                "acc,none": 0.9,
+                "acc_stderr,none": 0.01,
+            },
+            "child": {
+                "alias": "Child",
+                "sample_len": 50,
+                "acc,none": 0.8,
+            },
+            "standalone": {
+                "alias": "Standalone",
+                "loss,none": 0.2,
+            },
+        },
+        "versions": {"parent": 1, "child": 2, "standalone": 3},
+        "n-shot": {"parent": 5, "child": 0, "standalone": 2},
+        "higher_is_better": {
+            "parent": {"acc": True},
+            "child": {"acc": True},
+            "standalone": {"loss": False},
+        },
+        "group_subtasks": {"parent": ["child"]},
+    }
+
+    output = make_table(result_dict)
+
+    assert output == repr(
+        [
+            ["Parent", 1, "none", "5", "acc", "↑", "0.9000", "±", "0.0100"],
+            [" - Child", 2, "none", "0", "acc", "↑", "0.8000", "", ""],
+            ["Standalone", 3, "none", "2", "loss", "↓", "0.2000", "", ""],
+        ]
+    )
+    assert _FakeMarkdownTableWriter.instances[0].headers == [
+        "Tasks",
+        "Version",
+        "Filter",
+        "n-shot",
+        "Metric",
+        "",
+        "Value",
+        "",
+        "Stderr",
+    ]
+
+
+def test_make_table_regression_sorted_results_is_alphabetical(fake_pytablewriter):
+    result_dict = {
+        "results": {
+            "parent": {"alias": "Parent", "acc,none": 0.9},
+            "child": {"alias": "Child", "acc,none": 0.8},
+            "standalone": {"alias": "Standalone", "acc,none": 0.7},
+        },
+        "versions": {},
+        "group_subtasks": {"parent": ["child"]},
+    }
+
+    make_table(result_dict, sort_results=True)
+
+    assert _FakeMarkdownTableWriter.instances[0].value_matrix == [
+        [" - Child", "    N/A", "none", " ", "acc", "", "0.8000", "", ""],
+        ["Parent", "    N/A", "none", " ", "acc", "", "0.9000", "", ""],
+        ["Standalone", "    N/A", "none", " ", "acc", "", "0.7000", "", ""],
+    ]


### PR DESCRIPTION
## Summary
- add regression coverage for `make_table()` hierarchy and metadata formatting
- cover the sorted-results path without depending on the real `pytablewriter` package
- fix `make_table()` so missing `n-shot` metadata does not raise an `AttributeError`

## Testing
- `.venv/bin/python -m pytest tests/test_evaluator.py -k make_table_regression -vv`
- `python3 -m py_compile lm_eval/utils.py tests/test_evaluator.py`

## Notes
- A full `tests/test_evaluator.py` run in this local environment still requires `torch` for the existing Hugging Face integration tests. The new formatter regression tests pass independently.