### PR TITLE
fix: extract \boxed{} answers without requiring dollar signs (closes #2552)

### DIFF
--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -17,11 +17,20 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
 
 def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     retval = 0
-    indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
-    if len(indices) <= 1:
-        answer = results[0]
+    
+    # Try to extract \boxed{} from the model output first
+    boxed_match = last_boxed_only_string(results[0])
+    if boxed_match is not None:
+        try:
+            answer = remove_boxed(boxed_match)
+        except AssertionError:
+            answer = results[0]
     else:
-        answer = results[0][indices[0] + 1 : indices[-1]]
+        indices = [pos for pos, char in enumerate(results[0]) if char == "$"]
+        if len(indices) <= 1:
+            answer = results[0]
+        else:
+            answer = results[0][indices[0] + 1 : indices[-1]]
 
     if is_equiv(answer, remove_boxed(last_boxed_only_string(doc["solution"]))):
         retval = 1


### PR DESCRIPTION
## Problem
The current `process_results` logic in `hendrycks_math/utils.py` extracts 
the model's answer by scanning for `$` delimiters. If a model outputs 
`\boxed{42}` without surrounding dollar signs (common in chain-of-thought 
outputs), the parser fails to extract "42" and instead returns the full 
generation string, causing a false incorrect.

This was reported in #2552.

## Fix
Before falling back to the dollar-sign scan, we now try 
`last_boxed_only_string` + `remove_boxed` on the model output — the same 
functions already used to parse the reference solution. If no `\boxed{}` 
is found, the original `$...$` logic runs unchanged.

## Backward compatibility
The fix is purely additive. The original `$` parsing is preserved as a 
fallback, so no previously-passing test cases are affected.

## Test cases fixed
| Input | Before | After |
|---|---|---|
| `\boxed{42}` | `\boxed{42}` (wrong) | `42` ✓ |
| `The answer is \boxed{42}.` | full string (wrong) | `42` ✓ |
| `$42$` | `42` ✓ | `42` ✓ |