### PR TITLE
Fix infinite loop in Ruler sample generation when shrinking fails

### DIFF
--- a/lm_eval/tasks/ruler/cwe_utils.py
+++ b/lm_eval/tasks/ruler/cwe_utils.py
@@ -140,6 +140,8 @@ def sys_word_pair_random(
             except:  # noqa: E722
                 if used_words > incremental:
                     used_words -= incremental
+                else:
+                    raise
 
         if remove_newline_tab:
             input_text = " ".join(

--- a/lm_eval/tasks/ruler/cwe_utils.py
+++ b/lm_eval/tasks/ruler/cwe_utils.py
@@ -33,9 +33,7 @@ TEMPLATE = CONFIG["template"] + CONFIG["answer_prefix"]
 
 r = wonderwords.RandomWord()
 WORDS = sorted(
-    list(
-        set([item for x in ["noun", "adjective", "verb"] for item in r._categories[x]])
-    )
+    {item for x in ["noun", "adjective", "verb"] for item in r._categories[x]}
 )
 RNG.shuffle(WORDS)
 

--- a/lm_eval/tasks/ruler/prepare_niah.py
+++ b/lm_eval/tasks/ruler/prepare_niah.py
@@ -299,6 +299,8 @@ def generate_samples(
             except:
                 if used_haystack > incremental:
                     used_haystack -= incremental
+                else:
+                    raise
 
         if remove_newline_tab:
             input_text = " ".join(

--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -183,6 +183,8 @@ def generate_samples(
             except:  # noqa: E722
                 if used_docs > incremental:
                     used_docs -= incremental
+                else:
+                    raise
 
         if remove_newline_tab:
             input_text = " ".join(

--- a/lm_eval/tasks/ruler/vt_utils.py
+++ b/lm_eval/tasks/ruler/vt_utils.py
@@ -186,6 +186,8 @@ def sys_vartrack_w_noise_random(
             except:  # noqa: E722
                 if used_noises > incremental:
                     used_noises -= incremental
+                else:
+                    raise
 
         if add_fewshot and (icl_example is not None):
             # insert icl_example between model template and input

--- a/lm_eval/tasks/ruler/vt_utils.py
+++ b/lm_eval/tasks/ruler/vt_utils.py
@@ -89,8 +89,8 @@ def generate_input_output(num_noises, num_chains, num_hops, is_icl=False):
     # sample random positions to insert variable assignment
     for chain_i in chains:
         # sample random positions (sorted) to insert variable assignment
-        positions = list(sorted(random.sample(range(len(sentences)), len(chain_i))))
-        for insert_pi, j in zip(positions, range(len(chain_i))):
+        positions = sorted(random.sample(range(len(sentences)), len(chain_i)))
+        for insert_pi, j in zip(positions, range(len(chain_i)), strict=True):
             sentences.insert(insert_pi + j, chain_i[j])
 
     # Insert the passkey sentence at the random position
@@ -135,7 +135,7 @@ def sys_vartrack_w_noise_random(
     num_hops: int = 4,
     add_fewshot: bool = True,
     tokens_to_generate=30,
-    icl_example: dict = None,
+    icl_example: dict | None = None,
     remove_newline_tab=False,
 ):
     write_jsons = []


### PR DESCRIPTION
## Summary
- Raise when Ruler sample-generation retry loops cannot shrink `used_docs`, `used_noises`, `used_words`, or `used_haystack` any further
- Prevents hanging forever when `max_seq_length` is below 4096 and a sample cannot fit

## Issues addressed
Fixes #2963

## Test plan
- [ ] Run Ruler QA generation with `max_seq_length=2048` and confirm it fails fast instead of hanging
- [ ] Run `pytest lm_eval/tasks/ruler/test_prepare_niah_local.py -s -vv`

Made with [Cursor](https://cursor.com)