### PR TITLE
fix: add chat template fallback and convert_img_format to vllm-vlm

### DIFF
--- a/lm_eval/models/vllm_vlms.py
+++ b/lm_eval/models/vllm_vlms.py
@@ -41,6 +41,7 @@ class VLLM_VLM(VLLM):
         interleave: bool = True,
         # TODO<baber>: handle max_images and limit_mm_per_prompt better
         max_images: int = 999,
+        convert_img_format=False,
         image_width: int | None = None,
         image_height: int | None = None,
         image_max_side: int | None = None,
@@ -66,12 +67,14 @@ class VLLM_VLM(VLLM):
         )
         self.interleave = interleave
         self.max_images = max_images
+        self.rgb = convert_img_format
         self.processor = transformers.AutoProcessor.from_pretrained(
             pretrained,
             revision=revision,
             trust_remote_code=trust_remote_code,
         )
         self.chat_applied: bool = False
+        self._chat_template_warning_issued: bool = False
 
     def tok_batch_multimodal_encode(
         self,
@@ -80,9 +83,8 @@ class VLLM_VLM(VLLM):
         left_truncate_len: int | None = None,
         truncation: bool = False,
     ) -> list[TextPrompt]:
-        images = [img[: self.max_images] for img in images]
         # TODO<baber>: is the default placeholder always <image>?
-        if self.chat_applied is False:
+        if not self.chat_applied:
             strings = [
                 replace_placeholders(
                     string,
@@ -92,6 +94,10 @@ class VLLM_VLM(VLLM):
                 )
                 for string in strings
             ]
+
+        images = [img[: self.max_images] for img in images]
+        if self.rgb:
+            images = [[img.convert("RGB") for img in sublist] for sublist in images]
 
         outputs = []
         for x, i in zip(strings, images, strict=True):
@@ -154,10 +160,37 @@ class VLLM_VLM(VLLM):
             )
         return outputs
 
+    def _supports_processor_chat_template(self) -> bool:
+        """Check if the processor natively supports multimodal chat templates.
+
+        Some processors (e.g. Phi3VProcessor) lack a `chat_template` attribute,
+        requiring a fallback to the tokenizer for chat template formatting.
+        """
+        return hasattr(self.processor, "apply_chat_template") and hasattr(
+            self.processor, "chat_template"
+        )
+
     def apply_chat_template(
         self, chat_history: list[dict[str, Any]], add_generation_prompt=True
     ) -> str:
         self.chat_applied = True
+
+        if not self._supports_processor_chat_template():
+            # Fall back to tokenizer for models whose processor does not have
+            # a chat_template (e.g. Phi-3.5-vision). Keep content as plain
+            # strings so the tokenizer can handle them directly.
+            if not self._chat_template_warning_issued:
+                eval_logger.info(
+                    "Processor does not support chat templates, "
+                    "falling back to tokenizer.apply_chat_template"
+                )
+                self._chat_template_warning_issued = True
+            return self.tokenizer.apply_chat_template(
+                chat_history,
+                add_generation_prompt=add_generation_prompt,
+                tokenize=False,
+            )
+
         if not self.interleave:
             for content in chat_history:
                 c = []


### PR DESCRIPTION
## Summary

Adds chat template fallback and `convert_img_format` support to `vllm-vlm`. The `convert_img_format` flag mirrors the existing implementation in `lm_eval/models/hf_vlms.py` (used by the `hf-multimodal` model type). These changes apply to any vision model using `vllm-vlm`; validated on Phi-4-reasoning-vision (`RedHatAI/Phi-4-reasoning-vision-15B`) on MMMU.

Currently, using `--model vllm-vlm` with Phi-4-reasoning-vision fails due to two issues:

1. **Phi4VisionRProcessor lacks a `chat_template` attribute** — `apply_chat_template()` calls `self.processor.apply_chat_template()` unconditionally, which raises `AttributeError` for Phi-4-reasoning-vision since the processor does not expose `chat_template` (the tokenizer does).

2. **Non-RGB image formats on multimodal benchmarks** — In lm_eval, MMMU images are loaded from HuggingFace as PIL Image objects. Some samples use RGBA or other non-RGB modes, which can raise `ValueError: Unable to infer channel dimension format` in the vision preprocessor. `hf_vlms.py` provides `convert_img_format=True`, which when enabled converts images from these formats to RGB before inference (`hf-multimodal`). `vllm_vlms.py` did not provide this option for `vllm-vlm`.

## Changes

**File modified:** `lm_eval/models/vllm_vlms.py`

- **`_supports_processor_chat_template()`** — checks if the processor has both `apply_chat_template` and `chat_template`. Returns `False` for processors like `Phi4VisionRProcessor`.
- **`apply_chat_template()` fallback** — when the processor doesn't support chat templates, falls back to `self.tokenizer.apply_chat_template()` with plain string content.
- **`convert_img_format`** — new `vllm-vlm` model arg, mirroring `hf_vlms.py`. When `True`, converts PIL images to RGB in `tok_batch_multimodal_encode()` before passing them to vLLM. Images already in RGB are unchanged.

## How to reproduce (before fix)

```bash
lm_eval --model vllm-vlm \
  --model_args pretrained=RedHatAI/Phi-4-reasoning-vision-15B,dtype=bfloat16 \
  --tasks mmmu_val_tech_and_engineering \
  --batch_size auto \
  --trust_remote_code \
  --apply_chat_template \
  --fewshot_as_multiturn \
  --log_samples \
  --output_path <output_path>
```

## How to run (after fix)

```bash
lm_eval --model vllm-vlm \
  --model_args pretrained=RedHatAI/Phi-4-reasoning-vision-15B,dtype=bfloat16,convert_img_format=True \
  --tasks mmmu_val_tech_and_engineering \
  --batch_size auto \
  --trust_remote_code \
  --apply_chat_template \
  --fewshot_as_multiturn \
  --log_samples \
  --output_path <output_path>
```

**Note:** The only change from the before-fix command is the addition of `convert_img_format=True` in `--model_args`. Chat template fallback is applied automatically when the processor lacks `chat_template`.
