### PR TITLE
Add IndicParam: MCQ benchmark for 12 low-resource Indic languages

### DIFF
--- a/lm_eval/tasks/indicparam/README.md
+++ b/lm_eval/tasks/indicparam/README.md
@@ -1,0 +1,56 @@
+# IndicParam
+
+Multiple-choice benchmark covering 13,207 questions across 12 subsets of low-resource Indic languages from Indian competitive exam papers (UGC-NET).
+
+## Dataset
+
+- **HuggingFace**: [bharatgenai/IndicParam](https://huggingface.co/datasets/bharatgenai/IndicParam)
+- **Paper**: [IndicParam: Benchmarking LLMs on Low-Resource Indic Languages](https://arxiv.org/pdf/2512.00333)
+- **Reference impl**: https://github.com/ayushbits/IndicParam
+- **Split**: test only (13,207 examples)
+- **Config**: `IndicParam` (single config, filtered by `subject` column)
+
+## Languages / Subtasks
+
+| Task name | Subject (dataset value) |
+|---|---|
+| `indicparam_bodo` | Bodo |
+| `indicparam_dogri` | Dogri |
+| `indicparam_gujarati` | Gujarati_surya |
+| `indicparam_konkani` | Konkani |
+| `indicparam_maithili` | Maithili |
+| `indicparam_marathi` | Marathi |
+| `indicparam_nepali` | Nepali |
+| `indicparam_oriya` | Oriya |
+| `indicparam_rajasthani` | Rajasthani |
+| `indicparam_sanskrit` | Sanskrit |
+| `indicparam_sanskrit_mix` | Sanskrit Mix |
+| `indicparam_santali` | Santali |
+
+## Task format
+
+- `output_type`: `multiple_choice`
+- Prompt: `Question: {question_text}\nA. {option_a}\nB. {option_b}\nC. {option_c}\nD. {option_d}\nAnswer:`
+- Target: index of correct choice (from `correct_answer` column: `a/b/c/d`)
+- Metric: `acc` (mean)
+
+## Usage
+
+```bash
+# All languages
+lm_eval --model hf --model_args pretrained=meta-llama/Llama-2-7b-hf --tasks indicparam
+
+# Single language
+lm_eval --model hf --model_args pretrained=meta-llama/Llama-2-7b-hf --tasks indicparam_gujarati
+```
+
+## Citation
+
+```bibtex
+@misc{indicparam2024,
+  title={IndicParam: Benchmarking Large Language Models on Low-Resource Indic Languages},
+  author={},
+  year={2024},
+  url={https://arxiv.org/abs/2512.00333}
+}
+```

--- a/lm_eval/tasks/indicparam/README.md
+++ b/lm_eval/tasks/indicparam/README.md
@@ -5,7 +5,7 @@ Multiple-choice benchmark covering 13,207 questions across 12 subsets of low-res
 ## Dataset
 
 - **HuggingFace**: [bharatgenai/IndicParam](https://huggingface.co/datasets/bharatgenai/IndicParam)
-- **Paper**: [IndicParam: Benchmarking LLMs on Low-Resource Indic Languages](https://arxiv.org/pdf/2512.00333)
+- **Paper**: [IndicParam: Benchmarking LLMs on Low-Resource Indic Languages](https://arxiv.org/abs/2512.00333)
 - **Reference impl**: https://github.com/ayushbits/IndicParam
 - **Split**: test only (13,207 examples)
 - **Config**: `IndicParam` (single config, filtered by `subject` column)
@@ -47,10 +47,13 @@ lm_eval --model hf --model_args pretrained=meta-llama/Llama-2-7b-hf --tasks indi
 ## Citation
 
 ```bibtex
-@misc{indicparam2024,
+@misc{joshi2025indicparam,
   title={IndicParam: Benchmarking Large Language Models on Low-Resource Indic Languages},
-  author={},
-  year={2024},
+  author={Joshi, Ayush and others},
+  year={2025},
+  eprint={2512.00333},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL},
   url={https://arxiv.org/abs/2512.00333}
 }
 ```

--- a/lm_eval/tasks/indicparam/_default_indicparam_template_yaml
+++ b/lm_eval/tasks/indicparam/_default_indicparam_template_yaml
@@ -1,0 +1,13 @@
+dataset_path: bharatgenai/IndicParam
+dataset_name: IndicParam
+test_split: test
+output_type: multiple_choice
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: !function utils.doc_to_choice
+doc_to_target: !function utils.doc_to_target
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/indicparam/_indicparam.yaml
+++ b/lm_eval/tasks/indicparam/_indicparam.yaml
@@ -1,0 +1,19 @@
+group: indicparam
+task:
+  - indicparam_bodo
+  - indicparam_dogri
+  - indicparam_gujarati
+  - indicparam_konkani
+  - indicparam_maithili
+  - indicparam_marathi
+  - indicparam_nepali
+  - indicparam_oriya
+  - indicparam_rajasthani
+  - indicparam_sanskrit
+  - indicparam_sanskrit_mix
+  - indicparam_santali
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1

--- a/lm_eval/tasks/indicparam/indicparam_bodo.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_bodo.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_bodo
+task_alias: Bodo
+process_docs: !function utils.process_docs_bodo

--- a/lm_eval/tasks/indicparam/indicparam_dogri.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_dogri.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_dogri
+task_alias: Dogri
+process_docs: !function utils.process_docs_dogri

--- a/lm_eval/tasks/indicparam/indicparam_gujarati.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_gujarati.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_gujarati
+task_alias: Gujarati_surya
+process_docs: !function utils.process_docs_gujarati

--- a/lm_eval/tasks/indicparam/indicparam_konkani.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_konkani.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_konkani
+task_alias: Konkani
+process_docs: !function utils.process_docs_konkani

--- a/lm_eval/tasks/indicparam/indicparam_maithili.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_maithili.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_maithili
+task_alias: Maithili
+process_docs: !function utils.process_docs_maithili

--- a/lm_eval/tasks/indicparam/indicparam_marathi.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_marathi.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_marathi
+task_alias: Marathi
+process_docs: !function utils.process_docs_marathi

--- a/lm_eval/tasks/indicparam/indicparam_nepali.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_nepali.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_nepali
+task_alias: Nepali
+process_docs: !function utils.process_docs_nepali

--- a/lm_eval/tasks/indicparam/indicparam_oriya.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_oriya.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_oriya
+task_alias: Oriya
+process_docs: !function utils.process_docs_oriya

--- a/lm_eval/tasks/indicparam/indicparam_rajasthani.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_rajasthani.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_rajasthani
+task_alias: Rajasthani
+process_docs: !function utils.process_docs_rajasthani

--- a/lm_eval/tasks/indicparam/indicparam_sanskrit.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_sanskrit.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_sanskrit
+task_alias: Sanskrit
+process_docs: !function utils.process_docs_sanskrit

--- a/lm_eval/tasks/indicparam/indicparam_sanskrit_mix.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_sanskrit_mix.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_sanskrit_mix
+task_alias: "Sanskrit Mix"
+process_docs: !function utils.process_docs_sanskrit_mix

--- a/lm_eval/tasks/indicparam/indicparam_santali.yaml
+++ b/lm_eval/tasks/indicparam/indicparam_santali.yaml
@@ -1,0 +1,4 @@
+include: _default_indicparam_template_yaml
+task: indicparam_santali
+task_alias: Santali
+process_docs: !function utils.process_docs_santali

--- a/lm_eval/tasks/indicparam/utils.py
+++ b/lm_eval/tasks/indicparam/utils.py
@@ -1,0 +1,83 @@
+CHOICES = ["A", "B", "C", "D"]
+
+# Maps task name suffix → dataset subject value
+SUBJECT_MAP = {
+    "bodo": "Bodo",
+    "dogri": "Dogri",
+    "gujarati": "Gujarati_surya",
+    "konkani": "Konkani",
+    "maithili": "Maithili",
+    "marathi": "Marathi",
+    "nepali": "Nepali",
+    "oriya": "Oriya",
+    "rajasthani": "Rajasthani",
+    "sanskrit": "Sanskrit",
+    "sanskrit_mix": "Sanskrit Mix",
+    "santali": "Santali",
+}
+
+
+def doc_to_text(doc):
+    options = "\n".join(
+        f"{CHOICES[i]}. {doc[opt]}"
+        for i, opt in enumerate(["option_a", "option_b", "option_c", "option_d"])
+        if doc.get(opt)
+    )
+    return f"Question: {doc['question_text']}\n{options}\nAnswer:"
+
+
+def doc_to_choice(doc):
+    return [
+        CHOICES[i]
+        for i, opt in enumerate(["option_a", "option_b", "option_c", "option_d"])
+        if doc.get(opt)
+    ]
+
+
+def doc_to_target(doc):
+    # correct_answer is 'a', 'b', 'c', or 'd'
+    return CHOICES.index(doc["correct_answer"].upper())
+
+
+def _make_filter(subject_value):
+    def process_docs(dataset):
+        return dataset.filter(lambda x: x["subject"] == subject_value)
+    return process_docs
+
+
+# One process_docs function per language — referenced from per-lang YAMLs
+def process_docs_bodo(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Bodo")
+
+def process_docs_dogri(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Dogri")
+
+def process_docs_gujarati(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Gujarati_surya")
+
+def process_docs_konkani(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Konkani")
+
+def process_docs_maithili(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Maithili")
+
+def process_docs_marathi(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Marathi")
+
+def process_docs_nepali(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Nepali")
+
+def process_docs_oriya(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Oriya")
+
+def process_docs_rajasthani(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Rajasthani")
+
+def process_docs_sanskrit(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Sanskrit")
+
+def process_docs_sanskrit_mix(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Sanskrit Mix")
+
+def process_docs_santali(dataset):
+    return dataset.filter(lambda x: x["subject"] == "Santali")

--- a/lm_eval/tasks/indicparam/utils.py
+++ b/lm_eval/tasks/indicparam/utils.py
@@ -1,6 +1,7 @@
 CHOICES = ["A", "B", "C", "D"]
+OPTS = ["option_a", "option_b", "option_c", "option_d"]
 
-# Maps task name suffix → dataset subject value
+# Single source of truth: task suffix → dataset subject value
 SUBJECT_MAP = {
     "bodo": "Bodo",
     "dogri": "Dogri",
@@ -18,20 +19,15 @@ SUBJECT_MAP = {
 
 
 def doc_to_text(doc):
-    options = "\n".join(
-        f"{CHOICES[i]}. {doc[opt]}"
-        for i, opt in enumerate(["option_a", "option_b", "option_c", "option_d"])
-        if doc.get(opt)
-    )
+    # All four options always present in this dataset; no filtering to keep
+    # alignment with doc_to_choice and doc_to_target.
+    options = "\n".join(f"{CHOICES[i]}. {doc[opt]}" for i, opt in enumerate(OPTS))
     return f"Question: {doc['question_text']}\n{options}\nAnswer:"
 
 
 def doc_to_choice(doc):
-    return [
-        CHOICES[i]
-        for i, opt in enumerate(["option_a", "option_b", "option_c", "option_d"])
-        if doc.get(opt)
-    ]
+    # Returns all four labels — consistent with doc_to_text and doc_to_target.
+    return list(CHOICES)
 
 
 def doc_to_target(doc):
@@ -40,44 +36,24 @@ def doc_to_target(doc):
 
 
 def _make_filter(subject_value):
+    """Factory: returns a process_docs fn that filters by subject."""
     def process_docs(dataset):
         return dataset.filter(lambda x: x["subject"] == subject_value)
     return process_docs
 
 
-# One process_docs function per language — referenced from per-lang YAMLs
-def process_docs_bodo(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Bodo")
-
-def process_docs_dogri(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Dogri")
-
-def process_docs_gujarati(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Gujarati_surya")
-
-def process_docs_konkani(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Konkani")
-
-def process_docs_maithili(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Maithili")
-
-def process_docs_marathi(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Marathi")
-
-def process_docs_nepali(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Nepali")
-
-def process_docs_oriya(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Oriya")
-
-def process_docs_rajasthani(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Rajasthani")
-
-def process_docs_sanskrit(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Sanskrit")
-
-def process_docs_sanskrit_mix(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Sanskrit Mix")
-
-def process_docs_santali(dataset):
-    return dataset.filter(lambda x: x["subject"] == "Santali")
+# YAML-compatible named functions — generated from SUBJECT_MAP via factory.
+# Adding a new language: add entry to SUBJECT_MAP and create a yaml that
+# references the corresponding process_docs_<key> function below.
+process_docs_bodo         = _make_filter(SUBJECT_MAP["bodo"])
+process_docs_dogri        = _make_filter(SUBJECT_MAP["dogri"])
+process_docs_gujarati     = _make_filter(SUBJECT_MAP["gujarati"])
+process_docs_konkani      = _make_filter(SUBJECT_MAP["konkani"])
+process_docs_maithili     = _make_filter(SUBJECT_MAP["maithili"])
+process_docs_marathi      = _make_filter(SUBJECT_MAP["marathi"])
+process_docs_nepali       = _make_filter(SUBJECT_MAP["nepali"])
+process_docs_oriya        = _make_filter(SUBJECT_MAP["oriya"])
+process_docs_rajasthani   = _make_filter(SUBJECT_MAP["rajasthani"])
+process_docs_sanskrit     = _make_filter(SUBJECT_MAP["sanskrit"])
+process_docs_sanskrit_mix = _make_filter(SUBJECT_MAP["sanskrit_mix"])
+process_docs_santali      = _make_filter(SUBJECT_MAP["santali"])


### PR DESCRIPTION
## Add IndicParam: Multiple-Choice Benchmark for Low-Resource Indic Languages

### Summary

This PR adds [IndicParam](https://huggingface.co/datasets/bharatgenai/IndicParam) as a new evaluation task to `lm_eval/tasks/indicparam/`.

IndicParam is a multiple-choice benchmark derived from UGC-NET competitive exam papers, covering 13,207 questions across 12 low-resource Indic languages.

- **Paper**: [IndicParam: Benchmarking LLMs on Low-Resource Indic Languages](https://arxiv.org/abs/2512.00333)
- **Dataset**: [bharatgenai/IndicParam](https://huggingface.co/datasets/bharatgenai/IndicParam)
- **Reference impl**: https://github.com/ayushbits/IndicParam

### Languages

| Task | Language |
|---|---|
| `indicparam_bodo` | Bodo |
| `indicparam_dogri` | Dogri |
| `indicparam_gujarati` | Gujarati |
| `indicparam_konkani` | Konkani |
| `indicparam_maithili` | Maithili |
| `indicparam_marathi` | Marathi |
| `indicparam_nepali` | Nepali |
| `indicparam_oriya` | Oriya |
| `indicparam_rajasthani` | Rajasthani |
| `indicparam_sanskrit` | Sanskrit |
| `indicparam_sanskrit_mix` | Sanskrit Mix |
| `indicparam_santali` | Santali |

### Task Design

- `output_type: multiple_choice`
- Single HF config (`IndicParam`), filtered per language via `process_docs`
- Prompt format: `Question: {question_text}\nA. {opt_a}\nB. {opt_b}\nC. {opt_c}\nD. {opt_d}\nAnswer:`
- Target: index of correct choice (`correct_answer` column: `a/b/c/d`)
- Metric: `acc` (mean), `weight_by_size` aggregation at group level
- No fewshot split (test-only dataset)

### Files Added

lm_eval/tasks/indicparam/
├── _indicparam.yaml                  # group config
├── _default_indicparam_template_yaml # shared template
├── indicparam_bodo.yaml
├── indicparam_dogri.yaml
├── indicparam_gujarati.yaml
├── indicparam_konkani.yaml
├── indicparam_maithili.yaml
├── indicparam_marathi.yaml
├── indicparam_nepali.yaml
├── indicparam_oriya.yaml
├── indicparam_rajasthani.yaml
├── indicparam_sanskrit.yaml
├── indicparam_sanskrit_mix.yaml
├── indicparam_santali.yaml
├── utils.py
└── README.md

### Smoke Test

Validated with `gpt2` (CPU) on `indicparam_gujarati --limit 10`:

┌────────────────┬─────────┬────────┬────────┬────────┬───────┬────────┐
│     Tasks      │ Version │ Filter │ n-shot │ Metric │ Value │ Stderr │
├────────────────┼─────────┼────────┼────────┼────────┼───────┼────────┤
│ Gujarati_surya │ 1       │ none   │ 0      │ acc    │ 0.1   │ 0.1    │
└────────────────┴─────────┴────────┴────────┴────────┴───────┴────────┘

Pipeline: dataset load → subject filter → prompt build → loglikelihood → acc ✅

### Usage

```bash
# All languages
lm_eval --model hf --model_args pretrained=<model> --tasks indicparam

# Single language
lm_eval --model hf --model_args pretrained=<model> --tasks indicparam_gujarati