### PR TITLE
Add HMMT competition-math benchmark (#3557)

### DIFF
--- a/lm_eval/tasks/hmmt/README.md
+++ b/lm_eval/tasks/hmmt/README.md
@@ -1,0 +1,81 @@
+# HMMT
+
+### Paper
+
+The Harvard-MIT Mathematics Tournament (HMMT) is a high-school mathematics
+competition. Each event contains 30 short-answer problems whose gold answers
+are integers or short closed-form expressions, making it a close sibling of
+the AIME benchmark already supported by the harness.
+
+These tasks use the problem sets curated and answer-verified by
+[MathArena](https://matharena.ai/) ([eth-sri/matharena](https://github.com/eth-sri/matharena)),
+mirroring the AIME task setup but scoring answers with `math-verify` in
+addition to the AIME-style string-normalization exact-match (see the request in
+[issue #3557](https://github.com/EleutherAI/lm-evaluation-harness/issues/3557)).
+
+Homepage: https://matharena.ai/
+
+### Citation
+
+```text
+@article{dekoninck2026matharena,
+      title={Beyond Benchmarks: MathArena as an Evaluation Platform for Mathematics with LLMs},
+      author={Jasper Dekoninck and Nikola Jovanović and Tim Gehrunger and Kári Rögnvaldsson and Ivo Petrov and Chenhao Sun and Martin Vechev},
+      year={2026},
+      eprint={2605.00674},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2605.00674}
+}
+```
+
+The underlying datasets (`MathArena/hmmt_feb_2023`, `MathArena/hmmt_feb_2024`,
+`MathArena/hmmt_feb_2025`, `MathArena/hmmt_nov_2025`) are distributed under the
+CC BY-NC-SA 4.0 license. Please abide by the license when using the data.
+
+### Groups, Tags, and Tasks
+
+#### Tags
+
+* `hmmt`: runs all four per-period HMMT tasks together (mirrors how `aime` groups its
+  per-year tasks with a tag rather than an aggregating group). Each task reports its
+  own `exact_match` / `math_verify`; no cross-task aggregate metric is defined.
+* `math_word_problems`
+
+#### Tasks
+
+* `hmmt_feb_2023`: `HMMT February 2023 problems`
+* `hmmt_feb_2024`: `HMMT February 2024 problems`
+* `hmmt_feb_2025`: `HMMT February 2025 problems`
+* `hmmt_nov_2025`: `HMMT November 2025 problems`
+
+### Metrics
+
+Each task reports two metrics:
+
+* `exact_match`: AIME-style answer extraction (prefers a `\boxed{...}` answer,
+  falling back to the last `$...$` span) followed by LaTeX string-normalization
+  equivalence (copied from `lm_eval/tasks/aime/utils.py`).
+* `math_verify`: symbolic equivalence between the gold answer and the model
+  response via the `math-verify` library, which catches answers that are
+  mathematically equal but not string-identical (e.g. fractions, surds).
+
+`math-verify` is only available in the `[math]` extra:
+
+```sh
+pip install -e ".[math]"
+```
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+If other tasks on this dataset are already supported:
+
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [x] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [x] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/hmmt/hmmt_feb_2023.yaml
+++ b/lm_eval/tasks/hmmt/hmmt_feb_2023.yaml
@@ -1,0 +1,32 @@
+tag:
+  - hmmt
+  - math_word_problems
+task: hmmt_feb_2023
+dataset_path: MathArena/hmmt_feb_2023
+# dataset_name: null
+output_type: generate_until
+test_split: train
+fewshot_split: train
+doc_to_text: "Question: {{problem}}\nAnswer:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+  - metric: math_verify
+    aggregation: mean
+    higher_is_better: true
+generation_kwargs:
+  until:
+    - "Question:"
+    - "</s>"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 32768
+repeats: 1
+num_fewshot: 0
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/hmmt/hmmt_feb_2024.yaml
+++ b/lm_eval/tasks/hmmt/hmmt_feb_2024.yaml
@@ -1,0 +1,32 @@
+tag:
+  - hmmt
+  - math_word_problems
+task: hmmt_feb_2024
+dataset_path: MathArena/hmmt_feb_2024
+# dataset_name: null
+output_type: generate_until
+test_split: train
+fewshot_split: train
+doc_to_text: "Question: {{problem}}\nAnswer:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+  - metric: math_verify
+    aggregation: mean
+    higher_is_better: true
+generation_kwargs:
+  until:
+    - "Question:"
+    - "</s>"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 32768
+repeats: 1
+num_fewshot: 0
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/hmmt/hmmt_feb_2025.yaml
+++ b/lm_eval/tasks/hmmt/hmmt_feb_2025.yaml
@@ -1,0 +1,32 @@
+tag:
+  - hmmt
+  - math_word_problems
+task: hmmt_feb_2025
+dataset_path: MathArena/hmmt_feb_2025
+# dataset_name: null
+output_type: generate_until
+test_split: train
+fewshot_split: train
+doc_to_text: "Question: {{problem}}\nAnswer:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+  - metric: math_verify
+    aggregation: mean
+    higher_is_better: true
+generation_kwargs:
+  until:
+    - "Question:"
+    - "</s>"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 32768
+repeats: 1
+num_fewshot: 0
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/hmmt/hmmt_nov_2025.yaml
+++ b/lm_eval/tasks/hmmt/hmmt_nov_2025.yaml
@@ -1,0 +1,32 @@
+tag:
+  - hmmt
+  - math_word_problems
+task: hmmt_nov_2025
+dataset_path: MathArena/hmmt_nov_2025
+# dataset_name: null
+output_type: generate_until
+test_split: train
+fewshot_split: train
+doc_to_text: "Question: {{problem}}\nAnswer:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+  - metric: math_verify
+    aggregation: mean
+    higher_is_better: true
+generation_kwargs:
+  until:
+    - "Question:"
+    - "</s>"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 32768
+repeats: 1
+num_fewshot: 0
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/hmmt/utils.py
+++ b/lm_eval/tasks/hmmt/utils.py
@@ -1,0 +1,256 @@
+try:
+    from math_verify import (
+        ExprExtractionConfig,
+        LatexExtractionConfig,
+        parse,
+        verify,
+    )
+except ModuleNotFoundError as e:
+    raise type(e)(
+        "`math_verify` is required to score the HMMT tasks. "
+        "Please install the required packages via pip install lm-eval[math] or pip install -e .[math]"
+    ) from e
+
+
+def process_results(doc: dict, results: list[str]) -> dict[str, int]:
+    response = results[0]
+
+    # `answer` is the canonical answer key used by the MathArena/hmmt_* datasets,
+    # but we look it up case-insensitively to stay robust to capitalization.
+    answer_key = next(k for k in doc.keys() if k.lower() == "answer")
+    target = str(doc[answer_key])
+
+    # --- exact_match: boxed-answer extraction + string-normalization is_equiv ---
+    # (mirrors lm_eval/tasks/aime/utils.py)
+    # Try to extract answer from $...$ format first
+    indices = [pos for pos, char in enumerate(response) if char == "$"]
+    if len(indices) <= 1:
+        answer = response
+    else:
+        answer = response[indices[0] + 1 : indices[-1]]
+
+    # Extract from \\boxed{} if present
+    boxed_answer = last_boxed_only_string(response)
+    if boxed_answer is not None:
+        try:
+            boxed_content = remove_boxed(boxed_answer)
+            if boxed_content is not None:
+                answer = boxed_content
+        except (AssertionError, IndexError):
+            pass
+
+    exact_match = 1 if is_equiv(answer, target) else 0
+
+    # --- math_verify: symbolic equivalence (handles e.g. fractions, surds) ---
+    # The gold answer is a bare expression (e.g. "-95", "43"), so we allow both
+    # plain-expression and LaTeX extraction for the gold; the model response is
+    # parsed with the default config (LaTeX first, then expression).
+    try:
+        gold = parse(
+            target,
+            extraction_config=[ExprExtractionConfig(), LatexExtractionConfig()],
+        )
+        candidate = parse(response)
+        math_verify_match = 1 if verify(gold, candidate) else 0
+    except Exception:  # noqa: BLE001
+        math_verify_match = 0
+
+    return {"exact_match": exact_match, "math_verify": math_verify_match}
+
+
+# string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py
+def is_equiv(str1, str2, verbose=False):
+    if str1 is None and str2 is None:
+        print("WARNING: Both None")
+        return True
+    if str1 is None or str2 is None:
+        return False
+
+    try:
+        ss1 = strip_string(str1)
+        ss2 = strip_string(str2)
+        if verbose:
+            print(ss1, ss2)
+        return ss1 == ss2
+    except Exception:  # noqa: BLE001
+        return str1 == str2
+
+
+def remove_boxed(s):
+    if "\\boxed " in s:
+        left = "\\boxed "
+        assert s[: len(left)] == left
+        return s[len(left) :]
+
+    left = "\\boxed{"
+
+    assert s[: len(left)] == left
+    assert s[-1] == "}"
+
+    return s[len(left) : -1]
+
+
+def last_boxed_only_string(string):
+    idx = string.rfind("\\boxed")
+    if "\\boxed " in string:
+        return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
+    if idx < 0:
+        idx = string.rfind("\\fbox")
+        if idx < 0:
+            return None
+
+    i = idx
+    right_brace_idx = None
+    num_left_braces_open = 0
+    while i < len(string):
+        if string[i] == "{":
+            num_left_braces_open += 1
+        if string[i] == "}":
+            num_left_braces_open -= 1
+            if num_left_braces_open == 0:
+                right_brace_idx = i
+                break
+        i += 1
+
+    if right_brace_idx is None:
+        retval = None
+    else:
+        retval = string[idx : right_brace_idx + 1]
+
+    return retval
+
+
+def fix_fracs(string):
+    substrs = string.split("\\frac")
+    new_str = substrs[0]
+    if len(substrs) > 1:
+        substrs = substrs[1:]
+        for substr in substrs:
+            new_str += "\\frac"
+            if substr[0] == "{":
+                new_str += substr
+            else:
+                try:
+                    assert len(substr) >= 2
+                except AssertionError:
+                    return string
+                a = substr[0]
+                b = substr[1]
+                if b != "{":
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}{" + b + "}" + post_substr
+                    else:
+                        new_str += "{" + a + "}{" + b + "}"
+                else:
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}" + b + post_substr
+                    else:
+                        new_str += "{" + a + "}" + b
+    string = new_str
+    return string
+
+
+def fix_a_slash_b(string):
+    if len(string.split("/")) != 2:
+        return string
+    a = string.split("/")[0]
+    b = string.split("/")[1]
+    try:
+        a = int(a)
+        b = int(b)
+        assert string == f"{a}/{b}"
+        new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
+        return new_string
+    except AssertionError:
+        return string
+
+
+def remove_right_units(string):
+    # "\\text{ " only ever occurs (at least in the val set) when describing units
+    if "\\text{ " in string:
+        splits = string.split("\\text{ ")
+        assert len(splits) == 2
+        return splits[0]
+    else:
+        return string
+
+
+def fix_sqrt(string):
+    if "\\sqrt" not in string:
+        return string
+    splits = string.split("\\sqrt")
+    new_string = splits[0]
+    for split in splits[1:]:
+        if split[0] != "{":
+            a = split[0]
+            new_substr = "\\sqrt{" + a + "}" + split[1:]
+        else:
+            new_substr = "\\sqrt" + split
+        new_string += new_substr
+    return new_string
+
+
+def strip_string(string):
+    # linebreaks
+    string = string.replace("\n", "")
+
+    # remove inverse spaces
+    string = string.replace("\\!", "")
+
+    # replace \\ with \
+    string = string.replace("\\\\", "\\")
+
+    # replace tfrac and dfrac with frac
+    string = string.replace("tfrac", "frac")
+    string = string.replace("dfrac", "frac")
+
+    # remove \left and \right
+    string = string.replace("\\left", "")
+    string = string.replace("\\right", "")
+
+    # Remove circ (degrees)
+    string = string.replace("^{\\circ}", "")
+    string = string.replace("^\\circ", "")
+
+    # remove dollar signs
+    string = string.replace("\\$", "")
+
+    # remove units (on the right)
+    string = remove_right_units(string)
+
+    # remove percentage
+    string = string.replace("\\%", "")
+    string = string.replace("\%", "")  # noqa: W605
+
+    # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
+    string = string.replace(" .", " 0.")
+    string = string.replace("{.", "{0.")
+    # if empty, return empty string
+    if len(string) == 0:
+        return string
+    if string[0] == ".":
+        string = "0" + string
+
+    # to consider: get rid of e.g. "k = " or "q = " at beginning
+    if len(string.split("=")) == 2 and len(string.split("=")[0]) <= 2:
+        string = string.split("=")[1]
+
+    # fix sqrt3 --> sqrt{3}
+    string = fix_sqrt(string)
+
+    # remove spaces
+    string = string.replace(" ", "")
+
+    # \frac1b or \frac12 --> \frac{1}{b} and \frac{1}{2}, etc. Even works with \frac1{72} (but not \frac{72}1). Also does a/b --> \\frac{a}{b}
+    string = fix_fracs(string)
+
+    # manually change 0.5 --> \frac{1}{2}
+    if string == "0.5":
+        string = "\\frac{1}{2}"
+
+    # NOTE: X/Y changed to \frac{X}{Y} in dataset, but in simple cases fix in case the model output is X/Y
+    string = fix_a_slash_b(string)
+
+    return string


### PR DESCRIPTION
## Summary

Adds the HMMT (Harvard-MIT Mathematics Tournament) competition-math benchmark requested in #3557 — the four MathArena HMMT datasets (`feb_2023`, `feb_2024`, `feb_2025`, `nov_2025`) as `generate_until` tasks.

## Details

- Copy-adapts `lm_eval/tasks/aime/utils.py` for answer extraction (`\boxed{...}` → last `$...$` fallback → LaTeX string-normalization `exact_match`).
- Each task additionally reports `math_verify` (symbolic equivalence via the `math-verify` library, the `[math]` extra) to catch answers that are mathematically equal but not string-identical (fractions, surds, …).
- Follows the **`aime` pattern**: the four per-period tasks are grouped by a shared `hmmt` **tag** (not an aggregating `group:`), so `lm_eval --tasks hmmt` runs all four. This deliberately avoids an aggregating group, which would feed both the group and its members to `TaskManager.load()` and trip the standalone-vs-group duplicate guard during `Tasks Modified` collection (reproduces on `minerva_math`/`infinitebench`). Per-task scores are reported; no cross-task aggregate is defined (same as `aime`).

## Validation

- `ruff check` + `ruff format` clean.
- All 4 datasets verified present (train split, 30 problems each, `problem`/`answer` columns).
- Task collection green: `pytest tests/test_tasks.py --collect-only` with the task in the changed-files set → 52 tests collected, no Duplicate-task error.

---
*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
