### PR TITLE
Fix mbpp extract_code when prompt includes opening fence

### DIFF
--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -32,8 +32,17 @@ def pass_at_1(
 def extract_code_blocks(text: str) -> str:
     # Pattern to match ```...``` blocks
     pattern = r"```(?:\w+)?\n?(.*?)\n?```"
-    # (+ ```) as we add the opening "```python" to the gen_prefix
-    matches = re.findall(pattern, r"```" + text, re.DOTALL)
+    # Some tasks (e.g. `mbpp_instruct`) include an opening fence in `gen_prefix`
+    # (e.g. "```python\n"), so model generations commonly end with only the
+    # closing fence. In that case, prefix with "```\n" so the first token of the
+    # code doesn't get misinterpreted as the language tag (e.g. "def").
+    stripped = text.lstrip()
+    if not stripped.startswith("```") and stripped.endswith("```"):
+        candidate = "```\n" + text
+    else:
+        candidate = text
+
+    matches = re.findall(pattern, candidate, re.DOTALL)
     # if no matches, try to match ```...``` blocks (after removing the language)
     if not matches:
         text_without_lang = re.sub(r"```python", "```", text)

--- a/tests/test_mbpp_extract_code_blocks.py
+++ b/tests/test_mbpp_extract_code_blocks.py
@@ -1,0 +1,19 @@
+from lm_eval.tasks.mbpp.utils import extract_code_blocks
+
+
+def test_extract_code_blocks_when_only_closing_fence_present():
+    # `mbpp_instruct` includes an opening fence in gen_prefix (```python\n),
+    # so model output often ends with only the closing fence.
+    generation = "def square_perimeter(side):\n    return 4 * side\n```"
+    assert extract_code_blocks(generation).lstrip().startswith("def square_perimeter")
+
+
+def test_extract_code_blocks_from_fenced_block_with_language():
+    generation = "```python\ndef square_perimeter(side):\n    return 4 * side\n```"
+    assert extract_code_blocks(generation).lstrip().startswith("def square_perimeter")
+
+
+def test_extract_code_blocks_from_fenced_block_without_language():
+    generation = "```\ndef square_perimeter(side):\n    return 4 * side\n```"
+    assert extract_code_blocks(generation).lstrip().startswith("def square_perimeter")
+


### PR DESCRIPTION
Fixes #3447.

`mbpp_instruct` (and similar tasks) include an opening code fence in `gen_prefix` (e.g. ` ```python
 `), so model generations often end with only the closing fence. The existing `extract_code_blocks` implementation prepended ` ``` `, which caused the first token of code (e.g. `def`) to be treated as the language tag and stripped.

This change prefixes with ` ```
 ` only in the "closing fence only" case, so the first line of code is preserved.

Includes a small unit test covering the three common response shapes.