### PR TITLE
Reject wildcard promptsource selectors with an actionable error

### DIFF
--- a/docs/new_task_guide.md
+++ b/docs/new_task_guide.md
@@ -288,11 +288,25 @@ For example, For Super Glue BoolQ, if we want to use the prompt template `GPT-3 
 use_prompt: "promptsource:GPT-3 Style"
 ```
 
-If you would like to run evaluation on all prompt templates, you can simply call it this way.
+`use_prompt` selects a **single** template, so each template needs its own task config. To evaluate several templates of the same dataset at once, create one config per template, use `include` to share the common settings, and give them a common `tag` so they can be run together:
 
 ```yaml
-use_prompt: "promptsource:*"
+# wsc_gpt3.yaml
+tag: my_wsc_prompts
+include: default.yaml
+task: wsc_gpt3
+use_prompt: "promptsource:GPT-3 Style"
 ```
+
+```yaml
+# wsc_pronoun.yaml
+tag: my_wsc_prompts
+include: default.yaml
+task: wsc_pronoun
+use_prompt: "promptsource:the pronoun refers to"
+```
+
+Running `--tasks my_wsc_prompts` then evaluates every template sharing that tag.
 
 ### Setting metrics
 

--- a/lm_eval/prompts/__init__.py
+++ b/lm_eval/prompts/__init__.py
@@ -29,6 +29,15 @@ def get_prompt(prompt_id: str, dataset_name: str = None, subset_name: str = None
         dataset_full_name = f"{dataset_name}-{subset_name}"
     eval_logger.info(f"Loading prompt from {category_name} for {dataset_full_name}")
     if category_name == "promptsource":
+        if any(ch in prompt_name for ch in "*?[]"):
+            raise ValueError(
+                f"Wildcard prompt names such as `{prompt_id}` are not supported: "
+                "`use_prompt` selects a single Promptsource template. Name one "
+                "explicit template, and to evaluate several templates at once create "
+                "one task config per template (using `include` to share settings and "
+                "a common `tag` to run them together). See "
+                "docs/new_task_guide.md#importing-a-prompt-from-promptsource."
+            )
         try:
             from promptsource.templates import DatasetTemplates
         except ModuleNotFoundError as exception:

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -4,8 +4,22 @@ import numpy as np
 import pytest
 
 from lm_eval.api.instance import Instance
+from lm_eval.prompts import get_prompt
 from lm_eval.tasks import TaskManager
 from lm_eval.utils import join_iters
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    ["promptsource:*", "promptsource:GPT-3?", "promptsource:[abc]"],
+)
+def test_get_prompt_rejects_wildcards(pattern):
+    # Wildcard prompt selection (e.g. the `promptsource:*` catch-all once shown in
+    # the docs) is not supported; get_prompt should fail fast with an actionable
+    # message *before* importing promptsource, so the guard holds even when the
+    # optional promptsource dependency is not installed.
+    with pytest.raises(ValueError, match="not supported"):
+        get_prompt(pattern, dataset_name="super_glue", subset_name="wsc.fixed")
 
 
 MMLU_ANATOMY_ZERO_SHOT = """The following are multiple choice questions (with answers) about anatomy.


### PR DESCRIPTION
## Summary

`use_prompt: "promptsource:*"` is documented in `new_task_guide.md` as a catch-all to evaluate every template of a dataset, but it has never worked. The wildcard-expansion helper (`load_prompt_list`, which uses `pattern_match`) has no callers anywhere in the tree, so `use_prompt` always flows through `get_prompt`, which only does exact matching. As reported in #3365 this surfaces as a confusing error:

```
ValueError: * not in prompt list ['GPT-3 Style', ...]
```

Per @baberabb's triage the catch-all isn't supported and the docs are wrong. This PR makes the behavior honest and discoverable, rather than implementing the separately-tracked variant rework:

- **`lm_eval/prompts/__init__.py`** — guard the `promptsource` branch against glob patterns (`*`, `?`, `[`, `]`) and raise an actionable error pointing to the supported workflow. The check runs *before* importing `promptsource`, so it works even when the optional dependency isn't installed.
- **`docs/new_task_guide.md`** — drop the unsupported `promptsource:*` example and document the working pattern (one config per template via `include` + a shared `tag`).
- **`tests/test_prompt.py`** — regression test covering `*`, `?`, and `[abc]`.

## Notes

Scoped intentionally narrow to stay out of the prompt-variant rework on the `smolrefact` branch — happy to redirect if you'd prefer the real catch-all handled there instead. Leaves #3365 open to track the actual feature.
