### PR TITLE
feat(portuguese_bench): add ASSIN2 RTE and STS tasks

### DIFF
--- a/lm_eval/tasks/portuguese_bench/assin2_rte.yaml
+++ b/lm_eval/tasks/portuguese_bench/assin2_rte.yaml
@@ -10,9 +10,7 @@ target_delimiter: ""
 doc_to_choice: '{{[premise + ", certo? Não, " + hypothesis, premise + ", certo? Sim, " + hypothesis]}}'
 metric_list:
   - metric: f1
-    aggregation: mean
+    aggregation: !function assin2_utils.macro_f1
     higher_is_better: true
-    hf_evaluate: true
-    average: macro
 metadata:
   version: 1.0

--- a/lm_eval/tasks/portuguese_bench/assin2_rte.yaml
+++ b/lm_eval/tasks/portuguese_bench/assin2_rte.yaml
@@ -1,0 +1,18 @@
+task: assin2_rte
+dataset_path: nilc-nlp/assin2
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: ""
+doc_to_target: "{{entailment_judgment}}"
+target_delimiter: ""
+doc_to_choice: '{{[premise + ", certo? Não, " + hypothesis, premise + ", certo? Sim, " + hypothesis]}}'
+metric_list:
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+    hf_evaluate: true
+    average: macro
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/portuguese_bench/assin2_sts.yaml
+++ b/lm_eval/tasks/portuguese_bench/assin2_sts.yaml
@@ -1,0 +1,21 @@
+task: assin2_sts
+dataset_path: nilc-nlp/assin2
+output_type: generate_until
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "Frase 1: {{premise}}\nFrase 2: {{hypothesis}}\nQual é a similaridade semântica entre as frases acima? Responda com um número de 1 (completamente diferentes) a 5 (semanticamente equivalentes):\n"
+doc_to_target: "{{relatedness_score}}"
+generation_kwargs:
+  until:
+    - "\n"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 10
+process_results: !function assin2_utils.process_results_sts
+metric_list:
+  - metric: pearsonr
+    aggregation: !function assin2_utils.pearson_corr
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/portuguese_bench/assin2_utils.py
+++ b/lm_eval/tasks/portuguese_bench/assin2_utils.py
@@ -26,3 +26,11 @@ def pearson_corr(items):
     if len(set(preds)) < 2:
         return 0.0
     return float(pearsonr(preds, golds)[0])
+
+
+def macro_f1(items):
+    # the f1 metric hands the aggregator a list of (gold, pred) tuples (one per input)
+    from sklearn.metrics import f1_score
+
+    golds, preds = zip(*items, strict=True)
+    return float(f1_score(golds, preds, average="macro"))

--- a/lm_eval/tasks/portuguese_bench/assin2_utils.py
+++ b/lm_eval/tasks/portuguese_bench/assin2_utils.py
@@ -1,0 +1,28 @@
+import re
+
+from scipy.stats import pearsonr
+
+
+def parse_score(text: str):
+    """Extract a float in [1, 5] from model output; return None on failure."""
+    match = re.search(r"\b([1-5](?:[.,]\d+)?)\b", text)
+    if match:
+        score = float(match.group(1).replace(",", "."))
+        return max(1.0, min(5.0, score))
+    return None
+
+
+def process_results_sts(doc, results):
+    pred = parse_score(results[0].strip())
+    if pred is None:
+        pred = 3.0  # neutral fallback when model output is unparseable
+    gold = float(doc["relatedness_score"])
+    return {"pearsonr": (pred, gold)}
+
+
+def pearson_corr(items):
+    preds = [i[0] for i in items]
+    golds = [i[1] for i in items]
+    if len(set(preds)) < 2:
+        return 0.0
+    return float(pearsonr(preds, golds)[0])

--- a/lm_eval/tasks/portuguese_bench/portuguese_bench.yaml
+++ b/lm_eval/tasks/portuguese_bench/portuguese_bench.yaml
@@ -4,5 +4,7 @@ task:
   - flores_pt
   - assin_paraphrase
   - assin_entailment
+  - assin2_rte
+  - assin2_sts
 metadata:
   version: 1.0


### PR DESCRIPTION
## Summary

Adds two ASSIN2 subtasks to the `portuguese_bench` group, resolving #3765.

### New tasks

| Task | Type | Metric |
|------|------|--------|
| `assin2_rte` | `multiple_choice` | F1-macro |
| `assin2_sts` | `generate_until` | Pearson r |

**Dataset**: `nilc-nlp/assin2` (Brazilian Portuguese textual entailment + STS)

### Implementation details

- **`assin2_rte`**: Binary entailment (NONE=0 / ENTAILMENT=1) framed as multiple-choice with Portuguese prompts (`certo? Não` / `certo? Sim`). F1-macro via `hf_evaluate`.
- **`assin2_sts`**: Similarity score 1–5 generated as free text; `assin2_utils.parse_score` extracts the first numeric match with comma/period normalisation. Falls back to 3.0 (neutral) on parse failure. Pearson r computed via custom `pearson_corr` aggregator.
- **`assin2_utils.py`**: Shared helpers for score parsing and Pearson aggregation.

### Testing

```bash
# smoke test – task loading
python -c "
from lm_eval.tasks import TaskManager
tm = TaskManager()
tasks = tm.load_task_or_group(['assin2_rte', 'assin2_sts'])
print('Loaded:', list(tasks.keys()))
"

# unit tests
python -m pytest tests/test_assin2_utils.py -v
```

Closes #3765