### PR TITLE
fix(irokobench): repair afrimmlu/afrimgsm/afrixnli task registration and update READMEs

### DIFF
--- a/lm_eval/tasks/afrimgsm/README.md
+++ b/lm_eval/tasks/afrimgsm/README.md
@@ -1,4 +1,4 @@
-# MathQA
+# AfriMGSM
 
 ### Paper
 
@@ -26,17 +26,40 @@ mathematical reasoning (AfriMGSM), and multi-choice knowledge-based QA (AfriMMLU
 
 ### Groups and Tasks
 
+Every AfriMGSM task is evaluated with five different prompt templates (the
+updated IrokoBench/AfroBench prompts), so each per-language task name carries a
+`_prompt_{i}` suffix where `i` is the prompt id (1-5). The original
+`afrimgsm_direct_{language_code}`, `afrimgsm_en_cot_{language_code}` and
+`afrimgsm_translate_{language_code}` names without the suffix are no longer
+registered.
+
 #### Groups
 
-* `afrimgsm`: All afrimgsm tasks
-* `afrimgsm_direct`: afrimgsm_direct evaluates models performance on the curated dataset
-* `afrimgsm_en_cot`: afrimgsm_en_cot includes 5-shot of exemplars for chain-of-thought approach
-* `afrimgsm_translate`: afrimgsm_translate evaluates models in translate-test setting
+* `afrimgsm-irokobench`: evaluates all direct tasks over all five prompts and reports a size-weighted mean accuracy
+* `afrimgsm_cot-irokobench`: same as above with chain-of-thought prompting
+* `afrimgsm_tt-irokobench`: same as above in the translate-test setting
+* `afrimgsm_tt_cot-irokobench`: chain-of-thought in the translate-test setting
+
+#### Tags
+
+* `afrimgsm_tasks`: runs all direct tasks (all five prompts)
+* `afrimgsm_tasks_prompt_{i}`: runs all direct tasks for prompt `i` (1-5)
+* `afrimgsm_cot_tasks`: runs all chain-of-thought tasks (all five prompts)
+* `afrimgsm_cot_tasks_prompt_{i}`: runs all chain-of-thought tasks for prompt `i` (1-5)
+* `afrimgsm_tt_tasks`: runs all translate-test tasks
+* `afrimgsm_tt_cot_tasks`: runs all chain-of-thought translate-test tasks
 
 #### Tasks
-* `afrimgsm_direct_{language_code}`: each task evaluates for one language
-* `afrimgsm_en_cot_{language_code}`: each task evaluates for one language
-* `afrimgsm_translate_{language_code}`: each task evaluates for one language
+
+* `afrimgsm_{language_code}_prompt_{i}`: evaluates one language with prompt `i` (1-5) on the curated dataset, e.g. `afrimgsm_amh_prompt_1`
+* `afrimgsm_cot_{language_code}_prompt_{i}`: same as above with chain-of-thought prompting
+* `afrimgsm_translate_{language_code}_prompt_{i}`: same as above in the translate-test setting
+* `afrimgsm_cot_translate_{language_code}_prompt_{i}`: chain-of-thought in the translate-test setting
+
+with `language_code` one of `amh`, `eng`, `ewe`, `fra`, `hau`, `ibo`, `kin`,
+`lin`, `lug`, `orm`, `sna`, `sot`, `swa`, `twi`, `vai`, `wol`, `xho`, `yor`,
+`zul` (the translate-test variants have no `eng`, and `afrimgsm_translate` has
+no `vai`).
 
 ### Checklist
 

--- a/lm_eval/tasks/afrimgsm/direct/prompt_2/afrimgsm_yaml
+++ b/lm_eval/tasks/afrimgsm/direct/prompt_2/afrimgsm_yaml
@@ -1,6 +1,6 @@
 tag:
     - afrimgsm_tasks
-    - afrimgsm_tasks_prompt_1
+    - afrimgsm_tasks_prompt_2
 dataset_path: masakhane/afrimgsm
 output_type: generate_until
 test_split: test

--- a/lm_eval/tasks/afrimmlu/README.md
+++ b/lm_eval/tasks/afrimmlu/README.md
@@ -1,4 +1,4 @@
-# MathQA
+# AfriMMLU
 
 ### Paper
 
@@ -26,15 +26,32 @@ mathematical reasoning (AfriMGSM), and multi-choice knowledge-based QA (AfriMMLU
 
 ### Groups and Tasks
 
+Every AfriMMLU task is evaluated with five different prompt templates (the
+updated IrokoBench/AfroBench prompts), so each per-language task name carries a
+`_prompt_{i}` suffix where `i` is the prompt id (1-5). The original
+`afrimmlu_direct_{language_code}` and `afrimmlu_translate_{language_code}`
+names without the suffix are no longer registered.
+
 #### Groups
 
-* `afrimmlu`: All afrimmlu tasks
-* `afrimmlu_direct`: afrimmlu_direct evaluates models performance on the curated dataset
-* `afrimmlu_translate`: afrimmlu_translate evaluates models in translate-test setting
+* `afrimmlu-irokobench`: evaluates all direct tasks over all five prompts and reports a size-weighted mean accuracy
+* `afrimmlu_tt-irokobench`: same as above in the translate-test setting
+
+#### Tags
+
+* `afrimmlu_tasks`: runs all direct tasks (all five prompts)
+* `afrimmlu_tasks_prompt_{i}`: runs all direct tasks for prompt `i` (1-5)
+* `afrimmlu_tt_tasks`: runs all translate-test tasks
+* `afrobench_mmlu_tasks`: the AfriMMLU subset of the AfroBench benchmark (all direct tasks)
 
 #### Tasks
-* `afrimmlu_direct_{language_code}`: each task evaluates for one language
-* `afrimmlu_translate_{language_code}`: each task evaluates for one language
+
+* `afrimmlu_direct_{language_code}_prompt_{i}`: evaluates one language with prompt `i` (1-5) on the curated dataset, e.g. `afrimmlu_direct_amh_prompt_1`
+* `afrimmlu_translate_{language_code}_prompt_{i}`: same as above in the translate-test setting
+
+with `language_code` one of `amh`, `eng`, `ewe`, `fra`, `hau`, `ibo`, `kin`,
+`lin`, `lug`, `orm`, `sna`, `sot`, `swa`, `twi`, `wol`, `xho`, `yor`, `zul`
+(`eng` has no translate-test variant).
 
 ### Checklist
 

--- a/lm_eval/tasks/afrimmlu/direct/prompt_1/utils.py
+++ b/lm_eval/tasks/afrimmlu/direct/prompt_1/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/direct/prompt_2/utils.py
+++ b/lm_eval/tasks/afrimmlu/direct/prompt_2/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/direct/prompt_3/utils.py
+++ b/lm_eval/tasks/afrimmlu/direct/prompt_3/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/direct/prompt_4/utils.py
+++ b/lm_eval/tasks/afrimmlu/direct/prompt_4/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/direct/prompt_5/utils.py
+++ b/lm_eval/tasks/afrimmlu/direct/prompt_5/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/translate/prompt_1/utils.py
+++ b/lm_eval/tasks/afrimmlu/translate/prompt_1/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/translate/prompt_2/utils.py
+++ b/lm_eval/tasks/afrimmlu/translate/prompt_2/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/translate/prompt_3/utils.py
+++ b/lm_eval/tasks/afrimmlu/translate/prompt_3/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/translate/prompt_4/utils.py
+++ b/lm_eval/tasks/afrimmlu/translate/prompt_4/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrimmlu/translate/prompt_5/utils.py
+++ b/lm_eval/tasks/afrimmlu/translate/prompt_5/utils.py
@@ -1,5 +1,9 @@
 import ast
 
+# referenced as `!function utils.weighted_f1_score` in the task configs;
+# keep the import even though it looks unused (noqa guards against ruff --fix)
+from lm_eval.utils import weighted_f1_score  # noqa: F401
+
 
 def doc_to_choice(doc):
     choices = ast.literal_eval(doc["choices"])

--- a/lm_eval/tasks/afrixnli/README.md
+++ b/lm_eval/tasks/afrixnli/README.md
@@ -1,4 +1,4 @@
-# IrokoBench
+# AfriXNLI
 
 ### Paper
 
@@ -26,22 +26,45 @@ mathematical reasoning (AfriMGSM), and multi-choice knowledge-based QA (AfriMMLU
 
 ### Groups and Tasks
 
+AfriXNLI ships two generations of prompts. The newer per-prompt variants (the
+updated IrokoBench/AfroBench prompts) evaluate every language with five
+different prompt templates, so their task names carry a `_prompt_{i}` suffix
+where `i` is the prompt id (1-5). The original anli- and Lai-prompt tasks are
+still registered under their per-language names without the suffix.
+
 #### Groups
 
-* `afrixnli`: All afrixnli tasks
-* `afrixnli_en_direct`: afrixnli_en_direct evaluates models performance using the anli prompt on the curated dataset
-* `afrixnli_native_direct`: afrixnli_native_direct evaluates models performance using the anli prompt translated to the
-respective languages on the curated dataset
-* `afrixnli_translate`: afrixnli_translate evaluates models using the anli prompt in translate-test setting
-* `afrixnli_manual_direct`: afrixnli_manual_direct evaluates models performance using Lai's prompt on the curated dataset
-* `afrixnli_manual_translate`: afrixnli_manual_translate evaluates models using Lai's prompt in translate-test setting
+* `afrixnli-irokobench`: evaluates all direct tasks over all five prompts and reports a size-weighted mean accuracy
+* `afrixnli_tt-irokobench`: same as above in the translate-test setting
+
+#### Tags
+
+* `afrixnli_tasks`: runs all direct per-prompt tasks (all five prompts)
+* `afrixnli_tasks_prompt_{i}`: runs all direct per-prompt tasks for prompt `i` (1-5)
+* `afrixnli_tt_tasks`: runs all per-prompt translate-test tasks
+* `afrixnli`: runs all anli- and Lai-prompt tasks
+* `afrixnli_en_direct`: anli prompt on the curated dataset
+* `afrixnli_native_direct`: anli prompt translated to the respective languages on the curated dataset
+* `afrixnli_translate`: anli prompt in the translate-test setting
+* `afrixnli_manual_direct`: Lai's prompt on the curated dataset
+* `afrixnli_manual_translate`: Lai's prompt in the translate-test setting
 
 #### Tasks
+
+Per-prompt variants:
+* `afrixnli_{language_code}_prompt_{i}`: evaluates one language with prompt `i` (1-5) on the curated dataset, e.g. `afrixnli_amh_prompt_1`
+* `afrixnli_translate_{language_code}_prompt_{i}`: same as above in the translate-test setting
+
+Original anli- and Lai-prompt variants:
 * `afrixnli_en_direct_{language_code}`: each task evaluates for one language
 * `afrixnli_native_direct_{language_code}`: each task evaluates for one language
 * `afrixnli_translate_{language_code}`: each task evaluates for one language
 * `afrixnli_manual_direct_{language_code}`: each task evaluates for one language
 * `afrixnli_manual_translate_{language_code}`: each task evaluates for one language
+
+with `language_code` one of `amh`, `eng`, `ewe`, `fra`, `hau`, `ibo`, `kin`,
+`lin`, `lug`, `orm`, `sna`, `sot`, `swa`, `twi`, `wol`, `xho`, `yor`, `zul`
+(`eng` has no translate-test variant).
 
 ### Checklist
 

--- a/lm_eval/tasks/afrixnli/lai prompt/translate/afrixnli_manual_translate_yaml
+++ b/lm_eval/tasks/afrixnli/lai prompt/translate/afrixnli_manual_translate_yaml
@@ -1,6 +1,6 @@
 tag:
     - afrixnli
-    - afrixnli_manual_direct
+    - afrixnli_manual_translate
 dataset_path: masakhane/afrixnli-translate-test
 dataset_name: null
 output_type: multiple_choice

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -423,7 +423,7 @@ class TestTaskManagerIntegration:
         result = test_configs_task_manager.load_task_or_group(["test_group"])
         # Result is {ConfigurableGroup: {task_name: task_obj}}
         # Get the children dict from the group
-        children = list(result.values())[0]
+        children = next(iter(result.values()))
         # test_group contains inline tasks, namespaced as group_name::task_name
         assert "test_group::group_task_fs0" in children
         assert "test_group::group_task_fs2" in children
@@ -699,7 +699,7 @@ metadata:
         result = test_configs_task_manager.load_task_or_group(["tag_subgroup"])
 
         # Get the children dict from the group
-        group_key = list(result.keys())[0]
+        group_key = next(iter(result.keys()))
         children = result[group_key]
 
         # All 3 tasks from the tag should be expanded
@@ -724,14 +724,14 @@ metadata:
         result = test_configs_task_manager.load_task_or_group(["tag_parent_group"])
 
         # Navigate the nested structure
-        parent_key = list(result.keys())[0]
+        parent_key = next(iter(result.keys()))
         parent_children = result[parent_key]
 
         # Should contain the subgroup
         assert len(parent_children) == 1, "Parent should have 1 child (the subgroup)"
 
         # Get the subgroup
-        subgroup_key = list(parent_children.keys())[0]
+        subgroup_key = next(iter(parent_children.keys()))
         subgroup_children = parent_children[subgroup_key]
 
         # The subgroup should have all 3 tasks expanded from the TAG
@@ -1148,3 +1148,99 @@ class TestGroupBuilding:
 
         direct_tasks = parent.get_all_tasks(recursive=False)
         assert len(direct_tasks) == 0  # parent only has a subgroup, no direct tasks
+
+
+# =============================================================================
+# IrokoBench (AfriMMLU/AfriMGSM/AfriXNLI) registration tests
+# =============================================================================
+
+
+class TestIrokobenchRegistration:
+    """Regression tests for the IrokoBench task registry.
+
+    https://github.com/EleutherAI/lm-evaluation-harness/issues/3360
+    """
+
+    IROKOBENCH_GROUPS = (
+        "afrimgsm-irokobench",
+        "afrimgsm_cot-irokobench",
+        "afrimgsm_tt-irokobench",
+        "afrimgsm_tt_cot-irokobench",
+        "afrimmlu-irokobench",
+        "afrimmlu_tt-irokobench",
+        "afrixnli-irokobench",
+        "afrixnli_tt-irokobench",
+    )
+
+    # Spot-check of the names documented in the AfriMMLU/AfriMGSM/AfriXNLI
+    # READMEs (one language per task pattern).
+    DOCUMENTED_NAMES = (
+        # tags
+        "afrimmlu_tasks",
+        "afrimmlu_tasks_prompt_2",
+        "afrimmlu_tt_tasks",
+        "afrobench_mmlu_tasks",
+        "afrimgsm_tasks",
+        "afrimgsm_tasks_prompt_2",
+        "afrimgsm_cot_tasks",
+        "afrimgsm_cot_tasks_prompt_2",
+        "afrimgsm_tt_tasks",
+        "afrimgsm_tt_cot_tasks",
+        "afrixnli_tasks",
+        "afrixnli_tasks_prompt_2",
+        "afrixnli_tt_tasks",
+        "afrixnli",
+        "afrixnli_en_direct",
+        "afrixnli_native_direct",
+        "afrixnli_translate",
+        "afrixnli_manual_direct",
+        "afrixnli_manual_translate",
+        # per-language tasks
+        "afrimmlu_direct_amh_prompt_1",
+        "afrimmlu_translate_amh_prompt_5",
+        "afrimgsm_amh_prompt_1",
+        "afrimgsm_cot_amh_prompt_1",
+        "afrimgsm_translate_amh_prompt_1",
+        "afrimgsm_cot_translate_amh_prompt_1",
+        "afrixnli_amh_prompt_1",
+        "afrixnli_translate_amh_prompt_1",
+        "afrixnli_en_direct_amh",
+        "afrixnli_manual_translate_amh",
+    )
+
+    def test_group_members_are_registered(self, shared_task_manager):
+        """Every name referenced by an irokobench group must resolve.
+
+        afrimgsm direct prompt_2 used to carry the prompt_1 tag, so the
+        'afrimgsm_tasks_prompt_2' tag referenced by 'afrimgsm-irokobench'
+        was never registered and loading the group raised a KeyError.
+        """
+        for group in self.IROKOBENCH_GROUPS:
+            entry = shared_task_manager.task_index[group]
+            assert entry.kind == Kind.GROUP
+            assert entry.cfg is not None
+            for member in entry.cfg["task"]:
+                assert member in shared_task_manager.task_index, (
+                    f"group '{group}' references unregistered '{member}'"
+                )
+
+    def test_documented_names_are_registered(self, shared_task_manager):
+        """Names documented in the READMEs must be registered."""
+        for name in self.DOCUMENTED_NAMES:
+            assert name in shared_task_manager.task_index, name
+
+    def test_afrimmlu_yaml_functions_resolve(self, shared_task_manager):
+        """The afrimmlu per-prompt utils.py must re-export weighted_f1_score.
+
+        The import was dropped as unused by a lint cleanup, after which every
+        afrimmlu task failed to load with an AttributeError on the
+        '!function utils.weighted_f1_score' reference in the config.
+        """
+        for variant in ("direct", "translate"):
+            for i in range(1, 6):
+                entry = shared_task_manager.task_index[
+                    f"afrimmlu_{variant}_amh_prompt_{i}"
+                ]
+                cfg = load_yaml(entry.yaml_path, resolve_func=True)
+                aggregations = [m.get("aggregation") for m in cfg["metric_list"]]
+                assert any(callable(agg) for agg in aggregations), entry.yaml_path


### PR DESCRIPTION
Fixes #3360.

Updates the afrimmlu/afrimgsm/afrixnli READMEs to the registered post-AfroBench (#2825)
task names, as requested in the issue. While doing that I found the renamed tasks are also
partly broken at the registry level, so even the correct `_prompt_{i}` names don't all load:

- every afrimmlu task raises
  `AttributeError: Module '.../utils.py' has no function 'weighted_f1_score'` — ruff
  removed the "unused" re-import in #3577, but the task configs still reference it via
  `!function utils.weighted_f1_score`;
- the `afrimgsm-irokobench` group raises `KeyError: 'afrimgsm_tasks_prompt_2'` because the
  direct prompt_2 tasks were tagged `afrimgsm_tasks_prompt_1`;
- the `afrixnli_manual_translate` tag never resolves because those tasks were tagged
  `afrixnli_manual_direct`.

This PR restores the import (with `# noqa: F401` so it can't be auto-stripped again),
fixes the two tags, and rewrites the "Groups and Tasks" sections of the three READMEs to
match the registry.

Tested with a new `TestIrokobenchRegistration` class in `tests/test_task_manager.py`
(all three tests fail on main) plus a smoke run:
`lm-eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks afrimmlu_direct_amh_prompt_1 --limit 2 --device cpu`.

Also fixes 4 pre-existing RUF015 errors in `tests/test_task_manager.py` — touching the
file puts it in scope for the diff-based pre-commit Lint job, and they are not
auto-fixable without `--unsafe-fixes` (same bundling as #3748).
