### PR TITLE
fix(ruler): handle dict pretrained arg in get_dataset to avoid TypeError

### DIFF
--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -203,6 +203,8 @@ def generate_samples(
 
 
 def get_dataset(pretrained, docs, qas, max_seq_length=None, **kwargs) -> list[dict]:
+    if isinstance(pretrained, dict):
+        pretrained = pretrained.get("pretrained", pretrained.get("model", ""))
     tokenizer = get_tokenizer(pretrained)
     write_jsons = generate_samples(
         tokenizer=tokenizer,


### PR DESCRIPTION
Fixes #3441

When evaluating RULER tasks with an API-backed model (e.g. `local-chat-completions`), the model arguments arrive as a dict (`{'model': '...', 'base_url': '...'}`) rather than a plain string. `get_qa_dataset` extracts this dict and passes it as `pretrained` to `get_dataset`, which forwards it unchanged to `get_tokenizer`. `get_tokenizer` is decorated with `@cache`; `functools.cache` hashes its arguments, and dicts are not hashable, so the call raises `TypeError: unhashable type: 'dict'` before any inference runs.

**Root cause:** `get_dataset` passes `pretrained` straight to `get_tokenizer` without checking its type. When `pretrained` is a dict (from API model args), the `@cache` hash fails.

**Fix:** Two lines added at the top of `get_dataset` to extract the string model name from the dict before calling `get_tokenizer`. The lookup order is `'pretrained'` first (standard HuggingFace model arg key) then `'model'` (used by `local-chat-completions` and similar API backends). String values pass through unchanged.

**Why this is correct:** `get_tokenizer` expects a string tokenizer name, not a dict. When the RULER task is run with an API model, the user supplies the tokenizer name via `--model_args model=<name>`, and extracting it from the dict restores the intended behaviour. The fix is symmetric with the existing `get_qa_dataset` line that already tries `kwargs.get("tokenizer", kwargs.get("pretrained", {}))` — it just doesn't handle the `model` key that API models use.