### PR TITLE
IFEval_ca: ifx constained response validation for Catalan language

### DIFF
--- a/lm_eval/tasks/ifeval/multilingual/instructions/ca_instructions.py
+++ b/lm_eval/tasks/ifeval/multilingual/instructions/ca_instructions.py
@@ -42,7 +42,7 @@ _NUM_BULLETS = 5
 
 #The options of constrained response.
 _CONSTRAINED_RESPONSE_OPTIONS = (
-    "Sí.", "No.", "Quizás.")
+    "sí.", "no.", "potser.")
 
 #The options of starter keywords.
 _STARTER_OPTIONS = ("Diría que", "Mi respuesta es", "Creo que",
@@ -387,9 +387,9 @@ class ConstrainedResponseChecker(Instruction):
       True if the actual response contains one of the options in the constrained
       responses; otherwise False.
     """
-    value = value.strip()
+    value = value.strip().lower()
     for constrained_response in self._constrained_responses:
-      if constrained_response in value:
+      if constrained_response.lower() in value:
         return True
     return False
 


### PR DESCRIPTION
 Problem: In IFEval_ca, the ConstrainedResponseChecker used Spanish answer options ("Sí.", "No.", "Quizás.") instead of Catalan ("sí.", "no.", "potser."), and performed case-sensitive matching. This caused every constrained_response sample to always fail regardless of model capability.