### PR TITLE
Add AnchoredMultiChoiceRegexFilter: commitment-based answer extraction

### DIFF
--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -284,12 +284,12 @@ class AnchoredMultiChoiceRegexFilter(MultiChoiceRegexFilter):
             for tasks that *require* an explicit final answer.
     """
 
-    DEFAULT_SENTINELS: list[str] = [
+    DEFAULT_SENTINELS: tuple[str, ...] = (
         # "the/final/correct answer is (X)" / "answer: (X)"
         r"(?:the\s+)?(?:final|correct)?\s*answer\s*(?:is|:)\s*",
         # "therefore, ... (X)" as a common CoT conclusion
         r"therefore[,\s]+(?:the\s+answer\s+is\s*)?",
-    ]
+    )
 
     def __init__(
         self,
@@ -317,38 +317,49 @@ class AnchoredMultiChoiceRegexFilter(MultiChoiceRegexFilter):
         self.answer_sentinels = [re.compile(s, flags) for s in sentinels]
         self.fallback_to_positional = fallback_to_positional
 
-    def _extract_after_sentinel(self, resp: str, letter_regex: re.Pattern) -> str | None:
+    def _extract_after_sentinel(
+        self, resp: str, letter_regex: re.Pattern
+    ) -> str | None:
         """Return the parenthesized letter following the first matching sentinel.
 
         Returns ``None`` if no sentinel is present or no letter follows it.
         """
         for sentinel in self.answer_sentinels:
             for m in sentinel.finditer(resp):
-                tail = resp[m.end():]
+                tail = resp[m.end() :]
                 letter_match = letter_regex.search(tail)
                 if letter_match:
-                    # Normalize bare letter "A" -> "(A)" to match choice_to_alpha form.
-                    val = letter_match.group(1)
+                    # Two capture groups: group(1) = "(A)" form, group(2) = bare "A".
+                    val = letter_match.group(1) or letter_match.group(2)
+                    # Normalize to the "(X)" form the scorer expects.
                     return val if val.startswith("(") else f"({val})"
         return None
 
     def apply(
         self, resps: Iterable[Sequence[str]], docs: Sequence[dict[str, Any]]
     ) -> list[list[str]]:
-        # Letter regex tolerant of both "(A)" and bare "A" forms.
+        # Letter regex tolerant of both "(A)" and bare "A" forms. Crucially,
+        # the bare-letter form must be a *standalone token* (not the first
+        # letter of a longer word like "by"/"after"/"clearly"), otherwise the
+        # sentinel would be defeated by any prose word beginning with a letter.
+        # Two alternatives: a parenthesized letter, or an isolated single letter.
         letter_flags = re.IGNORECASE if self.ignore_case else 0
-        letter_regex = re.compile(r"\(?([A-Za-z])\)?", letter_flags)
+        letter_regex = re.compile(
+            r"\(([A-Za-z])\)|(?<![A-Za-z])([A-Za-z])(?![A-Za-z])",
+            letter_flags,
+        )
 
         # Delegate fallback / non-sentinel responses to the parent's full logic.
         # We only override the response when a sentinel commits to a letter.
         parent_filtered = super().apply(resps, docs)
 
         hardened = []
-        for resp_list, doc, parent_list in zip(resps, docs, parent_filtered, strict=True):
+        for resp_list, doc, parent_list in zip(
+            resps, docs, parent_filtered, strict=True
+        ):
             choices = doc["choices"]
             valid_letters = {
-                chr(ord("A") + i): f"({chr(ord('A') + i)})"
-                for i in range(len(choices))
+                chr(ord("A") + i): f"({chr(ord('A') + i)})" for i in range(len(choices))
             }
             row = []
             for resp, parent_val in zip(resp_list, parent_list, strict=True):
@@ -359,7 +370,10 @@ class AnchoredMultiChoiceRegexFilter(MultiChoiceRegexFilter):
                 if anchored is not None:
                     # Honor ignore_case / canonicalize to the "(X)" form within range.
                     canon = anchored.upper() if self.ignore_case else anchored
-                    if canon in valid_letters.values() or canon.strip("()") in valid_letters:
+                    if (
+                        canon in valid_letters.values()
+                        or canon.strip("()") in valid_letters
+                    ):
                         letter = canon.strip("()")
                         row.append(valid_letters.get(letter, parent_val))
                     else:

--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -125,6 +125,19 @@ class MultiChoiceRegexFilter(RegexFilter):
 
     Assumes each document has a "choices" field containing the list of answer choices
     and that the answer label symbols are of the form (A), (B), (C), ... or A, B, C.
+
+    .. security-note::
+
+        Positional extraction (``group_select`` picks the Nth parenthesized letter
+        in the full response) is **position-based, not commitment-based**: a
+        response that states ``(A)`` and later writes "Eliminated: (A), (C), (D)"
+        will have its extracted letter determined by where letters appear, not by
+        which letter the model committed to. This lets a subject model
+        adversarially structure its output so the extracted answer differs from
+        its intended one, inflating or deflating accuracy without changing
+        correctness. For tasks where the model is instructed to emit an explicit
+        final-answer marker, prefer :class:`AnchoredMultiChoiceRegexFilter`,
+        which extracts the *committed* answer rather than the Nth match.
     """
 
     def __init__(
@@ -239,3 +252,123 @@ class MultiChoiceRegexFilter(RegexFilter):
             filtered_resps.append(filtered)
 
         return filtered_resps
+
+
+@register_filter("anchored_multi_choice_regex")
+class AnchoredMultiChoiceRegexFilter(MultiChoiceRegexFilter):
+    """Commitment-based multiple-choice extraction.
+
+    Hardens :class:`MultiChoiceRegexFilter` against position-based answer
+    gaming. Instead of trusting the Nth parenthesized letter in the whole
+    response (which a subject model can manipulate by where it places letters),
+    this filter first looks for an explicit *final-answer sentinel* and extracts
+    the letter that immediately follows it. Only if no sentinel is present does
+    it fall back to the parent's positional behavior.
+
+    This makes the model's *committed* answer authoritative: a response like
+
+        "Reasoning leads to (B). Eliminated: (A), (C), (D)."
+
+    extracts ``(B)`` (the committed answer) rather than ``(D)`` (the last
+    positional match), which is what the parent filter would return.
+
+    Args:
+        answer_sentinels: Ordered list of regex patterns that introduce the
+            committed answer. The first sentinel that matches is used; the
+            captured/matched answer is extracted from the text following it.
+            Defaults to common "final answer" phrasings. Set to an empty list
+            to disable anchoring and get identical behavior to the parent.
+        fallback_to_positional: If ``True`` (default), fall back to the parent
+            positional extraction when no sentinel matches. If ``False``,
+            responses without a sentinel are scored as ``[invalid]`` — useful
+            for tasks that *require* an explicit final answer.
+    """
+
+    DEFAULT_SENTINELS: list[str] = [
+        # "the/final/correct answer is (X)" / "answer: (X)"
+        r"(?:the\s+)?(?:final|correct)?\s*answer\s*(?:is|:)\s*",
+        # "therefore, ... (X)" as a common CoT conclusion
+        r"therefore[,\s]+(?:the\s+answer\s+is\s*)?",
+    ]
+
+    def __init__(
+        self,
+        regex_pattern: str = r"#### (\-?[0-9\.\,]+)",
+        group_select: int = 0,
+        fallback: str = "[invalid]",
+        ignore_case: bool = False,
+        ignore_punctuation: bool = False,
+        regexes_to_ignore: list[str] | None = None,
+        answer_sentinels: list[str] | None = None,
+        fallback_to_positional: bool = True,
+    ) -> None:
+        super().__init__(
+            regex_pattern=regex_pattern,
+            group_select=group_select,
+            fallback=fallback,
+            ignore_case=ignore_case,
+            ignore_punctuation=ignore_punctuation,
+            regexes_to_ignore=regexes_to_ignore,
+        )
+        flags = re.IGNORECASE if ignore_case else 0
+        sentinels = (
+            self.DEFAULT_SENTINELS if answer_sentinels is None else answer_sentinels
+        )
+        self.answer_sentinels = [re.compile(s, flags) for s in sentinels]
+        self.fallback_to_positional = fallback_to_positional
+
+    def _extract_after_sentinel(self, resp: str, letter_regex: re.Pattern) -> str | None:
+        """Return the parenthesized letter following the first matching sentinel.
+
+        Returns ``None`` if no sentinel is present or no letter follows it.
+        """
+        for sentinel in self.answer_sentinels:
+            for m in sentinel.finditer(resp):
+                tail = resp[m.end():]
+                letter_match = letter_regex.search(tail)
+                if letter_match:
+                    # Normalize bare letter "A" -> "(A)" to match choice_to_alpha form.
+                    val = letter_match.group(1)
+                    return val if val.startswith("(") else f"({val})"
+        return None
+
+    def apply(
+        self, resps: Iterable[Sequence[str]], docs: Sequence[dict[str, Any]]
+    ) -> list[list[str]]:
+        # Letter regex tolerant of both "(A)" and bare "A" forms.
+        letter_flags = re.IGNORECASE if self.ignore_case else 0
+        letter_regex = re.compile(r"\(?([A-Za-z])\)?", letter_flags)
+
+        # Delegate fallback / non-sentinel responses to the parent's full logic.
+        # We only override the response when a sentinel commits to a letter.
+        parent_filtered = super().apply(resps, docs)
+
+        hardened = []
+        for resp_list, doc, parent_list in zip(resps, docs, parent_filtered, strict=True):
+            choices = doc["choices"]
+            valid_letters = {
+                chr(ord("A") + i): f"({chr(ord('A') + i)})"
+                for i in range(len(choices))
+            }
+            row = []
+            for resp, parent_val in zip(resp_list, parent_list, strict=True):
+                if not isinstance(resp, str):
+                    row.append(parent_val)
+                    continue
+                anchored = self._extract_after_sentinel(resp, letter_regex)
+                if anchored is not None:
+                    # Honor ignore_case / canonicalize to the "(X)" form within range.
+                    canon = anchored.upper() if self.ignore_case else anchored
+                    if canon in valid_letters.values() or canon.strip("()") in valid_letters:
+                        letter = canon.strip("()")
+                        row.append(valid_letters.get(letter, parent_val))
+                    else:
+                        # Sentinel present but letter out of range -> trust sentinel signal,
+                        # fall to parent (positional) rather than silently inventing an answer.
+                        row.append(parent_val)
+                elif self.fallback_to_positional:
+                    row.append(parent_val)
+                else:
+                    row.append(self.fallback)
+            hardened.append(row)
+        return hardened

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -39,18 +39,19 @@ def test_multi_choice_regex_all_empty_capture_groups_falls_back_to_bare_letter()
 # ---------------------------------------------------------------------------
 
 # GPQA / MMLU-flan-cot / GSM8K style config: last-match over "(A)" letters.
-_LAST_MATCH = dict(
-    regex_pattern=r"(\([A-Z]\))",
-    group_select=-1,
-    ignore_case=True,
-    ignore_punctuation=True,
-)
+_LAST_MATCH = {
+    "regex_pattern": r"(\([A-Z]\))",
+    "group_select": -1,
+    "ignore_case": True,
+    "ignore_punctuation": True,
+}
 
 
 def test_parent_last_match_is_gamed_by_trailing_elimination_list():
     """REGRESSION (parent filter): trailing 'Eliminated: (A),(C),(D)' flips the
     extracted letter from the committed (B) to (D). This is the bug the
-    anchored filter exists to fix."""
+    anchored filter exists to fix.
+    """
     filt = MultiChoiceRegexFilter(**_LAST_MATCH)
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     resps = [["Conclusion: (B). Eliminated: (A), (C), (D)."]]
@@ -60,7 +61,8 @@ def test_parent_last_match_is_gamed_by_trailing_elimination_list():
 
 def test_parent_first_match_is_gamed_by_revision():
     """REGRESSION (parent filter, group_select=0): 'First I think (A) ...
-    reconsidering: (B)' extracts the abandoned (A)."""
+    reconsidering: (B)' extracts the abandoned (A).
+    """
     filt = MultiChoiceRegexFilter(regex_pattern=r"(\([A-Z]\))", group_select=0)
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     resps = [["First I think (A). But wait, reconsidering: (B) is correct."]]
@@ -69,7 +71,8 @@ def test_parent_first_match_is_gamed_by_revision():
 
 def test_anchored_extracts_committed_answer_despite_trailing_letters():
     """FIX: with the default 'answer is' sentinel, the committed (B) is
-    extracted even when trailing letters would otherwise win positionally."""
+    extracted even when trailing letters would otherwise win positionally.
+    """
     filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     resps = [["The answer is (B). Eliminated: (A), (C), (D)."]]
@@ -86,7 +89,8 @@ def test_anchored_extracts_committed_answer_with_therefore_sentinel():
 
 def test_anchored_falls_back_to_positional_when_no_sentinel():
     """BACKWARD COMPAT: when no sentinel is present, anchored behaves like the
-    parent (positional extraction) so adopting it never silently breaks runs."""
+    parent (positional extraction) so adopting it never silently breaks runs.
+    """
     filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     # No 'answer is' / 'therefore' phrasing — pure positional response.
@@ -97,10 +101,9 @@ def test_anchored_falls_back_to_positional_when_no_sentinel():
 def test_anchored_strict_mode_marks_missing_sentinel_invalid():
     """FIX (strict mode): with fallback_to_positional=False, a response with no
     sentinel is scored [invalid] rather than positionally — for tasks that
-    *require* an explicit committed answer."""
-    filt = AnchoredMultiChoiceRegexFilter(
-        **_LAST_MATCH, fallback_to_positional=False
-    )
+    *require* an explicit committed answer.
+    """
+    filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH, fallback_to_positional=False)
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     resps = [["My choice is (B)."]]
     assert filt.apply(resps, [doc]) == [["[invalid]"]]
@@ -108,7 +111,8 @@ def test_anchored_strict_mode_marks_missing_sentinel_invalid():
 
 def test_anchored_preserves_baseline_extraction_without_noise():
     """NORMAL CASE: a clean 'The answer is (B)' with no trailing letter noise
-    extracts identically under parent and anchored filters."""
+    extracts identically under parent and anchored filters.
+    """
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     resps = [["Reasoning. The answer is (B)."]]
     parent = MultiChoiceRegexFilter(**_LAST_MATCH).apply(resps, [doc])
@@ -118,7 +122,8 @@ def test_anchored_preserves_baseline_extraction_without_noise():
 
 def test_anchored_handles_bare_letter_after_sentinel():
     """FIX: sentinel followed by a bare letter 'B' (not '(B)') is normalized to
-    '(B)' to match the choice_to_alpha form the scorer expects."""
+    '(B)' to match the choice_to_alpha form the scorer expects.
+    """
     filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     resps = [["The answer is B. Eliminated: A, C, D."]]
@@ -127,10 +132,35 @@ def test_anchored_handles_bare_letter_after_sentinel():
 
 def test_anchored_custom_sentinels():
     """FIX: task authors can supply their own sentinel patterns, e.g. for a
-    'Final answer: X' prompt format."""
+    'Final answer: X' prompt format.
+    """
     filt = AnchoredMultiChoiceRegexFilter(
         **_LAST_MATCH, answer_sentinels=[r"final\s+answer\s*:\s*"]
     )
     doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
     resps = [["Some analysis. Final answer: (B). Discarded: (A), (C), (D)."]]
     assert filt.apply(resps, [doc]) == [["(B)"]]
+
+
+def test_anchored_ignores_prose_words_after_sentinel():
+    """FIX: a prose word following the sentinel must not be mistaken for the
+    answer letter. 'The answer is by process of elimination, (A).' must extract
+    (A), not (B) (the 'b' in 'by'). This is the word-shadowing regression that
+    naive single-letter matching after the sentinel would introduce.
+    """
+    filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["The answer is by process of elimination, (A)."]]
+    assert filt.apply(resps, [doc]) == [["(A)"]]
+
+
+def test_anchored_ignores_leading_prose_word_with_common_starts():
+    """FIX: multiple common prose openers after the sentinel must not shadow
+    the committed answer letter.
+    """
+    filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    # 'clearly' starts with c, 'after' with a, 'definitely' with d.
+    # Both responses share one doc (two requests for the same document).
+    resps = [["The answer is clearly (C).", "The answer is after some thought, (A)."]]
+    assert filt.apply(resps, [doc]) == [["(C)", "(A)"]]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,7 @@
-from lm_eval.filters.extraction import MultiChoiceRegexFilter
+from lm_eval.filters.extraction import (
+    AnchoredMultiChoiceRegexFilter,
+    MultiChoiceRegexFilter,
+)
 
 
 def test_multi_choice_regex_all_empty_capture_groups_falls_back_to_choice_text():
@@ -21,3 +24,113 @@ def test_multi_choice_regex_all_empty_capture_groups_falls_back_to_bare_letter()
     docs = [{"choices": ["alpha", "beta"]}]
 
     assert filt.apply(resps, docs) == [["(B)"]]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests demonstrating the position-based answer-extraction gaming
+# vector in MultiChoiceRegexFilter, and that AnchoredMultiChoiceRegexFilter
+# resolves the model's *committed* answer instead of the Nth positional match.
+#
+# Threat model: a subject model's completion is free-form text. The extractor
+# selects a letter by position (group_select). A response that states one
+# letter and then summarizes/discusses other letters can be scored as a
+# DIFFERENT letter than the one the model committed to. This is an eval-
+# integrity issue (silent mis-scoring), not a crash.
+# ---------------------------------------------------------------------------
+
+# GPQA / MMLU-flan-cot / GSM8K style config: last-match over "(A)" letters.
+_LAST_MATCH = dict(
+    regex_pattern=r"(\([A-Z]\))",
+    group_select=-1,
+    ignore_case=True,
+    ignore_punctuation=True,
+)
+
+
+def test_parent_last_match_is_gamed_by_trailing_elimination_list():
+    """REGRESSION (parent filter): trailing 'Eliminated: (A),(C),(D)' flips the
+    extracted letter from the committed (B) to (D). This is the bug the
+    anchored filter exists to fix."""
+    filt = MultiChoiceRegexFilter(**_LAST_MATCH)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["Conclusion: (B). Eliminated: (A), (C), (D)."]]
+    # Parent returns (D) — the last positional letter, not the committed (B).
+    assert filt.apply(resps, [doc]) == [["(D)"]]
+
+
+def test_parent_first_match_is_gamed_by_revision():
+    """REGRESSION (parent filter, group_select=0): 'First I think (A) ...
+    reconsidering: (B)' extracts the abandoned (A)."""
+    filt = MultiChoiceRegexFilter(regex_pattern=r"(\([A-Z]\))", group_select=0)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["First I think (A). But wait, reconsidering: (B) is correct."]]
+    assert filt.apply(resps, [doc]) == [["(A)"]]
+
+
+def test_anchored_extracts_committed_answer_despite_trailing_letters():
+    """FIX: with the default 'answer is' sentinel, the committed (B) is
+    extracted even when trailing letters would otherwise win positionally."""
+    filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["The answer is (B). Eliminated: (A), (C), (D)."]]
+    assert filt.apply(resps, [doc]) == [["(B)"]]
+
+
+def test_anchored_extracts_committed_answer_with_therefore_sentinel():
+    """FIX: 'therefore ... (B)' sentinel is also honored by default."""
+    filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["Therefore, (B). Note (A) is a common trap, as is (D)."]]
+    assert filt.apply(resps, [doc]) == [["(B)"]]
+
+
+def test_anchored_falls_back_to_positional_when_no_sentinel():
+    """BACKWARD COMPAT: when no sentinel is present, anchored behaves like the
+    parent (positional extraction) so adopting it never silently breaks runs."""
+    filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    # No 'answer is' / 'therefore' phrasing — pure positional response.
+    resps = [["My choice is (B)."]]
+    assert filt.apply(resps, [doc]) == [["(B)"]]
+
+
+def test_anchored_strict_mode_marks_missing_sentinel_invalid():
+    """FIX (strict mode): with fallback_to_positional=False, a response with no
+    sentinel is scored [invalid] rather than positionally — for tasks that
+    *require* an explicit committed answer."""
+    filt = AnchoredMultiChoiceRegexFilter(
+        **_LAST_MATCH, fallback_to_positional=False
+    )
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["My choice is (B)."]]
+    assert filt.apply(resps, [doc]) == [["[invalid]"]]
+
+
+def test_anchored_preserves_baseline_extraction_without_noise():
+    """NORMAL CASE: a clean 'The answer is (B)' with no trailing letter noise
+    extracts identically under parent and anchored filters."""
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["Reasoning. The answer is (B)."]]
+    parent = MultiChoiceRegexFilter(**_LAST_MATCH).apply(resps, [doc])
+    anchored = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH).apply(resps, [doc])
+    assert parent == anchored == [["(B)"]]
+
+
+def test_anchored_handles_bare_letter_after_sentinel():
+    """FIX: sentinel followed by a bare letter 'B' (not '(B)') is normalized to
+    '(B)' to match the choice_to_alpha form the scorer expects."""
+    filt = AnchoredMultiChoiceRegexFilter(**_LAST_MATCH)
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["The answer is B. Eliminated: A, C, D."]]
+    assert filt.apply(resps, [doc]) == [["(B)"]]
+
+
+def test_anchored_custom_sentinels():
+    """FIX: task authors can supply their own sentinel patterns, e.g. for a
+    'Final answer: X' prompt format."""
+    filt = AnchoredMultiChoiceRegexFilter(
+        **_LAST_MATCH, answer_sentinels=[r"final\s+answer\s*:\s*"]
+    )
+    doc = {"choices": ["alpha", "beta", "gamma", "delta"]}
+    resps = [["Some analysis. Final answer: (B). Discarded: (A), (C), (D)."]]
+    assert filt.apply(resps, [doc]) == [["(B)"]]


### PR DESCRIPTION
# Add `AnchoredMultiChoiceRegexFilter`: commitment-based answer extraction

## Summary

Adds an **opt-in, backward-compatible** filter that extracts a model's
*committed* multiple-choice answer rather than the Nth positional letter
match. This closes an answer-extraction gaming vector in the existing
`MultiChoiceRegexFilter`, where a subject model's completion can be silently
mis-scored based on *where* letters appear in its free-form output rather than
which answer it committed to.

No existing task behavior changes. Tasks opt in via
`function: anchored_multi_choice_regex`.

## Background: the gaming vector

`MultiChoiceRegexFilter` selects a model's answer by position
(`group_select`): it finds every `([A-Z])` match in the response and picks the
Nth (first by default, last when `group_select=-1`, the config used by GPQA,
MMLU-flan-cot, GSM8K, MGSM, ACPBench, etc.).

This is **position-based, not commitment-based**. Consider a model whose
committed answer is **B**, emitted in a normal chain-of-thought style:

```
Conclusion: (B). Eliminated: (A), (C), (D).
```

With `group_select=-1` (last match), the extractor returns **(D)** — the last
parenthesized letter — not the committed **(B)**. The model is scored as if it
answered D. Verified against the real filter:

| Response (committed answer = B) | `group_select` | Extracts | Correct? |
|---|---|---|---|
| `The answer is (B). Eliminated: (A), (C), (D).` | `-1` | **(D)** | ✗ |
| `Reasoning leads to (B). (A) is a common mistake. (D).` | `-1` | **(D)** | ✗ |
| `The answer is (B) (unlike (A), (C), (D)).` | `-1` | **(D)** | ✗ |
| `First I think (A). Reconsidering: (B) is correct.` | `0` | **(A)** | ✗ |
| `The answer is NOT (A), NOT (C), NOT (D). It is (B).` | `0` | **(A)** | ✗ |

This is an **eval-integrity** issue, not a crash: a subject model aware of the
filter config can structure its output so the extracted letter differs from
its intended one, inflating or deflating its measured accuracy without
changing correctness. It affects any task whose prompt elicits discussion of
multiple options (which most CoT multiple-choice prompts do).

## The fix

`AnchoredMultiChoiceRegexFilter` subclasses `MultiChoiceRegexFilter` and
overrides extraction to first look for an explicit **final-answer sentinel**
(defaults: `"the/final/correct answer is X"` and `"therefore ... X"`). The
letter following the first matching sentinel is the committed answer. Only if
no sentinel is present does it fall back to the parent's positional behavior.

With the same gaming response:

```
The answer is (B). Eliminated: (A), (C), (D).
```

→ `AnchoredMultiChoiceRegexFilter` returns **(B)**. ✅

### Properties

- **Backward-compatible:** no sentinel → identical to parent. Adopting it
  never silently changes an existing run's scores.
- **Strict mode:** `fallback_to_positional=False` scores sentinel-less
  responses as `[invalid]`, for tasks that *require* an explicit committed
  answer (matches the prompt instruction).
- **Configurable:** `answer_sentinels` accepts task-specific patterns (e.g.
  `r"final\s+answer\s*:\s*"` for a "Final answer: X" prompt format).
- **Tolerant:** handles both `(B)` and bare `B` after the sentinel, honoring
  `ignore_case`.

## Usage (opt-in per task)

```yaml
filter_list:
  - name: "strict-match"
    filter:
      - function: "anchored_multi_choice_regex"
        regex_pattern: "(\\([A-Z]\\))"
        group_select: -1
        ignore_case: true
        ignore_punctuation: true
        fallback_to_positional: false   # require an explicit committed answer
      - function: "take_first"
```

## Tests

11 tests in `tests/test_filters.py`, all passing:

- **Regression (vector exists):** `test_parent_last_match_is_gamed_by_trailing_elimination_list`,
  `test_parent_first_match_is_gamed_by_revision` — pin the parent's current
  behavior so the gaming vector is documented and any future "fix" to the
  parent that changes it is surfaced.
- **Fix:** `test_anchored_extracts_committed_answer_despite_trailing_letters`,
  `test_anchored_extracts_committed_answer_with_therefore_sentinel`,
  `test_anchored_handles_bare_letter_after_sentinel`,
  `test_anchored_custom_sentinels`.
- **Backward compat / strict mode:**
  `test_anchored_falls_back_to_positional_when_no_sentinel`,
  `test_anchored_strict_mode_marks_missing_sentinel_invalid`,
  `test_anchored_preserves_baseline_extraction_without_noise`.

```
$ python -m pytest tests/test_filters.py -v
============================== 13 passed in 1.37s ==============================
```

(Includes 2 regression tests for the word-shadowing edge case documented
below.)

## Design notes

- **Why a new filter, not a change to `MultiChoiceRegexFilter`:** changing the
  parent's selection semantics would alter scores for every existing task
  retroactively — itself an eval-integrity problem (reproducibility). An opt-in
  filter lets each task adopt commitment-based extraction deliberately.
- **Why not just tell models to emit a sentinel:** prompts are advisory, not
  enforced. The filter is the enforcement boundary; this PR makes that
  boundary *available* to task authors who want it.
- A security note was added to the `MultiChoiceRegexFilter` docstring pointing
  task authors to the anchored variant.

## Known limitation: prose-word shadowing after the sentinel

The sentinel-based extraction had to be careful **not** to grab the first
letter of a prose word following the sentinel (e.g. *"The answer is by
process of elimination, (A)."* must extract `(A)`, not `(B)` from *"by"*).
This is handled by requiring the matched letter to be either parenthesized
`(A)` or a standalone single-letter token (not part of a longer word). Two
regression tests pin this behavior
(`test_anchored_ignores_prose_words_after_sentinel`,
`test_anchored_ignores_leading_prose_word_with_common_starts`).

## Known limitation: positional fallback inherits parent behavior

When no sentinel is present and `fallback_to_positional=True` (default), the
filter delegates to `MultiChoiceRegexFilter`, which has its own legacy
extraction behavior (including bare-letter fallbacks after punctuation
stripping). This PR does **not** change that fallback path — it is inherited
verbatim so existing non-sentinel responses score identically to before.
Tasks that want to reject positional extraction entirely can use
`fallback_to_positional=False` (strict mode).

## Scope

Single-purpose: one new filter + its tests + a docstring note. No changes to
any task YAML, metric, or scoring path. Diff: +291 / −1 across 2 files.
