### PR TITLE
feat(tasks): add ZeroSCROLLS benchmark

### DIFF
--- a/lm_eval/tasks/zero_scrolls/_zero_scrolls.yaml
+++ b/lm_eval/tasks/zero_scrolls/_zero_scrolls.yaml
@@ -1,0 +1,15 @@
+group: zero_scrolls
+group_alias: ZeroSCROLLS
+task:
+  - zero_scrolls_govreport
+  - zero_scrolls_summ_screen_fd
+  - zero_scrolls_qmsum
+  - zero_scrolls_squality
+  - zero_scrolls_qasper
+  - zero_scrolls_narrative_qa
+  - zero_scrolls_quality
+  - zero_scrolls_musique
+  - zero_scrolls_space_digest
+  - zero_scrolls_book_sum_sort
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/utils.py
+++ b/lm_eval/tasks/zero_scrolls/utils.py
@@ -1,0 +1,235 @@
+"""Utility functions for ZeroSCROLLS tasks.
+
+ZeroSCROLLS: A Zero-Shot Benchmark for Long Text Understanding
+https://arxiv.org/abs/2305.14196
+"""
+
+import math
+import re
+import string
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Dataset preprocessing
+# ---------------------------------------------------------------------------
+
+
+def process_docs(docs):
+    """Add 'question' and 'context' fields extracted from 'input' via index fields.
+
+    ZeroSCROLLS stores the full formatted input in a single 'input' field.
+    For QA/summarization tasks the query (if any) is prepended to the document
+    with '\n\n' as separator.  The byte-offset fields identify each part.
+    """
+
+    def _process(doc):
+        text = doc["input"]
+        n = len(text)
+
+        qs = doc.get("query_start_index") or -1
+        qe = doc.get("query_end_index") or -1
+        ds = doc.get("document_start_index") or 0
+        de = doc.get("document_end_index") or n
+
+        question = text[qs:qe] if 0 <= qs < qe <= n else ""
+        context = text[ds : min(de, n)]
+
+        return {**doc, "question": question, "context": context}
+
+    return docs.map(_process)
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_answer(text: str) -> str:
+    """Lower-case, strip punctuation, articles and extra whitespace."""
+    text = text.lower()
+    text = re.sub(r"\b(a|an|the)\b", " ", text)
+    text = "".join(ch for ch in text if ch not in set(string.punctuation))
+    text = " ".join(text.split())
+    return text
+
+
+def _get_tokens(text: str) -> List[str]:
+    return _normalize_answer(text).split()
+
+
+def _token_f1(prediction: str, reference: str) -> float:
+    pred_toks = _get_tokens(prediction)
+    ref_toks = _get_tokens(reference)
+    if not pred_toks or not ref_toks:
+        return 1.0 if pred_toks == ref_toks else 0.0
+    common = set(pred_toks) & set(ref_toks)
+    num_common = sum(min(pred_toks.count(t), ref_toks.count(t)) for t in common)
+    if num_common == 0:
+        return 0.0
+    precision = num_common / len(pred_toks)
+    recall = num_common / len(ref_toks)
+    return 2 * precision * recall / (precision + recall)
+
+
+def _refs(doc: dict) -> List[str]:
+    """Return a list of reference strings from a doc's 'output' field."""
+    out = doc.get("output")
+    if out is None:
+        return []
+    if isinstance(out, list):
+        return [str(r) for r in out if r is not None]
+    return [str(out)]
+
+
+# ---------------------------------------------------------------------------
+# ROUGE – geometric mean of ROUGE-1, ROUGE-2, ROUGE-L (ZeroSCROLLS metric)
+# ---------------------------------------------------------------------------
+
+
+def process_rouge(doc: dict, results: list) -> dict:
+    """Geometric mean of ROUGE-1/2/L F-measures, scaled to 0-100."""
+    try:
+        from rouge_score import rouge_scorer
+    except ImportError:
+        raise ImportError(
+            "rouge-score is required for ZeroSCROLLS tasks. "
+            "Install with: pip install rouge-score"
+        )
+
+    prediction = results[0].strip()
+    refs = _refs(doc)
+    if not prediction or not refs:
+        return {"rouge_geomean": 0.0}
+
+    scorer = rouge_scorer.RougeScorer(
+        ["rouge1", "rouge2", "rougeL"], use_stemmer=True
+    )
+    best = 0.0
+    for ref in refs:
+        s = scorer.score(ref, prediction)
+        r1 = s["rouge1"].fmeasure
+        r2 = s["rouge2"].fmeasure
+        rL = s["rougeL"].fmeasure
+        product = r1 * r2 * rL
+        geomean = product ** (1.0 / 3.0) if product > 0 else 0.0
+        best = max(best, geomean)
+
+    return {"rouge_geomean": best * 100}
+
+
+# ---------------------------------------------------------------------------
+# Token-level F1 (QA tasks)
+# ---------------------------------------------------------------------------
+
+
+def process_qa_f1(doc: dict, results: list) -> dict:
+    """Token-level F1, max over multiple references, scaled to 0-100."""
+    prediction = results[0].strip()
+    refs = _refs(doc)
+    if not refs:
+        return {"f1": 0.0}
+    score = max(_token_f1(prediction, ref) for ref in refs)
+    return {"f1": score * 100}
+
+
+# ---------------------------------------------------------------------------
+# Accuracy – QuALITY (multiple-choice, letter A/B/C/D)
+# ---------------------------------------------------------------------------
+
+
+def process_accuracy(doc: dict, results: list) -> dict:
+    """Extract A/B/C/D from model output and compare to reference letter."""
+    prediction = results[0].strip()
+    refs = _refs(doc)
+    if not refs:
+        return {"acc": 0.0}
+    ref = refs[0]
+
+    pred_match = re.search(r"\b([ABCD])\b", prediction.upper())
+    ref_match = re.search(r"\b([ABCD])\b", ref.upper())
+
+    pred_letter = pred_match.group(1) if pred_match else ""
+    ref_letter = ref_match.group(1) if ref_match else ref.strip()[:1].upper()
+
+    return {"acc": 1.0 if pred_letter == ref_letter else 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Exponential Similarity – SpaceDigest
+# ---------------------------------------------------------------------------
+
+
+def _extract_fraction(text: str) -> Optional[float]:
+    """Parse the first number from *text* and normalise to [0, 1]."""
+    nums = re.findall(r"\d+(?:\.\d+)?", text)
+    if not nums:
+        return None
+    val = float(nums[0])
+    # Accept both 0-1 and 0-100 representations
+    if val > 1.0:
+        val /= 100.0
+    return max(0.0, min(1.0, val))
+
+
+def process_space_digest(doc: dict, results: list) -> dict:
+    """ES(p, p_hat) = 2^(-10 * |p - p_hat|), scaled to 0-100.
+
+    p is the true fraction of reviews that recommend the hotel;
+    p_hat is the model's predicted fraction.  A perfect prediction
+    scores 100; a 10-percentage-point error scores ~50.
+    """
+    prediction = results[0].strip()
+    refs = _refs(doc)
+    if not refs:
+        return {"es": 0.0}
+
+    p = _extract_fraction(refs[0])
+    p_hat = _extract_fraction(prediction)
+    if p is None or p_hat is None:
+        return {"es": 0.0}
+
+    return {"es": 2 ** (-10 * abs(p - p_hat)) * 100}
+
+
+# ---------------------------------------------------------------------------
+# Concordance Index – BookSumSort
+# ---------------------------------------------------------------------------
+
+
+def process_book_sum_sort(doc: dict, results: list) -> dict:
+    """Fraction of chapter-pairs correctly ordered (concordance index).
+
+    The model outputs a sequence of chapter numbers in the order it thinks
+    they appear in the book.  We compare against the reference ordering.
+    Score is (correctly ordered pairs) / (total pairs), scaled to 0-100.
+    A random permutation expected to score ~50.
+    """
+    prediction = results[0].strip()
+    refs = _refs(doc)
+    if not refs:
+        return {"concordance": 0.0}
+
+    def _extract_order(text: str) -> List[int]:
+        return [int(x) for x in re.findall(r"\d+", text)]
+
+    pred_order = _extract_order(prediction)
+    ref_order = _extract_order(refs[0])
+
+    if len(pred_order) < 2 or not ref_order:
+        return {"concordance": 0.0}
+
+    ref_rank = {val: i for i, val in enumerate(ref_order)}
+    total, correct = 0, 0
+    for i in range(len(pred_order)):
+        for j in range(i + 1, len(pred_order)):
+            a, b = pred_order[i], pred_order[j]
+            if a not in ref_rank or b not in ref_rank:
+                continue
+            total += 1
+            if ref_rank[a] < ref_rank[b]:
+                correct += 1
+
+    if total == 0:
+        return {"concordance": 0.0}
+    return {"concordance": (correct / total) * 100}

--- a/lm_eval/tasks/zero_scrolls/utils.py
+++ b/lm_eval/tasks/zero_scrolls/utils.py
@@ -27,10 +27,16 @@ def process_docs(docs):
         text = doc["input"]
         n = len(text)
 
-        qs = doc.get("query_start_index") or -1
-        qe = doc.get("query_end_index") or -1
-        ds = doc.get("document_start_index") or 0
-        de = doc.get("document_end_index") or n
+        # Use explicit None checks: 0 is a valid start index but is falsy.
+        raw_qs = doc.get("query_start_index")
+        raw_qe = doc.get("query_end_index")
+        raw_ds = doc.get("document_start_index")
+        raw_de = doc.get("document_end_index")
+
+        qs = -1 if raw_qs is None else int(raw_qs)
+        qe = -1 if raw_qe is None else int(raw_qe)
+        ds = 0 if raw_ds is None else int(raw_ds)
+        de = n if raw_de is None else int(raw_de)
 
         question = text[qs:qe] if 0 <= qs < qe <= n else ""
         context = text[ds : min(de, n)]

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_book_sum_sort.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_book_sum_sort.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_book_sum_sort
 dataset_path: tau/zero_scrolls
 dataset_name: book_sum_sort
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_book_sum_sort.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_book_sum_sort.yaml
@@ -1,0 +1,20 @@
+group: zero_scrolls
+task: zero_scrolls_book_sum_sort
+dataset_path: tau/zero_scrolls
+dataset_name: book_sum_sort
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+# Input contains shuffled chapter summaries; model must output their correct order.
+doc_to_text: "{{context}}\n\nQuestion: Sort the above chapter summaries in the order they appear in the book by listing their numbers separated by commas.\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_book_sum_sort
+generation_kwargs:
+  max_gen_toks: 512
+  until: []
+metric_list:
+  - metric: concordance
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_govreport.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_govreport.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_govreport
 dataset_path: tau/zero_scrolls
 dataset_name: govreport
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_govreport.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_govreport.yaml
@@ -1,0 +1,19 @@
+group: zero_scrolls
+task: zero_scrolls_govreport
+dataset_path: tau/zero_scrolls
+dataset_name: govreport
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+doc_to_text: "{{context}}\n\nQuestion: What is a summary of the preceding text?\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_rouge
+generation_kwargs:
+  max_gen_toks: 1024
+  until: []
+metric_list:
+  - metric: rouge_geomean
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_musique.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_musique.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_musique
 dataset_path: tau/zero_scrolls
 dataset_name: musique
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_musique.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_musique.yaml
@@ -1,0 +1,20 @@
+group: zero_scrolls
+task: zero_scrolls_musique
+dataset_path: tau/zero_scrolls
+dataset_name: musique
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+doc_to_text: "{{question}}\n\n{{context}}\n\nQuestion: {{question}}\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_qa_f1
+generation_kwargs:
+  max_gen_toks: 128
+  until:
+    - "\n"
+metric_list:
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_narrative_qa.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_narrative_qa.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_narrative_qa
 dataset_path: tau/zero_scrolls
 dataset_name: narrative_qa
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_narrative_qa.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_narrative_qa.yaml
@@ -1,0 +1,20 @@
+group: zero_scrolls
+task: zero_scrolls_narrative_qa
+dataset_path: tau/zero_scrolls
+dataset_name: narrative_qa
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+doc_to_text: "{{question}}\n\n{{context}}\n\nQuestion: {{question}}\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_qa_f1
+generation_kwargs:
+  max_gen_toks: 128
+  until:
+    - "\n"
+metric_list:
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_qasper.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_qasper.yaml
@@ -1,0 +1,20 @@
+group: zero_scrolls
+task: zero_scrolls_qasper
+dataset_path: tau/zero_scrolls
+dataset_name: qasper
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+doc_to_text: "{{question}}\n\n{{context}}\n\nQuestion: {{question}}\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_qa_f1
+generation_kwargs:
+  max_gen_toks: 128
+  until:
+    - "\n"
+metric_list:
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_qasper.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_qasper.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_qasper
 dataset_path: tau/zero_scrolls
 dataset_name: qasper
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_qmsum.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_qmsum.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_qmsum
 dataset_path: tau/zero_scrolls
 dataset_name: qmsum
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_qmsum.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_qmsum.yaml
@@ -1,0 +1,19 @@
+group: zero_scrolls
+task: zero_scrolls_qmsum
+dataset_path: tau/zero_scrolls
+dataset_name: qmsum
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+doc_to_text: "{{question}}\n\n{{context}}\n\nQuestion: {{question}}\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_rouge
+generation_kwargs:
+  max_gen_toks: 1024
+  until: []
+metric_list:
+  - metric: rouge_geomean
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_quality.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_quality.yaml
@@ -1,0 +1,21 @@
+group: zero_scrolls
+task: zero_scrolls_quality
+dataset_path: tau/zero_scrolls
+dataset_name: quality
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+# The input already contains the story, question, and answer choices (A)–(D).
+doc_to_text: "{{input}}\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_accuracy
+generation_kwargs:
+  max_gen_toks: 8
+  until:
+    - "\n"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_quality.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_quality.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_quality
 dataset_path: tau/zero_scrolls
 dataset_name: quality
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_space_digest.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_space_digest.yaml
@@ -1,0 +1,22 @@
+group: zero_scrolls
+task: zero_scrolls_space_digest
+dataset_path: tau/zero_scrolls
+dataset_name: space_digest
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+# Input contains hotel reviews in shuffled order.
+# The model must estimate the percentage that recommend the hotel.
+doc_to_text: "{{context}}\n\nQuestion: What percentage of reviewers would recommend this hotel? Answer with a number between 0 and 100.\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_space_digest
+generation_kwargs:
+  max_gen_toks: 16
+  until:
+    - "\n"
+metric_list:
+  - metric: es
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_space_digest.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_space_digest.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_space_digest
 dataset_path: tau/zero_scrolls
 dataset_name: space_digest
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_squality.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_squality.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_squality
 dataset_path: tau/zero_scrolls
 dataset_name: squality
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_squality.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_squality.yaml
@@ -1,0 +1,19 @@
+group: zero_scrolls
+task: zero_scrolls_squality
+dataset_path: tau/zero_scrolls
+dataset_name: squality
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+doc_to_text: "{{question}}\n\n{{context}}\n\nQuestion: {{question}}\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_rouge
+generation_kwargs:
+  max_gen_toks: 1024
+  until: []
+metric_list:
+  - metric: rouge_geomean
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_summ_screen_fd.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_summ_screen_fd.yaml
@@ -1,7 +1,9 @@
-group: zero_scrolls
+tag: zero_scrolls
 task: zero_scrolls_summ_screen_fd
 dataset_path: tau/zero_scrolls
 dataset_name: summ_screen_fd
+dataset_kwargs:
+  trust_remote_code: true
 validation_split: validation
 process_docs: !function utils.process_docs
 output_type: generate_until

--- a/lm_eval/tasks/zero_scrolls/zero_scrolls_summ_screen_fd.yaml
+++ b/lm_eval/tasks/zero_scrolls/zero_scrolls_summ_screen_fd.yaml
@@ -1,0 +1,19 @@
+group: zero_scrolls
+task: zero_scrolls_summ_screen_fd
+dataset_path: tau/zero_scrolls
+dataset_name: summ_screen_fd
+validation_split: validation
+process_docs: !function utils.process_docs
+output_type: generate_until
+doc_to_text: "{{context}}\n\nQuestion: What is a summary of the preceding TV episode transcript?\nAnswer:"
+doc_to_target: "{{output}}"
+process_results: !function utils.process_rouge
+generation_kwargs:
+  max_gen_toks: 1024
+  until: []
+metric_list:
+  - metric: rouge_geomean
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/test_zero_scrolls.py
+++ b/test_zero_scrolls.py
@@ -1,0 +1,224 @@
+"""
+Smoke-test for the zero_scrolls lm-eval task implementation.
+
+Tests:
+  1. Task registration  — all 10 tasks + the group appear in TaskManager
+  2. process_docs       — query/context extraction from index fields
+  3. Metrics            — rouge_geomean, f1, accuracy, es, concordance
+  4. End-to-end         — synthetic dataset through the full lm-eval pipeline
+
+Run with:
+    python3 test_zero_scrolls.py
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+# ── make sure we're running from the repo root ──────────────────────────────
+ROOT = Path(__file__).parent
+sys.path.insert(0, str(ROOT))
+
+PASS = "\033[92m✔\033[0m"
+FAIL = "\033[91m✘\033[0m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+errors = []
+
+
+def check(label, condition, detail=""):
+    if condition:
+        print(f"  {PASS} {label}")
+    else:
+        print(f"  {FAIL} {label}" + (f"  →  {detail}" if detail else ""))
+        errors.append(label)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+print(f"\n{BOLD}1. Task registration{RESET}")
+# ─────────────────────────────────────────────────────────────────────────────
+from lm_eval.tasks import TaskManager
+
+tm = TaskManager()
+all_zs = sorted(t for t in tm.all_tasks if "zero_scroll" in t)
+print(f"  Found: {all_zs}")
+
+expected_tasks = [
+    "zero_scrolls_book_sum_sort",
+    "zero_scrolls_govreport",
+    "zero_scrolls_musique",
+    "zero_scrolls_narrative_qa",
+    "zero_scrolls_qasper",
+    "zero_scrolls_qmsum",
+    "zero_scrolls_quality",
+    "zero_scrolls_space_digest",
+    "zero_scrolls_squality",
+    "zero_scrolls_summ_screen_fd",
+]
+for t in expected_tasks:
+    check(t, t in all_zs)
+check("zero_scrolls group", "zero_scrolls" in all_zs)
+
+# ─────────────────────────────────────────────────────────────────────────────
+print(f"\n{BOLD}2. process_docs — index field extraction{RESET}")
+# ─────────────────────────────────────────────────────────────────────────────
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "utils", ROOT / "lm_eval/tasks/zero_scrolls/utils.py"
+)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+from datasets import Dataset
+
+sample_qa = {
+    "input": "Who wrote Hamlet?\n\nShakespeare wrote the play Hamlet around 1600.",
+    "output": "Shakespeare",
+    "id": "1",
+    "pid": "1",
+    "query_start_index": 0,
+    "query_end_index": 17,          # "Who wrote Hamlet?"
+    "document_start_index": 19,
+    "document_end_index": 63,
+    "truncation_separator": "",
+    "inner_docs_start_indices": [],
+}
+sample_summ = {
+    **sample_qa,
+    "query_start_index": -1,
+    "query_end_index": -1,
+    "document_start_index": 0,
+    "document_end_index": 63,
+}
+
+ds = Dataset.from_list([sample_qa, sample_summ])
+processed = utils.process_docs(ds)
+
+check(
+    "QA: question extracted",
+    processed[0]["question"] == "Who wrote Hamlet?",
+    repr(processed[0]["question"]),
+)
+check(
+    "QA: context extracted",
+    "Shakespeare" in processed[0]["context"],
+    repr(processed[0]["context"]),
+)
+check(
+    "Summarisation: question is empty string",
+    processed[1]["question"] == "",
+    repr(processed[1]["question"]),
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+print(f"\n{BOLD}3. Metric functions{RESET}")
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ROUGE geomean
+doc_rouge = {"output": "Shakespeare wrote Hamlet around 1600."}
+r = utils.process_rouge(doc_rouge, ["Shakespeare wrote the play Hamlet."])
+check("process_rouge returns rouge_geomean", "rouge_geomean" in r)
+check("process_rouge score > 0", r.get("rouge_geomean", 0) > 0, str(r))
+
+r_empty = utils.process_rouge({"output": ""}, ["some reference"])
+check("process_rouge handles empty prediction → 0", r_empty["rouge_geomean"] == 0.0)
+
+# Token F1
+doc_qa = {"output": "Shakespeare"}
+f = utils.process_qa_f1(doc_qa, ["shakespeare"])
+check("process_qa_f1 perfect match → 100", abs(f["f1"] - 100.0) < 1e-6, str(f))
+
+f2 = utils.process_qa_f1(doc_qa, ["Marlowe"])
+check("process_qa_f1 no-match → 0", f2["f1"] == 0.0, str(f2))
+
+f3 = utils.process_qa_f1({"output": None}, ["anything"])
+check("process_qa_f1 handles None output → 0", f3["f1"] == 0.0)
+
+# Accuracy (quality)
+a = utils.process_accuracy({"output": "B"}, ["(B) Hamlet"])
+check("process_accuracy correct letter → 1.0", a["acc"] == 1.0, str(a))
+
+a2 = utils.process_accuracy({"output": "A"}, ["(B) Hamlet"])
+check("process_accuracy wrong letter → 0.0", a2["acc"] == 0.0, str(a2))
+
+# Exponential similarity (space_digest)
+e = utils.process_space_digest({"output": "75"}, ["75"])
+check("process_space_digest perfect → 100", abs(e["es"] - 100.0) < 1e-6, str(e))
+
+e2 = utils.process_space_digest({"output": "25"}, ["75"])
+# 50-pt deviation: ES = 2^(-10 * 0.5) = 2^-5 = 3.125
+check("process_space_digest 50-pt error → ~3.125", abs(e2["es"] - 3.125) < 0.01, str(e2))
+
+e3 = utils.process_space_digest({"output": "no number here"}, ["75"])
+check("process_space_digest unparseable → 0", e3["es"] == 0.0)
+
+# Concordance index (book_sum_sort)
+c = utils.process_book_sum_sort({"output": "1, 2, 3"}, ["1, 2, 3"])
+check("process_book_sum_sort perfect order → 100", abs(c["concordance"] - 100.0) < 1e-6, str(c))
+
+c2 = utils.process_book_sum_sort({"output": "3, 2, 1"}, ["1, 2, 3"])
+check("process_book_sum_sort reversed → 0", c2["concordance"] == 0.0, str(c2))
+
+c3 = utils.process_book_sum_sort({"output": "1, 3, 2"}, ["1, 2, 3"])
+check(
+    "process_book_sum_sort one swap → 66.7",
+    abs(c3["concordance"] - 66.666) < 0.1,
+    str(c3),
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+print(f"\n{BOLD}4. End-to-end pipeline with synthetic dataset{RESET}")
+# ─────────────────────────────────────────────────────────────────────────────
+from unittest.mock import patch, MagicMock
+import lm_eval
+
+# Build a tiny synthetic dataset that looks exactly like tau/zero_scrolls govreport
+synthetic_rows = [
+    {
+        "input": "The government published a report on climate in 2023 showing record temperatures.",
+        "output": "2023 climate report shows record temperatures.",
+        "id": f"doc{i}",
+        "pid": f"doc{i}",
+        "query_start_index": -1,
+        "query_end_index": -1,
+        "document_start_index": 0,
+        "document_end_index": 79,
+        "truncation_separator": "",
+        "inner_docs_start_indices": [],
+    }
+    for i in range(4)
+]
+
+from datasets import DatasetDict
+
+synthetic_ds = DatasetDict({"validation": Dataset.from_list(synthetic_rows)})
+
+with patch("datasets.load_dataset", return_value=synthetic_ds):
+    results = lm_eval.simple_evaluate(
+        model="dummy",
+        tasks=["zero_scrolls_govreport"],
+        limit=3,
+        verbosity="WARNING",
+    )
+
+score = results["results"]["zero_scrolls_govreport"]["rouge_geomean,none"]
+check(
+    "End-to-end: rouge_geomean key present in results",
+    "rouge_geomean,none" in results["results"]["zero_scrolls_govreport"],
+)
+check(
+    "End-to-end: dummy model scores 0 (expected, outputs empty string)",
+    score == 0.0,
+    f"got {score}",
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+print(f"\n{'─' * 55}")
+if errors:
+    print(f"{FAIL} {len(errors)} check(s) failed: {errors}")
+    sys.exit(1)
+else:
+    total = 11 + 3 + 14 + 2   # registration + process_docs + metrics + e2e
+    print(f"{PASS} All checks passed ({total} assertions)")


### PR DESCRIPTION
## Summary

Implements the ZeroSCROLLS zero-shot long-context benchmark (Shaham et al., 2023 — https://arxiv.org/abs/2305.14196) as 10 lm-eval tasks backed by the `tau/zero_scrolls` HuggingFace dataset.

Closes #1083.

## Tasks added

| Task | Metric |
|------|--------|
| `zero_scrolls_govreport`, `summ_screen_fd`, `qmsum`, `squality` | ROUGE geomean (R-1/R-2/R-L) |
| `zero_scrolls_qasper`, `narrative_qa`, `musique` | token F1 |
| `zero_scrolls_quality` | accuracy (letter A–D) |
| `zero_scrolls_space_digest` | exponential similarity |
| `zero_scrolls_book_sum_sort` | concordance index |

## Run all 10 as a group:
```bash
lm_eval --model hf --model_args pretrained=<model> --tasks zero_scrolls
```

## Test results

All metric functions validated in isolation. YAML files use the same !function pattern as 5000+ existing task YAMLs in the repo.
<img width="1512" height="683" alt="Screenshot 2026-05-31 at 12 01 07 PM" src="https://github.com/user-attachments/assets/f9c557af-94cb-4ef8-a47d-30f81501af20" />


## AI assistance disclosure

This PR was developed with Claude (AI assistant). All changed lines have been reviewed by the submitter.


