### PR TITLE
Add ray to vllm optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ Repository = "https://github.com/EleutherAI/lm-evaluation-harness"
 api = ["requests", "aiohttp", "tenacity", "tqdm", "tiktoken"]
 archiver = ["jsonlines", "zstandard"]
 hf = ["transformers>=4.1","torch>=1.8", "accelerate>=0.26.0", "peft>=0.2.0",]
-vllm = ["vllm>=0.18"]
+vllm = ["vllm>=0.18", "ray"]
 gptq = ["auto-gptq[triton]>=0.6.0"]
 gptqmodel = ["gptqmodel>=1.0.9"]
 ipex = ["optimum-intel"]


### PR DESCRIPTION
## Summary
- Add `ray` to the `lm_eval[vllm]` optional dependency group in `pyproject.toml`
- The vllm backend imports `ray` at module load time (`vllm_causallms.py`, `vllm_vlms.py`), but `pip install lm_eval[vllm]` did not install it, causing `ImportError`

## Test plan
- [ ] `pip install -e ".[vllm]"` in a clean environment succeeds
- [ ] `python -c "from lm_eval.models.vllm_causallms import VLLM"` imports without error

Fixes #3688

Made with [Cursor](https://cursor.com)