### PR TITLE
feat: add CMATH Chinese elementary school math benchmark

### DIFF
--- a/lm_eval/tasks/cmath/README.md
+++ b/lm_eval/tasks/cmath/README.md
@@ -1,0 +1,43 @@
+# CMATH
+
+### Paper
+
+Title: CMATH: Can Your Language Model Pass Chinese Elementary School Math Test?
+
+Abstract: We introduce CMATH, a Chinese elementary school math word problem dataset, consisting of 1498 problems from real-world elementary school exams in China, accompanied by detailed annotations. These problems span six difficulty levels (grades 1–6) and cover a wide range of topics, including addition, subtraction, multiplication, division, fractions, and their combinations. This dataset can be used to evaluate the reasoning abilities of LLMs on Chinese math word problems.
+
+- Dataset: `weitianwen/cmath`
+- License: Apache 2.0
+- Paper: https://arxiv.org/abs/2306.16636
+
+### Citation
+
+```bibtex
+@misc{wei2023cmath,
+      title={CMATH: Can Your Language Model Pass Chinese Elementary School Math Test?},
+      author={Tianwen Wei and Jian Luan and Wei Liu and Shuang Dong and Bin Wang},
+      year={2023},
+      eprint={2306.16636},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+- `cmath`: All CMATH tasks (direct + cot)
+
+#### Tasks
+
+- `cmath_direct`: Direct answer (no chain-of-thought)
+- `cmath_cot`: Answer with chain-of-thought reasoning in Chinese
+
+### Checklist
+
+* [x] Is the task an existing benchmark in the literature?
+* [x] Have you referenced the original paper that introduced the task?
+* [x] If available, does your implementation match the original evaluation protocol from the paper?
+* [x] Does the task use a `validation` and `test` split?
+* [x] Have you verified the task metrics against the original paper?

--- a/lm_eval/tasks/cmath/_cmath.yaml
+++ b/lm_eval/tasks/cmath/_cmath.yaml
@@ -1,0 +1,10 @@
+group: cmath
+task:
+  - cmath_direct
+  - cmath_cot
+aggregate_metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/cmath/cmath_cot.yaml
+++ b/lm_eval/tasks/cmath/cmath_cot.yaml
@@ -1,0 +1,34 @@
+task: cmath_cot
+dataset_path: weitianwen/cmath
+dataset_name: default
+test_split: test
+validation_split: validation
+output_type: generate_until
+doc_to_text: "题目：{{question}}\n逐步解答："
+doc_to_target: "{{golden}}"
+generation_kwargs:
+  until:
+    - "\n\n"
+    - "题目："
+  do_sample: false
+  temperature: 0.0
+filter_list:
+  - name: strict-match
+    filter:
+      - function: regex
+        regex_pattern: '答案[是为：:]\s*(-?[0-9][0-9.,/]*)'
+      - function: take_first
+  - name: flexible-extract
+    filter:
+      - function: regex
+        group_select: -1
+        regex_pattern: "(-?[$0-9.,/]{2,})|(-?[0-9]+)"
+      - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/cmath/cmath_direct.yaml
+++ b/lm_eval/tasks/cmath/cmath_direct.yaml
@@ -1,0 +1,30 @@
+task: cmath_direct
+dataset_path: weitianwen/cmath
+dataset_name: default
+test_split: test
+validation_split: validation
+output_type: generate_until
+doc_to_text: "题目：{{question}}\n答案："
+doc_to_target: "{{golden}}"
+generation_kwargs:
+  until:
+    - "\n\n"
+    - "\n"
+    - "题目："
+  do_sample: false
+  temperature: 0.0
+filter_list:
+  - name: flexible-extract
+    filter:
+      - function: regex
+        group_select: -1
+        regex_pattern: "(-?[$0-9.,/]{2,})|(-?[0-9]+)"
+      - function: take_first
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+metadata:
+  version: 1.0


### PR DESCRIPTION
## Summary

This PR adds evaluation support for **CMATH** (Chinese Elementary School Math Test), a benchmark for evaluating LLMs on Chinese math word problems.

- **Dataset**: [`weitianwen/cmath`](https://huggingface.co/datasets/weitianwen/cmath)
- **Paper**: [CMATH: Can Your Language Model Pass Chinese Elementary School Math Test?](https://arxiv.org/abs/2306.16636) (Wei et al., 2023)
- **Size**: 1,498 problems (600 validation / 1,098 test) across grades 1–6

## Tasks added

| Task | Description |
|------|-------------|
| `cmath_direct` | Direct answer generation — prompt ends with `答案：` |
| `cmath_cot` | Chain-of-thought reasoning — prompt ends with `逐步解答：` |
| `cmath` | Group aggregating both tasks |

## Answer extraction

Both tasks use a two-stage filter strategy for robust number extraction:
1. **strict-match** (cot only): regex `答案[是为：:]\s*(-?[0-9][0-9.,/]*)` targeting explicit answer statements
2. **flexible-extract**: generic numeric regex as fallback

## Checklist

- [x] Is the task an existing benchmark in the literature?
- [x] Have you referenced the original paper that introduced the task?
- [x] Does your implementation match the original evaluation protocol?
- [x] Does the task use `validation` and `test` splits?
- [x] Verified prompt rendering and task loading via `TaskManager`