### PR TITLE
Add IndicQA: Extractive QA benchmark for 11 Indian languages

### DIFF
--- a/lm_eval/tasks/indicqa/_indicqa.yaml
+++ b/lm_eval/tasks/indicqa/_indicqa.yaml
@@ -1,0 +1,13 @@
+group: indicqa
+task:
+  - indicqa_bn
+  - indicqa_gu
+  - indicqa_hi
+  - indicqa_kn
+  - indicqa_ml
+  - indicqa_mr
+  - indicqa_or
+  - indicqa_pa
+  - indicqa_ta
+  - indicqa_te
+  - indicqa_ur

--- a/lm_eval/tasks/indicqa/indicqa_bn.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_bn.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_bn
+dataset_name: indicqa.bn

--- a/lm_eval/tasks/indicqa/indicqa_common_yaml
+++ b/lm_eval/tasks/indicqa/indicqa_common_yaml
@@ -1,0 +1,23 @@
+dataset_path: ai4bharat/IndicQA
+output_type: generate_until
+fewshot_split: test
+test_split: test
+doc_to_text: 'Context: {{context}}\n\nQuestion: {{question}}\nAnswer:'
+doc_to_target: '{{answers.text[0]}}'
+generation_kwargs:
+  until:
+  - "\n"
+  do_sample: false
+  temperature: 0.0
+process_results: !function utils.process_results_qa
+metric_list:
+- metric: exact_match
+  aggregation: mean
+  higher_is_better: true
+- metric: f1
+  aggregation: mean
+  higher_is_better: true
+metadata:
+  version: 1.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/indicqa/indicqa_gu.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_gu.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_gu
+dataset_name: indicqa.gu

--- a/lm_eval/tasks/indicqa/indicqa_hi.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_hi.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_hi
+dataset_name: indicqa.hi

--- a/lm_eval/tasks/indicqa/indicqa_kn.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_kn.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_kn
+dataset_name: indicqa.kn

--- a/lm_eval/tasks/indicqa/indicqa_ml.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_ml.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_ml
+dataset_name: indicqa.ml

--- a/lm_eval/tasks/indicqa/indicqa_mr.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_mr.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_mr
+dataset_name: indicqa.mr

--- a/lm_eval/tasks/indicqa/indicqa_or.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_or.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_or
+dataset_name: indicqa.or

--- a/lm_eval/tasks/indicqa/indicqa_pa.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_pa.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_pa
+dataset_name: indicqa.pa

--- a/lm_eval/tasks/indicqa/indicqa_ta.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_ta.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_ta
+dataset_name: indicqa.ta

--- a/lm_eval/tasks/indicqa/indicqa_te.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_te.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_te
+dataset_name: indicqa.te

--- a/lm_eval/tasks/indicqa/indicqa_ur.yaml
+++ b/lm_eval/tasks/indicqa/indicqa_ur.yaml
@@ -1,0 +1,3 @@
+include: indicqa_common_yaml
+task: indicqa_ur
+dataset_name: indicqa.ur

--- a/lm_eval/tasks/indicqa/utils.py
+++ b/lm_eval/tasks/indicqa/utils.py
@@ -1,0 +1,9 @@
+import transformers.data.metrics.squad_metrics as squad_metrics
+
+
+def process_results_qa(doc, results):
+    preds = results[0]
+    reference = doc["answers"]["text"][0]
+    f1_sum = squad_metrics.compute_f1(reference, preds)
+    exact_match = squad_metrics.compute_exact(reference, preds)
+    return {"f1": f1_sum, "exact_match": exact_match}


### PR DESCRIPTION
## Description
This PR adds the [ai4bharat/IndicQA](https://huggingface.co/datasets/ai4bharat/IndicQA) benchmark to the evaluation harness.

IndicQA is an extractive Question Answering dataset covering 11 Indian languages: 
Bengali (bn), Gujarati (gu), Hindi (hi), Kannada (kn), Malayalam (ml), Marathi (mr), Odia (or), Punjabi (pa), Tamil (ta), Telugu (te), and Urdu (ur).

## Implementation Details
- Created the indicqa group to execute evaluation across all 11 languages.
- Configured to use the test split, as the dataset does not provide training/validation splits. Few-shot examples are automatically drawn from the test split.
- Utilized a custom utils.py metrics hook to pipe the generative answers through the native SQuAD metrics evaluator (compute_f1 and compute_exact). This exactly mirrors how XQuAD natively handles extractive QA metric matching.

## Testing
Successfully smoke tested locally using --limit 5 on gpt2. Verified that exact_match and f1 scores correctly aggregated using the custom hook.

`ash
python -m lm_eval --model hf --model_args pretrained=gpt2 --tasks indicqa_hi --num_fewshot 1 --limit 5 --trust_remote_code
`
