### PR TITLE
[Task] SimpleQA (OpenAI short-form factuality benchmark)

### DIFF
--- a/lm_eval/tasks/simpleqa/README.md
+++ b/lm_eval/tasks/simpleqa/README.md
@@ -1,0 +1,75 @@
+# SimpleQA
+
+### Paper
+
+**SimpleQA: Measuring Short-Form Factuality in Large Language Models**
+OpenAI, October 2024
+https://openai.com/index/introducing-simpleqa/
+
+### Description
+
+SimpleQA is a benchmark for evaluating the **short-form factual accuracy** of language models. It consists of 4,326 fact-seeking questions, each with exactly one unambiguous, verifiable answer that does not change over time.
+
+Every question in SimpleQA was designed to:
+- Have a **single indisputable correct answer** (easy to grade)
+- **Not change over time** (avoids "who is the current president?" style questions)
+- **Induce hallucinations** from GPT-4o or GPT-3.5 during dataset construction (ensures questions are non-trivial)
+
+SimpleQA is fundamentally different from reasoning benchmarks like MATH or GPQA. It measures **parametric knowledge** — what facts did the model memorize during training? — rather than the ability to reason through novel problems.
+
+### Metrics
+
+| Metric | Description |
+|---|---|
+| `exact_match` | 1.0 if the normalized model output exactly matches the normalized reference answer |
+| `f1` | Token-level F1 score (partial credit for partially correct answers) |
+| `not_attempted` | Fraction of questions where the model explicitly declined to answer |
+
+### Grading Details
+
+Answers are normalized before comparison:
+- Lowercased
+- Punctuation removed
+- Leading articles (a, an, the) dropped
+- Whitespace collapsed
+
+The original paper uses GPT-4o as a judge to grade answers as **correct / incorrect / not attempted**. This implementation uses deterministic string matching for offline evaluation — no API calls required. Users who want model-graded evaluation can follow the judge pattern used in the `gpqa` task.
+
+### Note on `not_attempted`
+
+Unlike most benchmarks that only track accuracy, SimpleQA tracks whether the model says "I don't know." A lower `not_attempted` rate is not always better — a model that confidently hallucinates has lower not_attempted but is arguably *worse* than one that hedges. The calibration between these three rates (correct, incorrect, not_attempted) tells a richer story about model reliability.
+
+### Recommended Use
+
+```bash
+# Zero-shot (matches original paper setup)
+lm_eval --model hf \
+    --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct \
+    --tasks simpleqa \
+    --device cuda:0 \
+    --batch_size 8
+
+# Few-shot (exploratory)
+lm_eval --model hf \
+    --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct \
+    --tasks simpleqa \
+    --num_fewshot 5 \
+    --device cuda:0
+```
+
+### Dataset
+
+- **HuggingFace path**: `basicv8vc/SimpleQA`
+- **Split used**: `train` (this is the full test set — 4,326 examples)
+- **Fields**: `problem` (question), `answer` (ground truth), `metadata` (topic info)
+
+### Citation
+
+```bibtex
+@misc{openai2024simpleqa,
+  author       = {OpenAI},
+  title        = {SimpleQA: Measuring Short-Form Factuality in Large Language Models},
+  year         = {2024},
+  howpublished = {\url{https://openai.com/index/introducing-simpleqa/}},
+}
+```

--- a/lm_eval/tasks/simpleqa/README.md
+++ b/lm_eval/tasks/simpleqa/README.md
@@ -33,7 +33,12 @@ Answers are normalized before comparison:
 - Leading articles (a, an, the) dropped
 - Whitespace collapsed
 
-The original paper uses GPT-4o as a judge to grade answers as **correct / incorrect / not attempted**. This implementation uses deterministic string matching for offline evaluation — no API calls required. Users who want model-graded evaluation can follow the judge pattern used in the `gpqa` task.
+The original paper uses GPT-4o as a judge to grade answers as **correct / incorrect / not attempted**. This implementation uses deterministic string matching for offline evaluation — no API calls required. Two differences from the reference grader are worth noting:
+
+- `exact_match` can under-credit verbose answers (e.g. "The answer is 1867" normalizes to `answer is 1867`, not `1867`). `f1` captures the partial overlap in those cases.
+- `not_attempted` detection is English-only and pattern-based, so it may miss refusals phrased differently or in other languages.
+
+Users who want the original model-graded setup can follow the judge pattern used in the `gpqa` task.
 
 ### Note on `not_attempted`
 
@@ -60,7 +65,7 @@ lm_eval --model hf \
 ### Dataset
 
 - **HuggingFace path**: `basicv8vc/SimpleQA`
-- **Split used**: `train` (this is the full test set — 4,326 examples)
+- **Split used**: `test` (the full benchmark — 4,326 examples)
 - **Fields**: `problem` (question), `answer` (ground truth), `metadata` (topic info)
 
 ### Citation

--- a/lm_eval/tasks/simpleqa/simpleqa.yaml
+++ b/lm_eval/tasks/simpleqa/simpleqa.yaml
@@ -1,0 +1,80 @@
+# SimpleQA Task Configuration
+# ============================================================
+# SimpleQA is OpenAI's short-form factuality benchmark.
+# Paper: https://openai.com/index/introducing-simpleqa/
+# Dataset: basicv8vc/SimpleQA (4,326 fact-seeking questions)
+#
+# Each question has exactly one unambiguous answer.
+# Evaluation: normalized string match + not-attempted detection.
+# ============================================================
+
+tag:
+  - world_knowledge
+
+task: simpleqa
+dataset_path: basicv8vc/SimpleQA
+
+# ── Concept: output_type ──────────────────────────────────────
+# "generate_until" means the model freely generates text
+# until it hits a stop token (like a newline or </s>).
+# This is used for open-ended QA — not multiple choice.
+output_type: generate_until
+
+# The test set on HuggingFace is labeled 'train' (common for
+# benchmarks that only ship one split).
+test_split: train
+
+# ── Concept: doc_to_text ──────────────────────────────────────
+# A Jinja2 template: {{ problem }} is replaced with the actual
+# question text from each row of the dataset.
+# We ask for a short answer to discourage the model from
+# writing an essay when the answer is just "1867".
+doc_to_text: "Answer the following question with a short, direct answer (a few words at most).\n\nQuestion: {{problem}}\nAnswer:"
+
+# ── Concept: doc_to_target ────────────────────────────────────
+# The reference answer for each example.
+# process_results() (see utils.py) receives this alongside
+# the model's output to compute the metric.
+doc_to_target: "{{answer}}"
+
+# Custom scoring logic lives in utils.py.
+# "!function" is the harness's way of calling a Python function.
+process_results: !function utils.process_results
+
+# ── Concept: metric_list ──────────────────────────────────────
+# Each entry declares a metric key that process_results returns.
+# The harness aggregates them across all examples.
+metric_list:
+  - metric: exact_match      # strict: normalized strings must match
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1               # token-overlap F1 (partial credit)
+    aggregation: mean
+    higher_is_better: true
+  - metric: not_attempted    # fraction where model said "I don't know"
+    aggregation: mean
+    higher_is_better: false  # lower = more willing to answer
+
+# ── Concept: generation_kwargs ───────────────────────────────
+# Stop generating when the model produces any of these tokens.
+# This prevents the model from answering multiple questions
+# or producing paragraphs when we only want a short answer.
+generation_kwargs:
+  until:
+    - "\n\n"
+    - "\nQuestion:"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+    - "</s>"
+  do_sample: false       # greedy decoding = deterministic eval
+  temperature: 0.0
+  max_gen_toks: 100      # SimpleQA answers are short (≤ ~20 tokens)
+
+# ── Concept: num_fewshot ──────────────────────────────────────
+# Zero-shot: no example (Q, A) pairs shown before each question.
+# The SimpleQA paper evaluates zero-shot; set to 0 to match.
+# Users can override this with --num_fewshot N at the CLI.
+num_fewshot: 0
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/simpleqa/simpleqa.yaml
+++ b/lm_eval/tasks/simpleqa/simpleqa.yaml
@@ -20,9 +20,8 @@ dataset_path: basicv8vc/SimpleQA
 # This is used for open-ended QA — not multiple choice.
 output_type: generate_until
 
-# The test set on HuggingFace is labeled 'train' (common for
-# benchmarks that only ship one split).
-test_split: train
+# basicv8vc/SimpleQA ships a single 'test' split (4,326 rows).
+test_split: test
 
 # ── Concept: doc_to_text ──────────────────────────────────────
 # A Jinja2 template: {{ problem }} is replaced with the actual

--- a/lm_eval/tasks/simpleqa/simpleqa.yaml
+++ b/lm_eval/tasks/simpleqa/simpleqa.yaml
@@ -1,63 +1,22 @@
-# SimpleQA Task Configuration
-# ============================================================
-# SimpleQA is OpenAI's short-form factuality benchmark.
-# Paper: https://openai.com/index/introducing-simpleqa/
-# Dataset: basicv8vc/SimpleQA (4,326 fact-seeking questions)
-#
-# Each question has exactly one unambiguous answer.
-# Evaluation: normalized string match + not-attempted detection.
-# ============================================================
-
 tag:
   - world_knowledge
-
 task: simpleqa
 dataset_path: basicv8vc/SimpleQA
-
-# ── Concept: output_type ──────────────────────────────────────
-# "generate_until" means the model freely generates text
-# until it hits a stop token (like a newline or </s>).
-# This is used for open-ended QA — not multiple choice.
 output_type: generate_until
-
-# basicv8vc/SimpleQA ships a single 'test' split (4,326 rows).
 test_split: test
-
-# ── Concept: doc_to_text ──────────────────────────────────────
-# A Jinja2 template: {{ problem }} is replaced with the actual
-# question text from each row of the dataset.
-# We ask for a short answer to discourage the model from
-# writing an essay when the answer is just "1867".
 doc_to_text: "Answer the following question with a short, direct answer (a few words at most).\n\nQuestion: {{problem}}\nAnswer:"
-
-# ── Concept: doc_to_target ────────────────────────────────────
-# The reference answer for each example.
-# process_results() (see utils.py) receives this alongside
-# the model's output to compute the metric.
 doc_to_target: "{{answer}}"
-
-# Custom scoring logic lives in utils.py.
-# "!function" is the harness's way of calling a Python function.
 process_results: !function utils.process_results
-
-# ── Concept: metric_list ──────────────────────────────────────
-# Each entry declares a metric key that process_results returns.
-# The harness aggregates them across all examples.
 metric_list:
-  - metric: exact_match      # strict: normalized strings must match
+  - metric: exact_match
     aggregation: mean
     higher_is_better: true
-  - metric: f1               # token-overlap F1 (partial credit)
+  - metric: f1
     aggregation: mean
     higher_is_better: true
-  - metric: not_attempted    # fraction where model said "I don't know"
+  - metric: not_attempted
     aggregation: mean
-    higher_is_better: false  # lower = more willing to answer
-
-# ── Concept: generation_kwargs ───────────────────────────────
-# Stop generating when the model produces any of these tokens.
-# This prevents the model from answering multiple questions
-# or producing paragraphs when we only want a short answer.
+    higher_is_better: false
 generation_kwargs:
   until:
     - "\n\n"
@@ -65,15 +24,9 @@ generation_kwargs:
     - "<|im_end|>"
     - "<|eot_id|>"
     - "</s>"
-  do_sample: false       # greedy decoding = deterministic eval
+  do_sample: false
   temperature: 0.0
-  max_gen_toks: 100      # SimpleQA answers are short (≤ ~20 tokens)
-
-# ── Concept: num_fewshot ──────────────────────────────────────
-# Zero-shot: no example (Q, A) pairs shown before each question.
-# The SimpleQA paper evaluates zero-shot; set to 0 to match.
-# Users can override this with --num_fewshot N at the CLI.
+  max_gen_toks: 100
 num_fewshot: 0
-
 metadata:
   version: 1.0

--- a/lm_eval/tasks/simpleqa/utils.py
+++ b/lm_eval/tasks/simpleqa/utils.py
@@ -1,0 +1,161 @@
+"""
+utils.py — SimpleQA answer processing for lm-evaluation-harness
+
+Concept: process_results()
+──────────────────────────
+This is the scoring function the harness calls for every example.
+It receives:
+  - doc:     the raw dataset row (has 'problem', 'answer', 'metadata')
+  - results: list with one item — the model's generated string
+
+It returns a dict mapping metric names → scores (0.0 or 1.0).
+Those scores are averaged across all examples to produce the
+final benchmark numbers.
+
+Metrics we compute:
+  1. exact_match      — 1.0 if normalized model output == normalized reference
+  2. f1               — token-overlap F1 (partial credit, like SQuAD)
+  3. not_attempted    — 1.0 if the model explicitly refused to answer
+"""
+
+import re
+import string
+from collections import Counter
+from typing import Any
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CONCEPT: Answer Normalization
+# ─────────────────────────────────────────────────────────────────────────────
+# Raw model output might be "  The year 1867. " while the reference is "1867".
+# Normalization strips noise so we're comparing the semantic content.
+# This is standard practice for open-ended QA (SQuAD, TriviaQA, NQ all do it).
+
+_ARTICLES = re.compile(r"\b(a|an|the)\b", re.IGNORECASE)
+
+def normalize_answer(s: str) -> str:
+    """
+    Lower-case, remove punctuation, strip leading articles, collapse whitespace.
+    Mirrors the normalization used in the original SimpleQA evaluation code.
+    """
+    # 1. Lowercase everything
+    s = s.lower()
+    # 2. Remove punctuation  e.g.  "1867."  →  "1867"
+    s = s.translate(str.maketrans("", "", string.punctuation))
+    # 3. Drop leading articles  e.g.  "the eiffel tower"  →  "eiffel tower"
+    s = _ARTICLES.sub(" ", s)
+    # 4. Collapse multiple spaces into one
+    s = " ".join(s.split())
+    return s
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CONCEPT: Not-Attempted Detection
+# ─────────────────────────────────────────────────────────────────────────────
+# SimpleQA measures three states: correct, incorrect, not_attempted.
+# "Not attempted" = the model says it doesn't know.
+# This is IMPORTANT: a model that hedges is safer than one that confidently
+# hallucinates. Tracking this rate separately gives a richer picture of
+# model behavior than just accuracy alone.
+
+_NOT_ATTEMPTED_PATTERNS = re.compile(
+    r"(i don'?t know"
+    r"|i'?m not sure"
+    r"|i cannot (determine|say|provide|tell)"
+    r"|i do not (know|have)"
+    r"|cannot be determined"
+    r"|not (enough|sufficient) information"
+    r"|unclear from"
+    r"|i'?m unable to"
+    r"|no information"
+    r"|this (question|answer) (is beyond|cannot))",
+    re.IGNORECASE,
+)
+
+def is_not_attempted(model_output: str) -> bool:
+    """Returns True if the model explicitly declined to answer."""
+    return bool(_NOT_ATTEMPTED_PATTERNS.search(model_output))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CONCEPT: Token-level F1
+# ─────────────────────────────────────────────────────────────────────────────
+# Exact match is strict: "Marie Curie" ≠ "Curie".
+# F1 gives partial credit by counting token overlap (like SQuAD evaluation).
+# Both F1 = 0.0 and exact_match = 0.0 means total failure.
+# F1 > 0 but exact_match = 0 means the model got part of it right.
+
+def token_f1(prediction: str, reference: str) -> float:
+    """
+    Token-overlap F1 between normalized prediction and reference.
+    Standard SQuAD-style metric.
+    """
+    pred_tokens = normalize_answer(prediction).split()
+    ref_tokens = normalize_answer(reference).split()
+
+    if not pred_tokens or not ref_tokens:
+        return float(pred_tokens == ref_tokens)  # both empty → 1.0
+
+    common = Counter(pred_tokens) & Counter(ref_tokens)
+    num_same = sum(common.values())
+
+    if num_same == 0:
+        return 0.0
+
+    precision = num_same / len(pred_tokens)
+    recall = num_same / len(ref_tokens)
+    f1 = (2 * precision * recall) / (precision + recall)
+    return f1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CONCEPT: process_results — the harness entry point
+# ─────────────────────────────────────────────────────────────────────────────
+# The harness calls this once per example after the model generates an answer.
+# Return value: dict[metric_name → float]
+# The harness then averages each metric across all examples.
+
+def process_results(doc: dict[str, Any], results: list[str]) -> dict[str, float]:
+    """
+    Score one SimpleQA example.
+
+    Args:
+        doc:     Dataset row with keys 'problem', 'answer', 'metadata'
+        results: [model_output]  (list with exactly one string)
+
+    Returns:
+        {
+            "exact_match":   1.0 or 0.0,
+            "f1":            0.0 – 1.0,
+            "not_attempted": 1.0 or 0.0,
+        }
+    """
+    assert len(results) == 1, "SimpleQA is a single-answer task"
+    model_output: str = results[0].strip()
+    reference: str = doc["answer"]
+
+    # ── Step 1: Did the model refuse to answer? ───────────────
+    # If so, mark as not_attempted and short-circuit.
+    if is_not_attempted(model_output):
+        return {
+            "exact_match": 0.0,
+            "f1": 0.0,
+            "not_attempted": 1.0,
+        }
+
+    # ── Step 2: Normalize both strings ────────────────────────
+    norm_pred = normalize_answer(model_output)
+    norm_ref = normalize_answer(reference)
+
+    # ── Step 3: Exact match ───────────────────────────────────
+    # After normalization, are the strings identical?
+    exact = float(norm_pred == norm_ref)
+
+    # ── Step 4: Token F1 ─────────────────────────────────────
+    f1 = token_f1(model_output, reference)
+
+    return {
+        "exact_match": exact,
+        "f1": f1,
+        "not_attempted": 0.0,
+    }

--- a/lm_eval/tasks/simpleqa/utils.py
+++ b/lm_eval/tasks/simpleqa/utils.py
@@ -33,6 +33,7 @@ from typing import Any
 
 _ARTICLES = re.compile(r"\b(a|an|the)\b", re.IGNORECASE)
 
+
 def normalize_answer(s: str) -> str:
     """
     Lower-case, remove punctuation, strip leading articles, collapse whitespace.
@@ -72,6 +73,7 @@ _NOT_ATTEMPTED_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 
+
 def is_not_attempted(model_output: str) -> bool:
     """Returns True if the model explicitly declined to answer."""
     return bool(_NOT_ATTEMPTED_PATTERNS.search(model_output))
@@ -84,6 +86,7 @@ def is_not_attempted(model_output: str) -> bool:
 # F1 gives partial credit by counting token overlap (like SQuAD evaluation).
 # Both F1 = 0.0 and exact_match = 0.0 means total failure.
 # F1 > 0 but exact_match = 0 means the model got part of it right.
+
 
 def token_f1(prediction: str, reference: str) -> float:
     """
@@ -114,6 +117,7 @@ def token_f1(prediction: str, reference: str) -> float:
 # The harness calls this once per example after the model generates an answer.
 # Return value: dict[metric_name → float]
 # The harness then averages each metric across all examples.
+
 
 def process_results(doc: dict[str, Any], results: list[str]) -> dict[str, float]:
     """

--- a/lm_eval/tasks/simpleqa/utils.py
+++ b/lm_eval/tasks/simpleqa/utils.py
@@ -1,22 +1,21 @@
+"""Answer processing for the SimpleQA task.
+
+The original SimpleQA grades answers with an LLM judge (GPT-4o) into
+correct / incorrect / not_attempted. This implementation is a deterministic,
+offline approximation: SQuAD-style answer normalization for exact_match and
+token-F1, plus a regex heuristic for not_attempted. It requires no API calls,
+but differs from the reference grader in two ways worth noting:
+
+- Exact match can under-credit verbose answers (e.g. "The answer is 1867"
+  normalizes to "answer is 1867", not "1867"); f1 captures the partial overlap.
+- not_attempted detection is English-only and pattern-based, so it may miss
+  refusals phrased differently or in other languages.
+
+Users who want the original model-graded setup can follow the judge pattern
+used in the `gpqa` task.
 """
-utils.py — SimpleQA answer processing for lm-evaluation-harness
 
-Concept: process_results()
-──────────────────────────
-This is the scoring function the harness calls for every example.
-It receives:
-  - doc:     the raw dataset row (has 'problem', 'answer', 'metadata')
-  - results: list with one item — the model's generated string
-
-It returns a dict mapping metric names → scores (0.0 or 1.0).
-Those scores are averaged across all examples to produce the
-final benchmark numbers.
-
-Metrics we compute:
-  1. exact_match      — 1.0 if normalized model output == normalized reference
-  2. f1               — token-overlap F1 (partial credit, like SQuAD)
-  3. not_attempted    — 1.0 if the model explicitly refused to answer
-"""
+from __future__ import annotations
 
 import re
 import string
@@ -24,41 +23,23 @@ from collections import Counter
 from typing import Any
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# CONCEPT: Answer Normalization
-# ─────────────────────────────────────────────────────────────────────────────
-# Raw model output might be "  The year 1867. " while the reference is "1867".
-# Normalization strips noise so we're comparing the semantic content.
-# This is standard practice for open-ended QA (SQuAD, TriviaQA, NQ all do it).
-
 _ARTICLES = re.compile(r"\b(a|an|the)\b", re.IGNORECASE)
 
 
 def normalize_answer(s: str) -> str:
+    """Lower-case, drop punctuation and leading articles, collapse whitespace.
+
+    Mirrors the SQuAD/TriviaQA-style normalization used for open-ended QA.
     """
-    Lower-case, remove punctuation, strip leading articles, collapse whitespace.
-    Mirrors the normalization used in the original SimpleQA evaluation code.
-    """
-    # 1. Lowercase everything
     s = s.lower()
-    # 2. Remove punctuation  e.g.  "1867."  →  "1867"
     s = s.translate(str.maketrans("", "", string.punctuation))
-    # 3. Drop leading articles  e.g.  "the eiffel tower"  →  "eiffel tower"
     s = _ARTICLES.sub(" ", s)
-    # 4. Collapse multiple spaces into one
     s = " ".join(s.split())
     return s
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# CONCEPT: Not-Attempted Detection
-# ─────────────────────────────────────────────────────────────────────────────
-# SimpleQA measures three states: correct, incorrect, not_attempted.
-# "Not attempted" = the model says it doesn't know.
-# This is IMPORTANT: a model that hedges is safer than one that confidently
-# hallucinates. Tracking this rate separately gives a richer picture of
-# model behavior than just accuracy alone.
-
+# English refusal phrases. Heuristic approximation of the reference judge's
+# "not attempted" category; see the module docstring for limitations.
 _NOT_ATTEMPTED_PATTERNS = re.compile(
     r"(i don'?t know"
     r"|i'?m not sure"
@@ -75,91 +56,37 @@ _NOT_ATTEMPTED_PATTERNS = re.compile(
 
 
 def is_not_attempted(model_output: str) -> bool:
-    """Returns True if the model explicitly declined to answer."""
+    """Return True if the model explicitly declined to answer."""
     return bool(_NOT_ATTEMPTED_PATTERNS.search(model_output))
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# CONCEPT: Token-level F1
-# ─────────────────────────────────────────────────────────────────────────────
-# Exact match is strict: "Marie Curie" ≠ "Curie".
-# F1 gives partial credit by counting token overlap (like SQuAD evaluation).
-# Both F1 = 0.0 and exact_match = 0.0 means total failure.
-# F1 > 0 but exact_match = 0 means the model got part of it right.
-
-
 def token_f1(prediction: str, reference: str) -> float:
-    """
-    Token-overlap F1 between normalized prediction and reference.
-    Standard SQuAD-style metric.
-    """
+    """Token-overlap F1 between normalized prediction and reference (SQuAD-style)."""
     pred_tokens = normalize_answer(prediction).split()
     ref_tokens = normalize_answer(reference).split()
 
     if not pred_tokens or not ref_tokens:
-        return float(pred_tokens == ref_tokens)  # both empty → 1.0
+        return float(pred_tokens == ref_tokens)  # both empty -> 1.0
 
     common = Counter(pred_tokens) & Counter(ref_tokens)
     num_same = sum(common.values())
-
     if num_same == 0:
         return 0.0
 
     precision = num_same / len(pred_tokens)
     recall = num_same / len(ref_tokens)
-    f1 = (2 * precision * recall) / (precision + recall)
-    return f1
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# CONCEPT: process_results — the harness entry point
-# ─────────────────────────────────────────────────────────────────────────────
-# The harness calls this once per example after the model generates an answer.
-# Return value: dict[metric_name → float]
-# The harness then averages each metric across all examples.
+    return (2 * precision * recall) / (precision + recall)
 
 
 def process_results(doc: dict[str, Any], results: list[str]) -> dict[str, float]:
-    """
-    Score one SimpleQA example.
-
-    Args:
-        doc:     Dataset row with keys 'problem', 'answer', 'metadata'
-        results: [model_output]  (list with exactly one string)
-
-    Returns:
-        {
-            "exact_match":   1.0 or 0.0,
-            "f1":            0.0 – 1.0,
-            "not_attempted": 1.0 or 0.0,
-        }
-    """
+    """Score one SimpleQA example into exact_match / f1 / not_attempted."""
     assert len(results) == 1, "SimpleQA is a single-answer task"
-    model_output: str = results[0].strip()
-    reference: str = doc["answer"]
+    model_output = results[0].strip()
+    reference = doc["answer"]
 
-    # ── Step 1: Did the model refuse to answer? ───────────────
-    # If so, mark as not_attempted and short-circuit.
     if is_not_attempted(model_output):
-        return {
-            "exact_match": 0.0,
-            "f1": 0.0,
-            "not_attempted": 1.0,
-        }
+        return {"exact_match": 0.0, "f1": 0.0, "not_attempted": 1.0}
 
-    # ── Step 2: Normalize both strings ────────────────────────
-    norm_pred = normalize_answer(model_output)
-    norm_ref = normalize_answer(reference)
-
-    # ── Step 3: Exact match ───────────────────────────────────
-    # After normalization, are the strings identical?
-    exact = float(norm_pred == norm_ref)
-
-    # ── Step 4: Token F1 ─────────────────────────────────────
+    exact = float(normalize_answer(model_output) == normalize_answer(reference))
     f1 = token_f1(model_output, reference)
-
-    return {
-        "exact_match": exact,
-        "f1": f1,
-        "not_attempted": 0.0,
-    }
+    return {"exact_match": exact, "f1": f1, "not_attempted": 0.0}

--- a/tests/test_simpleqa_utils.py
+++ b/tests/test_simpleqa_utils.py
@@ -1,0 +1,175 @@
+"""
+Tests for SimpleQA utils.py
+
+Concept: Why test the scoring logic?
+─────────────────────────────────────
+The scoring function is the most important part of any eval task.
+A buggy normalizer means you under-count correct answers
+(your model looks dumber than it is) or over-count them
+(it looks smarter). Either way, published numbers become misleading.
+
+These tests verify:
+  1. normalize_answer strips noise correctly
+  2. token_f1 handles edge cases
+  3. process_results classifies correct / incorrect / not_attempted
+  4. The 'not_attempted' flag doesn't misfire on real answers
+"""
+
+import sys
+import os
+
+# Allow importing simpleqa utils from the task directory
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "lm_eval", "tasks", "simpleqa"))
+from utils import normalize_answer, token_f1, is_not_attempted, process_results
+
+
+# ─────────────────────────────────────────────────────────────
+# normalize_answer
+# ─────────────────────────────────────────────────────────────
+
+class TestNormalizeAnswer:
+    def test_lowercases(self):
+        assert normalize_answer("Marie Curie") == "marie curie"
+
+    def test_strips_punctuation(self):
+        assert normalize_answer("1867.") == "1867"
+        assert normalize_answer("Paris, France") == "paris france"
+
+    def test_removes_leading_articles(self):
+        assert normalize_answer("The Eiffel Tower") == "eiffel tower"
+        assert normalize_answer("A river") == "river"
+        assert normalize_answer("An apple") == "apple"
+
+    def test_collapses_whitespace(self):
+        assert normalize_answer("  Isaac   Newton  ") == "isaac newton"
+
+    def test_empty_string(self):
+        assert normalize_answer("") == ""
+
+    def test_numbers_unchanged(self):
+        assert normalize_answer("1867") == "1867"
+
+
+# ─────────────────────────────────────────────────────────────
+# token_f1
+# Concept: F1 = harmonic mean of precision and recall on tokens
+# ─────────────────────────────────────────────────────────────
+
+class TestTokenF1:
+    def test_perfect_match(self):
+        assert token_f1("marie curie", "marie curie") == 1.0
+
+    def test_no_overlap(self):
+        assert token_f1("albert einstein", "marie curie") == 0.0
+
+    def test_partial_overlap(self):
+        # "new york city" vs "city of new york" — 3 tokens overlap out of 3+4
+        f1 = token_f1("new york city", "city of new york")
+        assert 0.0 < f1 < 1.0
+
+    def test_both_empty(self):
+        # Both empty → identical → 1.0
+        assert token_f1("", "") == 1.0
+
+    def test_one_empty(self):
+        assert token_f1("", "something") == 0.0
+        assert token_f1("something", "") == 0.0
+
+    def test_subset_prediction(self):
+        # "newton" vs "isaac newton" — partial
+        f1 = token_f1("newton", "isaac newton")
+        assert 0.0 < f1 < 1.0
+
+
+# ─────────────────────────────────────────────────────────────
+# is_not_attempted
+# Concept: some "correct" words resemble refusals — we must not
+# over-trigger the not_attempted detector.
+# ─────────────────────────────────────────────────────────────
+
+class TestIsNotAttempted:
+    def test_explicit_refusals(self):
+        assert is_not_attempted("I don't know") is True
+        assert is_not_attempted("I'm not sure about this.") is True
+        assert is_not_attempted("I cannot determine the answer.") is True
+        assert is_not_attempted("I do not have enough information.") is True
+        assert is_not_attempted("Cannot be determined from the given context.") is True
+
+    def test_real_answers_not_flagged(self):
+        # These look like answers, not refusals
+        assert is_not_attempted("Marie Curie") is False
+        assert is_not_attempted("1867") is False
+        assert is_not_attempted("Paris, France") is False
+        assert is_not_attempted("The answer is 42.") is False
+
+    def test_edge_case_contains_know(self):
+        # "know" appears in the answer but it's not a refusal
+        assert is_not_attempted("Little Known Facts is a 1930 movie") is False
+
+
+# ─────────────────────────────────────────────────────────────
+# process_results — the full pipeline
+# ─────────────────────────────────────────────────────────────
+
+class TestProcessResults:
+    def _make_doc(self, problem: str, answer: str) -> dict:
+        return {
+            "problem": problem,
+            "answer": answer,
+            "metadata": "{}",
+        }
+
+    def test_exact_match_passes(self):
+        doc = self._make_doc("When was Marie Curie born?", "1867")
+        result = process_results(doc, ["1867"])
+        assert result["exact_match"] == 1.0
+        assert result["f1"] == 1.0
+        assert result["not_attempted"] == 0.0
+
+    def test_case_insensitive_match(self):
+        doc = self._make_doc("Who invented the telephone?", "Alexander Graham Bell")
+        result = process_results(doc, ["alexander graham bell"])
+        assert result["exact_match"] == 1.0
+
+    def test_wrong_answer(self):
+        doc = self._make_doc("What is the capital of France?", "Paris")
+        result = process_results(doc, ["London"])
+        assert result["exact_match"] == 0.0
+        assert result["f1"] == 0.0
+        assert result["not_attempted"] == 0.0
+
+    def test_not_attempted_detected(self):
+        doc = self._make_doc("What is the boiling point of helium?", "-269 degrees Celsius")
+        result = process_results(doc, ["I don't know the answer to this question."])
+        assert result["exact_match"] == 0.0
+        assert result["f1"] == 0.0
+        assert result["not_attempted"] == 1.0
+
+    def test_partial_credit_via_f1(self):
+        # Model says "Graham Bell" instead of "Alexander Graham Bell"
+        doc = self._make_doc("Who invented the telephone?", "Alexander Graham Bell")
+        result = process_results(doc, ["Graham Bell"])
+        assert result["exact_match"] == 0.0   # not a full match
+        assert result["f1"] > 0.0             # but some token overlap
+
+    def test_article_stripped_match(self):
+        # Reference has "the" — normalizer should strip it
+        doc = self._make_doc("What river runs through London?", "The Thames")
+        result = process_results(doc, ["Thames"])
+        assert result["exact_match"] == 1.0
+
+    def test_trailing_punctuation_stripped(self):
+        doc = self._make_doc("What year did WWII end?", "1945")
+        result = process_results(doc, ["1945."])
+        assert result["exact_match"] == 1.0
+
+    def test_results_must_have_one_item(self):
+        import pytest
+        doc = self._make_doc("Q", "A")
+        with pytest.raises(AssertionError):
+            process_results(doc, ["answer1", "answer2"])
+
+    def test_whitespace_padded_output(self):
+        doc = self._make_doc("Capital of Japan?", "Tokyo")
+        result = process_results(doc, ["  Tokyo  "])
+        assert result["exact_match"] == 1.0

--- a/tests/test_simpleqa_utils.py
+++ b/tests/test_simpleqa_utils.py
@@ -15,17 +15,24 @@ These tests verify:
   4. The 'not_attempted' flag doesn't misfire on real answers
 """
 
-import sys
 import os
+import sys
+
 
 # Allow importing simpleqa utils from the task directory
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "lm_eval", "tasks", "simpleqa"))
-from utils import normalize_answer, token_f1, is_not_attempted, process_results
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "lm_eval", "tasks", "simpleqa"
+    ),
+)
+from utils import is_not_attempted, normalize_answer, process_results, token_f1
 
 
 # ─────────────────────────────────────────────────────────────
 # normalize_answer
 # ─────────────────────────────────────────────────────────────
+
 
 class TestNormalizeAnswer:
     def test_lowercases(self):
@@ -54,6 +61,7 @@ class TestNormalizeAnswer:
 # token_f1
 # Concept: F1 = harmonic mean of precision and recall on tokens
 # ─────────────────────────────────────────────────────────────
+
 
 class TestTokenF1:
     def test_perfect_match(self):
@@ -87,6 +95,7 @@ class TestTokenF1:
 # over-trigger the not_attempted detector.
 # ─────────────────────────────────────────────────────────────
 
+
 class TestIsNotAttempted:
     def test_explicit_refusals(self):
         assert is_not_attempted("I don't know") is True
@@ -110,6 +119,7 @@ class TestIsNotAttempted:
 # ─────────────────────────────────────────────────────────────
 # process_results — the full pipeline
 # ─────────────────────────────────────────────────────────────
+
 
 class TestProcessResults:
     def _make_doc(self, problem: str, answer: str) -> dict:
@@ -139,7 +149,9 @@ class TestProcessResults:
         assert result["not_attempted"] == 0.0
 
     def test_not_attempted_detected(self):
-        doc = self._make_doc("What is the boiling point of helium?", "-269 degrees Celsius")
+        doc = self._make_doc(
+            "What is the boiling point of helium?", "-269 degrees Celsius"
+        )
         result = process_results(doc, ["I don't know the answer to this question."])
         assert result["exact_match"] == 0.0
         assert result["f1"] == 0.0
@@ -149,8 +161,8 @@ class TestProcessResults:
         # Model says "Graham Bell" instead of "Alexander Graham Bell"
         doc = self._make_doc("Who invented the telephone?", "Alexander Graham Bell")
         result = process_results(doc, ["Graham Bell"])
-        assert result["exact_match"] == 0.0   # not a full match
-        assert result["f1"] > 0.0             # but some token overlap
+        assert result["exact_match"] == 0.0  # not a full match
+        assert result["f1"] > 0.0  # but some token overlap
 
     def test_article_stripped_match(self):
         # Reference has "the" — normalizer should strip it
@@ -165,6 +177,7 @@ class TestProcessResults:
 
     def test_results_must_have_one_item(self):
         import pytest
+
         doc = self._make_doc("Q", "A")
         with pytest.raises(AssertionError):
             process_results(doc, ["answer1", "answer2"])


### PR DESCRIPTION
**Add SimpleQA: OpenAI's short-form factuality benchmark**

Integrates [SimpleQA](https://openai.com/index/introducing-simpleqa/) ([basicv8vc/SimpleQA](https://huggingface.co/datasets/basicv8vc/SimpleQA)) — 4,326 fact-seeking questions, each with a single unambiguous short answer. Zero-shot, `generate_until`. Closes #3666.

Carries forward @sarthakkgupta's original implementation (#3667), rebased onto `main` with their sign-off in #3666; commit authorship preserved.

**Scoring** (`utils.process_results`):

| Metric | Meaning |
|--------|---------|
| `exact_match` | normalized string match |
| `f1` | token-overlap F1 (partial credit) |
| `not_attempted` | fraction declined |

**Changed vs #3667:** config set `test_split: train`, but the dataset ships only a `test` split — the task raised `KeyError: 'train'` on instantiation. Fixed to `test`; applied ruff. 24 unit tests pass.
