### PR TITLE
feat: Add optional juryeval integration for LLM-as-Judge metrics

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -637,6 +637,15 @@ def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None)
     return np.sqrt(variance)
 
 
+# Register juryeval metrics if juryeval is installed
+try:
+    from juryeval.lmeval import register_all as _register_juryeval_metrics
+
+    _register_juryeval_metrics()
+except ImportError:
+    pass
+
+
 def aggregate_subtask_metrics(metrics, sizes, weight_by_size=True):
     # A helper function that is used to aggregate
     # subtask scores cross-task.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ unitxt = ["unitxt==1.22.0"]
 trackio = ["trackio>=0.23.0"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
+juryeval = ["juryeval>=0.4.0"]
 tasks = [
     "lm_eval[discrim_eval]",
     "lm_eval[ifeval]",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -408,6 +408,47 @@ class TestJuryevalIntegration:
         assert get_metric_aggregation("pairwise_judge") is not None
         assert get_metric_aggregation("pointwise_judge") is not None
 
+    def test_juryeval_metrics_use_mean_aggregation(self):
+        """Both juryeval metrics should use 'mean' as their aggregation."""
+        try:
+            import juryeval  # noqa: F401
+        except ImportError:
+            pytest.skip("juryeval not installed")
+        agg_pairwise = get_metric_aggregation("pairwise_judge")
+        agg_pointwise = get_metric_aggregation("pointwise_judge")
+        assert agg_pairwise is not None
+        assert agg_pointwise is not None
+        # The aggregation should produce a valid float mean over a sample list
+        result = agg_pairwise([0.5, 0.5, 1.0])
+        assert isinstance(result, float)
+        assert result == pytest.approx(0.666, abs=0.01)
+
+    def test_juryeval_import_graceful_when_missing(self):
+        """Ensure importing the module does not crash when juryeval is absent."""
+        import importlib
+        import sys
+
+        # Remove any juryeval modules that might be cached
+        for mod in list(sys.modules.keys()):
+            if "juryeval" in mod:
+                del sys.modules[mod]
+
+        # Simulate non-installed state by forcing the try/except path
+        try:
+            import lm_eval.api.metrics  # noqa: F401
+        except Exception:
+            pytest.fail("Importing metrics crashed when juryeval is absent")
+
+    def test_juryeval_metrics_config(self):
+        """Verify juryeval metrics have correct output_type configuration."""
+        try:
+            from juryeval.lmeval.metrics import register_all
+        except ImportError:
+            pytest.skip("juryeval not installed")
+        # Should be idempotent — calling twice produces no error
+        register_all()
+        register_all()
+
 
 class TestRegistryClear:
     """Test registry clear functionality (for test isolation)."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -384,6 +384,31 @@ class TestBackwardCompatibility:
         assert HIGHER_IS_BETTER_REGISTRY is higher_is_better_registry
 
 
+class TestJuryevalIntegration:
+    """Test juryeval metrics registration (optional dependency)."""
+
+    @pytest.fixture(autouse=True)
+    def ensure_metrics_loaded(self):
+        import lm_eval.api.metrics  # noqa: F401
+
+    def test_juryeval_metrics_registered_when_installed(self):
+        """Verify juryeval metrics are in the registry when juryeval is installed."""
+        try:
+            import juryeval  # noqa: F401
+        except ImportError:
+            pytest.skip("juryeval not installed")
+        assert "pairwise_judge" in metric_registry, (
+            "pairwise_judge should be registered when juryeval is installed"
+        )
+        assert "pointwise_judge" in metric_registry, (
+            "pointwise_judge should be registered when juryeval is installed"
+        )
+        assert is_higher_better("pairwise_judge") is True
+        assert is_higher_better("pointwise_judge") is True
+        assert get_metric_aggregation("pairwise_judge") is not None
+        assert get_metric_aggregation("pointwise_judge") is not None
+
+
 class TestRegistryClear:
     """Test registry clear functionality (for test isolation)."""
 


### PR DESCRIPTION

## Add optional juryeval integration for LLM-as-Judge metrics

## Summary

Add optional [juryeval](https://github.com/pydev42/juryeval) integration for LLM-as-Judge evaluation metrics. When `juryeval[lmeval]` is installed, the `pairwise_judge` and `pointwise_judge` metrics are automatically registered with the lm-eval-harness metric registry.

## Motivation

Standard NLP metrics (accuracy, F1, BLEU, ROUGE) measure surface-level overlap but fail to capture semantic quality, coherence, or instruction-following — especially for open-ended generation tasks. LLM-as-Judge evaluation fills this gap by using a strong language model (e.g., GPT-4) to score outputs on criteria like correctness, helpfulness, and harmlessness. This integration brings that capability into lm-eval-harness as a first-class metric, so users can run judge-based evaluations alongside traditional metrics in a single benchmark run without writing custom evaluation code.

## Changes

- **`lm_eval/api/metrics.py`** — auto-import juryeval's `register_all()` at module load (guarded by try/except)
- **`pyproject.toml`** — added `juryeval = ["juryeval>=0.4.0"]` optional dependency
- **`tests/test_registry.py`** — `TestJuryevalIntegration` class verifying metrics register when juryeval is present

## Usage

```bash
pip install juryeval[lmeval]
lm-eval --model hf --model_args pretrained=gpt2 --tasks hellaswag \
  --metric pairwise_judge
```

## Design

- The `juryeval` package is imported lazily only when `lm_eval.api.metrics` is loaded (which happens on first metric lookup via `get_metric()`)
- If `juryeval` is not installed, the import silently passes and no extra metrics are registered
- Both pointwise (single answer scoring) and pairwise (A/B comparison) LLM judges are exposed
