### PR TITLE
Evaluate every CoQA turn

### DIFF
--- a/lm_eval/tasks/coqa/README.md
+++ b/lm_eval/tasks/coqa/README.md
@@ -29,8 +29,7 @@ BibTeX-formatted citation goes here
 
 * `coqa`: evaluates each conversation turn separately, matching the official
   CoQA set-up where scores are averaged across all turn IDs.
-* `coqa_last_turn`: keeps the previous harness behaviour, evaluating only the
-  final turn from each conversation.
+* `coqa_last_turn`: evaluates only the final turn from each conversation.
 
 ### Checklist
 

--- a/lm_eval/tasks/coqa/README.md
+++ b/lm_eval/tasks/coqa/README.md
@@ -27,7 +27,10 @@ BibTeX-formatted citation goes here
 
 #### Tasks
 
-* `coqa`
+* `coqa`: evaluates each conversation turn separately, matching the official
+  CoQA set-up where scores are averaged across all turn IDs.
+* `coqa_last_turn`: keeps the previous harness behaviour, evaluating only the
+  final turn from each conversation.
 
 ### Checklist
 

--- a/lm_eval/tasks/coqa/_coqa.yaml
+++ b/lm_eval/tasks/coqa/_coqa.yaml
@@ -1,0 +1,21 @@
+dataset_path: EleutherAI/coqa
+output_type: generate_until
+training_split: train
+validation_split: validation
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+process_results: !function utils.process_results
+should_decontaminate: true
+doc_to_decontamination_query: "{{story}} {{question.input_text|join('\n')}}"
+generation_kwargs:
+  until:
+    - "\nQ:"
+metric_list:
+  - metric: em
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 3.0

--- a/lm_eval/tasks/coqa/_coqa.yaml
+++ b/lm_eval/tasks/coqa/_coqa.yaml
@@ -17,5 +17,3 @@ metric_list:
   - metric: f1
     aggregation: mean
     higher_is_better: true
-metadata:
-  version: 3.0

--- a/lm_eval/tasks/coqa/default.yaml
+++ b/lm_eval/tasks/coqa/default.yaml
@@ -1,22 +1,5 @@
 task: coqa
-dataset_path: EleutherAI/coqa
-output_type: generate_until
-training_split: train
-validation_split: validation
-doc_to_text: !function utils.doc_to_text
-doc_to_target: !function utils.doc_to_target
-process_results: !function utils.process_results
-should_decontaminate: true
-doc_to_decontamination_query: "{{story}} {{question.input_text|join('\n')}}"
-generation_kwargs:
-  until:
-    - "\nQ:"
-metric_list:
-  - metric: em
-    aggregation: mean
-    higher_is_better: true
-  - metric: f1
-    aggregation: mean
-    higher_is_better: true
+include: _coqa.yaml
+process_docs: !function utils.process_docs
 metadata:
-  version: 3.0
+  version: 4.0

--- a/lm_eval/tasks/coqa/last_turn.yaml
+++ b/lm_eval/tasks/coqa/last_turn.yaml
@@ -1,0 +1,2 @@
+task: coqa_last_turn
+include: _coqa.yaml

--- a/lm_eval/tasks/coqa/last_turn.yaml
+++ b/lm_eval/tasks/coqa/last_turn.yaml
@@ -1,2 +1,4 @@
 task: coqa_last_turn
 include: _coqa.yaml
+metadata:
+  version: 3.0

--- a/lm_eval/tasks/coqa/utils.py
+++ b/lm_eval/tasks/coqa/utils.py
@@ -1,7 +1,6 @@
 from itertools import zip_longest
 
-from datasets import Dataset
-from transformers.data.metrics import squad_metrics
+import transformers.data.metrics.squad_metrics as squad_metrics  # noqa: PLR0402
 
 
 def _slice_mapping_values(mapping, stop):
@@ -13,15 +12,14 @@ def _slice_mapping_values(mapping, stop):
 
 def _doc_for_turn(doc, turn_idx):
     stop = turn_idx + 1
-    turn_doc = {
-        "story": doc["story"],
-        "questions": _slice_mapping_values(doc["questions"], stop),
-        "answers": _slice_mapping_values(doc["answers"], stop),
-    }
-
-    for key in ("id", "source", "filename", "name"):
-        if key in doc:
-            turn_doc[key] = doc[key]
+    turn_doc = {}
+    for key, value in doc.items():
+        if key in ("questions", "answers"):
+            turn_doc[key] = _slice_mapping_values(value, stop)
+        elif key == "additional_answers":
+            continue
+        else:
+            turn_doc[key] = value
 
     additional_answers = doc.get("additional_answers")
     if additional_answers:
@@ -34,11 +32,17 @@ def _doc_for_turn(doc, turn_idx):
 
 
 def process_docs(dataset):
-    turn_docs = []
-    for doc in dataset:
-        num_turns = len(doc["questions"]["input_text"])
-        turn_docs.extend(_doc_for_turn(doc, turn_idx) for turn_idx in range(num_turns))
-    return Dataset.from_list(turn_docs)
+    def _expand_batch(batch):
+        turn_batch = {}
+        for row_idx, questions in enumerate(batch["questions"]):
+            doc = {key: value[row_idx] for key, value in batch.items()}
+            num_turns = len(questions["input_text"])
+            for turn_idx in range(num_turns):
+                for key, value in _doc_for_turn(doc, turn_idx).items():
+                    turn_batch.setdefault(key, []).append(value)
+        return turn_batch
+
+    return dataset.map(_expand_batch, batched=True, remove_columns=dataset.column_names)
 
 
 def doc_to_text(doc):

--- a/lm_eval/tasks/coqa/utils.py
+++ b/lm_eval/tasks/coqa/utils.py
@@ -1,6 +1,44 @@
 from itertools import zip_longest
 
-import transformers.data.metrics.squad_metrics as squad_metrics
+from datasets import Dataset
+from transformers.data.metrics import squad_metrics
+
+
+def _slice_mapping_values(mapping, stop):
+    return {
+        key: value[:stop] if isinstance(value, list) else value
+        for key, value in mapping.items()
+    }
+
+
+def _doc_for_turn(doc, turn_idx):
+    stop = turn_idx + 1
+    turn_doc = {
+        "story": doc["story"],
+        "questions": _slice_mapping_values(doc["questions"], stop),
+        "answers": _slice_mapping_values(doc["answers"], stop),
+    }
+
+    for key in ("id", "source", "filename", "name"):
+        if key in doc:
+            turn_doc[key] = doc[key]
+
+    additional_answers = doc.get("additional_answers")
+    if additional_answers:
+        turn_doc["additional_answers"] = {
+            key: _slice_mapping_values(answers, stop)
+            for key, answers in additional_answers.items()
+        }
+
+    return turn_doc
+
+
+def process_docs(dataset):
+    turn_docs = []
+    for doc in dataset:
+        num_turns = len(doc["questions"]["input_text"])
+        turn_docs.extend(_doc_for_turn(doc, turn_idx) for turn_idx in range(num_turns))
+    return Dataset.from_list(turn_docs)
 
 
 def doc_to_text(doc):

--- a/tests/test_coqa.py
+++ b/tests/test_coqa.py
@@ -28,6 +28,12 @@ def _sample_doc():
     }
 
 
+def _sample_doc_without_additional_answers():
+    doc = _sample_doc()
+    doc.pop("additional_answers")
+    return doc
+
+
 def test_process_docs_expands_each_coqa_turn():
     processed = utils.process_docs(Dataset.from_list([_sample_doc()]))
 
@@ -61,3 +67,14 @@ def test_all_turn_docs_use_current_turn_as_target():
 
 def test_unsplit_docs_keep_last_turn_behaviour():
     assert utils.doc_to_target(_sample_doc()) == ["to buy milk", "for milk"]
+
+
+def test_process_docs_handles_missing_additional_answers():
+    processed = utils.process_docs(
+        Dataset.from_list([_sample_doc_without_additional_answers()])
+    )
+
+    assert len(processed) == 2
+    assert "additional_answers" not in processed[0]
+    assert utils.doc_to_target(processed[0]) == ["the shop"]
+    assert utils.doc_to_target(processed[1]) == ["to buy milk"]

--- a/tests/test_coqa.py
+++ b/tests/test_coqa.py
@@ -1,0 +1,63 @@
+from datasets import Dataset
+
+from lm_eval.tasks.coqa import utils
+
+
+def _sample_doc():
+    return {
+        "id": "story-1",
+        "story": "Mary went to the shop.",
+        "questions": {
+            "input_text": ["Where did Mary go?", "Why?"],
+            "turn_id": [1, 2],
+        },
+        "answers": {
+            "input_text": ["the shop", "to buy milk"],
+            "turn_id": [1, 2],
+        },
+        "additional_answers": {
+            "turk1": {
+                "input_text": ["a shop", "for milk"],
+                "turn_id": [1, 2],
+            },
+            "turk2": {
+                "input_text": ["The shop", "to buy milk"],
+                "turn_id": [1, 2],
+            },
+        },
+    }
+
+
+def test_process_docs_expands_each_coqa_turn():
+    processed = utils.process_docs(Dataset.from_list([_sample_doc()]))
+
+    assert len(processed) == 2
+    assert processed[0]["questions"]["input_text"] == ["Where did Mary go?"]
+    assert processed[0]["answers"]["input_text"] == ["the shop"]
+    assert processed[0]["additional_answers"]["turk1"]["input_text"] == ["a shop"]
+    assert processed[1]["questions"]["input_text"] == [
+        "Where did Mary go?",
+        "Why?",
+    ]
+    assert processed[1]["answers"]["input_text"] == ["the shop", "to buy milk"]
+
+
+def test_all_turn_docs_use_current_turn_as_target():
+    processed = utils.process_docs(Dataset.from_list([_sample_doc()]))
+
+    assert utils.doc_to_text(processed[0]) == (
+        "Mary went to the shop.\n\nQ: Where did Mary go?\n\nA:"
+    )
+    assert utils.doc_to_target(processed[0]) == ["the shop", "a shop"]
+    assert utils.doc_to_text(processed[1]) == (
+        "Mary went to the shop.\n\n"
+        "Q: Where did Mary go?\n\n"
+        "A: the shop\n\n"
+        "Q: Why?\n\n"
+        "A:"
+    )
+    assert utils.doc_to_target(processed[1]) == ["to buy milk", "for milk"]
+
+
+def test_unsplit_docs_keep_last_turn_behaviour():
+    assert utils.doc_to_target(_sample_doc()) == ["to buy milk", "for milk"]


### PR DESCRIPTION
## What changed

- Split CoQA into one evaluation document per conversation turn for `coqa`.
- Moved the shared task config into `_coqa.yaml`.
- Added `coqa_last_turn` for the previous final-turn setup.
- Added unit coverage for turn expansion, prompt construction, target selection, and the final-turn variant.

## Testing

- `.venv/bin/python -m pytest tests/test_coqa.py -q`
- `.venv/bin/python -m ruff check lm_eval/tasks/coqa/utils.py tests/test_coqa.py`
- `.venv/bin/python -m ruff format --check lm_eval/tasks/coqa/utils.py tests/test_coqa.py`

Fixes #1231
