### PR TITLE
feat: add clinical hallucination detection task (MedQA-USMLE)

### DIFF
--- a/lm_eval/tasks/clinical_hallucination/medqa_hallucination.yaml
+++ b/lm_eval/tasks/clinical_hallucination/medqa_hallucination.yaml
@@ -1,0 +1,33 @@
+task: medqa_hallucination
+dataset_path: GBaker/MedQA-USMLE-4-options-hf
+output_type: generate_until
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: !function preprocess_clinical.doc_to_text
+doc_to_target: !function preprocess_clinical.doc_to_target
+metric_list:
+  - metric: !function metrics.hallucination_rate
+    aggregation: mean
+    higher_is_better: false
+  - metric: !function metrics.hallucination_rate_per_sample
+    aggregation: mean
+    higher_is_better: false
+generation_kwargs:
+  until:
+    - "Question:"
+    - "</s>"
+    - "<eos>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 256
+repeats: 1
+metadata:
+  version: 1.0
+  description: >
+    Clinical hallucination detection task based on MedQA-USMLE.
+    Measures the rate at which LLM-generated clinical explanations
+    contain fabricated medical terms not supported by the reference
+    answer. A response is flagged as hallucinated when more than 60
+    percent of its extracted medical terms are absent from the
+    reference text.

--- a/lm_eval/tasks/clinical_hallucination/medqa_hallucination.yaml
+++ b/lm_eval/tasks/clinical_hallucination/medqa_hallucination.yaml
@@ -4,6 +4,7 @@ output_type: generate_until
 training_split: train
 validation_split: validation
 test_split: test
+num_fewshot: 0
 doc_to_text: !function preprocess_clinical.doc_to_text
 doc_to_target: !function preprocess_clinical.doc_to_target
 metric_list:
@@ -21,7 +22,6 @@ generation_kwargs:
   do_sample: false
   temperature: 0.0
   max_gen_toks: 256
-repeats: 1
 metadata:
   version: 1.0
   description: >

--- a/lm_eval/tasks/clinical_hallucination/metrics.py
+++ b/lm_eval/tasks/clinical_hallucination/metrics.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""Clinical hallucination detection metrics for lm-evaluation-harness.
+
+Measures the hallucination rate in LLM responses to clinical QA questions by
+extracting medical terms from model predictions and checking what fraction
+are unsupported by the reference answer.
+
+A response is flagged as hallucinated when >60% of its extracted medical terms
+are NOT present in the reference text.
+
+Based on methodology from clinical-llm-eval hallucination detection.
+"""
+
+import re
+from typing import List, Set
+
+
+# ---------------------------------------------------------------------------
+# Medical term extraction
+# ---------------------------------------------------------------------------
+
+# Regex patterns for extracting clinical/medical terms
+_MEDICAL_PATTERNS = [
+    # Medication dosages and units (e.g. "500 mg", "0.5 mcg", "100 mmHg")
+    re.compile(
+        r"\b\d+(?:\.\d+)?\s*(?:mg|mcg|μg|µg|ml|ML|L|mmol|mmHg|bpm|"
+        r"mEq|IU|units?|mg/kg|mg/dL|mmol/L|mL/min|g/dL)\b",
+        re.IGNORECASE,
+    ),
+    # Standalone medical units
+    re.compile(
+        r"\b(?:mg|mcg|μg|µg|ml|L|mmol|mmHg|bpm|mEq|IU)\b",
+        re.IGNORECASE,
+    ),
+    # Drug name patterns – common pharmacological suffixes
+    re.compile(
+        r"\b[A-Z][a-z]+(?:ine|ol|an|ide|ate|ase|ium|ine|epam|statin|cillin|mycin|cycline|nib|mab)\b"
+    ),
+    # Disease staging / classification
+    re.compile(
+        r"\b(?:type\s*[0-9IV]+|stage\s*[IV0-9]+|grade\s*[0-9IV]+|"
+        r"class\s*[IV0-9]+|phase\s*[IV0-9]+)\b",
+        re.IGNORECASE,
+    ),
+    # Proper nouns (capitalized multi-word terms – often disease/syndrome names)
+    re.compile(r"\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+\b"),
+    # Common medical abbreviations (e.g. COPD, MI, CHF, DKA)
+    re.compile(r"\b[A-Z]{2,6}\b"),
+    # Lab value patterns (e.g. "WBC 11.2", "HbA1c 7.5%")
+    re.compile(
+        r"\b(?:WBC|RBC|Hgb|Hct|PLT|BUN|Cr|AST|ALT|ALP|GGT|LDH|CK|"
+        r"Troponin|BNP|D-dimer|INR|PT|PTT|aPTT|HbA1c|FBS|CBC|CMP|"
+        r"BMP|TSH|T3|T4|PSA|CEA|CA-?\d+)\b",
+        re.IGNORECASE,
+    ),
+]
+
+# Static set of medical keywords that are always considered "medical terms"
+MEDICAL_KEYWORDS: Set[str] = {
+    "diagnosis", "treatment", "prognosis", "medication", "surgery",
+    "therapy", "infection", "inflammation", "chronic", "acute",
+    "benign", "malignant", "biopsy", "metastasis", "carcinoma",
+    "sarcoma", "lymphoma", "leukemia", "pathogen", "antibody",
+    "antigen", "cytokine", "receptor", "enzyme", "inhibitor",
+    "agonist", "antagonist", "contraindication", "indication",
+    "adverse", "efficacy", "potency", "bioavailability",
+    "pharmacokinetics", "pharmacodynamics", "dosage", "regimen",
+    "prophylaxis", "comorbidity", "etiology", "pathogenesis",
+    "histology", "cytology", "necrosis", "apoptosis", "thrombosis",
+    "embolism", "ischemia", "infarction", "stenosis", "aneurysm",
+    "hypertension", "hypotension", "tachycardia", "bradycardia",
+    "arrhythmia", "edema", "fibrosis", "cirrhosis", "hepatitis",
+    "nephritis", "pancreatitis", "meningitis", "encephalitis",
+    "pneumonia", "bronchitis", "sepsis", "abscess", "ulcer",
+    "hemorrhage", "anemia", "thrombocytopenia", "neutropenia",
+}
+
+
+def _extract_medical_terms(text: str) -> Set[str]:
+    """Extract a set of medical terms from *text*.
+
+    Combines regex-pattern matches with keyword detection to build
+    a comprehensive term set.  All tokens are lower-cased for
+    case-insensitive comparison.
+    """
+    terms: Set[str] = set()
+
+    # Regex-based extraction
+    for pattern in _MEDICAL_PATTERNS:
+        for match in pattern.finditer(text):
+            terms.add(match.group().lower().strip())
+
+    # Keyword extraction – check every whitespace-delimited token
+    for token in text.lower().split():
+        # Strip trailing punctuation for matching
+        cleaned = re.sub(r"[^\w\s]", "", token)
+        if cleaned in MEDICAL_KEYWORDS:
+            terms.add(cleaned)
+
+    return terms
+
+
+# Threshold: a response is flagged as hallucinated when more than this
+# fraction of its extracted terms are absent from the reference.
+HALLUCINATION_THRESHOLD = 0.6
+
+
+def _is_hallucinated(reference: str, prediction: str) -> float:
+    """Return 1.0 if *prediction* is hallucinated, else 0.0.
+
+    A prediction is considered hallucinated when >60 % of its extracted
+    medical terms do not appear in the reference text.
+    """
+    pred_terms = _extract_medical_terms(prediction)
+    if not pred_terms:
+        # No medical terms extracted – cannot assess hallucination
+        return 0.0
+
+    ref_terms = _extract_medical_terms(reference)
+    # Also do a simple substring check against the lower-cased reference
+    # to catch terms that were split or embedded differently.
+    ref_lower = reference.lower()
+
+    unsupported = 0
+    for term in pred_terms:
+        # A term is "supported" if it appears either in the ref term set
+        # OR as a substring of the reference text.
+        if term not in ref_terms and term not in ref_lower:
+            unsupported += 1
+
+    unsupported_ratio = unsupported / len(pred_terms)
+    return 1.0 if unsupported_ratio > HALLUCINATION_THRESHOLD else 0.0
+
+
+def _unsupported_term_ratio(reference: str, prediction: str) -> float:
+    """Return the fraction of prediction terms not found in reference."""
+    pred_terms = _extract_medical_terms(prediction)
+    if not pred_terms:
+        return 0.0
+
+    ref_terms = _extract_medical_terms(reference)
+    ref_lower = reference.lower()
+
+    unsupported = sum(
+        1 for term in pred_terms
+        if term not in ref_terms and term not in ref_lower
+    )
+    return unsupported / len(pred_terms)
+
+
+# ---------------------------------------------------------------------------
+# Metric functions (called by lm-evaluation-harness via !function in YAML)
+# ---------------------------------------------------------------------------
+
+def hallucination_rate(predictions: List[str], references: List[str]) -> float:
+    """Compute per-sample hallucination flag (0.0 or 1.0).
+
+    Called once per (prediction, reference) pair by the harness.
+    The YAML ``aggregation: mean`` then averages these to produce
+    the overall hallucination rate across the dataset.
+
+    Parameters
+    ----------
+    predictions : list[str]
+        Model-generated text (first element used).
+    references : list[str]
+        Reference / ground-truth text (first element used).
+
+    Returns
+    -------
+    float
+        1.0 if the prediction is hallucinated, 0.0 otherwise.
+    """
+    return _is_hallucinated(references[0], predictions[0])
+
+
+def hallucination_rate_per_sample(
+    predictions: List[str], references: List[str]
+) -> float:
+    """Return the raw unsupported-term ratio for a single sample.
+
+    This gives a continuous score [0.0, 1.0] representing the fraction
+    of medical terms in the prediction that are absent from the reference,
+    enabling finer-grained per-sample analysis.
+
+    Parameters
+    ----------
+    predictions : list[str]
+        Model-generated text (first element used).
+    references : list[str]
+        Reference / ground-truth text (first element used).
+
+    Returns
+    -------
+    float
+        Ratio of unsupported medical terms (0.0 = fully grounded,
+        1.0 = all terms unsupported).
+    """
+    return _unsupported_term_ratio(references[0], predictions[0])

--- a/lm_eval/tasks/clinical_hallucination/metrics.py
+++ b/lm_eval/tasks/clinical_hallucination/metrics.py
@@ -34,7 +34,8 @@ _MEDICAL_PATTERNS = [
     ),
     # Drug name patterns – common pharmacological suffixes
     re.compile(
-        r"\b[A-Z][a-z]+(?:ine|ol|an|ide|ate|ase|ium|ine|epam|statin|cillin|mycin|cycline|nib|mab)\b"
+        r"\b[A-Za-z]+(?:ine|ol|an|ide|ate|ase|ium|epam|statin|cillin|mycin|cycline|nib|mab)\b",
+        re.IGNORECASE,
     ),
     # Disease staging / classification
     re.compile(
@@ -76,6 +77,10 @@ MEDICAL_KEYWORDS: Set[str] = {
 }
 
 
+# Pre-compiled regex for stripping trailing punctuation
+_PUNCT_RE = re.compile(r"[^\w\s]")
+
+
 def _extract_medical_terms(text: str) -> Set[str]:
     """Extract a set of medical terms from *text*.
 
@@ -93,7 +98,7 @@ def _extract_medical_terms(text: str) -> Set[str]:
     # Keyword extraction – check every whitespace-delimited token
     for token in text.lower().split():
         # Strip trailing punctuation for matching
-        cleaned = re.sub(r"[^\w\s]", "", token)
+        cleaned = _PUNCT_RE.sub("", token)
         if cleaned in MEDICAL_KEYWORDS:
             terms.add(cleaned)
 
@@ -111,25 +116,7 @@ def _is_hallucinated(reference: str, prediction: str) -> float:
     A prediction is considered hallucinated when >60 % of its extracted
     medical terms do not appear in the reference text.
     """
-    pred_terms = _extract_medical_terms(prediction)
-    if not pred_terms:
-        # No medical terms extracted – cannot assess hallucination
-        return 0.0
-
-    ref_terms = _extract_medical_terms(reference)
-    # Also do a simple substring check against the lower-cased reference
-    # to catch terms that were split or embedded differently.
-    ref_lower = reference.lower()
-
-    unsupported = 0
-    for term in pred_terms:
-        # A term is "supported" if it appears either in the ref term set
-        # OR as a substring of the reference text.
-        if term not in ref_terms and term not in ref_lower:
-            unsupported += 1
-
-    unsupported_ratio = unsupported / len(pred_terms)
-    return 1.0 if unsupported_ratio > HALLUCINATION_THRESHOLD else 0.0
+    return 1.0 if _unsupported_term_ratio(reference, prediction) > HALLUCINATION_THRESHOLD else 0.0
 
 
 def _unsupported_term_ratio(reference: str, prediction: str) -> float:
@@ -171,7 +158,10 @@ def hallucination_rate(predictions: List[str], references: List[str]) -> float:
     float
         1.0 if the prediction is hallucinated, 0.0 otherwise.
     """
-    return _is_hallucinated(references[0], predictions[0])
+    # Guard against None output (e.g. API timeout, model failure)
+    pred = predictions[0] or ""
+    ref = references[0] or ""
+    return _is_hallucinated(ref, pred)
 
 
 def hallucination_rate_per_sample(
@@ -196,4 +186,6 @@ def hallucination_rate_per_sample(
         Ratio of unsupported medical terms (0.0 = fully grounded,
         1.0 = all terms unsupported).
     """
-    return _unsupported_term_ratio(references[0], predictions[0])
+    pred = predictions[0] or ""
+    ref = references[0] or ""
+    return _unsupported_term_ratio(ref, pred)

--- a/lm_eval/tasks/clinical_hallucination/metrics.py
+++ b/lm_eval/tasks/clinical_hallucination/metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Clinical hallucination detection metrics for lm-evaluation-harness.
 
 Measures the hallucination rate in LLM responses to clinical QA questions by
@@ -12,7 +11,6 @@ Based on methodology from clinical-llm-eval hallucination detection.
 """
 
 import re
-from typing import List, Set
 
 
 # ---------------------------------------------------------------------------
@@ -57,23 +55,80 @@ _MEDICAL_PATTERNS = [
 ]
 
 # Static set of medical keywords that are always considered "medical terms"
-MEDICAL_KEYWORDS: Set[str] = {
-    "diagnosis", "treatment", "prognosis", "medication", "surgery",
-    "therapy", "infection", "inflammation", "chronic", "acute",
-    "benign", "malignant", "biopsy", "metastasis", "carcinoma",
-    "sarcoma", "lymphoma", "leukemia", "pathogen", "antibody",
-    "antigen", "cytokine", "receptor", "enzyme", "inhibitor",
-    "agonist", "antagonist", "contraindication", "indication",
-    "adverse", "efficacy", "potency", "bioavailability",
-    "pharmacokinetics", "pharmacodynamics", "dosage", "regimen",
-    "prophylaxis", "comorbidity", "etiology", "pathogenesis",
-    "histology", "cytology", "necrosis", "apoptosis", "thrombosis",
-    "embolism", "ischemia", "infarction", "stenosis", "aneurysm",
-    "hypertension", "hypotension", "tachycardia", "bradycardia",
-    "arrhythmia", "edema", "fibrosis", "cirrhosis", "hepatitis",
-    "nephritis", "pancreatitis", "meningitis", "encephalitis",
-    "pneumonia", "bronchitis", "sepsis", "abscess", "ulcer",
-    "hemorrhage", "anemia", "thrombocytopenia", "neutropenia",
+MEDICAL_KEYWORDS: set[str] = {
+    "diagnosis",
+    "treatment",
+    "prognosis",
+    "medication",
+    "surgery",
+    "therapy",
+    "infection",
+    "inflammation",
+    "chronic",
+    "acute",
+    "benign",
+    "malignant",
+    "biopsy",
+    "metastasis",
+    "carcinoma",
+    "sarcoma",
+    "lymphoma",
+    "leukemia",
+    "pathogen",
+    "antibody",
+    "antigen",
+    "cytokine",
+    "receptor",
+    "enzyme",
+    "inhibitor",
+    "agonist",
+    "antagonist",
+    "contraindication",
+    "indication",
+    "adverse",
+    "efficacy",
+    "potency",
+    "bioavailability",
+    "pharmacokinetics",
+    "pharmacodynamics",
+    "dosage",
+    "regimen",
+    "prophylaxis",
+    "comorbidity",
+    "etiology",
+    "pathogenesis",
+    "histology",
+    "cytology",
+    "necrosis",
+    "apoptosis",
+    "thrombosis",
+    "embolism",
+    "ischemia",
+    "infarction",
+    "stenosis",
+    "aneurysm",
+    "hypertension",
+    "hypotension",
+    "tachycardia",
+    "bradycardia",
+    "arrhythmia",
+    "edema",
+    "fibrosis",
+    "cirrhosis",
+    "hepatitis",
+    "nephritis",
+    "pancreatitis",
+    "meningitis",
+    "encephalitis",
+    "pneumonia",
+    "bronchitis",
+    "sepsis",
+    "abscess",
+    "ulcer",
+    "hemorrhage",
+    "anemia",
+    "thrombocytopenia",
+    "neutropenia",
 }
 
 
@@ -81,14 +136,14 @@ MEDICAL_KEYWORDS: Set[str] = {
 _PUNCT_RE = re.compile(r"[^\w\s]")
 
 
-def _extract_medical_terms(text: str) -> Set[str]:
+def _extract_medical_terms(text: str) -> set[str]:
     """Extract a set of medical terms from *text*.
 
     Combines regex-pattern matches with keyword detection to build
     a comprehensive term set.  All tokens are lower-cased for
     case-insensitive comparison.
     """
-    terms: Set[str] = set()
+    terms: set[str] = set()
 
     # Regex-based extraction
     for pattern in _MEDICAL_PATTERNS:
@@ -116,7 +171,11 @@ def _is_hallucinated(reference: str, prediction: str) -> float:
     A prediction is considered hallucinated when >60 % of its extracted
     medical terms do not appear in the reference text.
     """
-    return 1.0 if _unsupported_term_ratio(reference, prediction) > HALLUCINATION_THRESHOLD else 0.0
+    return (
+        1.0
+        if _unsupported_term_ratio(reference, prediction) > HALLUCINATION_THRESHOLD
+        else 0.0
+    )
 
 
 def _unsupported_term_ratio(reference: str, prediction: str) -> float:
@@ -129,8 +188,7 @@ def _unsupported_term_ratio(reference: str, prediction: str) -> float:
     ref_lower = reference.lower()
 
     unsupported = sum(
-        1 for term in pred_terms
-        if term not in ref_terms and term not in ref_lower
+        1 for term in pred_terms if term not in ref_terms and term not in ref_lower
     )
     return unsupported / len(pred_terms)
 
@@ -139,7 +197,8 @@ def _unsupported_term_ratio(reference: str, prediction: str) -> float:
 # Metric functions (called by lm-evaluation-harness via !function in YAML)
 # ---------------------------------------------------------------------------
 
-def hallucination_rate(predictions: List[str], references: List[str]) -> float:
+
+def hallucination_rate(predictions: list[str], references: list[str]) -> float:
     """Compute per-sample hallucination flag (0.0 or 1.0).
 
     Called once per (prediction, reference) pair by the harness.
@@ -153,7 +212,7 @@ def hallucination_rate(predictions: List[str], references: List[str]) -> float:
     references : list[str]
         Reference / ground-truth text (first element used).
 
-    Returns
+    Returns:
     -------
     float
         1.0 if the prediction is hallucinated, 0.0 otherwise.
@@ -165,7 +224,7 @@ def hallucination_rate(predictions: List[str], references: List[str]) -> float:
 
 
 def hallucination_rate_per_sample(
-    predictions: List[str], references: List[str]
+    predictions: list[str], references: list[str]
 ) -> float:
     """Return the raw unsupported-term ratio for a single sample.
 
@@ -180,7 +239,7 @@ def hallucination_rate_per_sample(
     references : list[str]
         Reference / ground-truth text (first element used).
 
-    Returns
+    Returns:
     -------
     float
         Ratio of unsupported medical terms (0.0 = fully grounded,

--- a/lm_eval/tasks/clinical_hallucination/preprocess_clinical.py
+++ b/lm_eval/tasks/clinical_hallucination/preprocess_clinical.py
@@ -30,14 +30,26 @@ def doc_to_text(doc) -> str:
 
 
 def doc_to_target(doc) -> str:
-    """Return the correct answer choice text as the reference.
+    """Return the correct answer choice text, question text, and all option texts as reference.
 
-    This serves as the ground-truth against which the model's generated
-    explanation is compared for hallucination detection.
+    This provides a broader context against which the model's generated
+    explanation is compared, ensuring that terms mentioned in the prompt
+    or any options are not incorrectly flagged as hallucinations.
     """
     label = doc["label"]
     choices = ["ending0", "ending1", "ending2", "ending3"]
     answer_text = doc[choices[label]]
-    # Include the answer letter and text as reference
     letter = chr(ord("A") + label)
-    return f"{letter}. {answer_text}"
+
+    # Extract the question (sent1) and optional sent2
+    question = doc.get("sent1", "")
+    if doc.get("sent2"):
+        question += " " + doc["sent2"]
+
+    options = " ".join(doc[c] for c in choices)
+
+    return (
+        f"Correct Answer: {letter}. {answer_text}\n"
+        f"Question: {question}\n"
+        f"Options: {options}"
+    )

--- a/lm_eval/tasks/clinical_hallucination/preprocess_clinical.py
+++ b/lm_eval/tasks/clinical_hallucination/preprocess_clinical.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Preprocessing functions for the clinical hallucination detection task.
 
 Transforms MedQA-USMLE questions into a generative prompt format suitable
@@ -6,7 +5,6 @@ for hallucination analysis.  The model is asked to provide both an answer
 and a clinical explanation so that the generated text contains enough
 medical terminology for the hallucination detector to evaluate.
 """
-
 
 
 def doc_to_text(doc) -> str:

--- a/lm_eval/tasks/clinical_hallucination/preprocess_clinical.py
+++ b/lm_eval/tasks/clinical_hallucination/preprocess_clinical.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Preprocessing functions for the clinical hallucination detection task.
+
+Transforms MedQA-USMLE questions into a generative prompt format suitable
+for hallucination analysis.  The model is asked to provide both an answer
+and a clinical explanation so that the generated text contains enough
+medical terminology for the hallucination detector to evaluate.
+"""
+
+
+
+def doc_to_text(doc) -> str:
+    """Build a generative prompt from the MedQA document.
+
+    The prompt asks the model to answer the clinical question AND provide
+    a brief explanation, giving the hallucination detector enough text to
+    analyze for fabricated medical terms.
+    """
+    option_choices = {
+        "A": doc["ending0"],
+        "B": doc["ending1"],
+        "C": doc["ending2"],
+        "D": doc["ending3"],
+    }
+    answers = "".join(f"{k}. {v}\n" for k, v in option_choices.items())
+    return (
+        f"Question: {doc['sent1']}\n"
+        f"{answers}"
+        f"Provide the correct answer letter and a brief clinical explanation "
+        f"of the diagnosis and treatment rationale.\nAnswer:"
+    )
+
+
+def doc_to_target(doc) -> str:
+    """Return the correct answer choice text as the reference.
+
+    This serves as the ground-truth against which the model's generated
+    explanation is compared for hallucination detection.
+    """
+    label = doc["label"]
+    choices = ["ending0", "ending1", "ending2", "ending3"]
+    answer_text = doc[choices[label]]
+    # Include the answer letter and text as reference
+    letter = chr(ord("A") + label)
+    return f"{letter}. {answer_text}"

--- a/tests/test_clinical_hallucination.py
+++ b/tests/test_clinical_hallucination.py
@@ -1,0 +1,36 @@
+from lm_eval.tasks.clinical_hallucination.preprocess_clinical import doc_to_target
+from lm_eval.tasks.clinical_hallucination.metrics import hallucination_rate, hallucination_rate_per_sample
+
+
+def test_clinical_hallucination_functions():
+    doc = {
+        "sent1": "A 45-year-old man presents with chest pain radiating to the left arm.",
+        "sent2": "ECG shows ST elevation in leads II, III, and aVF.",
+        "ending0": "Aortic dissection",
+        "ending1": "Inferior ST-elevation myocardial infarction (STEMI)",
+        "ending2": "Gastroesophageal reflux disease",
+        "ending3": "Pericarditis",
+        "label": 1,
+    }
+
+    # Test doc_to_target
+    target = doc_to_target(doc)
+    assert "Inferior ST-elevation myocardial infarction" in target
+    assert "Aortic dissection" in target
+    assert "ECG shows ST elevation" in target
+
+    # Test metric: completely aligned explanation (mostly words from reference target/context)
+    prediction = ["Inferior ST-elevation myocardial infarction occurs due to chest pain."]
+    ref = [target]
+
+    per_sample_ratio = hallucination_rate_per_sample(prediction, ref)
+    assert per_sample_ratio < 0.6
+    assert hallucination_rate(prediction, ref) == 0.0
+
+    # Test metric: explanation with completely unrelated/unsupported medical terms (hallucinated)
+    hallucinated_prediction = [
+        "Renal papillary necrosis is characterized by sloughing of renal papillae, causing gross hematuria."
+    ]
+    hall_ratio = hallucination_rate_per_sample(hallucinated_prediction, ref)
+    assert hall_ratio > 0.6
+    assert hallucination_rate(hallucinated_prediction, ref) == 1.0


### PR DESCRIPTION
## Summary

Adds a **clinical hallucination detection task** to lm-evaluation-harness — the first metric in the harness specifically designed to measure hallucination rates in LLM responses to medical questions.

## What's Included

### New task: `medqa_hallucination`

- **Dataset**: [GBaker/MedQA-USMLE-4-options-hf](https://huggingface.co/datasets/GBaker/MedQA-USMLE-4-options-hf)
- **Paper (MedQA)**: [What Disease Does This Patient Have? A Large-Scale Open Domain Question Answering Dataset from Medical Exams](https://arxiv.org/abs/2009.13081) (Jin et al., 2020)
- **Methodology**: [clinical-llm-eval](https://github.com/Sugumaran-Balasubramaniyan/clinical-llm-eval) hallucination detector — medical term extraction via regex patterns + keyword matching, >60% unsupported terms → flagged
- **Output type**: `generate_until` (free-text generation for hallucination analysis)
- **Metrics**:
  - `hallucination_rate` — binary flag (0.0/1.0) per sample, averaged across dataset
  - `hallucination_rate_per_sample` — continuous ratio [0.0, 1.0] for finer analysis

### Files

```
lm_eval/tasks/clinical_hallucination/
├── metrics.py                  # Hallucination detection metrics (ruff-clean)
├── preprocess_clinical.py      # Prompt formatting for clinical QA
└── medqa_hallucination.yaml    # Task configuration
```

### Test Results

| Test Case | hallucination_rate | Expected |
|-----------|:------------------:|----------|
| Grounded response (terms match reference) | 0.0 | 0.0 |
| Fully hallucinated response (all terms fabricated) | 1.0 | 1.0 |
| No medical terms in response | 0.0 | 0.0 |
| None/null output (API timeout) | 0.0 | 0.0 (no crash) |

## Contibution Checklist

- [x] ruff linting & formatting applied — all checks pass
- [x] Task YAML follows existing convention (based on medqa task)
- [x] Paper reference + dataset link included
- [x] CLA acknowledgment: will sign via CLAassistant bot
- [x] Code review pass: spec compliance + quality review completed
