### PR TITLE
Add paired significance testing (McNemar + paired bootstrap) for comparing two runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,30 @@ load_dataset("EleutherAI/lm-eval-results-private", "hellaswag", "latest")
 
 For a full list of supported arguments, check out the [interface](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/interface.md) guide in our documentation!
 
+## Comparing Two Runs
+
+The per-task standard error reported for a single run tells you how precise that run's score is, but it does not tell you whether the *gap* between two runs (two models, or two configurations of the same model) is statistically meaningful. To answer that, use [`scripts/compare_samples.py`](./scripts/compare_samples.py), which runs a **paired** significance test directly on the `samples_*.jsonl` files written with `--log_samples` — no model is reloaded, so it runs on CPU in well under a second.
+
+First produce per-sample logs for both runs:
+
+```bash
+lm_eval --model hf --model_args pretrained=modelA --tasks arc_easy \
+    --log_samples --output_path runs/A
+lm_eval --model hf --model_args pretrained=modelB --tasks arc_easy \
+    --log_samples --output_path runs/B
+```
+
+Then compare them on a shared metric:
+
+```bash
+python scripts/compare_samples.py runs/A runs/B --metric acc
+```
+
+This prints each run's mean, their difference (`A - B`) with a bootstrap confidence interval, the test used, a p-value, and a significance verdict.
+
+> [!Note]
+> Because both runs are scored on the *same* documents, their per-document outcomes are **paired** and usually positively correlated (hard items are hard for both models). The existing [`scripts/model_comparator.py`](./scripts/model_comparator.py) applies an *unpaired* two-sample z-test, which drops the covariance term and is therefore conservative / underpowered for this setting. `compare_samples.py` instead uses [McNemar's test](https://en.wikipedia.org/wiki/McNemar%27s_test) for binary metrics (e.g. `acc`) and a paired bootstrap for arbitrary metrics, following Dietterich (1998), ["Approximate Statistical Tests for Comparing Supervised Classification Learning Algorithms"](https://doi.org/10.1162/089976698300017197). The test selection (`--method auto`), bootstrap iterations (`--iters`), confidence level (`--confidence`), metric, and filter are all configurable; run `python scripts/compare_samples.py --help` for the full list. The underlying functions live in [`lm_eval/api/significance.py`](./lm_eval/api/significance.py) and can be called directly on aligned score vectors via `compare_paired(scores_a, scores_b)`.
+
 ## Visualizing Results
 
 You can seamlessly visualize and analyze the results of your evaluation harness runs using both Weights & Biases (W&B) and Zeno.

--- a/lm_eval/api/significance.py
+++ b/lm_eval/api/significance.py
@@ -1,0 +1,366 @@
+"""Paired significance testing for comparing two evaluation runs.
+
+`lm_eval` reports a per-task standard error for each metric, but it has no
+*principled* way to ask whether the gap between two models (or two runs of the
+same model) is statistically meaningful. The existing ``scripts/model_comparator.py``
+helper answers this with an **unpaired** two-sample z-test::
+
+    Z = (acc_a - acc_b) / sqrt(se_a**2 + se_b**2)
+
+That formula is only valid when the two accuracy estimates are independent. In
+`lm_eval` both models are evaluated on *the same documents*, so the per-document
+outcomes are paired and usually positively correlated (hard items are hard for
+both models). The variance of the difference is
+
+    Var(A - B) = Var(A) + Var(B) - 2 * Cov(A, B),
+
+and dropping the ``-2 * Cov(A, B)`` term inflates the standard error of the
+difference, making the unpaired test conservative / underpowered. The textbook
+remedy for comparing two classifiers on a shared test set is a *paired* test
+(McNemar's test for binary metrics, a paired bootstrap for arbitrary metrics);
+see Dietterich (1998), "Approximate Statistical Tests for Comparing Supervised
+Classification Learning Algorithms".
+
+This module provides those paired tests as small, dependency-free functions
+(``numpy`` + stdlib only -- ``scipy`` is intentionally avoided since it is not a
+core dependency). They operate on the per-document scores that `lm_eval` already
+writes to ``samples_*.jsonl`` when ``--log_samples`` is set, so a comparison can
+be run on saved logs without re-loading any model.
+"""
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+
+__all__ = [
+    "BootstrapResult",
+    "McNemarResult",
+    "PairedComparison",
+    "compare_paired",
+    "mcnemar_test",
+    "normal_ci",
+    "paired_bootstrap_test",
+]
+
+
+def _inv_norm_cdf(p: float) -> float:
+    """Inverse standard-normal CDF (quantile function) via Acklam's rational
+    approximation. Dependency-free stand-in for ``scipy.stats.norm.ppf`` with a
+    relative error below ~1e-9, which is far finer than any confidence level a
+    caller would specify.
+    """
+    if not 0.0 < p < 1.0:
+        raise ValueError("p must be in the open interval (0, 1)")
+    a = [
+        -3.969683028665376e01,
+        2.209460984245205e02,
+        -2.759285104469687e02,
+        1.383577518672690e02,
+        -3.066479806614716e01,
+        2.506628277459239e00,
+    ]
+    b = [
+        -5.447609879822406e01,
+        1.615858368580409e02,
+        -1.556989798598866e02,
+        6.680131188771972e01,
+        -1.328068155288572e01,
+    ]
+    c = [
+        -7.784894002430293e-03,
+        -3.223964580411365e-01,
+        -2.400758277161838e00,
+        -2.549732539343734e00,
+        4.374664141464968e00,
+        2.938163982698783e00,
+    ]
+    d = [
+        7.784695709041462e-03,
+        3.224671290700398e-01,
+        2.445134137142996e00,
+        3.754408661907416e00,
+    ]
+    p_low = 0.02425
+    p_high = 1.0 - p_low
+    if p < p_low:
+        q = math.sqrt(-2.0 * math.log(p))
+        return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+        )
+    if p <= p_high:
+        q = p - 0.5
+        r = q * q
+        return (
+            (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5])
+            * q
+            / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1.0)
+        )
+    q = math.sqrt(-2.0 * math.log(1.0 - p))
+    return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+        (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+    )
+
+
+def normal_ci(
+    mean: float, stderr: float, confidence: float = 0.95
+) -> tuple[float, float]:
+    """Two-sided normal-approximation confidence interval ``mean +/- z * stderr``.
+
+    This is the interval implied by the standard errors `lm_eval` already
+    reports. It is a Wald interval and can misbehave for accuracies very close to
+    0 or 1; for those cases prefer :func:`paired_bootstrap_test`, which makes no
+    normality assumption.
+    """
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be in the open interval (0, 1)")
+    z = _inv_norm_cdf(0.5 + confidence / 2.0)
+    half = z * stderr
+    return mean - half, mean + half
+
+
+@dataclass(frozen=True)
+class McNemarResult:
+    """Outcome of McNemar's test for a pair of binary (0/1) score vectors.
+
+    ``n_a_only`` counts documents that A got right and B got wrong; ``n_b_only``
+    the reverse. Concordant documents (both right or both wrong) carry no
+    information about the difference and are ignored by the test.
+    """
+
+    n_a_only: int
+    n_b_only: int
+    statistic: float | None
+    p_value: float
+    method: str
+
+    @property
+    def n_discordant(self) -> int:
+        return self.n_a_only + self.n_b_only
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Outcome of a paired bootstrap on the per-document score difference."""
+
+    diff: float
+    ci_low: float
+    ci_high: float
+    p_value: float
+    confidence: float
+    iters: int
+
+
+@dataclass(frozen=True)
+class PairedComparison:
+    """Unified result of comparing two aligned score vectors.
+
+    Always carries the two means, their difference (``a - b``), and a paired
+    bootstrap confidence interval on that difference. ``p_value`` comes from the
+    test named in ``method`` -- McNemar's test for binary metrics, the paired
+    bootstrap otherwise.
+    """
+
+    n: int
+    mean_a: float
+    mean_b: float
+    diff: float
+    ci_low: float
+    ci_high: float
+    p_value: float
+    confidence: float
+    method: str
+    mcnemar: McNemarResult | None = None
+    bootstrap: BootstrapResult | None = None
+
+    @property
+    def significant(self) -> bool:
+        """Whether the difference is significant at ``1 - confidence``."""
+        return self.p_value < (1.0 - self.confidence)
+
+
+def _binom_two_sided_p(b: int, c: int) -> float:
+    """Exact two-sided McNemar p-value: under H0 the ``b`` discordant successes
+    are ``Binomial(b + c, 0.5)``. Summed in closed form with ``math.comb``.
+    """
+    n = b + c
+    if n == 0:
+        return 1.0
+    k = min(b, c)
+    tail = sum(math.comb(n, i) for i in range(k + 1)) * (0.5**n)
+    return min(1.0, 2.0 * tail)
+
+
+def mcnemar_test(
+    n_a_only: int,
+    n_b_only: int,
+    *,
+    exact: bool | None = None,
+    continuity_correction: bool = True,
+) -> McNemarResult:
+    """McNemar's test for two paired binary classifiers.
+
+    Args:
+        n_a_only: documents A got right and B got wrong (discordant ``b``).
+        n_b_only: documents A got wrong and B got right (discordant ``c``).
+        exact: use the exact binomial test. Defaults to ``True`` when there are
+            at most 25 discordant pairs (where the chi-square approximation is
+            unreliable) and ``False`` otherwise.
+        continuity_correction: apply Edwards' continuity correction to the
+            chi-square statistic. Ignored by the exact test.
+    """
+    b, c = int(n_a_only), int(n_b_only)
+    if b < 0 or c < 0:
+        raise ValueError("discordant counts must be non-negative")
+    n = b + c
+    if n == 0:
+        return McNemarResult(b, c, 0.0, 1.0, "mcnemar_exact")
+
+    if exact is None:
+        exact = n <= 25
+
+    if exact:
+        return McNemarResult(b, c, None, _binom_two_sided_p(b, c), "mcnemar_exact")
+
+    delta = abs(b - c)
+    if continuity_correction:
+        delta = max(0.0, delta - 1.0)
+    statistic = (delta * delta) / n
+    # Survival function of a chi-square with 1 dof: P(X > x) = erfc(sqrt(x / 2)).
+    p_value = math.erfc(math.sqrt(statistic / 2.0))
+    method = "mcnemar_chi2_cc" if continuity_correction else "mcnemar_chi2"
+    return McNemarResult(b, c, statistic, p_value, method)
+
+
+def _resampled_diff_means(diffs: np.ndarray, iters: int, seed: int) -> np.ndarray:
+    """Bootstrap distribution of the mean paired difference.
+
+    Resamples document *indices* with replacement (so A and B always share the
+    same resampled documents -- this is what makes the bootstrap paired and what
+    preserves the cross-model correlation). Chunked to bound peak memory at a few
+    million floats regardless of ``n`` or ``iters``.
+    """
+    rng = np.random.default_rng(seed)
+    n = diffs.shape[0]
+    out = np.empty(iters, dtype=np.float64)
+    chunk = max(1, min(iters, 2_000_000 // max(1, n)))
+    done = 0
+    while done < iters:
+        size = min(chunk, iters - done)
+        idx = rng.integers(0, n, size=(size, n))
+        out[done : done + size] = diffs[idx].mean(axis=1)
+        done += size
+    return out
+
+
+def paired_bootstrap_test(
+    scores_a: Sequence[float],
+    scores_b: Sequence[float],
+    *,
+    iters: int = 10_000,
+    confidence: float = 0.95,
+    seed: int = 1234,
+) -> BootstrapResult:
+    """Paired bootstrap test on the difference of two aligned score vectors.
+
+    Works for any per-document metric (binary or continuous). The percentile
+    confidence interval is computed on the resampled mean difference; the
+    two-sided p-value is the bootstrap achieved significance level for
+    ``H0: mean(a - b) == 0``, using the ``(1 + count) / (1 + iters)`` estimator
+    (Davison & Hinkley) so it is never exactly zero.
+    """
+    a = np.asarray(scores_a, dtype=np.float64)
+    b = np.asarray(scores_b, dtype=np.float64)
+    if a.shape != b.shape or a.ndim != 1:
+        raise ValueError("scores_a and scores_b must be 1-D and the same length")
+    if a.size == 0:
+        raise ValueError("cannot test empty score vectors")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be in the open interval (0, 1)")
+
+    diffs = a - b
+    observed = float(diffs.mean())
+    boot = _resampled_diff_means(diffs, iters, seed)
+
+    alpha = 1.0 - confidence
+    ci_low, ci_high = np.quantile(boot, [alpha / 2.0, 1.0 - alpha / 2.0])
+
+    # Center the bootstrap distribution at the null and measure how often a
+    # resample is at least as extreme as what we observed.
+    centered = boot - observed
+    at_least_as_extreme = int(np.count_nonzero(np.abs(centered) >= abs(observed)))
+    p_value = (1.0 + at_least_as_extreme) / (1.0 + iters)
+
+    return BootstrapResult(
+        diff=observed,
+        ci_low=float(ci_low),
+        ci_high=float(ci_high),
+        p_value=min(1.0, p_value),
+        confidence=confidence,
+        iters=iters,
+    )
+
+
+def _is_binary(x: np.ndarray) -> bool:
+    return bool(np.all((x == 0.0) | (x == 1.0)))
+
+
+def compare_paired(
+    scores_a: Sequence[float],
+    scores_b: Sequence[float],
+    *,
+    method: Literal["auto", "mcnemar", "bootstrap"] = "auto",
+    iters: int = 10_000,
+    confidence: float = 0.95,
+    seed: int = 1234,
+) -> PairedComparison:
+    """Compare two aligned per-document score vectors with a paired test.
+
+    The two sequences must be aligned document-for-document (e.g. ordered by the
+    same ``doc_id``). With ``method="auto"`` (the default) McNemar's test is used
+    when both vectors are binary and the paired bootstrap otherwise. A paired
+    bootstrap confidence interval on the mean difference is always reported, even
+    when the p-value comes from McNemar's test.
+    """
+    a = np.asarray(scores_a, dtype=np.float64)
+    b = np.asarray(scores_b, dtype=np.float64)
+    if a.shape != b.shape or a.ndim != 1:
+        raise ValueError("scores_a and scores_b must be 1-D and the same length")
+    if a.size == 0:
+        raise ValueError("cannot compare empty score vectors")
+
+    boot = paired_bootstrap_test(a, b, iters=iters, confidence=confidence, seed=seed)
+
+    use_mcnemar = method == "mcnemar" or (
+        method == "auto" and _is_binary(a) and _is_binary(b)
+    )
+    if method == "mcnemar" and not (_is_binary(a) and _is_binary(b)):
+        raise ValueError("McNemar's test requires binary (0/1) scores")
+
+    mcnemar = None
+    if use_mcnemar:
+        n_a_only = int(np.count_nonzero((a == 1.0) & (b == 0.0)))
+        n_b_only = int(np.count_nonzero((a == 0.0) & (b == 1.0)))
+        mcnemar = mcnemar_test(n_a_only, n_b_only)
+        p_value = mcnemar.p_value
+        chosen = mcnemar.method
+    else:
+        p_value = boot.p_value
+        chosen = "paired_bootstrap"
+
+    return PairedComparison(
+        n=int(a.size),
+        mean_a=float(a.mean()),
+        mean_b=float(b.mean()),
+        diff=boot.diff,
+        ci_low=boot.ci_low,
+        ci_high=boot.ci_high,
+        p_value=p_value,
+        confidence=confidence,
+        method=chosen,
+        mcnemar=mcnemar,
+        bootstrap=boot,
+    )

--- a/scripts/compare_samples.py
+++ b/scripts/compare_samples.py
@@ -1,0 +1,142 @@
+r"""Compare two `lm_eval` runs with a paired significance test.
+
+Unlike ``scripts/model_comparator.py`` -- which re-runs both models and applies
+an *unpaired* z-test to the two accuracies -- this script works entirely from the
+``samples_*.jsonl`` files that `lm_eval` writes with ``--log_samples``. Because
+both runs scored the *same* documents, the per-document outcomes are paired, and
+this script uses the correct paired test (McNemar for binary metrics, a paired
+bootstrap otherwise) via :mod:`lm_eval.api.significance`. No model is loaded, so
+it runs on CPU in well under a second.
+
+Example::
+
+    lm_eval --model hf --model_args pretrained=A --tasks arc_easy \\
+        --log_samples --output_path runs/A
+    lm_eval --model hf --model_args pretrained=B --tasks arc_easy \\
+        --log_samples --output_path runs/B
+
+    python scripts/compare_samples.py runs/A runs/B --metric acc
+"""
+
+import argparse
+import glob
+import json
+import os
+
+from lm_eval.api.significance import compare_paired
+
+
+def _resolve_samples_file(path: str, task: str | None) -> str:
+    """Return a samples ``.jsonl`` path, expanding a directory if needed."""
+    if os.path.isfile(path):
+        return path
+    pattern = f"samples_{task}_*.jsonl" if task else "samples_*.jsonl"
+    matches = sorted(glob.glob(os.path.join(path, "**", pattern), recursive=True))
+    if not matches:
+        raise FileNotFoundError(
+            f"no file matching {pattern!r} found under {path!r}; pass --task or a direct path"
+        )
+    if len(matches) > 1:
+        raise ValueError(
+            "multiple samples files found; narrow with --task or pass a direct file path:\n  "
+            + "\n  ".join(matches)
+        )
+    return matches[0]
+
+
+def load_scores(
+    path: str, metric: str, filter_name: str, task: str | None = None
+) -> dict[int, float]:
+    """Load ``{doc_id: score}`` for one metric/filter from a samples file."""
+    samples_path = _resolve_samples_file(path, task)
+    scores: dict[int, float] = {}
+    with open(samples_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            if row.get("filter", "none") != filter_name:
+                continue
+            if metric not in row:
+                raise KeyError(
+                    f"metric {metric!r} not found in {samples_path}; "
+                    f"available per-sample metrics: {row.get('metrics')}"
+                )
+            scores[int(row["doc_id"])] = float(row[metric])
+    if not scores:
+        raise ValueError(f"no rows with filter={filter_name!r} found in {samples_path}")
+    return scores
+
+
+def align(
+    scores_a: dict[int, float], scores_b: dict[int, float]
+) -> tuple[list[float], list[float], int]:
+    """Align two ``{doc_id: score}`` maps on their shared documents."""
+    common = sorted(set(scores_a) & set(scores_b))
+    a = [scores_a[i] for i in common]
+    b = [scores_b[i] for i in common]
+    dropped = (len(scores_a) - len(common)) + (len(scores_b) - len(common))
+    return a, b, dropped
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("run_a", help="samples_*.jsonl file or output dir for run A")
+    parser.add_argument("run_b", help="samples_*.jsonl file or output dir for run B")
+    parser.add_argument(
+        "--metric", default="acc", help="per-sample metric (default: acc)"
+    )
+    parser.add_argument("--filter", default="none", help="filter name (default: none)")
+    parser.add_argument(
+        "--task",
+        default=None,
+        help="task name, to disambiguate when passing directories",
+    )
+    parser.add_argument(
+        "--method",
+        default="auto",
+        choices=["auto", "mcnemar", "bootstrap"],
+        help="paired test to use (default: auto)",
+    )
+    parser.add_argument(
+        "--iters", type=int, default=10_000, help="bootstrap iterations"
+    )
+    parser.add_argument("--confidence", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=1234)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    a_scores = load_scores(args.run_a, args.metric, args.filter, args.task)
+    b_scores = load_scores(args.run_b, args.metric, args.filter, args.task)
+    a, b, dropped = align(a_scores, b_scores)
+    if dropped:
+        print(f"warning: {dropped} non-shared document(s) dropped before pairing")
+
+    res = compare_paired(
+        a,
+        b,
+        method=args.method,
+        iters=args.iters,
+        confidence=args.confidence,
+        seed=args.seed,
+    )
+
+    pct = round(res.confidence * 100)
+    print(f"\nPaired comparison on {res.n} shared documents (metric={args.metric!r})")
+    print(f"  run A mean : {res.mean_a:.4f}")
+    print(f"  run B mean : {res.mean_b:.4f}")
+    print(f"  difference : {res.diff:+.4f}  (A - B)")
+    print(
+        f"  {pct}% CI     : [{res.ci_low:+.4f}, {res.ci_high:+.4f}]  (paired bootstrap)"
+    )
+    print(f"  test       : {res.method}")
+    print(f"  p-value    : {res.p_value:.4g}")
+    verdict = "significant" if res.significant else "not significant"
+    print(f"  verdict    : {verdict} at alpha={1 - res.confidence:.2g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_significance.py
+++ b/tests/test_significance.py
@@ -1,0 +1,160 @@
+"""Tests for the paired significance utilities in ``lm_eval.api.significance``.
+
+Expected values for the exact McNemar cases are computed by hand from the
+binomial mass function so the tests do not depend on ``scipy``.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from lm_eval.api.significance import (
+    compare_paired,
+    mcnemar_test,
+    normal_ci,
+    paired_bootstrap_test,
+)
+
+
+def test_normal_ci_matches_known_z():
+    low, high = normal_ci(0.5, 0.1, confidence=0.95)
+    # 95% two-sided z = 1.959964
+    assert low == pytest.approx(0.5 - 1.959964 * 0.1, abs=1e-5)
+    assert high == pytest.approx(0.5 + 1.959964 * 0.1, abs=1e-5)
+    # 99% two-sided z = 2.575829
+    low99, high99 = normal_ci(0.0, 1.0, confidence=0.99)
+    assert high99 == pytest.approx(2.575829, abs=1e-5)
+    assert low99 == pytest.approx(-2.575829, abs=1e-5)
+
+
+def test_normal_ci_rejects_bad_confidence():
+    with pytest.raises(ValueError):
+        normal_ci(0.5, 0.1, confidence=1.5)
+
+
+def test_mcnemar_exact_all_discordant_one_side():
+    # b=10, c=0 -> p = 2 * 0.5**10 = 2 / 1024
+    res = mcnemar_test(10, 0)
+    assert res.method == "mcnemar_exact"
+    assert res.statistic is None
+    assert res.p_value == pytest.approx(2.0 / 1024.0)
+    assert res.n_discordant == 10
+
+
+def test_mcnemar_exact_hand_value():
+    # b=8, c=2, n=10 -> p = 2 * (C(10,0)+C(10,1)+C(10,2)) / 2**10
+    #               = 2 * (1 + 10 + 45) / 1024 = 112 / 1024
+    res = mcnemar_test(8, 2)
+    assert res.p_value == pytest.approx(112.0 / 1024.0)
+
+
+def test_mcnemar_symmetric_is_not_significant():
+    res = mcnemar_test(7, 7)
+    assert res.p_value == pytest.approx(1.0)
+
+
+def test_mcnemar_no_discordant_pairs():
+    res = mcnemar_test(0, 0)
+    assert res.p_value == 1.0
+    assert res.statistic == 0.0
+
+
+def test_mcnemar_chi2_with_continuity_correction():
+    # b=30, c=10, n=40, cc -> chi2 = (|20| - 1)**2 / 40 = 361 / 40 = 9.025
+    res = mcnemar_test(30, 10, exact=False, continuity_correction=True)
+    assert res.method == "mcnemar_chi2_cc"
+    assert res.statistic == pytest.approx(9.025)
+    # P(chi2_1 > 9.025) = erfc(sqrt(9.025 / 2))
+    assert res.p_value == pytest.approx(math.erfc(math.sqrt(9.025 / 2.0)))
+    assert res.p_value < 0.05
+
+
+def test_mcnemar_rejects_negative_counts():
+    with pytest.raises(ValueError):
+        mcnemar_test(-1, 3)
+
+
+def test_paired_bootstrap_is_deterministic():
+    rng = np.random.default_rng(0)
+    a = rng.integers(0, 2, size=200).astype(float)
+    b = rng.integers(0, 2, size=200).astype(float)
+    r1 = paired_bootstrap_test(a, b, iters=2000, seed=42)
+    r2 = paired_bootstrap_test(a, b, iters=2000, seed=42)
+    assert r1 == r2
+    # CI must bracket the observed difference.
+    assert r1.ci_low <= r1.diff <= r1.ci_high
+
+
+def test_paired_bootstrap_detects_clear_difference():
+    # A correct everywhere, B correct on the first half only.
+    a = np.ones(100)
+    b = np.concatenate([np.ones(50), np.zeros(50)])
+    res = paired_bootstrap_test(a, b, iters=5000, seed=7)
+    assert res.diff == pytest.approx(0.5)
+    assert res.ci_low > 0.0  # zero difference excluded
+    assert res.p_value < 0.05
+
+
+def test_paired_bootstrap_rejects_mismatched_lengths():
+    with pytest.raises(ValueError):
+        paired_bootstrap_test([0, 1, 1], [0, 1])
+
+
+def test_compare_paired_auto_selects_mcnemar_for_binary():
+    a = np.concatenate([np.ones(40), np.zeros(60)])
+    b = np.concatenate([np.zeros(40), np.ones(60)])
+    res = compare_paired(a, b)
+    assert res.method.startswith("mcnemar")
+    assert res.mcnemar is not None
+    assert res.bootstrap is not None  # CI always present
+    assert res.n == 100
+
+
+def test_compare_paired_auto_selects_bootstrap_for_continuous():
+    rng = np.random.default_rng(1)
+    a = rng.normal(0.7, 0.1, size=300)
+    b = rng.normal(0.6, 0.1, size=300)
+    res = compare_paired(a, b, iters=3000)
+    assert res.method == "paired_bootstrap"
+    assert res.mcnemar is None
+    assert res.diff == pytest.approx(float((a - b).mean()))
+
+
+def test_compare_paired_rejects_mcnemar_on_continuous():
+    with pytest.raises(ValueError):
+        compare_paired([0.3, 0.7], [0.2, 0.9], method="mcnemar")
+
+
+def test_paired_test_more_powerful_than_unpaired_on_correlated_data():
+    """The motivating result: when two models agree on most documents and differ
+    on a consistent handful, the paired test detects the difference while the
+    unpaired z-test that ``model_comparator.py`` uses does not.
+    """
+    n = 1000
+    # 150 documents both get right, 800 both get wrong: pure concordant pairs
+    # that pin down the shared difficulty (positive correlation).
+    both_right = [(1.0, 1.0)] * 150
+    both_wrong = [(0.0, 0.0)] * 800
+    # 35 discordant in A's favour, 15 in B's favour: a real, consistent edge.
+    a_only = [(1.0, 0.0)] * 35
+    b_only = [(0.0, 1.0)] * 15
+    pairs = both_right + both_wrong + a_only + b_only
+    assert len(pairs) == n
+    a = np.array([p[0] for p in pairs])
+    b = np.array([p[1] for p in pairs])
+
+    paired = compare_paired(a, b, method="mcnemar")
+
+    # Unpaired two-sample z-test exactly as scripts/model_comparator.py computes
+    # it (treating the two accuracies as independent).
+    def _stderr(x):
+        return float(np.std(x, ddof=1) / math.sqrt(len(x)))
+
+    se_a, se_b = _stderr(a), _stderr(b)
+    z = (a.mean() - b.mean()) / math.sqrt(se_a**2 + se_b**2)
+    unpaired_p = math.erfc(abs(z) / math.sqrt(2.0))  # 2 * (1 - Phi(|z|))
+
+    assert paired.p_value < 0.05  # paired test: significant
+    assert unpaired_p > 0.05  # unpaired test: misses it
+    assert paired.p_value < unpaired_p


### PR DESCRIPTION
Implements the paired significance test discussed in #3831.

Adds a dependency-free `lm_eval/api/significance.py` (McNemar — exact binomial / continuity-corrected χ²; paired bootstrap; `compare_paired()` + `normal_ci()`) and a CPU-only `scripts/compare_samples.py` that runs the paired test directly on the `samples_*.jsonl` produced with `--log_samples` (no model reload). Tests include hand-verified McNemar values and a case where the paired test detects a difference the unpaired z-test misses.

Per the discussion in #3831, this is kept as a separate module + CLI from `scripts/model_comparator.py`, since it consumes per-doc outcomes rather than the aggregate stderrs that script uses — keeping each entry point honest about what input it needs. README docs added under "Comparing Two Runs".

Follow-up (separate PR): switch `model_comparator.py`'s `calculate_z_value` to the paired test, with a labeled fallback for when sample-level outputs aren't present.

Closes #3831.