### PR TITLE
fix: strip whitespace from input/target for FDA, SWDE, and SQuAD_completion tasks

### DIFF
--- a/lm_eval/tasks/fda/README.md
+++ b/lm_eval/tasks/fda/README.md
@@ -64,6 +64,10 @@ Description:
 
 * `fda`: the FDA task as implemented in the paper "Simple linear attention language models balance the recall-throughput tradeoff". Designed for zero-shot evaluation of small LMs.
 
+### Changelog
+
+* **v1** (2026-06-22, PR #3795): strip surrounding whitespace from the prompt (`doc_to_text`) and the gold target (`doc_to_target`), and route `process_results` through the stripped target so the `contains` metric compares against it. The raw `text`/`value` fields carry leading/trailing whitespace that previously corrupted both the prompt and the target, depressing `contains` scores. Results are not comparable to v0.
+
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:

--- a/lm_eval/tasks/fda/task.py
+++ b/lm_eval/tasks/fda/task.py
@@ -1,5 +1,4 @@
 import re
-from typing import List
 
 import numpy as np
 
@@ -28,10 +27,10 @@ class FDA(ConfigurableTask):
         return self.dataset["validation"]
 
     def doc_to_text(self, doc):
-        return doc["text"]
+        return doc["text"].strip()
 
     def doc_to_target(self, doc):
-        return doc["value"]
+        return doc["value"].strip()
 
     def construct_requests(
         self, doc, ctx, chat_template=None, apply_chat_template=False, **kwargs
@@ -93,7 +92,7 @@ class FDA(ConfigurableTask):
         }
 
 
-def contains_score(prediction: str, labels: List[str]):
+def contains_score(prediction: str, labels: list[str]):
     return max(
         int(bool(re.search(re.compile(re.escape(label), re.IGNORECASE), prediction)))
         for label in labels

--- a/lm_eval/tasks/fda/task.py
+++ b/lm_eval/tasks/fda/task.py
@@ -69,7 +69,7 @@ class FDA(ConfigurableTask):
         # continuation, (logprob_unanswerable, _) = results
         continuation = results
 
-        return {"contains": contains_score(continuation[0], [doc["value"]])}
+        return {"contains": contains_score(continuation[0], [self.doc_to_target(doc)])}
 
     def aggregation(self):
         """

--- a/lm_eval/tasks/fda/task.py
+++ b/lm_eval/tasks/fda/task.py
@@ -7,7 +7,7 @@ from lm_eval.api.task import ConfigurableTask
 
 
 class FDA(ConfigurableTask):
-    VERSION = 0
+    VERSION = 1
     DATASET_PATH = "hazyresearch/based-fda"
     DATASET_NAME = "default"
 
@@ -45,7 +45,6 @@ class FDA(ConfigurableTask):
             language description, as well as the few shot examples, and the question
             part of the document for `doc`.
         """
-
         return [
             Instance(
                 request_type="generate_until",

--- a/lm_eval/tasks/squad_completion/README.md
+++ b/lm_eval/tasks/squad_completion/README.md
@@ -40,6 +40,10 @@ Homepage: https://github.com/HazyResearch/based-evaluation-harness
 
 * `squad_completion`: the SQuAD task as implemented in the paper "Simple linear attention language models balance the recall-throughput tradeoff". Designed for zero-shot evaluation of small LMs.
 
+### Changelog
+
+* **v1** (2026-06-22, PR #3795): strip surrounding whitespace from the prompt (`doc_to_text`) and the gold target (`doc_to_target`), and route `process_results` through the stripped target so the `contains` metric compares against it. The raw `text`/`value` fields carry leading/trailing whitespace that previously corrupted both the prompt and the target, depressing `contains` scores. Results are not comparable to v0.
+
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:

--- a/lm_eval/tasks/squad_completion/task.py
+++ b/lm_eval/tasks/squad_completion/task.py
@@ -72,7 +72,7 @@ class SQUADCompletion(ConfigurableTask):
         # continuation, (logprob_unanswerable, _) = results
         continuation = results
 
-        return {"contains": contains_score(continuation[0], [doc["value"]])}
+        return {"contains": contains_score(continuation[0], [self.doc_to_target(doc)])}
 
     def aggregation(self):
         """

--- a/lm_eval/tasks/squad_completion/task.py
+++ b/lm_eval/tasks/squad_completion/task.py
@@ -1,6 +1,5 @@
 import re
 from copy import deepcopy
-from typing import List
 
 import numpy as np
 
@@ -29,10 +28,10 @@ class SQUADCompletion(ConfigurableTask):
         return self.dataset["validation"]
 
     def doc_to_text(self, doc):
-        return doc["text"]
+        return doc["text"].strip()
 
     def doc_to_target(self, doc):
-        return doc["value"]
+        return doc["value"].strip()
 
     def construct_requests(
         self, doc, ctx, chat_template=None, apply_chat_template=False, **kwargs
@@ -96,7 +95,7 @@ class SQUADCompletion(ConfigurableTask):
         }
 
 
-def contains_score(prediction: str, labels: List[str]):
+def contains_score(prediction: str, labels: list[str]):
     return max(
         int(bool(re.search(re.compile(re.escape(label), re.IGNORECASE), prediction)))
         for label in labels

--- a/lm_eval/tasks/squad_completion/task.py
+++ b/lm_eval/tasks/squad_completion/task.py
@@ -8,7 +8,7 @@ from lm_eval.api.task import ConfigurableTask
 
 
 class SQUADCompletion(ConfigurableTask):
-    VERSION = 0
+    VERSION = 1
     DATASET_PATH = "hazyresearch/based-squad"
     DATASET_NAME = "default"
 

--- a/lm_eval/tasks/swde/README.md
+++ b/lm_eval/tasks/swde/README.md
@@ -80,6 +80,10 @@ Description:
 
 * `swde`: the SWDE task as implemented in the paper "Simple linear attention language models balance the recall-throughput tradeoff". Designed for zero-shot evaluation of small LMs.
 
+### Changelog
+
+* **v1** (2026-06-22, PR #3795): strip surrounding whitespace from the prompt (`doc_to_text`) and the gold target (`doc_to_target`), and route `process_results` through the stripped target so the `contains` metric compares against it. The raw `text`/`value` fields carry leading/trailing whitespace that previously corrupted both the prompt and the target, depressing `contains` scores. Results are not comparable to v0.
+
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:

--- a/lm_eval/tasks/swde/task.py
+++ b/lm_eval/tasks/swde/task.py
@@ -69,7 +69,7 @@ class SWDE(ConfigurableTask):
         # continuation, (logprob_unanswerable, _) = results
         continuation = results
 
-        return {"contains": contains_score(continuation[0], [doc["value"]])}
+        return {"contains": contains_score(continuation[0], [self.doc_to_target(doc)])}
 
     def aggregation(self):
         """

--- a/lm_eval/tasks/swde/task.py
+++ b/lm_eval/tasks/swde/task.py
@@ -1,5 +1,4 @@
 import re
-from typing import List
 
 import numpy as np
 
@@ -28,10 +27,10 @@ class SWDE(ConfigurableTask):
         return self.dataset["validation"]
 
     def doc_to_text(self, doc):
-        return doc["text"]
+        return doc["text"].strip()
 
     def doc_to_target(self, doc):
-        return doc["value"]
+        return doc["value"].strip()
 
     def construct_requests(
         self, doc, ctx, chat_template=None, apply_chat_template=False, **kwargs
@@ -93,7 +92,7 @@ class SWDE(ConfigurableTask):
         }
 
 
-def contains_score(prediction: str, labels: List[str]):
+def contains_score(prediction: str, labels: list[str]):
     return max(
         int(bool(re.search(re.compile(re.escape(label), re.IGNORECASE), prediction)))
         for label in labels

--- a/lm_eval/tasks/swde/task.py
+++ b/lm_eval/tasks/swde/task.py
@@ -7,7 +7,7 @@ from lm_eval.api.task import ConfigurableTask
 
 
 class SWDE(ConfigurableTask):
-    VERSION = 0
+    VERSION = 1
     DATASET_PATH = "hazyresearch/based-swde-v2"
     DATASET_NAME = "default"
 
@@ -45,7 +45,6 @@ class SWDE(ConfigurableTask):
             language description, as well as the few shot examples, and the question
             part of the document for `doc`.
         """
-
         return [
             Instance(
                 request_type="generate_until",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -167,3 +167,35 @@ class TestNewTasksElseDefault(BaseTasks):
     Test class parameterized with a list of new/modified tasks
     (or a set of default tasks if none have been modified)
     """
+
+
+@pytest.mark.parametrize(
+    "task_cls_path",
+    [
+        "lm_eval.tasks.fda.task:FDA",
+        "lm_eval.tasks.swde.task:SWDE",
+        "lm_eval.tasks.squad_completion.task:SQUADCompletion",
+    ],
+    ids=["fda", "swde", "squad_completion"],
+)
+def test_strip_whitespace_in_target_and_metric(task_cls_path):
+    """Regression test for the FDA/SWDE/SQuAD_completion whitespace strip.
+
+    doc_to_text and doc_to_target strip surrounding whitespace, and
+    process_results must route the gold answer through doc_to_target so the
+    `contains` metric compares against the stripped target. Otherwise an
+    otherwise-correct prediction misses on the surrounding whitespace.
+    """
+    import importlib
+
+    module_path, cls_name = task_cls_path.split(":")
+    cls = getattr(importlib.import_module(module_path), cls_name)
+    task = cls()
+
+    doc = {"text": "  prompt  ", "value": "  answer  "}
+
+    assert task.doc_to_text(doc) == "prompt"
+    assert task.doc_to_target(doc) == "answer"
+    # The prediction has no surrounding whitespace; with the unstripped target
+    # this would be {"contains": 0}.
+    assert task.process_results(doc, ["answer"]) == {"contains": 1}


### PR DESCRIPTION
## Summary

Closes #2690.

The `fda`, `swde`, and `squad_completion` tasks returned raw `doc["text"]` and `doc["value"]` from `doc_to_text` and `doc_to_target`. Those fields carry leading and trailing whitespace. These tasks generate a completion from the prompt, so that whitespace corrupts both the prompt and the gold target and pushes the `contains` score abnormally low. This change applies `.strip()` to `doc_to_text` and `doc_to_target` in all three tasks, matching what was proposed and approved in #2690.

## Reported impact

The reporter measured these numbers in #2690 on a 410M LLaMA trained on FineWeb-EDU-10B.

| Task | contains (before) | contains (after) |
|------|------------------:|-----------------:|
| fda | 0.0281 | 0.1670 |
| squad_completion | 0.0000 | 0.3040 |
| swde | 0.1548 | 0.4482 |

## Notes

Scope stays limited to the three tasks shown to be affected. The issue also asks whether `.strip()` should apply more broadly, and that is left as a possible later change rather than bundled here. The diff also carries the repo's pinned ruff autofix on the three touched files, changing `typing.List` to `list` and dropping the import that is now unused, because CI lints the changed files.

## Testing

`pre-commit run --files` passes on all three changed files, covering ruff check, ruff format, and the rest. The change only affects how the prompt and target strings are built. The scoring path stays unchanged.
