### PR TITLE
fix: load SCROLLS without datasets scripts

### DIFF
--- a/lm_eval/tasks/scrolls/README.md
+++ b/lm_eval/tasks/scrolls/README.md
@@ -8,6 +8,9 @@ including summarization, question answering, and natural language inference.
 
 Homepage: https://www.scrolls-benchmark.com/
 
+Data loading does not use the `tau/scrolls` dataset script (removed in `datasets` 4+).
+Each subset is loaded from the published zip/jsonl files via an in-repo loader in `task.py`.
+
 Since SCROLLS tasks are generally longer than the maximum sequence length of many models,
 it is possible to create "subset" tasks that contain only those samples whose tokenized length
 is less than some pre-defined limit. For example, to create a subset of "Qasper" that would

--- a/lm_eval/tasks/scrolls/task.py
+++ b/lm_eval/tasks/scrolls/task.py
@@ -1,10 +1,12 @@
+import json
 import re
+import zipfile
 from abc import abstractmethod
 from functools import reduce
 
 import numpy as np
 import transformers.data.metrics.squad_metrics as squad_metrics
-from datasets import Dataset
+from datasets import Dataset, DatasetDict
 from evaluate import load
 from transformers import AutoTokenizer
 
@@ -41,6 +43,9 @@ _CITATION = """
 # To allow for evaluation of causal models, we'll
 # reformualte these with appropriate prompts
 
+_SCROLLS_FEATURES = ("id", "pid", "input", "output")
+_SCROLLS_SPLITS = ("train", "validation", "test")
+
 
 def _download_metric():
     import os
@@ -62,6 +67,39 @@ def _download_metric():
     shutil.copy(scrolls_metric_path, updated_scrolls_metric_path)
     return updated_scrolls_metric_path
 
+
+def _load_scrolls_dataset_from_zip(zip_path: str, dataset_name: str) -> DatasetDict:
+    """Load a SCROLLS subset from its Hub zip without running the dataset script.
+
+    ``tau/scrolls`` still ships only zip + ``scrolls.py``. datasets>=4 no longer
+    executes dataset scripts, so we mirror the script's jsonl parsing here.
+    """
+    splits = {}
+    with zipfile.ZipFile(zip_path) as zf:
+        for split in _SCROLLS_SPLITS:
+            member = f"{dataset_name}/{split}.jsonl"
+            with zf.open(member) as f:
+                rows = []
+                for line in f:
+                    if not line.strip():
+                        continue
+                    row = json.loads(line)
+                    # QuALITY rows may include is_hard; drop it to keep schema fixed.
+                    row.pop("is_hard", None)
+                    rows.append({key: row[key] for key in _SCROLLS_FEATURES})
+                splits[split] = Dataset.from_list(rows)
+    return DatasetDict(splits)
+
+
+def _load_scrolls_dataset(dataset_name: str) -> DatasetDict:
+    from huggingface_hub import hf_hub_download
+
+    zip_path = hf_hub_download(
+        repo_id="tau/scrolls",
+        repo_type="dataset",
+        filename=f"{dataset_name}.zip",
+    )
+    return _load_scrolls_dataset_from_zip(zip_path, dataset_name)
 
 def _process_doc_prepended_question(doc):
     # "When a query is given in addition to the raw text (as
@@ -162,8 +200,10 @@ class _SCROLLSTask(ConfigurableTask):
     def doc_to_decontamination_query(self, doc):
         return doc["input"]
 
-    def download(self, *args, **kwargs):
-        super().download(*args, **kwargs)
+    def download(self, dataset_kwargs=None, **kwargs):
+        # Bypass datasets.load_dataset("tau/scrolls"): the Hub repo is script-based
+        # and datasets>=4 refuses to run dataset scripts.
+        self.dataset = _load_scrolls_dataset(self.DATASET_NAME)
         del self.dataset["test"]
         for split in self.dataset:
             self.dataset[split] = _drop_duplicates_in_input(self.dataset[split])

--- a/lm_eval/tasks/scrolls/task.py
+++ b/lm_eval/tasks/scrolls/task.py
@@ -5,10 +5,10 @@ from abc import abstractmethod
 from functools import reduce
 
 import numpy as np
-import transformers.data.metrics.squad_metrics as squad_metrics
 from datasets import Dataset, DatasetDict
 from evaluate import load
 from transformers import AutoTokenizer
+from transformers.data.metrics import squad_metrics
 
 from lm_eval.api.instance import Instance
 from lm_eval.api.metrics import mean
@@ -101,6 +101,7 @@ def _load_scrolls_dataset(dataset_name: str) -> DatasetDict:
     )
     return _load_scrolls_dataset_from_zip(zip_path, dataset_name)
 
+
 def _process_doc_prepended_question(doc):
     # "When a query is given in addition to the raw text (as
     # in QMSum, Qasper, NarrativeQA, QuALITY, and ContractNLI),
@@ -124,7 +125,7 @@ def _drop_duplicates_in_input(untokenized_dataset):
     id_to_idx = {}
     outputs = []
     for i, (id_, output) in enumerate(
-        zip(untokenized_dataset["id"], untokenized_dataset["output"])
+        zip(untokenized_dataset["id"], untokenized_dataset["output"], strict=True)
     ):
         if id_ in id_to_idx:
             outputs[id_to_idx[id_]].append(output)
@@ -226,7 +227,7 @@ class _SCROLLSTask(ConfigurableTask):
 
         def _filter(sample):
             text = self._get_prune_text(sample)
-            cached = cache.get(text, None)
+            cached = cache.get(text)
             if cached is None:
                 for tokenizer in tokenizers:
                     if len(tokenizer(text).input_ids) > self.PRUNE_MAX_TOKENS:
@@ -254,7 +255,7 @@ class _SCROLLSTask(ConfigurableTask):
 
     def _make_compute_metrics(self, value):
         def compute_metrics(samples):
-            predictions, references = zip(*samples)  # unzip, if you will
+            predictions, references = zip(*samples, strict=True)  # unzip, if you will
             computed = self.metric.compute(
                 predictions=predictions, references=references
             )
@@ -285,7 +286,7 @@ class _SCROLLSMultipleChoiceTask(_SCROLLSTask):
     def process_results(self, doc, results):
         gold = doc["gold"]
 
-        lls, _ = zip(*results)
+        lls, _ = zip(*results, strict=True)
         acc = 1.0 if np.argmax(lls) == gold else 0.0
         completion_len = np.array([float(len(i)) for i in doc["choices"]])
         acc_norm = 1.0 if np.argmax(lls / completion_len) == gold else 0.0
@@ -303,9 +304,9 @@ class _SCROLLSMultipleChoiceTask(_SCROLLSTask):
             Instance(
                 request_type="loglikelihood",
                 doc=doc,
-                arguments=(ctx, " {}".format(choice))
+                arguments=(ctx, f" {choice}")
                 if not apply_chat_template
-                else (ctx, "{}".format(choice)),
+                else (ctx, f"{choice}"),
                 idx=i,
                 **kwargs,
             )
@@ -357,8 +358,9 @@ class Qasper(_SCROLLSTask):
     def _process_doc(self, doc):
         doc = _process_doc_prepended_question(doc)
         doc["is_yes_no"] = reduce(
-            lambda prev, cur: prev
-            and squad_metrics.normalize_answer(cur) in ["yes", "no"],
+            lambda prev, cur: (
+                prev and squad_metrics.normalize_answer(cur) in ["yes", "no"]
+            ),
             doc["outputs"],
             True,
         )
@@ -477,7 +479,7 @@ class ContractNLI(_SCROLLSMultipleChoiceTask):
     """
 
     DATASET_NAME = "contract_nli"
-    CHOICES = ["Not mentioned", "Entailment", "Contradiction"]
+    CHOICES = ("Not mentioned", "Entailment", "Contradiction")
 
     def _process_doc(self, doc):
         doc = _process_doc_prepended_question(doc)

--- a/tests/test_scrolls_loader.py
+++ b/tests/test_scrolls_loader.py
@@ -1,0 +1,87 @@
+import json
+import zipfile
+from pathlib import Path
+
+from lm_eval.tasks.scrolls.task import (
+    _drop_duplicates_in_input,
+    _load_scrolls_dataset_from_zip,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_load_scrolls_dataset_from_zip(tmp_path: Path):
+    dataset_name = "qasper"
+    root = tmp_path / dataset_name
+    root.mkdir()
+
+    train_rows = [
+        {
+            "id": "a",
+            "pid": "a_0",
+            "input": "q1?\n\ntext one",
+            "output": "ans1",
+        }
+    ]
+    validation_rows = [
+        {
+            "id": "b",
+            "pid": "b_0",
+            "input": "q2?\n\ntext two",
+            "output": "ans2a",
+        },
+        {
+            "id": "b",
+            "pid": "b_1",
+            "input": "q2?\n\ntext two",
+            "output": "ans2b",
+        },
+        {
+            "id": "c",
+            "pid": "c_0",
+            "input": "hard?\n\ntext three",
+            "output": "ans3",
+            "is_hard": True,
+        },
+    ]
+    test_rows = [
+        {
+            "id": "d",
+            "pid": "d_0",
+            "input": "q4?\n\ntest",
+            "output": "",
+        }
+    ]
+
+    _write_jsonl(root / "train.jsonl", train_rows)
+    _write_jsonl(root / "validation.jsonl", validation_rows)
+    _write_jsonl(root / "test.jsonl", test_rows)
+
+    zip_path = tmp_path / f"{dataset_name}.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for split in ("train", "validation", "test"):
+            zf.write(root / f"{split}.jsonl", arcname=f"{dataset_name}/{split}.jsonl")
+
+    dataset = _load_scrolls_dataset_from_zip(str(zip_path), dataset_name)
+
+    assert set(dataset.keys()) == {"train", "validation", "test"}
+    assert len(dataset["train"]) == 1
+    assert len(dataset["validation"]) == 3
+    assert len(dataset["test"]) == 1
+    assert dataset["train"][0]["id"] == "a"
+    assert "is_hard" not in dataset["validation"][2]
+    assert set(dataset["validation"].column_names) == {
+        "id",
+        "pid",
+        "input",
+        "output",
+    }
+
+    deduped = _drop_duplicates_in_input(dataset["validation"])
+    assert len(deduped) == 2
+    assert deduped[0]["outputs"] == ["ans2a", "ans2b"]
+    assert deduped[1]["outputs"] == ["ans3"]


### PR DESCRIPTION
## Summary
- Load `tau/scrolls` subsets from the published zip/jsonl files via an in-repo loader, instead of `datasets.load_dataset` + the Hub dataset script (removed in datasets 4+)
- Drop the temporary `datasets<4.0.0` pin approach
- Add a unit test for the zip/jsonl loader and duplicate-collapse helper

Fixes #3859

## Test plan
- [x] `pytest tests/test_scrolls_loader.py`
- [x] Smoke-load real `qasper.zip` and instantiate `Qasper` (validation docs present, test split dropped)
- [ ] `lm_eval --tasks scrolls_qasper` on datasets 4+/5.x without `Dataset scripts are no longer supported`