### PR TITLE
feat: add SLM-Bench task suite for sub-10M model evaluation

### DIFF
--- a/lm_eval/tasks/arithmark/README.md
+++ b/lm_eval/tasks/arithmark/README.md
@@ -1,0 +1,53 @@
+# ArithMark-2.0
+
+### Paper / Dataset
+
+Title: `ArithMark-2.0: A Benchmark for Integer Arithmetic Reasoning in Language Models`
+
+Homepage: https://huggingface.co/datasets/AxiomicLabs/ArithMark-2.0
+
+### Citation
+
+```bibtex
+@dataset{arithmark2024,
+  author = {Axiomic Labs},
+  title = {ArithMark-2.0},
+  year = {2024},
+  url = {https://huggingface.co/datasets/AxiomicLabs/ArithMark-2.0},
+  publisher = {Hugging Face}
+}
+```
+
+### Description
+
+ArithMark-2.0 is a synthetic benchmark of 2,500 integer arithmetic problems designed to evaluate language model arithmetic reasoning capabilities. Problems span four difficulty levels (easy, medium, hard) and cover operations including addition, subtraction, multiplication, division, mixed operations, and parenthesized expressions.
+
+Each instance presents an arithmetic expression (e.g., `59 + 45 =`) followed by four candidate answers. Models are evaluated via multiple-choice log-likelihood scoring, selecting the answer with the highest probability.
+
+### Groups, Tags, and Tasks
+
+#### Groups
+
+* `arithmark`: Evaluates all difficulty levels together (weighted aggregate)
+
+#### Tags
+
+* `arithmark_tasks`: Includes `arithmark_default`, `arithmark_easy`, `arithmark_medium`, `arithmark_hard`
+
+#### Tasks
+
+* `arithmark_default`: Full benchmark (2,500 problems)
+* `arithmark_easy`: Single-operation problems (addition, subtraction, multiplication, division)
+* `arithmark_medium`: Two-operation and parenthesized two-operation problems
+* `arithmark_hard`: Three-operation and parenthesized three-operation problems
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+### Changelog
+
+* Version 1.0: Initial addition of ArithMark-2.0 task with difficulty-based subtasks.

--- a/lm_eval/tasks/arithmark/arithmark.yaml
+++ b/lm_eval/tasks/arithmark/arithmark.yaml
@@ -1,0 +1,11 @@
+group: arithmark
+task:
+  - arithmark_default
+  - arithmark_easy
+  - arithmark_medium
+  - arithmark_hard
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/arithmark/arithmark_default.yaml
+++ b/lm_eval/tasks/arithmark/arithmark_default.yaml
@@ -1,0 +1,20 @@
+tag:
+  - arithmark_tasks
+task: arithmark_default
+dataset_path: AxiomicLabs/ArithMark-2.0
+output_type: multiple_choice
+test_split: train
+process_docs: !function utils.process_docs
+doc_to_text: "{{ctx}}"
+doc_to_target: "{{gold}}"
+doc_to_choice: "{{endings}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/arithmark/arithmark_easy.yaml
+++ b/lm_eval/tasks/arithmark/arithmark_easy.yaml
@@ -1,0 +1,20 @@
+tag:
+  - arithmark_tasks
+task: arithmark_easy
+dataset_path: AxiomicLabs/ArithMark-2.0
+output_type: multiple_choice
+test_split: train
+process_docs: !function utils.process_docs_easy
+doc_to_text: "{{ctx}}"
+doc_to_target: "{{gold}}"
+doc_to_choice: "{{endings}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/arithmark/arithmark_hard.yaml
+++ b/lm_eval/tasks/arithmark/arithmark_hard.yaml
@@ -1,0 +1,20 @@
+tag:
+  - arithmark_tasks
+task: arithmark_hard
+dataset_path: AxiomicLabs/ArithMark-2.0
+output_type: multiple_choice
+test_split: train
+process_docs: !function utils.process_docs_hard
+doc_to_text: "{{ctx}}"
+doc_to_target: "{{gold}}"
+doc_to_choice: "{{endings}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/arithmark/arithmark_medium.yaml
+++ b/lm_eval/tasks/arithmark/arithmark_medium.yaml
@@ -1,0 +1,20 @@
+tag:
+  - arithmark_tasks
+task: arithmark_medium
+dataset_path: AxiomicLabs/ArithMark-2.0
+output_type: multiple_choice
+test_split: train
+process_docs: !function utils.process_docs_medium
+doc_to_text: "{{ctx}}"
+doc_to_target: "{{gold}}"
+doc_to_choice: "{{endings}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/arithmark/utils.py
+++ b/lm_eval/tasks/arithmark/utils.py
@@ -1,0 +1,49 @@
+import datasets
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        out_doc = {
+            "ctx": doc["ctx"],
+            "endings": doc["endings"],
+            "gold": int(doc["label"]),
+        }
+        return out_doc
+
+    return dataset.map(_process_doc)
+
+
+def process_docs_easy(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        out_doc = {
+            "ctx": doc["ctx"],
+            "endings": doc["endings"],
+            "gold": int(doc["label"]),
+        }
+        return out_doc
+
+    return dataset.filter(lambda doc: doc["metadata"]["difficulty"] == "easy").map(_process_doc)
+
+
+def process_docs_medium(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        out_doc = {
+            "ctx": doc["ctx"],
+            "endings": doc["endings"],
+            "gold": int(doc["label"]),
+        }
+        return out_doc
+
+    return dataset.filter(lambda doc: doc["metadata"]["difficulty"] == "medium").map(_process_doc)
+
+
+def process_docs_hard(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        out_doc = {
+            "ctx": doc["ctx"],
+            "endings": doc["endings"],
+            "gold": int(doc["label"]),
+        }
+        return out_doc
+
+    return dataset.filter(lambda doc: doc["metadata"]["difficulty"] == "hard").map(_process_doc)

--- a/lm_eval/tasks/slm_bench/README.md
+++ b/lm_eval/tasks/slm_bench/README.md
@@ -1,0 +1,62 @@
+# SLM-Bench
+
+### Paper / Dataset
+
+Title: `SLM-Bench: A Benchmark for Evaluating Sub-10M Language Models`
+
+Homepage: https://huggingface.co/datasets/liodon-ai/slm-bench
+
+### Citation
+
+```bibtex
+@dataset{slm_bench_2024,
+  author = {Liodon AI},
+  title = {SLM-Bench},
+  year = {2024},
+  url = {https://huggingface.co/datasets/liodon-ai/slm-bench},
+  publisher = {Hugging Face}
+}
+```
+
+### Description
+
+SLM-Bench is a comprehensive benchmark designed specifically for evaluating sub-10M language models. It covers six core capability areas with 500 questions each (3,000 total), split into train/validation/test sets.
+
+| Category | Description | Example |
+|---|---|---|
+| `arithmetic` | Math problems with plausible distractors | "What is 47 + 23?" |
+| `pattern` | Sequence completion | "What comes next: 2, 6, 18, 54, ?" |
+| `grammar` | Grammatical correctness MCQs | "She ___ to school every day." |
+| `vocabulary` | WordNet-based vocab questions | Antonyms, synonyms, definitions |
+| `logic` | Syllogism and logical reasoning | "Given: All A are B. Is C valid?" |
+| `word_analogy` | Word relationship analogies | "hot : cold :: up : ?" |
+
+### Groups, Tags, and Tasks
+
+#### Groups
+
+* `slm_bench`: Evaluates all six categories together (weighted aggregate)
+
+#### Tags
+
+* `slm_bench_tasks`: Includes all six subtasks
+
+#### Tasks
+
+* `slm_bench_arithmetic`: Math problems (500 questions)
+* `slm_bench_pattern`: Sequence completion (500 questions)
+* `slm_bench_grammar`: Grammar MCQs (500 questions)
+* `slm_bench_vocabulary`: Vocabulary questions (500 questions)
+* `slm_bench_logic`: Logical reasoning (500 questions)
+* `slm_bench_word_analogy`: Word analogies (500 questions)
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+* [x] Referenced the original dataset
+* [x] Followed lm-eval-harness task conventions
+
+### Changelog
+
+* Version 1.0: Initial addition of SLM-Bench task suite.

--- a/lm_eval/tasks/slm_bench/slm_bench.yaml
+++ b/lm_eval/tasks/slm_bench/slm_bench.yaml
@@ -1,0 +1,13 @@
+group: slm_bench
+task:
+  - slm_bench_arithmetic
+  - slm_bench_pattern
+  - slm_bench_grammar
+  - slm_bench_vocabulary
+  - slm_bench_logic
+  - slm_bench_word_analogy
+aggregate_metric_list:
+  - metric: acc
+    weight_by_size: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slm_bench/slm_bench_arithmetic.yaml
+++ b/lm_eval/tasks/slm_bench/slm_bench_arithmetic.yaml
@@ -1,0 +1,22 @@
+tag:
+  - slm_bench_tasks
+task: slm_bench_arithmetic
+dataset_path: liodon-ai/slm-bench
+dataset_name: arithmetic
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "{{question}}"
+doc_to_target: "{{answer}}"
+doc_to_choice: "{{choices}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slm_bench/slm_bench_grammar.yaml
+++ b/lm_eval/tasks/slm_bench/slm_bench_grammar.yaml
@@ -1,0 +1,22 @@
+tag:
+  - slm_bench_tasks
+task: slm_bench_grammar
+dataset_path: liodon-ai/slm-bench
+dataset_name: grammar
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "{{question}}"
+doc_to_target: "{{answer}}"
+doc_to_choice: "{{choices}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slm_bench/slm_bench_logic.yaml
+++ b/lm_eval/tasks/slm_bench/slm_bench_logic.yaml
@@ -1,0 +1,22 @@
+tag:
+  - slm_bench_tasks
+task: slm_bench_logic
+dataset_path: liodon-ai/slm-bench
+dataset_name: logic
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "{{question}}"
+doc_to_target: "{{answer}}"
+doc_to_choice: "{{choices}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slm_bench/slm_bench_pattern.yaml
+++ b/lm_eval/tasks/slm_bench/slm_bench_pattern.yaml
@@ -1,0 +1,22 @@
+tag:
+  - slm_bench_tasks
+task: slm_bench_pattern
+dataset_path: liodon-ai/slm-bench
+dataset_name: pattern
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "{{question}}"
+doc_to_target: "{{answer}}"
+doc_to_choice: "{{choices}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slm_bench/slm_bench_vocabulary.yaml
+++ b/lm_eval/tasks/slm_bench/slm_bench_vocabulary.yaml
@@ -1,0 +1,22 @@
+tag:
+  - slm_bench_tasks
+task: slm_bench_vocabulary
+dataset_path: liodon-ai/slm-bench
+dataset_name: vocabulary
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "{{question}}"
+doc_to_target: "{{answer}}"
+doc_to_choice: "{{choices}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/slm_bench/slm_bench_word_analogy.yaml
+++ b/lm_eval/tasks/slm_bench/slm_bench_word_analogy.yaml
@@ -1,0 +1,22 @@
+tag:
+  - slm_bench_tasks
+task: slm_bench_word_analogy
+dataset_path: liodon-ai/slm-bench
+dataset_name: word_analogy
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: "{{question}}"
+doc_to_target: "{{answer}}"
+doc_to_choice: "{{choices}}"
+target_delimiter: ""
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0


### PR DESCRIPTION
## Summary

Add support for evaluating language models on [SLM-Bench](https://huggingface.co/datasets/liodon-ai/slm-bench), a benchmark designed specifically for sub-10M language models.

## Dataset

- **Source**: liodon-ai/slm-bench (Apache 2.0)
- **Size**: 3,000 questions (500 per category)
- **Format**: Multiple-choice with 4 candidate answers per problem
- **Splits**: train (200), validation (150), test (150) per category

## Tasks Added

| Task | Description |
|------|-------------|
| `slm_bench_arithmetic` | Math problems with plausible distractors |
| `slm_bench_pattern` | Sequence completion (arithmetic, geometric, fibonacci, etc.) |
| `slm_bench_grammar` | Grammatical correctness MCQs (tense, articles, prepositions, etc.) |
| `slm_bench_vocabulary` | WordNet-based vocab questions (antonyms, synonyms, definitions) |
| `slm_bench_logic` | Syllogism and logical reasoning |
| `slm_bench_word_analogy` | Word relationship analogies |
| `slm_bench` | Group with weighted aggregate accuracy |

## Usage

```bash
# Run full benchmark
lm_eval --model hf --model_args pretrained=liodon-ai/slm-10m,trust_remote_code=True --tasks slm_bench --device cuda:0 --batch_size 64

# Run specific category
lm_eval --model hf --model_args pretrained=liodon-ai/slm-10m,trust_remote_code=True --tasks slm_bench_arithmetic --device cuda:0

# Run all subtasks
lm_eval --model hf --model_args pretrained=liodon-ai/slm-10m,trust_remote_code=True --tasks slm_bench_tasks --device cuda:0
```

## Implementation Details

- Uses `multiple_choice` output_type with log-likelihood scoring
- Includes `acc` and `acc_norm` metrics
- Follows existing task patterns (similar to ARC, HellaSwag structure)
- Each category is a separate `dataset_name` under the same `dataset_path`

## Checklist

- [x] Is the task an existing benchmark in the literature?
- [x] Referenced the original dataset
- [x] Followed lm-eval-harness task conventions
- [x] Included README with citation, description, and usage