### PR TITLE
fix: keep Anthropic stop sequences nonempty

### DIFF
--- a/lm_eval/models/anthropic_llms.py
+++ b/lm_eval/models/anthropic_llms.py
@@ -344,6 +344,8 @@ class AnthropicChat(LocalCompletionsAPI):
 
         # Filter out empty or whitespace-only stop sequences for Anthropic API
         stop = [s for s in stop if s and s.strip()]
+        if not stop:
+            stop = [eos]
 
         out = {
             "messages": cleaned_messages,

--- a/tests/models/test_anthropic_llms.py
+++ b/tests/models/test_anthropic_llms.py
@@ -1,0 +1,23 @@
+from lm_eval.models.anthropic_llms import AnthropicChat
+
+
+def test_anthropic_chat_uses_default_stop_when_until_is_missing():
+    api = AnthropicChat(model="claude-test", tokenizer_backend=None)
+
+    payload = api._create_payload(
+        [{"role": "user", "content": "hello"}],
+        gen_kwargs={},
+    )
+
+    assert payload["stop_sequences"] == ["\n\nHuman:"]
+
+
+def test_anthropic_chat_uses_default_stop_when_until_is_whitespace_only():
+    api = AnthropicChat(model="claude-test", tokenizer_backend=None)
+
+    payload = api._create_payload(
+        [{"role": "user", "content": "hello"}],
+        gen_kwargs={"until": ["\n\n", "  "]},
+    )
+
+    assert payload["stop_sequences"] == ["\n\nHuman:"]


### PR DESCRIPTION
## Summary
- keep Anthropic chat `stop_sequences` non-empty after filtering whitespace-only values
- preserve the existing default `\n\nHuman:` stop when a task's `until` list contains only whitespace
- add regression coverage for missing and whitespace-only `until`

## To verify
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\models\test_anthropic_llms.py -q`
- `python -m py_compile lm_eval\models\anthropic_llms.py tests\models\test_anthropic_llms.py`
- `ruff check tests\models\test_anthropic_llms.py`
- `git diff --check`

Fixes #2412
