### PR TITLE
[Task] Add SAS-Bench — LLM-based Short Answer Scoring (arXiv:2505.07247)

### DIFF
--- a/lm_eval/tasks/sas_bench/README.md
+++ b/lm_eval/tasks/sas_bench/README.md
@@ -7,6 +7,7 @@ Scoring with Large Language Models](https://arxiv.org/abs/2505.07247)
 Dataset: `aleversn/SAS-Bench`
 
 ## What it tests
+
 Given a physics exam question, a reference answer, and a student's
 step-by-step response, the model must assign an integer score matching
 expert human annotation.
@@ -14,11 +15,21 @@ expert human annotation.
 - 4,109 student responses across 1,030 questions
 - Expert-annotated step-wise scores and error labels
 - Domain: Chinese high school / undergraduate Physics
+- Only a `test` split is available
 
 ## Metric
-Exact match between model-predicted score and human `manual_label`.
+
+Primary: **QWK** (quadratic weighted kappa) between the model-predicted
+score and the human `manual_label`. Scoring is ordinal, so QWK — the
+standard metric for short-answer scoring — is more appropriate than exact
+agreement. Exact match is also reported as a secondary metric.
+
+**Known limitation:** QWK is currently computed over raw scores pooled
+across questions with differing maximum scores. Scale-normalized or
+per-question QWK is left as future work.
 
 ## Run it
+
 ```bash
 lm_eval --model hf \
     --model_args pretrained=EleutherAI/pythia-70m \
@@ -27,6 +38,7 @@ lm_eval --model hf \
 ```
 
 ## Citation
+
 ```bibtex
 @article{lai2025sasbench,
   title={SAS-Bench: A Fine-Grained Benchmark for Evaluating Short Answer

--- a/lm_eval/tasks/sas_bench/README.md
+++ b/lm_eval/tasks/sas_bench/README.md
@@ -1,0 +1,38 @@
+# SAS-Bench
+
+Paper: [SAS-Bench: A Fine-Grained Benchmark for Evaluating Short Answer
+Scoring with Large Language Models](https://arxiv.org/abs/2505.07247)
+(Lai et al., Peking University, 2025)
+
+Dataset: `aleversn/SAS-Bench`
+
+## What it tests
+Given a physics exam question, a reference answer, and a student's
+step-by-step response, the model must assign an integer score matching
+expert human annotation.
+
+- 4,109 student responses across 1,030 questions
+- Expert-annotated step-wise scores and error labels
+- Domain: Chinese high school / undergraduate Physics
+
+## Metric
+Exact match between model-predicted score and human `manual_label`.
+
+## Run it
+```bash
+lm_eval --model hf \
+    --model_args pretrained=EleutherAI/pythia-70m \
+    --tasks sas_bench \
+    --limit 10
+```
+
+## Citation
+```bibtex
+@article{lai2025sasbench,
+  title={SAS-Bench: A Fine-Grained Benchmark for Evaluating Short Answer
+         Scoring with Large Language Models},
+  author={Peichao Lai and others},
+  year={2025},
+  journal={arXiv preprint arXiv:2505.07247}
+}
+```

--- a/lm_eval/tasks/sas_bench/sas_bench.yaml
+++ b/lm_eval/tasks/sas_bench/sas_bench.yaml
@@ -1,22 +1,23 @@
 task: sas_bench
 dataset_path: aleversn/SAS-Bench
-dataset_name: null
 test_split: test
 output_type: generate_until
-
-doc_to_text: "You are an expert grader. Read the question, the reference answer, and the student's response below. Output a single integer score between 0 and {{total}}.\n\nQuestion:\n{{question}}\n\nReference Answer:\n{{reference}}\n\nStudent Response:\n{{steps | map(attribute='response') | join(' | ')}}\n\nMax Score: {{total}}\nScore (integer only):"
-
+doc_to_text: !function utils.doc_to_text
 doc_to_target: "{{manual_label}}"
-
+process_results: !function utils.process_results
 generation_kwargs:
   max_gen_toks: 16
+  do_sample: false
+  temperature: 0.0
   until:
     - "\n"
-    - " "
-
 metric_list:
   - metric: exact_match
     aggregation: mean
     higher_is_better: true
-
+  - metric: qwk
+    aggregation: !function utils.qwk_agg
+    higher_is_better: true
 num_fewshot: 0
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/sas_bench/sas_bench.yaml
+++ b/lm_eval/tasks/sas_bench/sas_bench.yaml
@@ -1,0 +1,22 @@
+task: sas_bench
+dataset_path: aleversn/SAS-Bench
+dataset_name: null
+test_split: test
+output_type: generate_until
+
+doc_to_text: "You are an expert grader. Read the question, the reference answer, and the student's response below. Output a single integer score between 0 and {{total}}.\n\nQuestion:\n{{question}}\n\nReference Answer:\n{{reference}}\n\nStudent Response:\n{{steps | map(attribute='response') | join(' | ')}}\n\nMax Score: {{total}}\nScore (integer only):"
+
+doc_to_target: "{{manual_label}}"
+
+generation_kwargs:
+  max_gen_toks: 16
+  until:
+    - "\n"
+    - " "
+
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+
+num_fewshot: 0

--- a/lm_eval/tasks/sas_bench/utils.py
+++ b/lm_eval/tasks/sas_bench/utils.py
@@ -2,56 +2,56 @@ import re
 from sklearn.metrics import cohen_kappa_score
 
 
-def extract_score(prediction: str, max_score: int) -> int:
-    """Extract numeric score from model output."""
+def extract_score(prediction, max_score):
+    """Pull an integer score out of the model's generation."""
+    text = str(prediction).strip()
     patterns = [
-        r"^\s*(\d+)",                          # number at very start
-        r"[Ss]core[:\s]+(\d+)",               # "Score: 5"
-        r"总分[：:]\s*(\d+)",                   # Chinese "Total score: 5"
-        r"(\d+)\s*(?:分|points|/|out of)",     # "5分" or "5 points"
+        r"[Ss]core[:\s]+(\d+)",            # "Score: 5"
+        r"总分[：:]\s*(\d+)",               # Chinese "Total score: 5"
+        r"(\d+)\s*(?:分|points|/|out of)",  # "5分", "5 points"
+        r"(\d+)",                          # fallback: first integer anywhere
     ]
     for pattern in patterns:
-        match = re.search(pattern, prediction.strip())
-        if match:
-            val = int(match.group(1))
-            return min(val, max_score)
-    return 0
+        m = re.search(pattern, text)
+        if m:
+            return max(0, min(int(m.group(1)), int(max_score)))
+    return 0  # no parseable number -> treated as 0 (documented limitation)
 
 
-def process_steps(steps):
-    """Join all student step responses into one string."""
-    if not steps:
-        return ""
-    parts = []
-    for i, step in enumerate(steps, 1):
-        response = step.get("response", "").strip()
-        if response:
-            parts.append(f"Step {i}: {response}")
-    return "\n".join(parts)
+def doc_to_text(doc):
+    steps = doc.get("steps") or []
+    response = "\n".join(
+        f"Step {i}: {s.get('response', '').strip()}"
+        for i, s in enumerate(steps, 1)
+        if s.get("response", "").strip()
+    )
+    return (
+        "You are an expert grader. Read the question, the reference answer, "
+        "and the student's response below. Output a single integer score "
+        f"between 0 and {doc['total']}.\n\n"
+        f"Question:\n{doc['question']}\n\n"
+        f"Reference Answer:\n{doc['reference']}\n\n"
+        f"Student Response:\n{response}\n\n"
+        f"Max Score: {doc['total']}\n"
+        "Score (integer only):"
+    )
+
+
+def process_results(doc, results):
+    gold = int(doc["manual_label"])
+    pred = extract_score(results[0], doc["total"])
+    return {
+        "exact_match": float(pred == gold),
+        "qwk": (gold, pred),
+    }
 
 
 def qwk_agg(items):
-    """Aggregation function — receives list of (reference, prediction) tuples."""
-    refs = [int(item[0]) for item in items]
-    preds = [item[1] for item in items]
-
-    if len(set(refs)) < 2:
-        # QWK undefined with one unique class — fall back to exact match
-        return sum(r == p for r, p in zip(refs, preds)) / len(refs)
-
-    return float(cohen_kappa_score(refs, preds, weights="quadratic"))
-
-
-def qwk_score(references, predictions, **kwargs):
-    """Called by lm-eval with lists of references and predictions."""
-    max_scores = kwargs.get("max_scores", [100] * len(predictions))
-    refs = [int(r) for r in references]
-    preds = [
-        extract_score(str(p), max_scores[i] if i < len(max_scores) else 100)
-        for i, p in enumerate(predictions)
-    ]
-
-    if len(set(refs)) < 2:
-        return sum(r == p for r, p in zip(refs, preds)) / len(refs)
-
-    return float(cohen_kappa_score(refs, preds, weights="quadratic"))
+    """items: list of (gold, pred) tuples for the whole dataset."""
+    golds = [int(g) for g, _ in items]
+    preds = [int(p) for _, p in items]
+    if len(set(golds)) < 2 or len(set(preds)) < 2:
+        # kappa is undefined/unstable with no variance -> fall back
+        return sum(g == p for g, p in zip(golds, preds)) / len(golds)
+    score = cohen_kappa_score(golds, preds, weights="quadratic")
+    return float(score) if score == score else 0.0  # NaN guard

--- a/lm_eval/tasks/sas_bench/utils.py
+++ b/lm_eval/tasks/sas_bench/utils.py
@@ -1,0 +1,57 @@
+import re
+from sklearn.metrics import cohen_kappa_score
+
+
+def extract_score(prediction: str, max_score: int) -> int:
+    """Extract numeric score from model output."""
+    patterns = [
+        r"^\s*(\d+)",                          # number at very start
+        r"[Ss]core[:\s]+(\d+)",               # "Score: 5"
+        r"总分[：:]\s*(\d+)",                   # Chinese "Total score: 5"
+        r"(\d+)\s*(?:分|points|/|out of)",     # "5分" or "5 points"
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, prediction.strip())
+        if match:
+            val = int(match.group(1))
+            return min(val, max_score)
+    return 0
+
+
+def process_steps(steps):
+    """Join all student step responses into one string."""
+    if not steps:
+        return ""
+    parts = []
+    for i, step in enumerate(steps, 1):
+        response = step.get("response", "").strip()
+        if response:
+            parts.append(f"Step {i}: {response}")
+    return "\n".join(parts)
+
+
+def qwk_agg(items):
+    """Aggregation function — receives list of (reference, prediction) tuples."""
+    refs = [int(item[0]) for item in items]
+    preds = [item[1] for item in items]
+
+    if len(set(refs)) < 2:
+        # QWK undefined with one unique class — fall back to exact match
+        return sum(r == p for r, p in zip(refs, preds)) / len(refs)
+
+    return float(cohen_kappa_score(refs, preds, weights="quadratic"))
+
+
+def qwk_score(references, predictions, **kwargs):
+    """Called by lm-eval with lists of references and predictions."""
+    max_scores = kwargs.get("max_scores", [100] * len(predictions))
+    refs = [int(r) for r in references]
+    preds = [
+        extract_score(str(p), max_scores[i] if i < len(max_scores) else 100)
+        for i, p in enumerate(predictions)
+    ]
+
+    if len(set(refs)) < 2:
+        return sum(r == p for r, p in zip(refs, preds)) / len(refs)
+
+    return float(cohen_kappa_score(refs, preds, weights="quadratic"))


### PR DESCRIPTION
## Summary
Adds SAS-Bench as a new evaluation task to the harness.

**Paper:** https://arxiv.org/abs/2505.07247 (May 2025, Peking University + Shanghai AI Lab)  
**Dataset:** aleversn/SAS-Bench (Apache 2.0)  
**Related issue:** #3849

## What this adds
- `sas_bench` task: evaluates LLMs on scoring short student answers against expert rubrics
- Metric: exact_match between predicted score and human `manual_label`
- 4,109 annotated student responses across 1,030 exam questions

## Verified locally
python3 -m lm_eval 

--model hf 
--model_args pretrained=EleutherAI/pythia-70m 
--tasks sas_bench 
--limit 5 
--device cpu

Task runs end-to-end successfully.