### PR TITLE
Fix dataset paths for xnli, xcopa, paws-x, and xquad

### DIFF
--- a/lm_eval/tasks/paws-x/pawsx_template_yaml
+++ b/lm_eval/tasks/paws-x/pawsx_template_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 task: null
-dataset_path: paws-x
+dataset_path: google-research-datasets/paws-x
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/xcopa/default_et.yaml
+++ b/lm_eval/tasks/xcopa/default_et.yaml
@@ -1,5 +1,5 @@
 task: xcopa_et
-dataset_path: xcopa
+dataset_path: cambridgeltl/xcopa
 dataset_name: et
 output_type: multiple_choice
 validation_split: validation

--- a/lm_eval/tasks/xnli/xnli_common_yaml
+++ b/lm_eval/tasks/xnli/xnli_common_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 task: null
-dataset_path: xnli
+dataset_path: facebook/xnli
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/xquad/xquad_common_yaml
+++ b/lm_eval/tasks/xquad/xquad_common_yaml
@@ -3,7 +3,7 @@
 # by the harness.
 tag: xquad
 task: null
-dataset_path: xquad
+dataset_path: google/xquad
 dataset_name: null
 output_type: generate_until
 validation_split: validation


### PR DESCRIPTION
## Summary
Hugging Face Hub now requires `namespace/name` repo ids. Tasks using bare names like `xcopa` fail at load time with `HfUriError`.

## Fix
Update the shared task YAML templates to the canonical Hub paths:
- `xcopa` → `cambridgeltl/xcopa`
- `xnli` → `facebook/xnli`
- `paws-x` → `google-research-datasets/paws-x`
- `xquad` → `google/xquad`

Fixes #3846


Made with [Cursor](https://cursor.com)