### PR TITLE
Fix ContextSampler crash when few-shot pool contains duplicate eval_doc rows

### DIFF
--- a/lm_eval/api/samplers.py
+++ b/lm_eval/api/samplers.py
@@ -61,6 +61,14 @@ class ContextSampler:
                 eval_doc, self.rnd.sample(self.fewshot_docs(), n + 1), n
             )
         )
+        if len(res) < n:
+            # The eval_doc path samples n + 1 docs to leave headroom for removing
+            # a single eval_doc occurrence. If the pool holds duplicate rows equal
+            # to eval_doc, more than one copy can be drawn and removed, leaving
+            # fewer than n. Resample from the pool with every eval_doc copy
+            # removed so we still return n examples.
+            pool = [x for x in self.fewshot_docs() if x != eval_doc]
+            res = self.rnd.sample(pool, n)
         assert len(res) == n, (
             f"Error: number of fewshot samples returned ({len(res)}) not equal to number requested ({n})."
         )

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -107,6 +107,29 @@ class TestContextSampler:
         assert len(result) == 4
         assert eval_doc not in result
 
+    def test_sample_with_duplicate_eval_doc_in_pool(self):
+        """Duplicate rows equal to eval_doc must not drop the result below n.
+
+        The eval_doc path samples n + 1 docs as headroom for removing a single
+        eval_doc occurrence. When the pool holds duplicate copies of eval_doc,
+        more than one can be drawn and removed; seed=4 below draws two copies and
+        previously tripped the `len(res) == n` assertion.
+        """
+        eval_doc = {"id": 0, "text": "dup"}
+        pool = [
+            dict(eval_doc),
+            {"id": 1, "text": "b"},
+            dict(eval_doc),
+            {"id": 2, "text": "c"},
+            {"id": 3, "text": "d"},
+        ]
+        sampler = ContextSampler(pool, rnd=4)
+
+        result = sampler.sample(n=2, eval_doc=dict(eval_doc))
+
+        assert len(result) == 2
+        assert eval_doc not in result
+
     def test_fewshot_indices_filters_documents(self, sample_docs):
         """fewshot_indices parameter limits which docs are available."""
         indices = [0, 2, 4]  # Only use docs at positions 0, 2, 4


### PR DESCRIPTION
## Summary

When few-shot examples are drawn from the same split being evaluated (`fewshot_split == test_split`), the eval doc is passed to `ContextSampler.sample`. To avoid using the eval doc as one of its own few-shot examples, `sample` draws `n + 1` docs and then calls `rm_eval_doc` to drop the eval doc before truncating to `n`:

```python
self.rm_eval_doc(eval_doc, self.rnd.sample(self.fewshot_docs(), n + 1), n)
```

The `+ 1` headroom only accounts for **one** occurrence of the eval doc. `rm_eval_doc` filters by value (`[x for x in _iter if x != doc]`), so if the pool contains **duplicate rows equal to the eval doc**, more than one copy can be sampled and removed, leaving fewer than `n` examples. This trips the assertion and aborts the entire evaluation:

```
AssertionError: Error: number of fewshot samples returned (1) not equal to number requested (2).
```

Duplicate rows occur in real datasets, and the failure is seed-dependent (≈30% of seeds for a pool with one duplicate of the eval doc), so it surfaces as an intermittent crash.

## Fix

After the existing sample-and-filter step, detect the short result and resample from the pool with every `eval_doc` copy removed, guaranteeing `n` examples:

```python
if len(res) < n:
    pool = [x for x in self.fewshot_docs() if x != eval_doc]
    res = self.rnd.sample(pool, n)
```

The common (no-duplicate) path returns exactly `n` and skips the new branch entirely, so **existing few-shot selections stay byte-for-byte reproducible** — verified against the prior `rnd.sample(pool, n + 1)[:n]` behavior across multiple seeds.

## Test plan

- Added `test_sample_with_duplicate_eval_doc_in_pool` (seed `4` deterministically draws two copies of the eval doc). It **fails on `main`** with the assertion above and **passes** with this change.
- Full sampler suite green: `pytest tests/test_samplers.py` → 35 passed.
- Verified reproducibility of the no-duplicate path and the single-occurrence path is unchanged.