### PR TITLE
Add PerspectiveGap benchmark (arXiv:2606.08878)

### DIFF
--- a/lm_eval/tasks/perspective_gap/README.md
+++ b/lm_eval/tasks/perspective_gap/README.md
@@ -1,0 +1,30 @@
+# PerspectiveGap
+
+PerspectiveGap ([arXiv:2606.08878](https://arxiv.org/abs/2606.08878)) evaluates LLMs' ability to compose orchestration prompts for multi-agent systems, testing whether a model can decide what each sub-agent needs to know without leaking irrelevant context.
+
+- Dataset: [sun1245/PerspectiveGap](https://huggingface.co/datasets/sun1245/PerspectiveGap)
+- 220 evaluations (110 scenarios x 2 shuffle seeds)
+- Scoring: [WhymustIhaveaname/PerspectiveGap](https://github.com/WhymustIhaveaname/PerspectiveGap)
+
+## Tasks
+
+- `perspective_gap_role_assignment` — output a JSON object mapping roles to fragment IDs
+- `perspective_gap_prompt_writing` — write one markdown prompt per role with relevant fragments verbatim
+
+## Metrics
+
+| Metric | Description |
+|--------|-------------|
+| strict_pass | 1 if all roles correct, 0 otherwise |
+| net_match_score | (TP - FP - FN) / expected, clipped to [0, 1] |
+| required_coverage | TP / (TP + FN) |
+| boundary_precision | TP / (TP + FP) |
+| distractor_leakage | times the distractor was incorrectly included |
+
+## Dependencies
+
+Requires the `perspective-gap` package for scoring:
+
+```bash
+pip install git+https://github.com/WhymustIhaveaname/PerspectiveGap.git
+```

--- a/lm_eval/tasks/perspective_gap/README.md
+++ b/lm_eval/tasks/perspective_gap/README.md
@@ -26,5 +26,5 @@ PerspectiveGap ([arXiv:2606.08878](https://arxiv.org/abs/2606.08878)) evaluates 
 Requires the `perspective-gap` package for scoring:
 
 ```bash
-pip install git+https://github.com/WhymustIhaveaname/PerspectiveGap.git
+pip install "perspective-gap @ git+https://github.com/WhymustIhaveaname/PerspectiveGap.git@9c6921b3337ff3e6a6a453f68d117a8c1663135e"
 ```

--- a/lm_eval/tasks/perspective_gap/prompt_writing.yaml
+++ b/lm_eval/tasks/perspective_gap/prompt_writing.yaml
@@ -1,0 +1,32 @@
+task: perspective_gap_prompt_writing
+task_alias: PerspectiveGap (Prompt Writing)
+tag:
+  - perspective_gap
+dataset_path: sun1245/PerspectiveGap
+test_split: test
+output_type: generate_until
+doc_to_text: "{{prompt_writing_prompt}}"
+doc_to_target: ""
+process_results: !function utils.process_results_prompt_writing
+generation_kwargs:
+  max_gen_toks: 16384
+  until:
+    - "<|endoftext|>"
+metric_list:
+  - metric: strict_pass
+    aggregation: mean
+    higher_is_better: true
+  - metric: net_match_score
+    aggregation: mean
+    higher_is_better: true
+  - metric: required_coverage
+    aggregation: mean
+    higher_is_better: true
+  - metric: boundary_precision
+    aggregation: mean
+    higher_is_better: true
+  - metric: distractor_leakage
+    aggregation: mean
+    higher_is_better: false
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/perspective_gap/role_assignment.yaml
+++ b/lm_eval/tasks/perspective_gap/role_assignment.yaml
@@ -1,0 +1,32 @@
+task: perspective_gap_role_assignment
+task_alias: PerspectiveGap (Role Assignment)
+tag:
+  - perspective_gap
+dataset_path: sun1245/PerspectiveGap
+test_split: test
+output_type: generate_until
+doc_to_text: "{{role_assignment_prompt}}"
+doc_to_target: ""
+process_results: !function utils.process_results_role_assignment
+generation_kwargs:
+  max_gen_toks: 8192
+  until:
+    - "<|endoftext|>"
+metric_list:
+  - metric: strict_pass
+    aggregation: mean
+    higher_is_better: true
+  - metric: net_match_score
+    aggregation: mean
+    higher_is_better: true
+  - metric: required_coverage
+    aggregation: mean
+    higher_is_better: true
+  - metric: boundary_precision
+    aggregation: mean
+    higher_is_better: true
+  - metric: distractor_leakage
+    aggregation: mean
+    higher_is_better: false
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/perspective_gap/utils.py
+++ b/lm_eval/tasks/perspective_gap/utils.py
@@ -1,4 +1,25 @@
 import re
+import warnings
+
+_SCORER_INSTALL_CMD = (
+    'pip install "perspective-gap @ '
+    'git+https://github.com/WhymustIhaveaname/PerspectiveGap.git"'
+)
+
+
+def _load_scorer(name):
+    try:
+        from perspective_gap import scoring
+    except ImportError:
+        warnings.warn(
+            "Evaluating PerspectiveGap requires the optional "
+            "`perspective-gap` dependency. Install it with: "
+            f"{_SCORER_INSTALL_CMD}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        raise
+    return getattr(scoring, name)
 
 
 def _strip_think_tags(text):
@@ -10,8 +31,7 @@ def _strip_think_tags(text):
 
 
 def process_results_role_assignment(doc, results):
-    from perspective_gap.scoring import score_role_assignment
-
+    score_role_assignment = _load_scorer("score_role_assignment")
     pred = _strip_think_tags(results[0])
     result = score_role_assignment(
         pred,
@@ -22,8 +42,7 @@ def process_results_role_assignment(doc, results):
 
 
 def process_results_prompt_writing(doc, results):
-    from perspective_gap.scoring import score_prompt_writing
-
+    score_prompt_writing = _load_scorer("score_prompt_writing")
     pred = _strip_think_tags(results[0])
     result = score_prompt_writing(
         pred,

--- a/lm_eval/tasks/perspective_gap/utils.py
+++ b/lm_eval/tasks/perspective_gap/utils.py
@@ -1,0 +1,34 @@
+import re
+
+
+def _strip_think_tags(text):
+    """Extract the answer after </think>, or return text as-is."""
+    parts = text.rsplit("</think>", 1)
+    if len(parts) == 2:
+        return parts[1].strip()
+    return text.strip()
+
+
+def process_results_role_assignment(doc, results):
+    from perspective_gap.scoring import score_role_assignment
+
+    pred = _strip_think_tags(results[0])
+    result = score_role_assignment(
+        pred,
+        doc["reference_need_sets"],
+        doc.get("distractor_id"),
+    )
+    return result["metrics"]
+
+
+def process_results_prompt_writing(doc, results):
+    from perspective_gap.scoring import score_prompt_writing
+
+    pred = _strip_think_tags(results[0])
+    result = score_prompt_writing(
+        pred,
+        doc["fragments"],
+        doc["reference_need_sets"],
+        doc.get("distractor_id"),
+    )
+    return result["metrics"]

--- a/lm_eval/tasks/perspective_gap/utils.py
+++ b/lm_eval/tasks/perspective_gap/utils.py
@@ -1,9 +1,10 @@
-import re
 import warnings
+
 
 _SCORER_INSTALL_CMD = (
     'pip install "perspective-gap @ '
-    'git+https://github.com/WhymustIhaveaname/PerspectiveGap.git"'
+    "git+https://github.com/WhymustIhaveaname/PerspectiveGap.git@"
+    '9c6921b3337ff3e6a6a453f68d117a8c1663135e"'
 )
 
 


### PR DESCRIPTION
## Summary

Add [PerspectiveGap](https://arxiv.org/abs/2606.08878) benchmark for evaluating LLMs' ability to compose orchestration prompts for multi-agent systems.

- **Dataset**: [sun1245/PerspectiveGap](https://huggingface.co/datasets/sun1245/PerspectiveGap) (220 evaluations, 110 scenarios x 2 seeds)
- **Two tasks**:
  - `perspective_gap_role_assignment`: model outputs JSON mapping roles to fragment IDs
  - `perspective_gap_prompt_writing`: model writes one prompt per role with relevant fragments verbatim
- **Scoring**: uses the [PerspectiveGap scorer](https://github.com/WhymustIhaveaname/PerspectiveGap), pinned to commit `9c6921b3337ff3e6a6a453f68d117a8c1663135e`
- **Reasoning model support**: strips `</think>` tags before scoring

## Validation

Tested on all 220 samples per task with gpt-5.4 (both within 95% CI of paper):

| Task | lm-eval result | Paper |
|---|---|---|
| role_assignment (strict_pass) | 26.8% | 25.5% |
| prompt_writing (strict_pass) | 3.2% | 2.3% |

The current branch is rebased onto `main`. Repository pre-commit checks pass, and the changed-task suite reports 16 passed tests.

## Files

- `lm_eval/tasks/perspective_gap/role_assignment.yaml`
- `lm_eval/tasks/perspective_gap/prompt_writing.yaml`
- `lm_eval/tasks/perspective_gap/utils.py`
- `lm_eval/tasks/perspective_gap/README.md`
