### PR TITLE
fix(squadv2): credit "unanswerable" generations on no-answer questions

### DIFF
--- a/lm_eval/tasks/squadv2/task.py
+++ b/lm_eval/tasks/squadv2/task.py
@@ -44,13 +44,13 @@ def _squad_metric(predictions, references):
 
 
 def _squad_agg(key, items):
-    predictions, references = zip(*items)
+    predictions, references = zip(*items, strict=True)
 
     return _squad_metric(predictions=predictions, references=references).get(key, 0)
 
 
 class SQuAD2(ConfigurableTask):
-    VERSION = 3
+    VERSION = 4
     DATASET_PATH = "lighteval/squad_v2"
     DATASET_NAME = None
 
@@ -150,6 +150,13 @@ class SQuAD2(ConfigurableTask):
         continuation, (logprob_unanswerable, _) = results
 
         no_answer_probability = exp(logprob_unanswerable)
+
+        # doc_to_target teaches the model to generate the literal string
+        # "unanswerable" for no-answer documents, but the squad_v2 metric only
+        # credits an empty prediction against a no-answer reference, so map
+        # such generations to an empty string.
+        if continuation.strip().lower() == "unanswerable":
+            continuation = ""
 
         predictions = {
             "id": doc["id"],

--- a/tests/test_squadv2.py
+++ b/tests/test_squadv2.py
@@ -1,0 +1,67 @@
+"""Regression tests for the SQuAD2 task.
+
+https://github.com/EleutherAI/lm-evaluation-harness/issues/3212
+
+The task's ``doc_to_target`` teaches the model (via fewshot examples) to emit
+the literal string "unanswerable" for unanswerable questions, but the HF
+``squad_v2`` metric only credits an *empty* prediction for no-answer
+references. ``process_results`` must therefore map an "unanswerable"
+generation to an empty ``prediction_text``.
+"""
+
+import pytest
+
+from lm_eval.tasks.squadv2.task import SQuAD2, _squad_agg
+
+
+NO_ANSWER_DOC = {
+    "id": "no-answer-0",
+    "title": "Normans",
+    "context": "The Normans were a population arising in the medieval Duchy of Normandy.",
+    "question": "Who gave their name to Normandy in the 1000s and 1100s?",
+    "answers": {"text": [], "answer_start": []},
+}
+
+HAS_ANSWER_DOC = {
+    "id": "has-answer-0",
+    "title": "Normans",
+    "context": "The Normans were a population arising in the medieval Duchy of Normandy.",
+    "question": "Where did the Normans arise?",
+    "answers": {"text": ["Normandy"], "answer_start": [63]},
+}
+
+# (logprob of " unanswerable", is_greedy) from the loglikelihood request.
+LOGLIKELIHOOD_RESULT = (-24.5, False)
+
+
+@pytest.fixture(scope="module")
+def task() -> SQuAD2:
+    # process_results/aggregation use no instance state, so bypass __init__
+    # (which would download the full dataset).
+    return object.__new__(SQuAD2)
+
+
+def aggregate(task: SQuAD2, doc: dict, continuation: str, keys: list[str]) -> dict:
+    results = task.process_results(doc, [continuation, LOGLIKELIHOOD_RESULT])
+    return {key: _squad_agg(key, [results[key]]) for key in keys}
+
+
+@pytest.mark.parametrize(
+    "continuation", ["unanswerable", " Unanswerable ", "UNANSWERABLE"]
+)
+def test_unanswerable_generation_credited_on_no_answer_doc(task, continuation):
+    scores = aggregate(task, NO_ANSWER_DOC, continuation, ["NoAns_exact", "NoAns_f1"])
+    assert scores["NoAns_exact"] == 100.0
+    assert scores["NoAns_f1"] == 100.0
+
+
+def test_wrong_generation_not_credited_on_no_answer_doc(task):
+    scores = aggregate(task, NO_ANSWER_DOC, " Dyrrachium", ["NoAns_exact", "NoAns_f1"])
+    assert scores["NoAns_exact"] == 0.0
+    assert scores["NoAns_f1"] == 0.0
+
+
+def test_correct_generation_credited_on_answerable_doc(task):
+    scores = aggregate(task, HAS_ANSWER_DOC, " Normandy", ["HasAns_exact", "HasAns_f1"])
+    assert scores["HasAns_exact"] == 100.0
+    assert scores["HasAns_f1"] == 100.0


### PR DESCRIPTION
Fixes #3212.

`squadv2` teaches the model (via `doc_to_target`) to generate the literal string "unanswerable" for no-answer questions, but `process_results` passes the raw continuation to the HF `squad_v2` metric, which only credits an empty prediction against a no-answer reference — so correct abstentions score 0 on `NoAns_exact`/`NoAns_f1`.

One detail the thread left open ("the corresponding scores still sit at 0.0 and I don't get why"): the `no_answer_probability` side-channel cannot rescue these metrics either, because evaluate's squad_v2 applies it with default `no_answer_threshold=1.0` and a strict `>` comparison. Only `best_exact`/`best_f1` (threshold sweep) escape, which matches the reported `best_exact=74` vs `NoAns_exact=0`.

This PR maps generations that normalize (strip + lowercase) to "unanswerable" to an empty `prediction_text` in `process_results` — the prediction-side normalization from the second comment, minus the `no_answer_probability > 0.95` clause, which would conflate the loglikelihood side-channel with the generation channel (the metric already consumes `no_answer_probability` for `best_*`). It does not touch `doc_to_target`'s leading space or the `" unanswerable"` loglikelihood request — the parts of the earlier patch that drew the "sorta helps but sorta breaks" concern; the chat-template/delimiter issues there are real but separable. `VERSION` is bumped 3 -> 4 since reported scores change.

Validated against the real metric: on a synthetic no-answer doc with the model emitting exactly "unanswerable", `NoAns_exact`/`NoAns_f1` flip 0.0 -> 100.0 while `HasAns_*` are unchanged. New unit tests in `tests/test_squadv2.py` cover the no-answer (credited, normalized variants, and wrong-answer) and answerable paths without any model or dataset download. The diff also carries the pinned ruff's B905 fix (`zip(..., strict=True)`) in `_squad_agg` because CI lints changed files.
