### PR TITLE
fix: skip cache writes for sampled generations

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -232,6 +232,17 @@ def hash_args(attr: str, args: Iterable[Any]) -> str:
     return hashlib.sha256(dat.encode("utf-8")).hexdigest()
 
 
+def _should_cache_request(attr: str, args: Iterable[Any]) -> bool:
+    if attr != "generate_until":
+        return True
+
+    args = tuple(args)
+    if len(args) < 2 or not isinstance(args[1], dict):
+        return True
+
+    return not args[1].get("do_sample", False)
+
+
 class CacheHook:
     def __init__(self, cachinglm: Optional["CachingLM"]) -> None:
         if cachinglm is None:
@@ -242,6 +253,8 @@ class CacheHook:
 
     def add_partial(self, attr: str, req: Iterable[Any], res: Any) -> None:
         if self.dbdict is None:
+            return
+        if not _should_cache_request(attr, req):
             return
         hsh = hash_args(attr, req)
         self.dbdict[hsh] = res
@@ -282,7 +295,7 @@ class CachingLM:
             )
             for req in tqdm(requests, desc="Checking cached requests"):
                 hsh = hash_args(attr, req.args)
-                if attr == "generate_until" and req.args[1].get("do_sample", False):
+                if not _should_cache_request(attr, req.args):
                     # when we are doing non-greedy generation, don't use the cache
                     # (else every "randomly sampled" generation would be identical for repeats > 1).
                     if not warned:
@@ -316,8 +329,9 @@ class CachingLM:
                 res[resptr] = r
 
                 # caching
-                hsh = hash_args(attr, req.args)
-                self.dbdict[hsh] = r
+                if _should_cache_request(attr, req.args):
+                    hsh = hash_args(attr, req.args)
+                    self.dbdict[hsh] = r
             self.dbdict.commit()
 
             return res

--- a/tests/test_caching_lm.py
+++ b/tests/test_caching_lm.py
@@ -1,0 +1,52 @@
+from lm_eval.api.instance import Instance
+from lm_eval.api.model import LM, CachingLM, hash_args
+
+
+class ToyLM(LM):
+    def __init__(self):
+        super().__init__()
+        self.generate_calls = 0
+
+    def loglikelihood(self, requests):
+        return [(0.0, True) for _ in requests]
+
+    def loglikelihood_rolling(self, requests):
+        return [0.0 for _ in requests]
+
+    def generate_until(self, requests):
+        results = []
+        for request in requests:
+            result = f"generated-{self.generate_calls}"
+            self.generate_calls += 1
+            self.cache_hook.add_partial("generate_until", request.args, result)
+            results.append(result)
+        return results
+
+
+def generate_request(gen_kwargs):
+    return Instance(
+        request_type="generate_until",
+        doc={},
+        arguments=("prompt", gen_kwargs),
+        idx=0,
+        metadata=("task", 0, 1),
+    )
+
+
+def test_caching_lm_does_not_write_sampled_generations(tmp_path):
+    lm = ToyLM()
+    cached_lm = CachingLM(lm, str(tmp_path / "cache.sqlite"))
+    request = generate_request({"do_sample": True, "until": ["\n"]})
+
+    assert cached_lm.generate_until([request]) == ["generated-0"]
+    assert hash_args("generate_until", request.args) not in cached_lm.dbdict
+
+
+def test_caching_lm_reads_deterministic_generations(tmp_path):
+    lm = ToyLM()
+    cached_lm = CachingLM(lm, str(tmp_path / "cache.sqlite"))
+    request = generate_request({"until": ["\n"]})
+
+    assert cached_lm.generate_until([request]) == ["generated-0"]
+    assert cached_lm.generate_until([request]) == ["generated-0"]
+    assert lm.generate_calls == 1


### PR DESCRIPTION
## Summary

This makes CachingLM's sampled-generation policy consistent in both directions.

`generate_until` requests with `do_sample=True` were already skipped on cache reads, but they could still be written through either the model cache hook or the wrapper's post-call writeback. That leaves random generations stored under the same deterministic key even though the caller was warned that caching would not be used for those requests.

The patch centralizes the cacheability check and applies it to:

- CacheHook.add_partial
- CachingLM cache lookup
- CachingLM post-call writeback

Deterministic generation requests keep the existing cache behavior.

Fixes #3046.

## To verify

- python -m pytest tests\test_caching_lm.py -q
- python -m ruff check lm_eval\api\model.py tests\test_caching_lm.py
- python -m ruff format --check lm_eval\api\model.py tests\test_caching_lm.py
- git diff --check