### PR TITLE
Fix broken afrobench group task references (afrisenti/mafand prompt_2)

### DIFF
--- a/lm_eval/tasks/afrobench/afrisenti/prompt_2/afrisenti
+++ b/lm_eval/tasks/afrobench/afrisenti/prompt_2/afrisenti
@@ -1,6 +1,6 @@
 tag:
     - afrobench_sentiment_tasks
-    - afrisent_prompt_2
+    - afrisenti_prompt_2
 dataset_path: masakhane/afrisenti
 dataset_name: null
 output_type: multiple_choice

--- a/lm_eval/tasks/afrobench/mafand/prompt_2/african-english/mafand
+++ b/lm_eval/tasks/afrobench/mafand/prompt_2/african-english/mafand
@@ -1,7 +1,7 @@
 tag:
 - mafand_tasks
 - mafand_afr-eng
-- mafand_afr-eng_prompt_3
+- mafand_afr-eng_prompt_2
 - afrobench_MT_tasks
 dataset_path: masakhane/mafand
 dataset_kwargs: {trust_remote_code: True}

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -413,6 +413,15 @@ class TestTaskManagerIntegration:
                 and shared_task_manager._entry(t).kind == Kind.TAG
             )
 
+    def test_afrobench_prompt_2_tags_registered(self, shared_task_manager):
+        """Regression: afrobench afrisenti/mafand groups list ``*_prompt_2`` tags
+        that must be registered. Previously the prompt_2 templates declared the
+        wrong tag (``afrisent_prompt_2`` typo; ``mafand_afr-eng_prompt_3``
+        duplicating prompt_3), so loading those groups raised a not-found error."""
+        tags = set(shared_task_manager.all_tags)
+        assert "afrisenti_prompt_2" in tags
+        assert "mafand_afr-eng_prompt_2" in tags
+
     def test_load_task_by_name(self, test_configs_task_manager):
         """Load a single task by name"""
         result = test_configs_task_manager.load_task_or_group(["simple_task"])


### PR DESCRIPTION
## What

Two `afrobench` `prompt_2` task templates declare a `tag:` that does not match the name their parent group references, so the referenced prompt_2 subtasks are not registered and loading the group fails to resolve them (same failure class as #3841):

| group | group references | prompt_2 template declared | issue |
|---|---|---|---|
| `afrisenti` | `afrisenti_prompt_2` | `afrisent_prompt_2` | typo (missing "i") |
| `mafand` | `mafand_afr-eng_prompt_2` | `mafand_afr-eng_prompt_3` | wrong number — duplicates the prompt_3 tag while the file lives in `prompt_2/` and uses `create_text_prompt_2` |

In both cases the correct `*_prompt_2` tag was registered **nowhere**, so the group's task list pointed at a non-existent tag.

## Fix

- `afrobench/afrisenti/prompt_2/afrisenti`: `afrisent_prompt_2` → `afrisenti_prompt_2`
- `afrobench/mafand/prompt_2/african-english/mafand`: `mafand_afr-eng_prompt_3` → `mafand_afr-eng_prompt_2`

No dataset or metric semantics change — only the misregistered tag names.

## Test

Added `test_afrobench_prompt_2_tags_registered` to `tests/test_task_manager.py` asserting both tags are registered (fails on `main`, passes here). Verified locally:

```
tests/test_task_manager.py::TestTaskManagerIntegration::test_afrobench_prompt_2_tags_registered PASSED
```

Scoped to `afrobench/`; does not overlap #3841 (which covers afrimgsm/afrixnli/afrimmlu). AI-assisted (human-reviewed and locally validated).