### PR TITLE
Add optional juryeval integration for LLM-as-Judge metrics

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -637,6 +637,15 @@ def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None)
     return np.sqrt(variance)
 
 
+# Register juryeval metrics if juryeval is installed
+try:
+    from juryeval.lmeval import register_all as _register_juryeval_metrics
+
+    _register_juryeval_metrics()
+except ImportError:
+    pass
+
+
 def aggregate_subtask_metrics(metrics, sizes, weight_by_size=True):
     # A helper function that is used to aggregate
     # subtask scores cross-task.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ unitxt = ["unitxt==1.22.0"]
 trackio = ["trackio>=0.23.0"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
+juryeval = ["juryeval>=0.4.0"]
 tasks = [
     "lm_eval[discrim_eval]",
     "lm_eval[ifeval]",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -399,3 +399,28 @@ class TestRegistryClear:
 
         assert len(reg) == 0
         assert "a" not in reg
+
+
+class TestJuryevalIntegration:
+    """Test juryeval metrics registration (optional dependency)."""
+
+    @pytest.fixture(autouse=True)
+    def ensure_metrics_loaded(self):
+        import lm_eval.api.metrics  # noqa: F401
+
+    def test_juryeval_metrics_registered_when_installed(self):
+        """Verify juryeval metrics are in the registry when juryeval is installed."""
+        try:
+            import juryeval  # noqa: F401
+        except ImportError:
+            pytest.skip("juryeval not installed")
+        assert "pairwise_judge" in metric_registry, (
+            "pairwise_judge should be registered when juryeval is installed"
+        )
+        assert "pointwise_judge" in metric_registry, (
+            "pointwise_judge should be registered when juryeval is installed"
+        )
+        assert is_higher_better("pairwise_judge") is True
+        assert is_higher_better("pointwise_judge") is True
+        assert get_metric_aggregation("pairwise_judge") is not None
+        assert get_metric_aggregation("pointwise_judge") is not None


### PR DESCRIPTION
## Summary

Adds optional integration with [juryeval](https://github.com/liodon-ai/juryeval) — an open-source NLP/LLM evaluation toolkit that provides LLM-as-Judge infrastructure (pairwise comparison, pointwise scoring), statistical significance testing, and prompt robustness analysis.

When `juryeval` is installed (via `pip install lm-eval[juryeval]`), two new metrics become available for use in task YAML files:

- `pairwise_judge` — compares two model outputs and returns a winner (A/B/tie)
- `pointwise_judge` — scores a single model output on a 0-1 scale

### Changes

- **`lm_eval/api/metrics.py`**: Adds an auto-import hook that calls `juryeval.lmeval.register_all()` at import time, which registers `pairwise_judge` and `pointwise_judge` via `@register_metric`
- **`pyproject.toml`**: Adds `[juryeval]` extra (`juryeval>=0.4.0`)
- **`tests/test_registry.py`**: Adds `TestJuryevalIntegration` — verifies metrics are registered when juryeval is installed, skipped otherwise

### Usage

```bash
pip install lm-eval[juryeval]
```

Then in a task YAML:

```yaml
metric_list:
  - metric: pairwise_judge
    aggregation: mean
    higher_is_better: true
```

### Notes

- Follows the existing pattern of guarding optional dependencies with try/except imports
- The hook is at module level in `lm_eval/api/metrics.py`, so it fires during lazy metric loading (same as built-in metrics)
- juryeval's own `@register_metric` calls are idempotent (guarded against duplicate registration)