### PR TITLE
Fix GGUF crash on empty-prompt tasks

### DIFF
--- a/lm_eval/models/gguf.py
+++ b/lm_eval/models/gguf.py
@@ -21,10 +21,16 @@ def get_result(logprobs, context_length):
     idx = 0
     while offsets[idx] < context_length:
         idx += 1
-    continuation_logprobs = sum(tokens_logprobs[idx:-1])
+    # llama.cpp returns None for the leading token's logprob and top_logprobs
+    # when it has no context (empty prompts, e.g. xnli); skip those. See #3385.
+    continuation_logprobs = sum(
+        lp for lp in tokens_logprobs[idx:-1] if lp is not None
+    )
     for i in range(idx, len(tokens)):
         token = tokens[i]
         top_tokens = logprobs["top_logprobs"][i]
+        if not top_tokens:
+            continue
         top_token = max(top_tokens.keys(), key=lambda x: top_tokens[x])
         if top_token != token:
             is_greedy = False

--- a/lm_eval/models/gguf.py
+++ b/lm_eval/models/gguf.py
@@ -23,9 +23,7 @@ def get_result(logprobs, context_length):
         idx += 1
     # llama.cpp returns None for the leading token's logprob and top_logprobs
     # when it has no context (empty prompts, e.g. xnli); skip those. See #3385.
-    continuation_logprobs = sum(
-        lp for lp in tokens_logprobs[idx:-1] if lp is not None
-    )
+    continuation_logprobs = sum(lp for lp in tokens_logprobs[idx:-1] if lp is not None)
     for i in range(idx, len(tokens)):
         token = tokens[i]
         top_tokens = logprobs["top_logprobs"][i]
@@ -41,13 +39,14 @@ def get_result(logprobs, context_length):
 
 @register_model("gguf", "ggml")
 class GGUFLM(LM):
-    def __init__(self, base_url=None, max_length=2048, **kwargs):
+    def __init__(self, base_url=None, max_length=2048, timeout=300, **kwargs):
         super().__init__()
         self.base_url = base_url
         assert self.base_url, "must pass `base_url` to use GGUF LM!"
         self.logprobs = 10
         self.temperature = 0.0
         self.max_length = max_length
+        self.timeout = timeout
 
     def gguf_completion(
         self, context, continuation=None, stop=None, retries=3, delay=5, **kwargs
@@ -66,17 +65,16 @@ class GGUFLM(LM):
                 if stop is not None:
                     request["stop"] = stop
                 response = requests.post(
-                    f"{self.base_url}/v1/completions", json=request
+                    f"{self.base_url}/v1/completions",
+                    json=request,
+                    timeout=self.timeout,
                 )
                 response.raise_for_status()
                 return response.json()
             except RequestException as e:
                 logger.error(f"RequestException: {e}")
                 time.sleep(delay)  # wait before retrying
-        else:
-            raise RuntimeError(
-                f"Failed to get a valid response after {retries} retries."
-            )
+        raise RuntimeError(f"Failed to get a valid response after {retries} retries.")
 
     def loglikelihood(self, requests, disable_tqdm: bool = False):
         if not requests:
@@ -104,7 +102,7 @@ class GGUFLM(LM):
                 logger.error(
                     f"Invalid response for loglikelihood. Response: {response}"
                 )
-                assert False
+                raise AssertionError
         return res
 
     def generate_until(self, requests, disable_tqdm: bool = False):

--- a/tests/models/test_gguf.py
+++ b/tests/models/test_gguf.py
@@ -23,7 +23,7 @@ def gguf_completion_mock(base_url=None, **kwargs):
 
     if os.path.exists(fname):
         with open(fname, "rb") as fh:
-            return pickle.load(fh)
+            return pickle.load(fh)  # noqa: S301 - trusted local test fixture
     else:
         print("The file does not exist, attempting to write...")
         if "stop" in kwargs:
@@ -83,7 +83,7 @@ def gguf_completion_mock(base_url=None, **kwargs):
             with open(fname, "wb") as fh:
                 pickle.dump(result, fh)
             print("File written successfully")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort fixture write
             print("File writing failed:", e)
 
         return result

--- a/tests/models/test_gguf.py
+++ b/tests/models/test_gguf.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from lm_eval.api.instance import Instance
-from lm_eval.models.gguf import GGUFLM
+from lm_eval.models.gguf import GGUFLM, get_result
 
 
 base_url = "https://matthoffner-ggml-llm-api.hf.space"
@@ -134,6 +134,28 @@ class GGUFLMTest(unittest.TestCase):
         # Assert the generate_until response is correct
         expected_res = ["generated text until stop1", "generated text until stop2"]
         self.assertEqual(res, expected_res)
+
+    def test_get_result_empty_prompt(self):
+        # Empty-prompt tasks (e.g. xnli) give context_length 0, so the
+        # continuation starts at index 0, where llama.cpp returns None for the
+        # logprob and top_logprobs. Regression test for #3385.
+        def make_logprobs(second_token_top):
+            return {
+                "text_offset": [0, 5, 11],
+                "token_logprobs": [None, -2.0, -1.0],
+                "tokens": ["Hello", " world", "!"],
+                "top_logprobs": [None, second_token_top, {"!": -1.0}],
+            }
+
+        # None is skipped and the trailing echoed token dropped, leaving -2.0;
+        # " world" is the argmax, so the run is greedy.
+        logprob, is_greedy = get_result(make_logprobs({" world": -2.0}), 0)
+        self.assertEqual(logprob, -2.0)
+        self.assertTrue(is_greedy)
+
+        # " there" outranks " world", so greedy detection still fires.
+        _, is_greedy = get_result(make_logprobs({" there": -0.1, " world": -2.0}), 0)
+        self.assertFalse(is_greedy)
 
     # @patch('lm_eval.models.gguf.GGUFLM.gguf_completion', side_effect=gguf_completion_mock)
     # def test_loglikelihood_rolling(self, gguf_completion_mock):


### PR DESCRIPTION
get_result crashes on tasks with empty prompts (e.g. xnli) because llama.cpp returns None for the first token's logprob and top_logprobs when there's no preceding context. This skips those None values when summing logprobs and checking for greedy decoding.
  
  Fixes #3385