### PR TITLE
feat(eval): Add collie

### DIFF
--- a/lm_eval/tasks/collie/README.md
+++ b/lm_eval/tasks/collie/README.md
@@ -1,0 +1,48 @@
+# COLLIE
+
+### Paper
+
+Title: COLLIE: Systematic Construction of Constrained Text Generation Tasks
+Abstract: https://arxiv.org/abs/2307.08689
+
+Text generation under constraints have seen increasing interests in natural language processing, especially with the rapidly improving capabilities of large language models. However, existing benchmarks for constrained generation usually focus on fixed constraint types (e.g.,generate a sentence containing certain words) that have proved to be easy for state-of-the-art models like GPT-4. We present COLLIE, a grammar-based framework that allows the specification of rich, compositional constraints with diverse generation levels (word, sentence, paragraph, passage) and modeling challenges (e.g.,language understanding, logical reasoning, counting, semantic planning). We also develop tools for automatic extraction of task instances given a constraint structure and a raw text corpus. Using COLLIE, we compile the COLLIE-v1 dataset with 2080 instances comprising 13 constraint structures. We perform systematic experiments across five state-of-the-art instruction-tuned language models and analyze their performances to reveal shortcomings. COLLIE is designed to be extensible and lightweight, and we hope the community finds it useful to develop more complex constraints and evaluations in the future.
+
+Homepage: https://github.com/princeton-nlp/Collie
+
+
+### Citation
+
+```
+@misc{yao2023collie,
+      title={{COLLIE}: Systematic Construction of Constrained Text Generation Tasks},
+      author={Shunyu Yao and Howard Chen and Austin W. Hanjie and Runzhe Yang and Karthik Narasimhan},
+      year={2023},
+      eprint={2307.08689},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* Not part of a group yet
+
+#### Tasks
+
+* `collie`
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+    * Scoring reuses the upstream constraint checker directly. `constraints.py` is from `github.com/princeton-nlp/collie` and the official `all_data.dill` is loaded as-is.
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/collie/collie.yaml
+++ b/lm_eval/tasks/collie/collie.yaml
@@ -1,8 +1,7 @@
 task: collie
-dataset_path: bdytx5/collie
-dataset_name: null
+custom_dataset: !function utils.load_dataset
 output_type: generate_until
-test_split: train
+test_split: test
 num_fewshot: 0
 doc_to_text: prompt
 doc_to_target: 0
@@ -12,5 +11,9 @@ generation_kwargs:
   temperature: 0.0
   max_gen_toks: 1280
 process_results: !function utils.process_results
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
 metadata:
-  version: 1.0
+  version: 2.0

--- a/lm_eval/tasks/collie/collie.yaml
+++ b/lm_eval/tasks/collie/collie.yaml
@@ -1,0 +1,16 @@
+task: collie
+dataset_path: bdytx5/collie
+dataset_name: null
+output_type: generate_until
+test_split: train
+num_fewshot: 0
+doc_to_text: prompt
+doc_to_target: 0
+generation_kwargs:
+  until: []
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 1280
+process_results: !function utils.process_results
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/collie/constraints.py
+++ b/lm_eval/tasks/collie/constraints.py
@@ -133,7 +133,7 @@ class Level:
         elif isinstance(text, list):
             return [self(unit) for unit in text]
         else:
-            raise ValueError(
+            raise TypeError(
                 f"Input text must be a string or a list of strings, not {type(text)}."
             )
 
@@ -158,8 +158,6 @@ class TargetLevel(Level):
 
 class Transformation:
     """Base class for transformations"""
-
-    pass
 
 
 class Count(Transformation):
@@ -202,7 +200,7 @@ class Position(Transformation):
         elif isinstance(self.position, list):
             return [self.get(units, i) for i in self.position]
         else:
-            raise ValueError(
+            raise TypeError(
                 f"Position must be an integer or a list of integers, not {type(self.position)}."
             )
 

--- a/lm_eval/tasks/collie/constraints.py
+++ b/lm_eval/tasks/collie/constraints.py
@@ -25,10 +25,41 @@
 
 from __future__ import annotations
 
+import os
 import string
+from importlib.metadata import version
 from typing import TYPE_CHECKING
 
+import nltk
 from nltk import sent_tokenize, word_tokenize
+from packaging.version import parse as parse_version
+
+
+# Downloading 'punkt' with nltk<3.9 has a remote code vuln.
+# see  https://github.com/EleutherAI/lm-evaluation-harness/issues/2210
+# and https://github.com/nltk/nltk/issues/3266
+# for more information.
+NLTK_MIN_VERSION = "3.9.1"
+RANK = os.environ.get("LOCAL_RANK", "0")
+
+
+def download_nltk_resources():
+    """Download 'punkt' if not already installed"""
+    assert (nltk_version := parse_version(version("nltk"))) >= parse_version(
+        NLTK_MIN_VERSION
+    ), (
+        f"`nltk` version {nltk_version} is not >= {NLTK_MIN_VERSION}. Please update `nltk` before proceeding--older versions are vulnerable to a remote code execution vulnerability."
+    )
+
+    try:
+        nltk.data.find("tokenizers/punkt_tab")
+    except LookupError:
+        if RANK == "0":
+            nltk.download("punkt_tab")
+            print("Downloaded punkt_tab on rank 0")
+
+
+download_nltk_resources()
 
 
 if TYPE_CHECKING:

--- a/lm_eval/tasks/collie/constraints.py
+++ b/lm_eval/tasks/collie/constraints.py
@@ -1,6 +1,3 @@
-# From https://github.com/princeton-nlp/collie
-#
-# Upstream License:
 #   MIT License
 #   Copyright (c) 2023 Howard Chen
 #
@@ -21,7 +18,20 @@
 #   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
-#
+
+"""COLLIE constraint DSL.
+
+A constraint is composed from:
+
+  - ``Level``:  tokenize text into units
+  - ``Transformation``:  reduce or reshape those units.
+  - ``Relation``: the comparison operator.
+  - ``Reduction``: quantify over results (``all``, ``any``, ``at least N``, …).
+  - ``Logic``: (``And`` / ``Or`` / ``All``) combine whole constraints.
+
+This copy is lightly adapted from upstream:
+(https://github.com/princeton-nlp/Collie/blob/master/collie/constraints.py)
+"""
 
 from __future__ import annotations
 
@@ -41,25 +51,6 @@ from packaging.version import parse as parse_version
 # for more information.
 NLTK_MIN_VERSION = "3.9.1"
 RANK = os.environ.get("LOCAL_RANK", "0")
-
-
-def download_nltk_resources():
-    """Download 'punkt' if not already installed"""
-    assert (nltk_version := parse_version(version("nltk"))) >= parse_version(
-        NLTK_MIN_VERSION
-    ), (
-        f"`nltk` version {nltk_version} is not >= {NLTK_MIN_VERSION}. Please update `nltk` before proceeding--older versions are vulnerable to a remote code execution vulnerability."
-    )
-
-    try:
-        nltk.data.find("tokenizers/punkt_tab")
-    except LookupError:
-        if RANK == "0":
-            nltk.download("punkt_tab")
-            print("Downloaded punkt_tab on rank 0")
-
-
-download_nltk_resources()
 
 
 if TYPE_CHECKING:
@@ -86,6 +77,25 @@ if TYPE_CHECKING:
         def extract(self, x: Any) -> Any: ...
 
 
+def download_nltk_resources():
+    """Download 'punkt' if not already installed"""
+    assert (nltk_version := parse_version(version("nltk"))) >= parse_version(
+        NLTK_MIN_VERSION
+    ), (
+        f"`nltk` version {nltk_version} is not >= {NLTK_MIN_VERSION}. Please update `nltk` before proceeding--older versions are vulnerable to a remote code execution vulnerability."
+    )
+
+    try:
+        nltk.data.find("tokenizers/punkt_tab")
+    except LookupError:
+        if RANK == "0":
+            nltk.download("punkt_tab")
+            print("Downloaded punkt_tab on rank 0")
+
+
+download_nltk_resources()
+
+
 def sus_target(t: str) -> bool:
     """Returns True if the target t is suspicious."""
     if not isinstance(t, str):
@@ -104,23 +114,24 @@ class Level:
     def __init__(self, level: LevelStr | None = None) -> None:
         self.level = level
 
-    def __call__(self, text: Any) -> Any:
+    def __call__(self, value: Any) -> Any:
+        # `value` is a raw string, or a (possibly nested) list of already-tokenized
         if self.level is None:
-            return text
-        if isinstance(text, str):
+            return value
+        if isinstance(value, str):
             tokenized = None
             if self.level == "character":
-                tokenized = list(text)
+                tokenized = list(value)
             elif self.level == "word":
                 tokenized = [
-                    x for x in word_tokenize(text) if x not in string.punctuation
+                    x for x in word_tokenize(value) if x not in string.punctuation
                 ]
             elif self.level == "phrase":
                 raise NotImplementedError
             elif self.level == "sentence":
-                tokenized = sent_tokenize(text)
+                tokenized = sent_tokenize(value)
             elif self.level == "paragraph":
-                tokenized = self.split_paragraphs(text)
+                tokenized = self.split_paragraphs(value)
             elif self.level == "passage":
                 raise NotImplementedError
             # TODO: make this more general
@@ -130,11 +141,11 @@ class Level:
                 else None
             )
             return tokenized
-        elif isinstance(text, list):
-            return [self(unit) for unit in text]
+        elif isinstance(value, list):
+            return [self(unit) for unit in value]
         else:
             raise TypeError(
-                f"Input text must be a string or a list of strings, not {type(text)}."
+                f"Input must be a string or a list of strings, not {type(value)}."
             )
 
     @staticmethod
@@ -146,6 +157,7 @@ class Level:
         return text.split(Level._para_delim)
 
 
+# NOTE: renaming/merging subclasses or moving `level` into the type breaks deserialization.
 class InputLevel(Level):
     def __str__(self) -> str:
         return f"InputLevel({self.level})"
@@ -158,6 +170,12 @@ class TargetLevel(Level):
 
 class Transformation:
     """Base class for transformations"""
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        raise NotImplementedError("Transformations are implemented by subclasses")
+
+    def __str__(self) -> str:
+        raise NotImplementedError("String representation are implemented by subclasses")
 
 
 class Count(Transformation):
@@ -218,7 +236,7 @@ class PositionOf(Transformation):
         return [i for i, u in enumerate(units)]
 
     def __str__(self) -> str:
-        return f"PositionsOf({self.func})"
+        return f"PositionOf({self.func})"
 
 
 class MapPosition(Transformation):
@@ -264,6 +282,7 @@ class Max(Transformation):
 
 class ForEach(Transformation):
     def __init__(self, func: Any) -> None:
+        super().__init__()
         self.func = func
 
     def __call__(self, units: list) -> list:

--- a/lm_eval/tasks/collie/constraints.py
+++ b/lm_eval/tasks/collie/constraints.py
@@ -1,0 +1,486 @@
+# From https://github.com/princeton-nlp/collie
+#
+# Upstream License:
+#   MIT License
+#   Copyright (c) 2023 Howard Chen
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in all
+#   copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#   SOFTWARE.
+#
+
+from __future__ import annotations
+
+import string
+from typing import TYPE_CHECKING
+
+from nltk import sent_tokenize, word_tokenize
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from typing import Any, Literal, Protocol
+
+    OperandStr = Literal["==", "!=", "<", ">", "<=", ">=", "in", "not in"]
+    ReductionStr = Literal["at least", "at most", "exactly", "all", "any"]
+    LevelStr = Literal[
+        "character", "word", "phrase", "sentence", "paragraph", "passage"
+    ]
+
+    class _Checkable(Protocol):
+        """Structural type for constraint-like callables (Constraint / Logic).
+
+        Sub-constraints stored in `And`/`Or`/`All` are invoked with either one
+        argument (`x`) or two (`x, target`) and expose `extract`.
+        """
+
+        def __call__(self, x: Any, target: Any = ...) -> Any: ...
+
+        def check(self, text: Any, target: Any) -> bool: ...
+
+        def extract(self, x: Any) -> Any: ...
+
+
+def sus_target(t: str) -> bool:
+    """Returns True if the target t is suspicious."""
+    if not isinstance(t, str):
+        return False
+    t = t.strip()  # leading / trailing whitespace ok
+    if t[0] not in string.ascii_letters + string.digits:
+        return True  # first letter not a letter
+    return t[-1] not in string.ascii_letters + string.digits + string.punctuation
+
+
+class Level:
+    """Level Base class."""
+
+    _para_delim = "\n\n"
+
+    def __init__(self, level: LevelStr | None = None) -> None:
+        self.level = level
+
+    def __call__(self, text: Any) -> Any:
+        if self.level is None:
+            return text
+        if isinstance(text, str):
+            tokenized = None
+            if self.level == "character":
+                tokenized = list(text)
+            elif self.level == "word":
+                tokenized = [
+                    x for x in word_tokenize(text) if x not in string.punctuation
+                ]
+            elif self.level == "phrase":
+                raise NotImplementedError
+            elif self.level == "sentence":
+                tokenized = sent_tokenize(text)
+            elif self.level == "paragraph":
+                tokenized = self.split_paragraphs(text)
+            elif self.level == "passage":
+                raise NotImplementedError
+            # TODO: make this more general
+            tokenized = (
+                [tok.strip().strip(".") for tok in tokenized]
+                if tokenized is not None
+                else None
+            )
+            return tokenized
+        elif isinstance(text, list):
+            return [self(unit) for unit in text]
+        else:
+            raise ValueError(
+                f"Input text must be a string or a list of strings, not {type(text)}."
+            )
+
+    @staticmethod
+    def join_paragraphs(text: Iterable[str]) -> str:
+        return Level._para_delim.join(text)
+
+    @staticmethod
+    def split_paragraphs(text: str) -> list[str]:
+        return text.split(Level._para_delim)
+
+
+class InputLevel(Level):
+    def __str__(self) -> str:
+        return f"InputLevel({self.level})"
+
+
+class TargetLevel(Level):
+    def __str__(self) -> str:
+        return f"TargetLevel({self.level})"
+
+
+class Transformation:
+    """Base class for transformations"""
+
+    pass
+
+
+class Count(Transformation):
+    def __init__(self, count_target: str | None = None) -> None:
+        super().__init__()
+        self.count_target = count_target
+
+    def __call__(self, units: list) -> int:
+        if self.count_target is None:
+            count = len(units)
+        else:
+            count = len([unit for unit in units if unit == self.count_target])
+        return count
+
+    def __str__(self) -> str:
+        if self.count_target is None:
+            return "Count()"
+        else:
+            return f"Count({self.count_target})"
+
+
+class Position(Transformation):
+    def __init__(self, position: int | list[int] | None = None) -> None:
+        super().__init__()
+        self.position = position
+
+    @staticmethod
+    def get(units: list, position: int) -> Any:
+        if len(units) == 0:
+            return None
+        if position >= len(units):
+            return None
+        if position < -len(units):
+            return None
+        return units[position]
+
+    def __call__(self, units: list) -> Any:
+        if isinstance(self.position, int):
+            return self.get(units, self.position)
+        elif isinstance(self.position, list):
+            return [self.get(units, i) for i in self.position]
+        else:
+            raise ValueError(
+                f"Position must be an integer or a list of integers, not {type(self.position)}."
+            )
+
+    def __str__(self) -> str:
+        return f"Position({self.position})"
+
+
+class PositionOf(Transformation):
+    def __init__(self, func: Callable) -> None:
+        super().__init__()
+        self.func = func
+
+    def __call__(self, x: Any) -> list[int]:
+        units = self.func(x)
+        return [i for i, u in enumerate(units)]
+
+    def __str__(self) -> str:
+        return f"PositionsOf({self.func})"
+
+
+class MapPosition(Transformation):
+    def __init__(self, func: Callable, map_pos_func: Callable) -> None:
+        super().__init__()
+        self.func = func
+        self.map_pos_func = map_pos_func
+
+    def __call__(self, x: Any) -> Any:
+        units = self.func(x)
+        return self.map_pos_func(units)
+
+    def __str__(self) -> str:
+        return f"MapPosition({self.func}, {self.map_pos_func})"
+
+
+class Aggregate(Transformation):
+    def __init__(self, func: Callable) -> None:
+        super().__init__()
+        self.func = func
+
+    def __call__(self, x: Any) -> str:
+        # TODO: need to merge with the level class
+        units = self.func(x)
+        return "".join(units)
+
+    def __str__(self) -> str:
+        return f"Aggregate({self.func})"
+
+
+class Max(Transformation):
+    def __init__(self, func: Callable) -> None:
+        super().__init__()
+        self.func = func
+
+    def __call__(self, x: Any) -> Any:
+        units = self.func(x)
+        return max(units)
+
+    def __str__(self) -> str:
+        return f"Max({self.func})"
+
+
+class ForEach(Transformation):
+    def __init__(self, func: Any) -> None:
+        self.func = func
+
+    def __call__(self, units: list) -> list:
+        if self.func is Ellipsis:
+            func = lambda x: x
+        else:
+            func = self.func
+        return [func(unit) for unit in units]
+
+    def __str__(self) -> str:
+        if self.func is Ellipsis:
+            return "ForEach(...)"
+        else:
+            return f"ForEach({self.func})"
+
+
+class Logic:
+    """Base class for composite constraints; subclasses implement `__call__`."""
+
+    def __call__(self, x: Any, target: Any = None) -> bool:
+        raise NotImplementedError("Logic subclasses must implement __call__")
+
+    def check(self, x: Any, target: Any) -> bool:
+        return self(x, target)
+
+    def extract(self, x: Any) -> Any:
+        raise NotImplementedError("Logic subclasses must implement extract")
+
+
+class And(Logic):
+    def __init__(self, callable_1: _Checkable, callable_2: _Checkable) -> None:
+        super().__init__()
+        self.callable_1 = callable_1
+        self.callable_2 = callable_2
+        self.callables = [callable_1, callable_2]
+
+    def __call__(self, x: Any, target: Any = None) -> bool:
+        if target is None:
+            return self.callable_1(x) and self.callable_2(x)
+        elif isinstance(target, list):
+            assert len(target) == 2
+            return self.callable_1(x, target[0]) and self.callable_2(x, target[1])
+        else:
+            return self.callable_1(x, target) and self.callable_2(x, target)
+
+    def __str__(self) -> str:
+        return f"And({self.callable_1}, {self.callable_2})"
+
+    def extract(self, x: Any) -> list:
+        return [callable_.extract(x) for callable_ in self.callables]
+
+
+class Or(Logic):
+    def __init__(self, callable_1: _Checkable, callable_2: _Checkable) -> None:
+        super().__init__()
+        self.callable_1 = callable_1
+        self.callable_2 = callable_2
+        self.callables = [callable_1, callable_2]
+
+    def __call__(self, x: Any, target: Any = None) -> bool:
+        if target is None:
+            return self.callable_1(x) or self.callable_2(x)
+        elif isinstance(target, list):
+            assert len(target) == 2
+            return self.callable_1(x, target[0]) or self.callable_2(x, target[1])
+        else:
+            return self.callable_1(x, target) or self.callable_2(x, target)
+
+    def __str__(self) -> str:
+        return f"Or({self.callable_1}, {self.callable_2})"
+
+    def extract(self, x: Any) -> list:
+        return [callable_.extract(x) for callable_ in self.callables]
+
+
+class All(Logic):
+    def __init__(self, *callables: _Checkable) -> None:
+        super().__init__()
+        self.callables = callables
+
+    def __call__(self, x: Any, target: Any = None) -> bool:
+        if target is None:
+            return all(callable_(x) for callable_ in self.callables)
+        elif isinstance(target, list):
+            return all(
+                callable_(x, t)
+                for callable_, t in zip(self.callables, target, strict=False)
+            )
+        else:
+            raise NotImplementedError
+
+    def __str__(self) -> str:
+        return f"All({', '.join([str(c) for c in self.callables])})"
+
+    def extract(self, x: Any) -> list:
+        return [callable_.extract(x) for callable_ in self.callables]
+
+
+class Relation:
+    """
+    Abstract relation class that works for more literal types.
+    """
+
+    def __init__(self, operand: OperandStr) -> None:
+        self.operand = operand
+
+    def _patch_literal(self, literal: Any) -> Any:
+        # apply transformations on literal to remove artifacts and casing
+
+        def _patch(literal: Any) -> Any:
+            # apply the patch if it is
+            if not isinstance(literal, str):
+                return literal
+            stripped = literal.lower().strip(string.punctuation + " ")
+            return literal if stripped == "" else stripped
+
+        if isinstance(literal, list):
+            return [_patch(x) for x in literal]
+
+        return _patch(literal)
+
+    def __call__(self, literal_1: Any, literal_2: Any) -> bool:
+        literal_1, literal_2 = (
+            self._patch_literal(literal_1),
+            self._patch_literal(literal_2),
+        )
+        if self.operand in ["==", "!=", "<", ">", "<=", ">="]:
+            if isinstance(literal_2, list) and len(literal_2) == 1:
+                literal_2 = literal_2[0]
+            if self.operand == "==":
+                return literal_1 == literal_2
+            elif self.operand == "!=":
+                return literal_1 != literal_2
+            elif self.operand == "<":
+                return literal_1 < literal_2
+            elif self.operand == "<=":
+                return literal_1 <= literal_2
+            elif self.operand == ">":
+                return literal_1 > literal_2
+            else:  # ">="
+                return literal_1 >= literal_2
+        elif self.operand in ["in", "not in"]:
+            if self.operand == "in":
+                if isinstance(literal_2, list):
+                    return all(l in literal_1 for l in literal_2)
+                else:
+                    return literal_2 in literal_1
+            else:  # "not in"
+                if isinstance(literal_2, list):
+                    return not any(l in literal_1 for l in literal_2)
+                else:
+                    return literal_2 not in literal_1
+        else:
+            raise NotImplementedError
+
+    def __str__(self) -> str:
+        return f"Relation({self.operand})"
+
+
+class Reduction:
+    def __init__(
+        self, reduction: ReductionStr | None = None, value: int | None = None
+    ) -> None:
+        """
+        Reduction (str): one of ['at least', 'at most', 'exactly', 'all', 'any']
+        """
+        self.reduction = reduction
+        self.value = value
+
+    def __call__(self, x: Any, target: Any, relation: Relation) -> bool:
+        if self.reduction is None:
+            return relation(x, target)
+        if not isinstance(target, list):
+            target = [target] * len(x)
+        if len(x) != len(target):
+            return False
+        # assert len(x) == len(target), f'Length of x ({len(x)}) and target ({len(target)}) must be the same.'
+        results = [
+            relation(x_i, target_i) for x_i, target_i in zip(x, target, strict=False)
+        ]
+
+        if self.reduction == "all":
+            return all(results)
+        elif self.reduction == "any":
+            return any(results)
+        elif self.reduction == "at least":
+            assert self.value is not None
+            return sum(results) >= self.value
+        elif self.reduction == "at most":
+            assert self.value is not None
+            return sum(results) <= self.value
+        elif self.reduction == "exactly":
+            return sum(results) == self.value
+        else:
+            raise ValueError(f"Unknown reduction: {self.reduction!r}")
+
+    def __str__(self) -> str:
+        if self.value is not None:
+            return f"Reduction({self.reduction} {self.value})"
+        else:
+            return f"Reduction({self.reduction})"
+
+
+class Constraint:
+    def __init__(
+        self,
+        input_level: InputLevel | None = None,
+        target_level: TargetLevel | None = None,
+        transformation: Callable | None = None,
+        relation: Relation | None = None,
+        reduction: Reduction | None = None,
+    ) -> None:
+        self.input_level = input_level or InputLevel()
+        self.target_level = target_level or TargetLevel()
+        self.transformation = transformation
+        self.relation = relation
+        self.reduction = reduction or Reduction()
+
+    def extract(self, text: Any) -> Any:
+        if self.input_level is not None:
+            input_units = self.input_level(text)
+        else:
+            input_units = text
+        x = self.target_level(input_units)
+        if self.transformation is not None:
+            x = self.transformation(x)
+        return x
+
+    def check(self, text: Any, target: Any) -> bool:
+        x = self.extract(text)
+        assert self.relation is not None
+        return self.reduction(x, target, self.relation)
+
+    def __call__(self, text: Any, target: Any) -> bool:
+        return self.check(text, target)
+
+    def __str__(self) -> str:
+        return (
+            f"Constraint(\n"
+            f"    {self.input_level},\n"
+            f"    {self.target_level},\n"
+            f"    Transformation({self.transformation}),\n"
+            f"    {self.relation},\n"
+            f"    {self.reduction}\n"
+            f")"
+        )
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/lm_eval/tasks/collie/utils.py
+++ b/lm_eval/tasks/collie/utils.py
@@ -39,8 +39,8 @@ def load_dill(path: str) -> dict[str, list[dict[str, Any]]]:
 
     Note:
     Constraint classes are pickled under the path ``src.constraints``;
-    defined in the upstream repo ``github.com/stanford-nlp/collie``.
-    We redirect to the our version of `constraints.py` by subclassing
+    defined in the upstream repo ``github.com/princeton-nlp/collie``.
+    We redirect to our version of ``constraints.py`` by subclassing
     ``dill.Unpickler``.
     """
     import importlib

--- a/lm_eval/tasks/collie/utils.py
+++ b/lm_eval/tasks/collie/utils.py
@@ -1,0 +1,4 @@
+def process_results(doc, results):
+    return {
+        "accuracy": 0.0
+    }

--- a/lm_eval/tasks/collie/utils.py
+++ b/lm_eval/tasks/collie/utils.py
@@ -1,4 +1,94 @@
+"""Helpers for the `collie` task."""
+
+import base64
+import json
+import os
+import urllib.request
+
+
+_COLLIE_URL = "https://collie-benchmark.github.io/data/all_data.dill"
+
+
+def _download_dill():
+    """Return a local path to the official COLLIE dill, downloading if absent."""
+    cache = os.path.join(
+        os.environ.get("HF_DATASETS_CACHE", os.path.expanduser("~/.cache/lm_eval")),
+        "collie",
+        "all_data.dill",
+    )
+    if not os.path.exists(cache):
+        os.makedirs(os.path.dirname(cache), exist_ok=True)
+        urllib.request.urlretrieve(_COLLIE_URL, cache)  # fails explicitly if absent
+    return cache
+
+
+def load_dill(path):
+    """Deserialize the COLLIE dill, returning ``dict[str, list[record]]``.
+
+    Each record is a dict with keys: ``example``, ``metadata``, ``targets``,
+    ``constraint`` (a live constraint object), and ``prompt``.
+
+    The file pickles constraint classes under the upstream module path
+    ``src.constraints``; we redirect those to the vendored, importable
+    ``lm_eval.tasks.collie.constraints`` so resolution is by reference (no
+    global ``sys.modules`` mutation).
+    """
+    import importlib
+
+    import dill
+
+    vendored = importlib.import_module("lm_eval.tasks.collie.constraints")
+
+    class _Unpickler(dill.Unpickler):  # noqa: S301
+        def find_class(self, module, name):
+            if module == "src.constraints":
+                return getattr(vendored, name)
+            return super().find_class(module, name)
+
+    with open(path, "rb") as f:
+        # Trusted official COLLIE data file (not user-supplied input).
+        return _Unpickler(f).load()
+
+
+def load_dataset(**kwargs):
+    """Build the COLLIE table for use as an lm-eval ``custom_dataset`` loader.
+
+    Downloads the official benchmark dill, flattens its ``dict[str, list]`` of
+    constraint buckets into rows, and returns a single eval split. Heterogeneous
+    fields are JSON-encoded so the Arrow schema is homogeneous; the live
+    constraint is dill-serialized (by reference, ~340 B) and base64-encoded so
+    docs stay JSON-safe for ``--log_samples``.
+    """
+    import datasets
+    import dill
+
+    data = load_dill(_download_dill())  # dict[str, list[record]]
+    rows = []
+    for bucket, records in data.items():
+        for r in records:
+            rows.append(
+                {
+                    "bucket": bucket,
+                    "prompt": r["prompt"],
+                    "example": r["example"],
+                    "targets": json.dumps(r["targets"]),
+                    "metadata": json.dumps(r["metadata"]),
+                    "constraint": base64.b64encode(
+                        dill.dumps(r["constraint"], byref=True)
+                    ).decode(),
+                }
+            )
+    return {"test": datasets.Dataset.from_list(rows)}
+
+
 def process_results(doc, results):
-    return {
-        "accuracy": 0.0
-    }
+    """Score a generation against its COLLIE constraint (pass-rate accuracy)."""
+    import dill
+
+    constraint = dill.loads(base64.b64decode(doc["constraint"]))  # noqa: S301
+    targets = json.loads(doc["targets"])
+    try:
+        passed = bool(constraint.check(results[0], targets))
+    except Exception:  # noqa: BLE001
+        passed = False
+    return {"acc": passed}

--- a/lm_eval/tasks/collie/utils.py
+++ b/lm_eval/tasks/collie/utils.py
@@ -1,15 +1,24 @@
 """Helpers for the `collie` task."""
 
+from __future__ import annotations
+
 import base64
 import json
 import os
 import urllib.request
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    import datasets
 
 
 _COLLIE_URL = "https://collie-benchmark.github.io/data/all_data.dill"
 
 
-def _download_dill():
+def _download_dill() -> str:
     """Return a local path to the official COLLIE dill, downloading if absent."""
     cache = os.path.join(
         os.environ.get("HF_DATASETS_CACHE", os.path.expanduser("~/.cache/lm_eval")),
@@ -22,16 +31,17 @@ def _download_dill():
     return cache
 
 
-def load_dill(path):
+def load_dill(path: str) -> dict[str, list[dict[str, Any]]]:
     """Deserialize the COLLIE dill, returning ``dict[str, list[record]]``.
 
     Each record is a dict with keys: ``example``, ``metadata``, ``targets``,
     ``constraint`` (a live constraint object), and ``prompt``.
 
-    The file pickles constraint classes under the upstream module path
-    ``src.constraints``; we redirect those to the vendored, importable
-    ``lm_eval.tasks.collie.constraints`` so resolution is by reference (no
-    global ``sys.modules`` mutation).
+    Note:
+    Constraint classes are pickled under the path ``src.constraints``;
+    defined in the upstream repo ``github.com/stanford-nlp/collie``.
+    We redirect to the our version of `constraints.py` by subclassing
+    ``dill.Unpickler``.
     """
     import importlib
 
@@ -39,18 +49,18 @@ def load_dill(path):
 
     vendored = importlib.import_module("lm_eval.tasks.collie.constraints")
 
+    # Subclassing dill.Unpickler to redirect constraint class lookups to the vendored module.
     class _Unpickler(dill.Unpickler):  # noqa: S301
-        def find_class(self, module, name):
+        def find_class(self, module: str, name: str) -> Any:
             if module == "src.constraints":
                 return getattr(vendored, name)
             return super().find_class(module, name)
 
     with open(path, "rb") as f:
-        # Trusted official COLLIE data file (not user-supplied input).
         return _Unpickler(f).load()
 
 
-def load_dataset(**kwargs):
+def load_dataset(**kwargs: Any) -> dict[str, datasets.Dataset]:
     """Build the COLLIE table for use as an lm-eval ``custom_dataset`` loader.
 
     Downloads the official benchmark dill, flattens its ``dict[str, list]`` of
@@ -81,7 +91,7 @@ def load_dataset(**kwargs):
     return {"test": datasets.Dataset.from_list(rows)}
 
 
-def process_results(doc, results):
+def process_results(doc: dict[str, Any], results: list[str]) -> dict[str, bool]:
     """Score a generation against its COLLIE constraint (pass-rate accuracy)."""
     import dill
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ acpbench = ["lark>=1.1.9", "tarski[clingo]==0.8.2", "pddl==0.4.2", "kstar-planne
 audiolm_qwen = ["librosa", "soundfile"]
 dev = ["pytest>=9.0", "pytest-cov", "pytest-xdist", "requests", "aiohttp", "tenacity", "tqdm", "tiktoken", "sentencepiece"]
 ifeval = ["langdetect", "immutabledict", "nltk>=3.9.1"]
+collie = ["nltk>=3.9.1"]
 japanese_leaderboard = ["emoji==2.14.0", "neologdn==0.5.3", "fugashi[unidic-lite]", "rouge_score>=0.1.2"]
 longbench = ["jieba", "fuzzywuzzy", "rouge"]
 libra = ["pymorphy2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ trackio = ["trackio>=0.23.0"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
 zeno = ["pandas", "zeno-client"]
 tasks = [
+    "lm_eval[collie]",
     "lm_eval[discrim_eval]",
     "lm_eval[ifeval]",
     "lm_eval[japanese_leaderboard]",


### PR DESCRIPTION
This PR closes #1013

  ## Implementation Details
  - Vendors `constraints.py` from https://github.com/princeton-nlp/collie, so scoring
  reuses the upstream constraint checker directly.
  - Loads the dataset from the official benchmark site
  (https://collie-benchmark.github.io/data/all_data.dill) via a custom `dill` unpickler
  that redirects the pickled `src.constraints` classes to the vendored module.
  - Adds a `custom_dataset` loader and constraint-based scoring, reporting a single
  pass-rate accuracy (`acc`) averaged across all examples.
  - Adds a `collie` optional dependency extra (`nltk>=3.9.1`).

  ## Usage
  ```bash
  lm_eval --tasks collie --model hf --model_args pretrained=<model>


