### PR TITLE
fix(mgsm): use scriptless dataset mirror

### DIFF
--- a/lm_eval/tasks/japanese_leaderboard/ja_leaderboard_mgsm.yaml
+++ b/lm_eval/tasks/japanese_leaderboard/ja_leaderboard_mgsm.yaml
@@ -1,6 +1,6 @@
 task: ja_leaderboard_mgsm
 
-dataset_path: juletxara/mgsm
+dataset_path: jbross-ibm-research/mgsm
 dataset_name: ja
 
 training_split: train

--- a/lm_eval/tasks/mgsm/direct/direct_yaml
+++ b/lm_eval/tasks/mgsm/direct/direct_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 tag: mgsm_direct
-dataset_path: juletxara/mgsm
+dataset_path: jbross-ibm-research/mgsm
 dataset_name: null  # Overridden by language-specific config.
 output_type: generate_until
 training_split: train

--- a/lm_eval/tasks/mgsm/en_cot/cot_yaml
+++ b/lm_eval/tasks/mgsm/en_cot/cot_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 tag: mgsm_cot_native
-dataset_path: juletxara/mgsm
+dataset_path: jbross-ibm-research/mgsm
 dataset_name: null  # Overridden by language-specific config.
 output_type: generate_until
 training_split: train

--- a/lm_eval/tasks/mgsm/native_cot/cot_yaml
+++ b/lm_eval/tasks/mgsm/native_cot/cot_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 tag: mgsm_cot_native
-dataset_path: juletxara/mgsm
+dataset_path: jbross-ibm-research/mgsm
 dataset_name: null  # Overridden by language-specific config.
 output_type: generate_until
 training_split: train


### PR DESCRIPTION
Fixes #3390

## Bug
MGSM tasks still point at `juletxara/mgsm`, which now requires loading a dataset script and fails with current `datasets` releases.

## Root cause
The task YAMLs reference the original scripted dataset repository directly, so the harness hits the removed dataset-script loading path before evaluation starts.

## Why this fix is correct
`jbross-ibm-research/mgsm` provides the same MGSM configs without a dataset script, so the existing task definitions can load through the supported dataset path without changing prompts, splits, metrics, or filters.