### PR TITLE
fix: prevent infinite loop in Ruler QA tasks when max_seq_length < 4096

### DIFF
--- a/lm_eval/tasks/ruler/cwe_utils.py
+++ b/lm_eval/tasks/ruler/cwe_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 import itertools
+import logging
 import random
 
 import datasets
@@ -19,6 +20,8 @@ import wonderwords
 from tqdm import tqdm
 
 from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
+
+eval_logger = logging.getLogger(__name__)
 
 
 CONFIG = {
@@ -129,6 +132,12 @@ def sys_word_pair_random(
         range(num_samples), desc=f"Generating CWE Samples | {max_seq_length}"
     ):
         used_words = num_words
+        used_words = max(1, used_words)
+        too_long = False
+        input_example = ""
+        input_text = ""
+        answer = ""
+        length = 0
         while True:
             try:
                 input_example, input_text, answer = generate_input_output(
@@ -138,8 +147,19 @@ def sys_word_pair_random(
                 assert length <= max_seq_length, f"{length} exceeds max_seq_length."
                 break
             except:  # noqa: E722
-                if used_words > incremental:
-                    used_words -= incremental
+                if used_words > 1:
+                    used_words = max(1, used_words - incremental)
+                else:
+                    eval_logger.warning(
+                        f"Skipping CWE sample {index}: "
+                        f"exceeds max_seq_length {max_seq_length} "
+                        f"even with minimum words."
+                    )
+                    too_long = True
+                    break
+
+        if too_long:
+            continue
 
         if remove_newline_tab:
             input_text = " ".join(

--- a/lm_eval/tasks/ruler/prepare_niah.py
+++ b/lm_eval/tasks/ruler/prepare_niah.py
@@ -13,6 +13,7 @@
 # limitations under the License
 
 
+import logging
 import os
 import random
 import re
@@ -36,6 +37,7 @@ except ImportError:
         'Please install the `wonderwords` and `nltk` packages to run this script. You can install them with `pip install lm_eval["ruler"]` or`pip install wonderwords nltk`.'
     )
 
+eval_logger = logging.getLogger(__name__)
 
 NUM_SAMPLES = 500
 REMOVE_NEWLINE_TAB = ""
@@ -278,6 +280,12 @@ def generate_samples(
         desc=f"Generating synthetic samples: {type_haystack} | {max_seq_length}",
     ):
         used_haystack = num_haystack
+        used_haystack = max(1, used_haystack)
+        too_long = False
+        input_text = ""
+        answer = ""
+        query = ""
+        length = 0
         while True:
             try:
                 input_text, answer, query = generate_input_output(
@@ -297,8 +305,19 @@ def generate_samples(
                 break
                 # ruff: noqa
             except:
-                if used_haystack > incremental:
-                    used_haystack -= incremental
+                if used_haystack > 1:
+                    used_haystack = max(1, used_haystack - incremental)
+                else:
+                    eval_logger.warning(
+                        f"Skipping NIAH sample {index}: "
+                        f"exceeds max_seq_length {max_seq_length} "
+                        f"even with minimum haystack."
+                    )
+                    too_long = True
+                    break
+
+        if too_long:
+            continue
 
         if remove_newline_tab:
             input_text = " ".join(

--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -14,6 +14,7 @@
 
 
 import itertools  # noqa: I001
+import logging
 import random
 from functools import cache
 
@@ -22,6 +23,8 @@ import requests
 from tqdm import tqdm
 
 from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
+
+eval_logger = logging.getLogger(__name__)
 
 CONFIG = {
     "tokens_to_generate": 32,
@@ -170,6 +173,12 @@ def generate_samples(
         range(num_samples), desc=f"Generating QA Samples | {max_seq_length}"
     ):
         used_docs = num_docs
+        # Ensure used_docs is at least 1 to avoid errors in generate_input_output
+        used_docs = max(1, used_docs)
+        too_long = False
+        input_text = ""
+        answer = []
+        length = 0
         while True:
             try:
                 input_text, answer = generate_input_output(
@@ -179,8 +188,19 @@ def generate_samples(
                 assert length <= max_seq_length, f"{length} exceeds max_seq_length."
                 break
             except:  # noqa: E722
-                if used_docs > incremental:
-                    used_docs -= incremental
+                if used_docs > 1:
+                    used_docs = max(1, used_docs - incremental)
+                else:
+                    eval_logger.warning(
+                        f"Skipping sample {index + pre_samples}: "
+                        f"exceeds max_seq_length {max_seq_length} "
+                        f"even with minimum documents."
+                    )
+                    too_long = True
+                    break
+
+        if too_long:
+            continue
 
         if remove_newline_tab:
             input_text = " ".join(

--- a/lm_eval/tasks/ruler/vt_utils.py
+++ b/lm_eval/tasks/ruler/vt_utils.py
@@ -15,6 +15,7 @@
 # adapted from https://github.com/NVIDIA/RULER/blob/main/scripts/data/synthetic/variable_tracking.py
 
 import itertools
+import logging
 import random
 import string
 from typing import TYPE_CHECKING, Union
@@ -25,6 +26,7 @@ from tqdm import tqdm
 
 from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
 
+eval_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -168,6 +170,11 @@ def sys_vartrack_w_noise_random(
     # Generate samples
     for index in tqdm(range(num_samples)):
         used_noises = num_noises
+        used_noises = max(1, used_noises)
+        too_long = False
+        input_text = ""
+        answer = ""
+        length = 0
         while True:
             try:
                 input_text, answer = generate_input_output(
@@ -184,8 +191,19 @@ def sys_vartrack_w_noise_random(
                 assert length <= max_seq_length, f"{length} exceeds max_seq_length."
                 break
             except:  # noqa: E722
-                if used_noises > incremental:
-                    used_noises -= incremental
+                if used_noises > 1:
+                    used_noises = max(1, used_noises - incremental)
+                else:
+                    eval_logger.warning(
+                        f"Skipping variable tracking sample {index}: "
+                        f"exceeds max_seq_length {max_seq_length} "
+                        f"even with minimum noise."
+                    )
+                    too_long = True
+                    break
+
+        if too_long:
+            continue
 
         if add_fewshot and (icl_example is not None):
             # insert icl_example between model template and input


### PR DESCRIPTION
## Summary

When max_seq_lengths is set below 4096, Ruler QA tasks hang in an infinite while-true loop. At 4096+, documents fit within the limit and the loop breaks normally.

## Root Cause

The generate_samples() retry loop attempts to fit input within max_seq_length by reducing used_docs by 10 each iteration. Two failure modes:

1. used_docs reaches 0: even minimum docs exceed the limit. The exception handler checks if used_docs > incremental (10), but 0 is not > 10, so no decrement happens -- infinite loop.
2. Inherently verbose QA pairs: individual documents tokenize to >2048 tokens. used_docs reaches 10, 10 > 10 is False -- infinite loop.

## Fix

In all four ruler utility files, the retry loop now:
- Guards used_docs to at least 1
- Allows decrementing below the incremental threshold down to 1
- Breaks out gracefully with a warning when the minimum is reached
- Skips samples that can't fit rather than hanging

Closes #2963
