### PR TITLE
fix(hendrycks): normalize math answer extraction

### DIFF
--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+import re
 
 import datasets
 
@@ -15,13 +15,9 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     return dataset.map(_process_doc)
 
 
-def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
+def process_results(doc: dict, results: list[str]) -> dict[str, int]:
     retval = 0
-    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
-    if len(indices) <= 1:
-        answer = results[0]
-    else:
-        answer = results[0][indices[0] + 1 : indices[-1]]
+    answer = extract_answer(results[0])
 
     if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
         retval = 1
@@ -45,9 +41,118 @@ def is_equiv(str1, str2, verbose=False):
         ss2 = strip_string(str2)
         if verbose:
             print(ss1, ss2)
-        return ss1 == ss2
-    except Exception:
+        if ss1 == ss2:
+            return True
+        if are_base_form_equivalent(ss1, ss2):
+            return True
+        return are_unordered_list_equivalent(ss1, ss2)
+    except Exception:  # noqa: BLE001
         return str1 == str2
+
+
+def extract_answer(string):
+    answer_region = extract_math_region(string)
+    boxed_answers = extract_boxed_answers(answer_region)
+    if boxed_answers:
+        return ", ".join(boxed_answers)
+
+    boxed_answers = extract_boxed_answers(string)
+    if boxed_answers:
+        return ", ".join(boxed_answers)
+
+    return answer_region
+
+
+def extract_math_region(string):
+    indices = [pos for pos, char in enumerate(string) if char == "$"]
+    if len(indices) <= 1:
+        return string
+    return string[indices[0] + 1 : indices[-1]]
+
+
+def extract_boxed_answers(string):
+    answers = []
+    start = 0
+    while True:
+        boxed = first_boxed_only_string(string[start:])
+        if boxed is None:
+            return answers
+        answers.append(remove_boxed(boxed))
+        start += string[start:].find(boxed) + len(boxed)
+
+
+def first_boxed_only_string(string):
+    idx = string.find("\\boxed")
+    if idx < 0:
+        idx = string.find("\\fbox")
+        if idx < 0:
+            return None
+
+    if string.startswith("\\boxed ", idx) or string.startswith("\\fbox ", idx):
+        next_dollar = string.find("$", idx)
+        if next_dollar < 0:
+            return string[idx:]
+        return string[idx:next_dollar]
+
+    i = idx
+    right_brace_idx = None
+    num_left_braces_open = 0
+    while i < len(string):
+        if string[i] == "{":
+            num_left_braces_open += 1
+        if string[i] == "}":
+            num_left_braces_open -= 1
+            if num_left_braces_open == 0:
+                right_brace_idx = i
+                break
+        i += 1
+
+    if right_brace_idx is None:
+        return None
+    return string[idx : right_brace_idx + 1]
+
+
+BASE_FORM_RE = re.compile(r"^(?P<value>[A-Za-z0-9+-]+)_(?P<base>\d+)$")
+INLINE_FRACTION_RE = re.compile(r"(?<![A-Za-z])(-?\d+)/(\d+)(?!\d)")
+NEGATIVE_FRAC_RE = re.compile(r"\\frac\{-(?P<num>[^{}]+)\}\{(?P<den>[^{}]+)\}")
+
+
+def canonicalize_base_form(string):
+    match = BASE_FORM_RE.fullmatch(string)
+    if match is None:
+        return string
+    return match.group("value")
+
+
+def are_base_form_equivalent(str1, str2):
+    return canonicalize_base_form(str1) == canonicalize_base_form(str2)
+
+
+def parse_simple_comma_answers(string):
+    parts = string.split(",")
+    if len(parts) <= 1:
+        return None
+    if any(part == "" for part in parts):
+        return None
+    if any(any(char in part for char in "\\{}()[]") for part in parts):
+        return None
+    return sorted(canonicalize_base_form(part) for part in parts)
+
+
+def are_unordered_list_equivalent(str1, str2):
+    parts1 = parse_simple_comma_answers(str1)
+    parts2 = parse_simple_comma_answers(str2)
+    if parts1 is None or parts2 is None:
+        return False
+    return parts1 == parts2
+
+
+def fix_inline_numeric_fracs(string):
+    return INLINE_FRACTION_RE.sub(r"\\frac{\1}{\2}", string)
+
+
+def normalize_negative_fracs(string):
+    return NEGATIVE_FRAC_RE.sub(r"-\\frac{\g<num>}{\g<den>}", string)
 
 
 def remove_boxed(s):
@@ -56,7 +161,14 @@ def remove_boxed(s):
         assert s[: len(left)] == left
         return s[len(left) :]
 
+    if "\\fbox " in s:
+        left = "\\fbox "
+        assert s[: len(left)] == left
+        return s[len(left) :]
+
     left = "\\boxed{"
+    if not s.startswith(left):
+        left = "\\fbox{"
 
     assert s[: len(left)] == left
     assert s[-1] == "}"
@@ -134,7 +246,7 @@ def fix_a_slash_b(string):
     try:
         a = int(a)
         b = int(b)
-        assert string == "{}/{}".format(a, b)
+        assert string == f"{a}/{b}"
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
     except AssertionError:
@@ -190,13 +302,14 @@ def strip_string(string):
 
     # remove dollar signs
     string = string.replace("\\$", "")
+    string = string.replace("$", "")
 
     # remove units (on the right)
     string = remove_right_units(string)
 
     # remove percentage
     string = string.replace("\\%", "")
-    string = string.replace("\%", "")  # noqa: W605
+    string = string.replace(r"\%", "")
 
     # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
     string = string.replace(" .", " 0.")
@@ -208,9 +321,8 @@ def strip_string(string):
         string = "0" + string
 
     # to consider: get rid of e.g. "k = " or "q = " at beginning
-    if len(string.split("=")) == 2:
-        if len(string.split("=")[0]) <= 2:
-            string = string.split("=")[1]
+    if len(string.split("=")) == 2 and len(string.split("=")[0]) <= 2:
+        string = string.split("=")[1]
 
     # fix sqrt3 --> sqrt{3}
     string = fix_sqrt(string)
@@ -227,5 +339,7 @@ def strip_string(string):
 
     # NOTE: X/Y changed to \frac{X}{Y} in dataset, but in simple cases fix in case the model output is X/Y
     string = fix_a_slash_b(string)
+    string = fix_inline_numeric_fracs(string)
+    string = normalize_negative_fracs(string)
 
     return string

--- a/tests/test_hendrycks_math.py
+++ b/tests/test_hendrycks_math.py
@@ -1,0 +1,47 @@
+from lm_eval.tasks.hendrycks_math.utils import process_results
+
+
+def test_process_results_accepts_multiple_boxed_answers():
+    doc = {"solution": r"Thus, the answer is $\boxed{3, 5, 7}.$"}
+    result = r"""### Final Answer
+
+$$
+\boxed{3}, \boxed{5}, \boxed{7}
+$$"""
+
+    assert process_results(doc, [result]) == {"exact_match": 1}
+
+
+def test_process_results_accepts_unordered_simple_answer_lists():
+    doc = {"solution": r"Thus, the answer is $\boxed{1,-2}.$"}
+    result = r"""Final answer:
+
+$$
+\boxed{-2}, \boxed{1}
+$$"""
+
+    assert process_results(doc, [result]) == {"exact_match": 1}
+
+
+def test_process_results_strips_display_math_delimiters():
+    doc = {
+        "solution": r"Thus, the answer is $\boxed{\begin{pmatrix} -1/3 \\ 2/3 \\ 5/3 \end{pmatrix}}.$"
+    }
+    result = r"""### Final Answer
+
+$$
+\boxed{\begin{pmatrix} -\dfrac{1}{3} \\ \dfrac{2}{3} \\ \dfrac{5}{3} \end{pmatrix}}
+$$"""
+
+    assert process_results(doc, [result]) == {"exact_match": 1}
+
+
+def test_process_results_accepts_base_suffix_omitted_from_boxed_answer():
+    doc = {"solution": r"Thus, the answer is $\boxed{52_8}.$"}
+    result = r"""Thus, the product is:
+
+$$
+\boxed{52}
+$$"""
+
+    assert process_results(doc, [result]) == {"exact_match": 1}


### PR DESCRIPTION
## Summary
- prefer boxed answer extraction for Hendrycks/MATH generation results
- normalize multiple boxed answers, simple unordered answer lists, base-form suffixes, display-math delimiters, and inline numeric fractions
- add regression coverage for issue-derived answer formats

Fixes #3652.

## Validation
- targeted Hendrycks/MATH regression tests passed
- touched Python files compile
- touched-file ruff check passed