### PR TITLE
fix(ruler): replace defunct hotpot dataset host with pinned HF mirror

### DIFF
--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -74,7 +74,9 @@ def read_squad(
 
 @cache
 def read_hotpotqa(
-    url="http://curtis.ml.cmu.edu/datasets/hotpot/hotpot_dev_distractor_v1.json",
+    # Original host (curtis.ml.cmu.edu) is defunct; use a HF mirror pinned to an
+    # immutable revision so eval inputs stay reproducible. See issue #3805.
+    url="https://huggingface.co/datasets/namlh2004/hotpotqa/resolve/7e54db4656209750ff487f6fdf8e39a66dba136b/hotpot_dev_distractor_v1.json",
 ) -> tuple[list[dict], list[str]]:
     data = download_json(url)
     total_docs = [f"{t}\n{''.join(p)}" for d in data for t, p in d["context"]]

--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -35,7 +35,7 @@ DOCUMENT_PROMPT = "Document {i}:\n{document}"
 
 @cache
 def download_json(url) -> dict:
-    response = requests.get(url)
+    response = requests.get(url, timeout=60)
     response.raise_for_status()
     data = response.json()
     return data
@@ -47,7 +47,7 @@ def read_squad(
 ) -> tuple[list[dict], list[str]]:
     data = download_json(url)
     total_docs = [p["context"] for d in data["data"] for p in d["paragraphs"]]
-    total_docs = sorted(list(set(total_docs)))
+    total_docs = sorted(set(total_docs))
     total_docs_dict = {c: idx for idx, c in enumerate(total_docs)}
 
     total_qas = []
@@ -80,7 +80,7 @@ def read_hotpotqa(
 ) -> tuple[list[dict], list[str]]:
     data = download_json(url)
     total_docs = [f"{t}\n{''.join(p)}" for d in data for t, p in d["context"]]
-    total_docs = sorted(list(set(total_docs)))
+    total_docs = sorted(set(total_docs))
     total_docs_dict = {c: idx for idx, c in enumerate(total_docs)}
 
     total_qas = []


### PR DESCRIPTION
## Summary

`RULER` QA tasks (`hotpotqa`) fail to download their source data because the hardcoded host `curtis.ml.cmu.edu` is no longer reachable:

```
requests.exceptions.ConnectTimeout: HTTPConnectionPool(host='curtis.ml.cmu.edu', port=80):
Max retries exceeded with url: /datasets/hotpot/hotpot_dev_distractor_v1.json
```

This makes the RULER `hotpotqa` subtasks unrunnable out of the box.

## Fix

Point `read_hotpotqa()` at a Hugging Face mirror of the identical `hotpot_dev_distractor_v1.json`, pinned to an **immutable commit revision** (`/resolve/<sha>/`) so that eval inputs stay byte-stable and reproducible across runs. The file structure is unchanged, so no parser changes are needed.

- Confirmed the original host times out (`curl: (28) Connection timed out`).
- Confirmed the mirror URL serves the file as `application/json` (302 → CDN), which `requests.get(...)` follows by default.

Closes #3805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
