### PR TITLE
Warn when vLLM ignores device argument

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -102,7 +102,13 @@ class VLLM(TemplateLM):
         assert max_length is None or max_model_len is None, (
             "Either max_length or max_model_len may be provided, but not both"
         )
-        kwargs.pop("device", None)
+        if "device" in kwargs:
+            eval_logger.warning(
+                "The `device` argument is ignored by the vLLM backend. To select "
+                "which GPU(s) vLLM can use, set the `CUDA_VISIBLE_DEVICES` "
+                "environment variable before running lm-eval."
+            )
+            kwargs.pop("device")
         self.think_end_token = think_end_token
         self._max_length = max_model_len if max_model_len is not None else max_length
         self.tensor_parallel_size = int(tensor_parallel_size)


### PR DESCRIPTION
## Summary

This PR addresses #1846 by making the vLLM backend explicit about a currently silent behavior: when users pass a `device` model argument, the vLLM backend ignores it.

The change keeps the existing behavior unchanged, but replaces the silent discard with a warning that tells users to select visible GPU(s) with `CUDA_VISIBLE_DEVICES` before running `lm-eval`.

## Change

- Detect `device` in vLLM model kwargs.
- Emit a warning before removing it from kwargs.
- Leave vLLM initialization behavior unchanged.

## Validation

- The touched file passes linting.
- The touched file compiles successfully.
- No vLLM integration behavior was changed; this PR only adds the user-facing warning requested in #1846.