### PR TITLE
Fix "trasnlation" typo in DarijaBench translation task names

### DIFF
--- a/lm_eval/tasks/darija_bench/darija_translation/doda_translation_all.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/doda_translation_all.yaml
@@ -3,7 +3,7 @@ include:
   - doda_common_yaml
 "tag":
 - "darija_translation_tasks_doda"
-"task": "trasnlation_all_doda"
+"task": "translation_all_doda"
 "task_alias": "all_doda"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/doda_translation_dr_en.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/doda_translation_dr_en.yaml
@@ -4,7 +4,7 @@ include:
   - doda_common_yaml
 "tag":
 - "darija_translation_tasks_doda"
-"task": "trasnlation_dr_en_doda"
+"task": "translation_dr_en_doda"
 "task_alias": "dr_en_doda"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/doda_translation_dr_fr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/doda_translation_dr_fr.yaml
@@ -4,7 +4,7 @@ include:
   - doda_common_yaml
 "tag":
 - "darija_translation_tasks_doda"
-"task": "trasnlation_dr_fr_doda"
+"task": "translation_dr_fr_doda"
 "task_alias": "dr_fr_doda"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/doda_translation_dr_msa.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/doda_translation_dr_msa.yaml
@@ -4,7 +4,7 @@ include:
   - doda_common_yaml
 "tag":
 - "darija_translation_tasks_doda"
-"task": "trasnlation_dr_msa_doda"
+"task": "translation_dr_msa_doda"
 "task_alias": "dr_msa_doda"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/doda_translation_en_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/doda_translation_en_dr.yaml
@@ -4,7 +4,7 @@ include:
   - doda_common_yaml
 "tag":
   - "darija_translation_tasks_doda"
-"task": "trasnlation_en_dr_doda"
+"task": "translation_en_dr_doda"
 "task_alias": "en_dr_doda"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/doda_translation_fr_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/doda_translation_fr_dr.yaml
@@ -4,7 +4,7 @@ include:
   - doda_common_yaml
 "tag":
 - "darija_translation_tasks_doda"
-"task": "trasnlation_fr_dr_doda"
+"task": "translation_fr_dr_doda"
 "task_alias": "fr_dr_doda"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/doda_translation_msa_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/doda_translation_msa_dr.yaml
@@ -4,7 +4,7 @@ include:
   - doda_common_yaml
 "tag":
 - "darija_translation_tasks_doda"
-"task": "trasnlation_msa_dr_doda"
+"task": "translation_msa_dr_doda"
 "task_alias": "msa_dr_doda"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/flores_translation_all.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/flores_translation_all.yaml
@@ -3,7 +3,7 @@ include:
   - flores_common_yaml
 "tag":
 - "darija_translation_tasks_flores"
-"task": "trasnlation_all_flores"
+"task": "translation_all_flores"
 "task_alias": "all_flores"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/flores_translation_dr_en.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/flores_translation_dr_en.yaml
@@ -4,7 +4,7 @@ include:
   - flores_common_yaml
 "tag":
 - "darija_translation_tasks_flores"
-"task": "trasnlation_dr_en_flores"
+"task": "translation_dr_en_flores"
 "task_alias": "dr_en_flores"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/flores_translation_dr_fr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/flores_translation_dr_fr.yaml
@@ -4,7 +4,7 @@ include:
   - flores_common_yaml
 "tag":
 - "darija_translation_tasks_flores"
-"task": "trasnlation_dr_fr_flores"
+"task": "translation_dr_fr_flores"
 "task_alias": "dr_fr_flores"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/flores_translation_dr_msa.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/flores_translation_dr_msa.yaml
@@ -4,7 +4,7 @@ include:
   - flores_common_yaml
 "tag":
 - "darija_translation_tasks_flores"
-"task": "trasnlation_dr_msa_flores"
+"task": "translation_dr_msa_flores"
 "task_alias": "dr_msa_flores"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/flores_translation_en_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/flores_translation_en_dr.yaml
@@ -4,7 +4,7 @@ include:
   - flores_common_yaml
 "tag":
   - "darija_translation_tasks_flores"
-"task": "trasnlation_en_dr_flores"
+"task": "translation_en_dr_flores"
 "task_alias": "en_dr_flores"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/flores_translation_fr_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/flores_translation_fr_dr.yaml
@@ -4,7 +4,7 @@ include:
   - flores_common_yaml
 "tag":
 - "darija_translation_tasks_flores"
-"task": "trasnlation_fr_dr_flores"
+"task": "translation_fr_dr_flores"
 "task_alias": "fr_dr_flores"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/flores_translation_msa_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/flores_translation_msa_dr.yaml
@@ -4,7 +4,7 @@ include:
   - flores_common_yaml
 "tag":
 - "darija_translation_tasks_flores"
-"task": "trasnlation_msa_dr_flores"
+"task": "translation_msa_dr_flores"
 "task_alias": "msa_dr_flores"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/madar_translation_all.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/madar_translation_all.yaml
@@ -3,7 +3,7 @@ include:
   - madar_common_yaml
 "tag":
 - "darija_translation_tasks_madar"
-"task": "trasnlation_all_madar"
+"task": "translation_all_madar"
 "task_alias": "all_madar"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/madar_translation_dr_msa.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/madar_translation_dr_msa.yaml
@@ -4,7 +4,7 @@ include:
   - madar_common_yaml
 "tag":
 - "darija_translation_tasks_madar"
-"task": "trasnlation_dr_msa_madar"
+"task": "translation_dr_msa_madar"
 "task_alias": "dr_msa_madar"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/madar_translation_msa_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/madar_translation_msa_dr.yaml
@@ -4,7 +4,7 @@ include:
   - madar_common_yaml
 "tag":
 - "darija_translation_tasks_madar"
-"task": "trasnlation_msa_dr_madar"
+"task": "translation_msa_dr_madar"
 "task_alias": "msa_dr_madar"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/seed_translation_all.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/seed_translation_all.yaml
@@ -3,7 +3,7 @@ include:
   - seed_common_yaml
 "tag":
 - "darija_translation_tasks_seed"
-"task": "trasnlation_all_seed"
+"task": "translation_all_seed"
 "task_alias": "all_seed"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/seed_translation_dr_en.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/seed_translation_dr_en.yaml
@@ -4,7 +4,7 @@ include:
   - seed_common_yaml
 "tag":
 - "darija_translation_tasks_seed"
-"task": "trasnlation_dr_en_seed"
+"task": "translation_dr_en_seed"
 "task_alias": "dr_en_seed"
 metric_list:
   - metric: !function utils.bert

--- a/lm_eval/tasks/darija_bench/darija_translation/seed_translation_en_dr.yaml
+++ b/lm_eval/tasks/darija_bench/darija_translation/seed_translation_en_dr.yaml
@@ -4,7 +4,7 @@ include:
   - seed_common_yaml
 "tag":
   - "darija_translation_tasks_seed"
-"task": "trasnlation_en_dr_seed"
+"task": "translation_en_dr_seed"
 "task_alias": "en_dr_seed"
 metric_list:
   - metric: !function utils.bert


### PR DESCRIPTION
## What

The 20 translation tasks under `lm_eval/tasks/darija_bench/darija_translation/` register their `task:` identifiers as **`trasnlation_*`** (e.g. `trasnlation_dr_en_doda`, `trasnlation_all_flores`), a misspelling of "translation".

These `task:` values are the public identifiers users pass on the command line (`--tasks ...`). The typo means the tasks are only discoverable under the misspelled name — anyone reaching for the natural spelling (`translation_dr_en_doda`) gets a "task not found" error.

## Why it's clearly an unintended typo

- The **file names** all use the correct spelling (`doda_translation_dr_en.yaml`, …).
- The **group tags** use the correct spelling (`darija_translation_tasks_doda`).
- The **README** (`darija_translation/README.md`) documents the group/tasks with the correct spelling (`darija_translation_doda`, etc.).

Only the inner `task:` fields are misspelled.

## Change

Rename the task identifiers `trasnlation_*` → `translation_*` across the 20 YAMLs (one line each).

## Safety

- `grep -rn trasnlation` across the repo returns **only** these 20 `task:` fields — nothing else references the misspelled names, so no group/doc/test breaks.
- The corrected names (`translation_*_doda` / `_flores` / `_madar` / `_seed`) do **not** collide with any existing task.
