### PR TITLE
Fix namespaced dataset paths

### DIFF
--- a/lm_eval/tasks/paws-x/pawsx_template_yaml
+++ b/lm_eval/tasks/paws-x/pawsx_template_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 task: null
-dataset_path: paws-x
+dataset_path: google-research-datasets/paws-x
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/spanish_bench/paws_es_spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/paws_es_spanish_bench.yaml
@@ -1,5 +1,5 @@
 task: paws_es_spanish_bench
-dataset_path: paws-x
+dataset_path: google-research-datasets/paws-x
 dataset_name: es
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
@@ -1,6 +1,6 @@
 # Task configuration derived from Eleuther AI's implementation as of March 22, 2024, supplemented with an additional preprocessing function
 task: xnli_es_spanish_bench
-dataset_path: xnli
+dataset_path: facebook/xnli
 dataset_name: es
 output_type: multiple_choice
 doc_to_choice: '{{[premise+", ¿correcto? Sí, "+hypothesis,premise+", ¿correcto? Así

--- a/lm_eval/tasks/xcopa/default_et.yaml
+++ b/lm_eval/tasks/xcopa/default_et.yaml
@@ -1,5 +1,5 @@
 task: xcopa_et
-dataset_path: xcopa
+dataset_path: cambridgeltl/xcopa
 dataset_name: et
 output_type: multiple_choice
 validation_split: validation

--- a/lm_eval/tasks/xnli/xnli_common_yaml
+++ b/lm_eval/tasks/xnli/xnli_common_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 task: null
-dataset_path: xnli
+dataset_path: facebook/xnli
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/xnli_eu/xnli_common_yaml
+++ b/lm_eval/tasks/xnli_eu/xnli_common_yaml
@@ -1,5 +1,5 @@
 task: null
-dataset_path: xnli
+dataset_path: facebook/xnli
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/xquad/xquad_common_yaml
+++ b/lm_eval/tasks/xquad/xquad_common_yaml
@@ -3,7 +3,7 @@
 # by the harness.
 tag: xquad
 task: null
-dataset_path: xquad
+dataset_path: google/xquad
 dataset_name: null
 output_type: generate_until
 validation_split: validation


### PR DESCRIPTION
## Summary
- replace bare Hub dataset IDs for XNLI, XCOPA, PAWS-X, and XQuAD with their namespaced dataset paths
- update shared task templates plus Spanish/XNLI-EU configs that referenced the same bare dataset IDs

## Root cause
Recent Hugging Face Hub resolution requires dataset repository IDs in namespace/name form. Bare IDs such as xnli, xcopa, paws-x, and xquad can fail before task loading with an HF URI error.

## Validation
- curl -L Dataset Viewer /is-valid and /splits for facebook/xnli, cambridgeltl/xcopa, google-research-datasets/paws-x, and google/xquad
- .venv/bin/python -m pytest tests/test_registry.py
- representative task-load check for xnli_en, xcopa_et, paws_en, paws_es_spanish_bench, xquad_en, and xnli_eu

Fixes #3846