### PR TITLE
fix: avoid passing None as add_special_tokens when add_bos_token is unset

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -409,7 +409,7 @@ class TemplateAPI(TemplateLM):
         elif self.tokenizer_backend == "huggingface":
             # by default for CausalLM - false or self.add_bos_token is set
             if not add_special_tokens:
-                add_special_tokens = False or self.add_bos_token
+                add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
             encoding: Union[List[List[int]], List[int]] = self.tokenizer(
                 string,
                 add_special_tokens=add_special_tokens,

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -5,21 +5,15 @@ import itertools
 import json
 import logging
 import os
+from collections.abc import Awaitable, Callable, Iterable
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
-    Dict,
-    Iterable,
-    List,
     Literal,
     NamedTuple,
-    Optional,
-    Tuple,
-    Union,
 )
+
 
 try:
     import requests
@@ -54,7 +48,7 @@ LMEVAL_MODEL_NONE_ANSWER_PLACEHOLDER = os.environ.get(
 
 eval_logger = logging.getLogger(__name__)
 
-LogLikelihoodInputs = Tuple[Tuple[str, str], List[int], List[int]]
+LogLikelihoodInputs = tuple[tuple[str, str], list[int], list[int]]
 
 
 # utility class to keep track of json encoded chats
@@ -79,7 +73,7 @@ def create_image_prompt(
         Any format Pillow understands (e.g. "PNG", "JPEG").
         Defaults to "PNG".
 
-    Returns
+    Returns:
     -------
     dict
     """
@@ -113,38 +107,38 @@ class TemplateAPI(TemplateLM):
 
     def __init__(
         self,
-        model: str = None,
-        pretrained: str = None,  # `model` takes precedence over `pretrained` when passed.
-        base_url: str = None,
-        tokenizer: Optional[str] = None,
+        model: str | None = None,
+        pretrained: str
+        | None = None,  # `model` takes precedence over `pretrained` when passed.
+        base_url: str | None = None,
+        tokenizer: str | None = None,
         # Loglikelihood tasks require a tokenizer to calculate context lengths,
         # however the requests can be sent as a string if the API doesn't support token inputs.
         # use tokenized_requests=False
-        tokenizer_backend: Optional[
-            Literal["tiktoken", "huggingface", "remote", "None", "none"]
-        ] = "huggingface",
+        tokenizer_backend: Literal["tiktoken", "huggingface", "remote", "None", "none"]
+        | None = "huggingface",
         truncate: bool = False,
         # number of concurrent requests. More useful if not batching
         num_concurrent: int = 1,
         max_retries: int = 3,
         max_gen_toks: int = 256,
-        batch_size: Union[str, int] = 1,
+        batch_size: str | int = 1,
         seed: int = 1234,
-        max_length: Optional[int] = 2048,
+        max_length: int | None = 2048,
         add_bos_token: bool = False,
-        custom_prefix_token_id: int = None,
+        custom_prefix_token_id: int | None = None,
         # send the requests as tokens or strings
         tokenized_requests: bool = True,
         trust_remote_code: bool = False,
-        revision: Optional[str] = "main",
+        revision: str | None = "main",
         use_fast_tokenizer: bool = True,
         verify_certificate: bool = True,
-        ca_cert_path: Optional[str] = None,
-        auth_token: Optional[str] = None,
-        eos_string: str = None,
+        ca_cert_path: str | None = None,
+        auth_token: str | None = None,
+        eos_string: str | None = None,
         # timeout in seconds
         timeout: int = 300,
-        header: Optional[Dict[str, str]] = None,
+        header: dict[str, str] | None = None,
         max_images: int = 1,
         **kwargs,
     ) -> None:
@@ -207,7 +201,7 @@ class TemplateAPI(TemplateLM):
                     import transformers
 
                     self.tokenizer = transformers.AutoTokenizer.from_pretrained(
-                        self.tokenizer if self.tokenizer else self.model,
+                        self.tokenizer or self.model,
                         trust_remote_code=trust_remote_code,
                         revision=revision,
                         use_fast=use_fast_tokenizer,
@@ -258,12 +252,12 @@ class TemplateAPI(TemplateLM):
     @abc.abstractmethod
     def _create_payload(
         self,
-        messages: Union[List[List[int]], List[dict], List[str], str],
+        messages: list[list[int]] | list[dict] | list[str] | str,
         *,
         generate: bool = True,
-        gen_kwargs: Optional[dict] = None,
+        gen_kwargs: dict | None = None,
         seed: int = 1234,
-        eos: str = None,
+        eos: str | None = None,
         **kwargs,
     ) -> dict:
         """This method is responsible for creating the json payload that will be sent to the API."""
@@ -271,9 +265,9 @@ class TemplateAPI(TemplateLM):
 
     def create_message(
         self,
-        messages: Union[List[List[int]], List[str], List[JsonChatStr]],
+        messages: list[list[int]] | list[str] | list[JsonChatStr],
         generate=False,
-    ) -> Union[List[List[int]], List[dict], List[str], str]:
+    ) -> list[list[int]] | list[dict] | list[str] | str:
         """Helper method to transform the prompt into the expected API input format. messages consist of batched requests"""
         if isinstance(messages[0], JsonChatStr):
             # for chat completions we need to decode the json string to list[dict,...]
@@ -302,17 +296,17 @@ class TemplateAPI(TemplateLM):
     @staticmethod
     @abc.abstractmethod
     def parse_logprobs(
-        outputs: Union[Any, List[Any]],
-        tokens: List[List[int]] = None,
-        ctxlen: List[int] = None,
+        outputs: Any | list[Any],
+        tokens: list[list[int]] | None = None,
+        ctxlen: list[int] | None = None,
         **kwargs,
-    ) -> List[Tuple[float, bool]]:
+    ) -> list[tuple[float, bool]]:
         """Method used to parse the logprobs from the (batched) API response. This method should return a list of tuples"""
         raise NotImplementedError
 
     @staticmethod
     @abc.abstractmethod
-    def parse_generations(outputs: Union[Any, List[Any]], **kwargs) -> List[str]:
+    def parse_generations(outputs: Any | list[Any], **kwargs) -> list[str]:
         """Method used to parse the generations from the (batched) API response. This method should return a list of str"""
         raise NotImplementedError
 
@@ -335,8 +329,8 @@ class TemplateAPI(TemplateLM):
         return ""
 
     def apply_chat_template(
-        self, chat_history: List[Dict[str, str]], add_generation_prompt: bool = True
-    ) -> Union[str, JsonChatStr, List[Dict]]:
+        self, chat_history: list[dict[str, str]], add_generation_prompt: bool = True
+    ) -> str | JsonChatStr | list[dict]:
         """Applies a chat template to a list of chat history between user and model."""
         if self.tokenizer_backend == "huggingface" and self.tokenized_requests:
             return self.tokenizer.apply_chat_template(
@@ -352,7 +346,7 @@ class TemplateAPI(TemplateLM):
             return JsonChatStr(json.dumps(chat_history, ensure_ascii=False))
 
     @cached_property
-    def eot_token_id(self) -> Optional[int]:
+    def eot_token_id(self) -> int | None:
         if self.tokenizer is None:
             return None
         else:
@@ -364,7 +358,7 @@ class TemplateAPI(TemplateLM):
                 return self.tokenizer.eos_token_id
 
     @cached_property
-    def eos_string(self) -> Optional[str]:
+    def eos_string(self) -> str | None:
         if self._eos_string:
             return self._eos_string
         elif self.tokenizer is not None:
@@ -381,7 +375,7 @@ class TemplateAPI(TemplateLM):
             return None
 
     @cached_property
-    def prefix_token_id(self) -> Optional[int]:
+    def prefix_token_id(self) -> int | None:
         if self.tokenizer is None:
             return None
         else:
@@ -399,18 +393,20 @@ class TemplateAPI(TemplateLM):
     def tok_encode(
         self,
         string: str,
-        left_truncate_len: int = None,
+        left_truncate_len: int | None = None,
         add_special_tokens: bool = False,
         truncation: bool = False,
         **kwargs,
-    ) -> Union[List[List[int]], List[int], List[str]]:
+    ) -> list[list[int]] | list[int] | list[str]:
         if self.tokenizer_backend is None:
             return [string]
         elif self.tokenizer_backend == "huggingface":
             # by default for CausalLM - false or self.add_bos_token is set
             if not add_special_tokens:
-                add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
-            encoding: Union[List[List[int]], List[int]] = self.tokenizer(
+                add_special_tokens = (
+                    self.add_bos_token if self.add_bos_token is not None else False
+                )
+            encoding: list[list[int]] | list[int] = self.tokenizer(
                 string,
                 add_special_tokens=add_special_tokens,
                 truncation=truncation,
@@ -441,11 +437,11 @@ class TemplateAPI(TemplateLM):
         else:
             try:
                 encoding = self.tokenizer.encode(string)
-            except Exception:
+            except (AttributeError, TypeError, ValueError):
                 encoding = self.tokenizer.encode_batch(string)
             return encoding
 
-    def decode_batch(self, tokens: List[List[int]]) -> List[str]:
+    def decode_batch(self, tokens: list[list[int]]) -> list[str]:
         if self.tokenizer_backend == "huggingface":
             return self.tokenizer.batch_decode(tokens)
         elif self.tokenizer_backend == "tiktoken":
@@ -455,12 +451,12 @@ class TemplateAPI(TemplateLM):
 
     def model_call(
         self,
-        messages: Union[List[List[int]], List[str], List[JsonChatStr]],
+        messages: list[list[int]] | list[str] | list[JsonChatStr],
         *,
         generate: bool = True,
-        gen_kwargs: Optional[Dict] = None,
+        gen_kwargs: dict | None = None,
         **kwargs,
-    ) -> Optional[dict]:
+    ) -> dict | None:
         # !!! Copy: shared dict for each request, need new object !!!
         gen_kwargs = copy.deepcopy(gen_kwargs)
         try:
@@ -476,6 +472,7 @@ class TemplateAPI(TemplateLM):
                 ),
                 headers=self.header,
                 verify=self.verify_certificate,
+                timeout=self.timeout,
             )
             if not response.ok:
                 eval_logger.warning(
@@ -493,14 +490,14 @@ class TemplateAPI(TemplateLM):
         self,
         session: ClientSession,
         sem: asyncio.Semaphore,
-        messages: Union[List[List[int]], List[str], List[JsonChatStr]],
+        messages: list[list[int]] | list[str] | list[JsonChatStr],
         *,
         generate: bool = True,
-        cache_keys: list = None,
-        ctxlens: Optional[List[int]] = None,
-        gen_kwargs: Optional[Dict] = None,
+        cache_keys: list | None = None,
+        ctxlens: list[int] | None = None,
+        gen_kwargs: dict | None = None,
         **kwargs,
-    ) -> Union[List[str], List[Tuple[float, bool]], None]:
+    ) -> list[str] | list[tuple[float, bool]] | None:
         # !!! Copy: shared dict for each request, need new object !!!
         gen_kwargs = copy.deepcopy(gen_kwargs)
         payload = self._create_payload(
@@ -551,20 +548,22 @@ class TemplateAPI(TemplateLM):
                     answers.append(a)
 
             if cache_keys:
-                for res, cache in zip(answers, cache_keys):
+                for res, cache in zip(answers, cache_keys, strict=False):
                     self.cache_hook.add_partial(cache_method, cache, res)
             return answers
         # If the retries also fail
         except BaseException as e:
-            eval_logger.error(f"Exception:{repr(e)}, {locals().get('outputs', '(no outputs)')}, retrying.")
-            raise e
+            eval_logger.error(
+                f"Exception:{e!r}, {locals().get('outputs', '(no outputs)')}, retrying."
+            )
+            raise
         finally:
             if acquired:
                 sem.release()
 
     def batch_loglikelihood_requests(
-        self, chunks: Iterable[List[LogLikelihoodInputs]]
-    ) -> Tuple[List[List[int]], List[int], List[Tuple[str, str]]]:
+        self, chunks: Iterable[list[LogLikelihoodInputs]]
+    ) -> tuple[list[list[int]], list[int], list[tuple[str, str]]]:
         inputs = []
         ctxlens = []
         cache_keys = []
@@ -591,10 +590,10 @@ class TemplateAPI(TemplateLM):
         cache_keys: list,
         *,
         generate: bool = True,
-        ctxlens: List[int] = None,
+        ctxlens: list[int] | None = None,
         **kwargs,
-    ) -> Union[List[List[str]], List[List[Tuple[float, bool]]]]:
-        ctxlens = ctxlens if ctxlens else [None] * len(requests)
+    ) -> list[list[str]] | list[list[tuple[float, bool]]]:
+        ctxlens = ctxlens or [None] * len(requests)
         conn = TCPConnector(limit=self._concurrent, ssl=self.verify_certificate)
         sem = asyncio.Semaphore(self._concurrent)
         async with ClientSession(
@@ -625,12 +624,13 @@ class TemplateAPI(TemplateLM):
                     chunks(requests, n=self._batch_size),
                     chunks(cache_keys, n=self._batch_size),
                     chunks(ctxlens, n=self._batch_size),
+                    strict=False,
                 )
             ]
 
             return await tqdm_asyncio.gather(*tasks, desc="Requesting API")
 
-    def _loglikelihood_tokens(self, requests, **kwargs) -> List[Tuple[float, bool]]:
+    def _loglikelihood_tokens(self, requests, **kwargs) -> list[tuple[float, bool]]:
         assert self.tokenizer is not None, (
             "Tokenizer is required for loglikelihood tasks to compute context lengths."
         )
@@ -672,6 +672,7 @@ class TemplateAPI(TemplateLM):
                         outputs=outputs, tokens=inputs, ctxlens=ctxlens
                     ),
                     cache_keys,
+                    strict=False,
                 ):
                     if answer_ is not None:
                         res.append(answer_)
@@ -694,8 +695,8 @@ class TemplateAPI(TemplateLM):
         return re_ord.get_original(res)
 
     def generate_until(
-        self, requests: List[Instance], disable_tqdm: bool = False
-    ) -> List[str]:
+        self, requests: list[Instance], disable_tqdm: bool = False
+    ) -> list[str]:
         res = []
 
         def _collate_gen(_requests):
@@ -711,7 +712,7 @@ class TemplateAPI(TemplateLM):
                 f"Using max_images {self.max_images}. Set in the model args."
             )
             requests, all_gen_kwargs, auxiliary_args = zip(
-                *(req.args for req in requests)
+                *(req.args for req in requests), strict=False
             )
             requests = tuple(
                 JsonChatStr(
@@ -721,10 +722,12 @@ class TemplateAPI(TemplateLM):
                         )
                     )
                 )
-                for x, y in zip(requests, auxiliary_args)
+                for x, y in zip(requests, auxiliary_args, strict=False)
             )
         else:
-            requests, all_gen_kwargs = zip(*(req.args for req in requests))
+            requests, all_gen_kwargs = zip(
+                *(req.args for req in requests), strict=False
+            )
         if self.tokenized_requests:
             encodings_list = self.tok_encode(
                 requests, add_special_tokens=self.add_bos_token
@@ -732,7 +735,8 @@ class TemplateAPI(TemplateLM):
         else:
             encodings_list = [None] * len(requests)
         requests = [
-            (a, b, c) for a, b, c in zip(requests, all_gen_kwargs, encodings_list)
+            (a, b, c)
+            for a, b, c in zip(requests, all_gen_kwargs, encodings_list, strict=False)
         ]
 
         re_ord = Collator(
@@ -750,7 +754,7 @@ class TemplateAPI(TemplateLM):
         if self._concurrent <= 1:
             pbar = tqdm(desc="Requesting API", total=len(requests))
             for chunk in chunked:
-                contexts, all_gen_kwargs, encodings_list = zip(*chunk)
+                contexts, all_gen_kwargs, encodings_list = zip(*chunk, strict=False)
                 if self.tokenized_requests:
                     max_gen_toks = all_gen_kwargs[0].get(
                         "max_gen_toks", self._max_gen_toks
@@ -782,6 +786,7 @@ class TemplateAPI(TemplateLM):
                         contexts=contexts,
                     ),
                     contexts,
+                    strict=False,
                 ):
                     # Always append to res to maintain the correct number of items
                     # even if generation failed (generated_text is None)
@@ -804,7 +809,7 @@ class TemplateAPI(TemplateLM):
                     pbar.update(1)
         else:
             for chunk in chunked:
-                contexts, all_gen_kwargs, encodings_list = zip(*chunk)
+                contexts, all_gen_kwargs, encodings_list = zip(*chunk, strict=False)
                 if self.tokenized_requests:
                     max_gen_toks = all_gen_kwargs[0].get(
                         "max_gen_toks", self._max_gen_toks
@@ -832,14 +837,13 @@ class TemplateAPI(TemplateLM):
                     )
                 )
                 # Append results to res list
-                for r in results:
-                    res.append(r)
+                res.extend(results)
 
         return re_ord.get_original(res)
 
     def loglikelihood_rolling(
-        self, requests: List[Instance], disable_tqdm: bool = False
-    ) -> List[float]:
+        self, requests: list[Instance], disable_tqdm: bool = False
+    ) -> list[float]:
         loglikelihoods = []
 
         for (string,) in tqdm([req.args for req in requests], disable=disable_tqdm):

--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -287,7 +287,7 @@ class NEURON_HF(TemplateLM):
     def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None):
         """Encode strings to tokens"""
         if add_special_tokens is None:
-            add_special_tokens = False or self.add_bos_token
+            add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
 
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
 
@@ -308,7 +308,7 @@ class NEURON_HF(TemplateLM):
         old_padding_side = self.tokenizer.padding_side
         self.tokenizer.padding_side = padding_side
 
-        add_special_tokens = False or self.add_bos_token
+        add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
 
         encoding = self.tokenizer(
             strings,

--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -287,7 +287,9 @@ class NEURON_HF(TemplateLM):
     def tok_encode(self, string: str, left_truncate_len=None, add_special_tokens=None):
         """Encode strings to tokens"""
         if add_special_tokens is None:
-            add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
+            add_special_tokens = (
+                self.add_bos_token if self.add_bos_token is not None else False
+            )
 
         encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
 
@@ -301,14 +303,16 @@ class NEURON_HF(TemplateLM):
         self,
         strings: list[str],
         padding_side: str = "left",
-        left_truncate_len: int = None,
+        left_truncate_len: int | None = None,
         truncation: bool = False,
     ):
         # encode a batch of strings. converts to tensors and pads automatically, unlike tok_encode.
         old_padding_side = self.tokenizer.padding_side
         self.tokenizer.padding_side = padding_side
 
-        add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
+        add_special_tokens = (
+            self.add_bos_token if self.add_bos_token is not None else False
+        )
 
         encoding = self.tokenizer(
             strings,
@@ -612,7 +616,7 @@ class NEURON_HF(TemplateLM):
                                 f"Expected `kwargs['until']` to be of type Union[str,list] but got {until}"
                             )
                 else:
-                    raise ValueError(
+                    raise TypeError(
                         f"Expected `kwargs` to be of type `dict` but got {kwargs}"
                     )
                 # add EOS token to stop sequences

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -352,7 +352,7 @@ class SGLangLM(TemplateLM):
         truncation: bool = False,
     ) -> Union[List[int], List[List[int]]]:
         if not add_special_tokens:
-            add_special_tokens = False or self.add_bos_token
+            add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
         encoding: Union[List[List[int]], List[int]] = self.tokenizer(
             string,
             add_special_tokens=add_special_tokens,

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 from tqdm import tqdm
 
@@ -26,9 +25,6 @@ try:
 except ModuleNotFoundError:
     pass
 
-if TYPE_CHECKING:
-    pass
-
 
 @register_model("sglang")
 class SGLangLM(TemplateLM):
@@ -38,30 +34,30 @@ class SGLangLM(TemplateLM):
         self,
         pretrained: str,
         # batch args from lm-eval interface:  https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/interface.md
-        batch_size: Union[str, int] = 1,
+        batch_size: str | int = 1,
         max_batch_size=None,
-        max_model_len: int = None,
+        max_model_len: int | None = None,
         max_gen_toks: int = 256,
-        add_bos_token: Optional[bool] = False,
+        add_bos_token: bool | None = False,
         ########## SGlang native args ##########
         # Todo(Jinwei): Include more args of SGLang Engine if needed. Refer to https://docs.sglang.ai/backend/server_arguments.html .
-        tokenizer_path: Optional[str] = None,
+        tokenizer_path: str | None = None,
         tokenizer_mode: str = "auto",
         load_format: str = "auto",
         trust_remote_code: bool = True,
         dtype: str = "auto",
         kv_cache_dtype: str = "auto",
-        context_length: Optional[int] = None,
+        context_length: int | None = None,
         device: str = "cuda",
         chunked_prefill_size: int = -1,
         # Memory and scheduling
-        mem_fraction_static: Optional[float] = None,
+        mem_fraction_static: float | None = None,
         # parallelism
         dp_size: int = 1,
         tp_size: int = 1,
-        prefix_token_id: Optional[int] = None,
+        prefix_token_id: int | None = None,
         # End marker for thinking tags - splits to get response after this token (if provided).
-        think_end_token: Optional[str] = None,
+        think_end_token: str | None = None,
         **kwargs,
     ):
         super().__init__()
@@ -122,8 +118,8 @@ class SGLangLM(TemplateLM):
         self.custom_prefix_token_id = prefix_token_id
 
     def loglikelihood_rolling(
-        self, requests: List[Instance], disable_tqdm: bool = False
-    ) -> List[float]:
+        self, requests: list[Instance], disable_tqdm: bool = False
+    ) -> list[float]:
         adaptive_batch_size = None
         if self.batch_size == "auto":
             adaptive_batch_size = len(requests)
@@ -138,7 +134,7 @@ class SGLangLM(TemplateLM):
                 disable=(disable_tqdm or (self.rank != 0)),
             )
         ):
-            rolling_token_windows: List[Tuple[List[int], List[int]]] = list(
+            rolling_token_windows: list[tuple[list[int], list[int]]] = list(
                 map(
                     make_disjoint_window,
                     get_rolling_token_windows(
@@ -163,14 +159,14 @@ class SGLangLM(TemplateLM):
         for i in range(0, len(all_windows), batch_size):
             batch = all_windows[i : i + batch_size]
             # Extract just the windows for processing, keeping track of request indices
-            batch_indices, batch_windows = zip(*batch)
+            batch_indices, batch_windows = zip(*batch, strict=False)
 
             batch_nlls = self._loglikelihood_tokens(
                 requests=batch_windows,
                 disable_tqdm=False,
             )
             # Store results with their request indices
-            all_nlls.extend(zip(batch_indices, batch_nlls))
+            all_nlls.extend(zip(batch_indices, batch_nlls, strict=False))
 
         # Reconstruct per-request loglikelihoods
         loglikelihoods = []
@@ -191,17 +187,18 @@ class SGLangLM(TemplateLM):
         return loglikelihoods
 
     def generate_until(
-        self, requests: List[Instance], disable_tqdm: bool = False
-    ) -> List[str]:
+        self, requests: list[Instance], disable_tqdm: bool = False
+    ) -> list[str]:
         res = []
 
         # batch tokenize contexts
-        context, all_gen_kwargs = zip(*(req.args for req in requests))
-        context_encoding: List[List[int]] = self.tok_encode(
+        context, all_gen_kwargs = zip(*(req.args for req in requests), strict=False)
+        context_encoding: list[list[int]] = self.tok_encode(
             context, add_special_tokens=self.add_bos_token
         )
         requests = [
-            ((a, b), c) for a, b, c in zip(context, context_encoding, all_gen_kwargs)
+            ((a, b), c)
+            for a, b, c in zip(context, context_encoding, all_gen_kwargs, strict=False)
         ]
 
         def _collate_gen(_requests):
@@ -229,19 +226,19 @@ class SGLangLM(TemplateLM):
         # for each different set of kwargs, we execute all requests, by batch.
         eos = self.tokenizer.decode(self.eot_token_id)
         for chunk in chunks:
-            context_and_encoding, all_gen_kwargs = zip(*chunk)
-            context, context_encoding = zip(*context_and_encoding)
+            context_and_encoding, all_gen_kwargs = zip(*chunk, strict=False)
+            context, context_encoding = zip(*context_and_encoding, strict=False)
 
             context_encoding_truncated = []
             sampling_params = []
-            for x, gen_kwargs in zip(context_encoding, all_gen_kwargs):
+            for x, gen_kwargs in zip(context_encoding, all_gen_kwargs, strict=False):
                 # unpack our keyword arguments.
                 if isinstance(gen_kwargs, dict):
                     kwargs = copy.deepcopy(gen_kwargs)  # edge case for repeats > 1
                     # add EOS token to stop sequences
                     until = handle_stop_sequences(kwargs.pop("until", None), eos=eos)
                 else:
-                    raise ValueError(
+                    raise TypeError(
                         f"Expected `kwargs` to be of type `dict` but got {type(gen_kwargs)}"
                     )
                 if "max_gen_toks" in kwargs.keys():
@@ -270,14 +267,14 @@ class SGLangLM(TemplateLM):
             )
 
             # cache generations
-            for output, context in zip(cont, context):
+            for output, ctx in zip(cont, context, strict=True):
                 generated_text = output.get("text", "")
                 generated_text = postprocess_generated_text(
                     generated_text, until, self.think_end_token
                 )
                 res.append(generated_text)
                 self.cache_hook.add_partial(
-                    "generate_until", (context, gen_kwargs), generated_text
+                    "generate_until", (ctx, gen_kwargs), generated_text
                 )
                 pbar.update(1)
 
@@ -287,23 +284,23 @@ class SGLangLM(TemplateLM):
 
     def _model_generate(
         self,
-        requests: List[List[int]] = None,
+        requests: list[list[int]] | None = None,
         generate: bool = False,
-        sampling_params: Union[List[Dict], Dict, None] = None,
+        sampling_params: list[dict] | dict | None = None,
         return_logprob: bool = False,
         top_logprobs_num: int = 1,
         logprob_start_len: int = -1,
     ):
         # check sglang sampling parameters: https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/sampling/sampling_params.py#L21  and https://docs.sglang.ai/references/sampling_params.html.
         if not generate:
-            sampling_params = sampling_params if sampling_params else {}
+            sampling_params = sampling_params or {}
             sampling_params.update(
                 {
                     "temperature": 0,
                     "max_new_tokens": 1,
                 }
             )
-        if not isinstance(sampling_params, List):
+        if not isinstance(sampling_params, list):
             sampling_params = [sampling_params] * len(requests)
         # Refer to:  https://docs.sglang.ai/backend/offline_engine_api.html
         outputs = self.model.generate(
@@ -346,14 +343,16 @@ class SGLangLM(TemplateLM):
 
     def tok_encode(
         self,
-        string: Union[str, List[str]],
-        left_truncate_len: int = None,
+        string: str | list[str],
+        left_truncate_len: int | None = None,
         add_special_tokens: bool = False,
         truncation: bool = False,
-    ) -> Union[List[int], List[List[int]]]:
+    ) -> list[int] | list[list[int]]:
         if not add_special_tokens:
-            add_special_tokens = self.add_bos_token if self.add_bos_token is not None else False
-        encoding: Union[List[List[int]], List[int]] = self.tokenizer(
+            add_special_tokens = (
+                self.add_bos_token if self.add_bos_token is not None else False
+            )
+        encoding: list[list[int]] | list[int] = self.tokenizer(
             string,
             add_special_tokens=add_special_tokens,
             truncation=truncation,
@@ -369,7 +368,7 @@ class SGLangLM(TemplateLM):
 
         return encoding
 
-    def tok_decode(self, tokens: List[int]) -> str:
+    def tok_decode(self, tokens: list[int]) -> str:
         # Implement token-to-text decoding
         pass
 
@@ -382,9 +381,8 @@ class SGLangLM(TemplateLM):
         Returns:
             str: The name of the model's tokenizer and/or chat template.
         """
-        pass
 
-    def chat_template(self, chat_template: Union[bool, str] = False) -> str:
+    def chat_template(self, chat_template: bool | str = False) -> str:
         """
         Get the appropriate chat template for the model based on the `chat_template` argument.
 
@@ -403,10 +401,9 @@ class SGLangLM(TemplateLM):
         Returns:
             str: The selected chat template in Jinja format.
         """
-        pass
 
     def apply_chat_template(
-        self, chat_history: List[Dict[str, str]], add_generation_prompt: bool = True
+        self, chat_history: list[dict[str, str]], add_generation_prompt: bool = True
     ) -> str:
         """
         Method to apply a chat template to a list of chat history between user and model.
@@ -422,9 +419,9 @@ class SGLangLM(TemplateLM):
 
     def _loglikelihood_tokens(
         self,
-        requests: List[Tuple[Tuple[str, str], List[int], List[int]]],
+        requests: list[tuple[tuple[str, str], list[int], list[int]]],
         disable_tqdm: bool = False,
-    ) -> List[Tuple[float, bool]]:
+    ) -> list[tuple[float, bool]]:
         res = []
 
         def _collate(x):
@@ -444,7 +441,7 @@ class SGLangLM(TemplateLM):
         for chunk in chunks:
             inputs = []
             ctxlens = []
-            for cache_key, context_enc, continuation_enc in chunk:
+            for _cache_key, context_enc, continuation_enc in chunk:
                 inp = (context_enc + continuation_enc)[-(self.max_length) :]
                 ctxlen = len(context_enc) - max(
                     0, len(context_enc) + len(continuation_enc) - (self.max_length)
@@ -461,7 +458,7 @@ class SGLangLM(TemplateLM):
                 logprob_start_len=0,
             )
             for output, ctxlen, (cache_key, _, _), inp in zip(
-                outputs, ctxlens, chunk, inputs
+                outputs, ctxlens, chunk, inputs, strict=False
             ):
                 answer = self._parse_logprobs(
                     tokens=inp,
@@ -480,7 +477,7 @@ class SGLangLM(TemplateLM):
         return re_ord.get_original(res)
 
     @staticmethod
-    def _parse_logprobs(tokens: List, outputs, ctxlen: int) -> Tuple[float, bool]:
+    def _parse_logprobs(tokens: list, outputs, ctxlen: int) -> tuple[float, bool]:
         """Process logprobs and tokens.
 
         :param tokens: list
@@ -507,7 +504,9 @@ class SGLangLM(TemplateLM):
 
         # Determine if is_greedy
         is_greedy = True
-        for token, top_logprobs in zip(tokens[ctxlen:], top_logprobs_lists[ctxlen:]):
+        for token, top_logprobs in zip(
+            tokens[ctxlen:], top_logprobs_lists[ctxlen:], strict=False
+        ):
             if top_logprobs:
                 top_token = max(top_logprobs, key=lambda x: x[0])[1]
                 if top_token != token:


### PR DESCRIPTION
Fixes #3075

When `add_bos_token` defaults to `None`, `False or self.add_bos_token` evaluates to `None`. HuggingFace fast tokenizers then crash with `TypeError: argument 'add_special_tokens': 'NoneType' object cannot be converted to 'PyBool'`.

Use an explicit `False` fallback when `add_bos_token` is unset in `TemplateAPI`, `SGLangLM`, and `NeuronOptimumLM`.