### PR TITLE
fix(ruler): prevent infinite loop in QA sample generation

### DIFF
--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -183,6 +183,8 @@ def generate_samples(
             except:  # noqa: E722
                 if used_docs > incremental:
                     used_docs -= incremental
+                else:
+                    raise
 
         if remove_newline_tab:
             input_text = " ".join(


### PR DESCRIPTION
## Summary
- Fix an infinite `while True` loop in `qa_utils.generate_samples()` when `max_seq_length < 4096`
- When sample generation still fails after reducing `used_docs` to `incremental`, raise instead of looping forever
- Matches the existing pattern in `prepare_niah.py` and `cwe_utils.py`

Fixes #2963

## Test plan
- [ ] Run Ruler QA task generation with `max_seq_lengths=[2048]` and confirm it completes or fails fast with a clear error
- [ ] Confirm `max_seq_lengths=[4096]` behavior is unchanged


Made with [Cursor](https://cursor.com)