### PR TITLE
Add ignore_whitespace option to exact_match metric

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -244,12 +244,8 @@ def exact_match_hf_evaluate(
     # Opt-in to preserve existing behavior: collapse runs of whitespace to a
     # single space and trim both ends before comparison.
     if ignore_whitespace:
-        predictions = np.array(
-            [" ".join(str(x).split()) for x in predictions]
-        )
-        references = np.array(
-            [" ".join(str(x).split()) for x in references]
-        )
+        predictions = np.array([" ".join(str(x).split()) for x in predictions])
+        references = np.array([" ".join(str(x).split()) for x in references])
 
     score_list = predictions == references
 

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -214,6 +214,7 @@ def exact_match_hf_evaluate(
     ignore_case=False,
     ignore_punctuation=False,
     ignore_numbers=False,
+    ignore_whitespace=False,
 ):
     if regexes_to_ignore is not None:
         for s in regexes_to_ignore:
@@ -236,6 +237,19 @@ def exact_match_hf_evaluate(
         repl_table = string.digits.maketrans("", "", string.digits)
         predictions = np.char.translate(predictions, table=repl_table)
         references = np.char.translate(references, table=repl_table)
+
+    # Whitespace normalization. Stripping punctuation/digits via the flags
+    # above can leave internal/edge whitespace behind (e.g. "( B )" -> " B "),
+    # causing semantically identical answers to be scored as mismatches.
+    # Opt-in to preserve existing behavior: collapse runs of whitespace to a
+    # single space and trim both ends before comparison.
+    if ignore_whitespace:
+        predictions = np.array(
+            [" ".join(str(x).split()) for x in predictions]
+        )
+        references = np.array(
+            [" ".join(str(x).split()) for x in references]
+        )
 
     score_list = predictions == references
 

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -4,8 +4,8 @@ import os
 import random
 import re
 import string
-from collections.abc import Iterable
-from typing import Callable, List, Optional, Sequence, TypeVar
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeVar
 
 import numpy as np
 import sacrebleu
@@ -62,7 +62,7 @@ def bits_per_byte(items):
 def f1_score(items):
     from sklearn.metrics import f1_score
 
-    unzipped_list = list(zip(*items))
+    unzipped_list = list(zip(*items, strict=False))
     golds = unzipped_list[0]
     preds = unzipped_list[1]
     fscore = f1_score(golds, preds)
@@ -74,7 +74,7 @@ def f1_score(items):
 def matthews_corrcoef(items):
     from sklearn.metrics import matthews_corrcoef
 
-    unzipped_list = list(zip(*items))
+    unzipped_list = list(zip(*items, strict=False))
     golds = unzipped_list[0]
     preds = unzipped_list[1]
     return matthews_corrcoef(golds, preds)
@@ -92,8 +92,8 @@ def bleu(items):
 
     Higher is better
     """
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
+    refs = next(zip(*items, strict=False))
+    preds = list(zip(*items, strict=False))[1]
     refs, preds = _sacreformat(refs, preds)
     return sacrebleu.corpus_bleu(preds, refs).score
 
@@ -107,8 +107,8 @@ def chrf(items):
 
     Higher is better  # TODO I think
     """
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
+    refs = next(zip(*items, strict=False))
+    preds = list(zip(*items, strict=False))[1]
     refs, preds = _sacreformat(refs, preds)
     return sacrebleu.corpus_chrf(preds, refs).score
 
@@ -123,16 +123,16 @@ def ter(items):
 
     Lower is better
     """
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
+    refs = next(zip(*items, strict=False))
+    preds = list(zip(*items, strict=False))[1]
     refs, preds = _sacreformat(refs, preds)
     return sacrebleu.corpus_ter(preds, refs).score
 
 
 @register_aggregation("brier_score")
 def brier_score(items):  # This is a passthrough function
-    gold, predictions = list(zip(*items))
-    bs, num_class = np.array(predictions).shape
+    gold, predictions = list(zip(*items, strict=False))
+    _bs, num_class = np.array(predictions).shape
 
     gold = list(gold)
     gold_one_hot = np.eye(num_class)[gold]
@@ -317,12 +317,12 @@ def bits_per_byte_fn(items):  # This is a passthrough function
 
 def pop_stddev(arr):
     mu = mean(arr)
-    return math.sqrt(sum([(x - mu) ** 2 for x in arr]) / len(arr))
+    return math.sqrt(sum((x - mu) ** 2 for x in arr) / len(arr))
 
 
 def sample_stddev(arr: Sequence[T]) -> float:
     mu = mean(arr)
-    return math.sqrt(sum([(x - mu) ** 2 for x in arr]) / (len(arr) - 1))
+    return math.sqrt(sum((x - mu) ** 2 for x in arr) / (len(arr) - 1))
 
 
 def mean_stderr(arr):
@@ -398,10 +398,10 @@ def ter_fn(items):  # This is a passthrough function
 def acc_all(items):
     # Only count as correct if all answers are labeled correctly for each question
     question_scoring_dict = {}
-    preds = list(zip(*items))[0]
-    docs = list(zip(*items))[1]
+    preds = next(zip(*items, strict=False))
+    docs = list(zip(*items, strict=False))[1]
 
-    for doc, pred in zip(docs, preds):
+    for doc, pred in zip(docs, preds, strict=False):
         paragraph_id = doc["idx"]["paragraph"]
         question_id = doc["idx"]["question"]
         if (paragraph_id, question_id) not in question_scoring_dict:
@@ -417,10 +417,10 @@ def acc_all(items):
 def acc_all_stderr(items):
     # Only count as correct if all answers are labeled correctly for each question
     question_scoring_dict = {}
-    preds = list(zip(*items))[0]
-    docs = list(zip(*items))[1]
+    preds = next(zip(*items, strict=False))
+    docs = list(zip(*items, strict=False))[1]
 
-    for doc, pred in zip(docs, preds):
+    for doc, pred in zip(docs, preds, strict=False):
         question_id = doc["idx"]["question"]
         if question_id not in question_scoring_dict:
             question_scoring_dict[question_id] = []
@@ -442,7 +442,7 @@ def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
 
 
 def weighted_mean(items):
-    a, b = zip(*items)
+    a, b = zip(*items, strict=False)
     return sum(a) / sum(b)
 
 
@@ -465,7 +465,7 @@ def _sacreformat(refs, preds):
         refs = list(refs)
     if not is_non_str_iterable(refs[0]):
         refs = [[ref] for ref in refs]
-    refs = list(zip(*refs))
+    refs = list(zip(*refs, strict=False))
     # Note the number of refs in each ref list much match the number of preds
 
     # We expect preds to be List[str] or List[List[str]]. Must become List[str]
@@ -564,7 +564,7 @@ def bootstrap_stderr(
 
 def stderr_for_metric(
     metric: Callable[[Sequence[T]], float], bootstrap_iters: int
-) -> Optional[Callable[[Sequence[T]], float]]:
+) -> Callable[[Sequence[T]], float] | None:
     """
     Return a function that estimates the standard error of `metric(xs)`.
 
@@ -594,10 +594,10 @@ def stderr_for_metric(
 
     stderr = {mean: mean_stderr, acc_all: acc_all_stderr}
 
-    return stderr.get(metric, None)
+    return stderr.get(metric)
 
 
-def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
+def pooled_sample_stderr(stderrs: list[float], sizes: list[int]):
     # Used to aggregate bootstrapped stderrs across subtasks in a group,
     # when we are weighting by the size of each subtask.
     #
@@ -609,13 +609,16 @@ def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
     # this empirically seems to match running `stderr_for_metric` on all instances
     # from the subtasks concatenated with each other.
     pooled_sample_var = (
-        sum([(size - 1) * stderr**2 * size for size, stderr in zip(sizes, stderrs)])
+        sum(
+            (size - 1) * stderr**2 * size
+            for size, stderr in zip(sizes, stderrs, strict=False)
+        )
     ) / (sum(sizes) - len(sizes))
 
     return np.sqrt(pooled_sample_var / sum(sizes))
 
 
-def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None):
+def combined_sample_stderr(stderrs: list[float], sizes: list[int], metrics=None):
     assert metrics is not None, (
         "Need to pass a list of each subtask's metric for this stderr aggregation"
     )
@@ -633,7 +636,7 @@ def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None)
     curr_size = sizes[0]
     curr_score = metrics[0]
 
-    for stderr, size, score in zip(stderrs[1:], sizes[1:], metrics[1:]):
+    for stderr, size, score in zip(stderrs[1:], sizes[1:], metrics[1:], strict=False):
         curr_score = ((curr_score * curr_size) + (score * size)) / (
             curr_size + size
         )  # NOTE: this assumes our aggregation fn is "mean"
@@ -656,4 +659,6 @@ def aggregate_subtask_metrics(metrics, sizes, weight_by_size=True):
 
     assert len(metrics) == len(sizes)
 
-    return sum([metric * size for metric, size in zip(metrics, sizes)]) / sum(sizes)
+    return sum(
+        metric * size for metric, size in zip(metrics, sizes, strict=False)
+    ) / sum(sizes)

--- a/tests/test_exact_match.py
+++ b/tests/test_exact_match.py
@@ -1,0 +1,74 @@
+"""Tests for exact_match whitespace normalization.
+
+Demonstrates that ignore_punctuation / ignore_numbers / regexes_to_ignore can
+leave internal/edge whitespace behind, causing semantically identical answers
+to be scored as mismatches, and that the opt-in ``ignore_whitespace`` flag
+resolves this without changing default behavior.
+"""
+from lm_eval.api.metrics import exact_match_hf_evaluate
+
+
+def _score(pred, ref, **kw):
+    return exact_match_hf_evaluate([pred], [ref], **kw)["exact_match"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: whitespace gap (default behavior, no ignore_whitespace)
+# ---------------------------------------------------------------------------
+
+def test_punctuation_strip_leaves_inner_whitespace_causing_mismatch():
+    """REGRESSION: '( B )' vs '(B)' with ignore_punctuation should be the same
+    answer, but leftover inner whitespace makes them mismatch."""
+    assert _score("( B )", "(B)", ignore_punctuation=True) == 0.0
+
+
+def test_punctuation_strip_leaves_edge_whitespace_causing_mismatch():
+    """REGRESSION: leading/trailing space survives ignore_punctuation."""
+    assert _score(" (B)", "(B)", ignore_punctuation=True) == 0.0
+    assert _score("(B) ", "(B)", ignore_punctuation=True) == 0.0
+
+
+def test_numbers_strip_leaves_inner_whitespace_causing_mismatch():
+    """REGRESSION: '4 2' vs '42' with ignore_numbers mismatches."""
+    assert _score("4 2", "42", ignore_numbers=True) == 0.0
+
+
+def test_baseline_identical_strings_still_match():
+    """SANITY: identical inputs still match with normalization flags on."""
+    assert _score("(B)", "(B)", ignore_punctuation=True) == 1.0
+    assert _score("42", "42", ignore_numbers=True) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Fix: ignore_whitespace resolves the gap
+# ---------------------------------------------------------------------------
+
+def test_ignore_whitespace_resolves_inner_whitespace_after_punct_strip():
+    """FIX: ignore_whitespace collapses '( B )' and '(B)' to a match."""
+    assert _score("( B )", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+
+
+def test_ignore_whitespace_resolves_edge_whitespace():
+    """FIX: leading/trailing/inner whitespace no longer causes mismatches."""
+    assert _score(" (B) ", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+    assert _score("( B ) ", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+
+
+def test_ignore_whitespace_collapses_multiple_internal_spaces():
+    """FIX: runs of spaces collapse to one, so '(B)    (C)' style outputs
+    compare consistently with references."""
+    assert (
+        _score("a    b", "a b", ignore_whitespace=True) == 1.0
+    )
+
+
+def test_ignore_whitespace_preserves_distinct_answers():
+    """FIX: distinct answers still don't match after whitespace normalization."""
+    assert _score("(A)", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 0.0
+
+
+def test_ignore_whitespace_is_opt_in_and_does_not_change_defaults():
+    """BACKWARD COMPAT: without ignore_whitespace, the legacy mismatch behavior
+    is unchanged so existing task scores are not silently altered."""
+    assert _score("( B )", "(B)", ignore_punctuation=True) == 0.0
+    assert _score("( B )", "(B)", ignore_punctuation=True, ignore_whitespace=False) == 0.0

--- a/tests/test_exact_match.py
+++ b/tests/test_exact_match.py
@@ -5,6 +5,7 @@ leave internal/edge whitespace behind, causing semantically identical answers
 to be scored as mismatches, and that the opt-in ``ignore_whitespace`` flag
 resolves this without changing default behavior.
 """
+
 from lm_eval.api.metrics import exact_match_hf_evaluate
 
 
@@ -16,9 +17,11 @@ def _score(pred, ref, **kw):
 # Regression: whitespace gap (default behavior, no ignore_whitespace)
 # ---------------------------------------------------------------------------
 
+
 def test_punctuation_strip_leaves_inner_whitespace_causing_mismatch():
     """REGRESSION: '( B )' vs '(B)' with ignore_punctuation should be the same
-    answer, but leftover inner whitespace makes them mismatch."""
+    answer, but leftover inner whitespace makes them mismatch.
+    """
     assert _score("( B )", "(B)", ignore_punctuation=True) == 0.0
 
 
@@ -43,23 +46,29 @@ def test_baseline_identical_strings_still_match():
 # Fix: ignore_whitespace resolves the gap
 # ---------------------------------------------------------------------------
 
+
 def test_ignore_whitespace_resolves_inner_whitespace_after_punct_strip():
     """FIX: ignore_whitespace collapses '( B )' and '(B)' to a match."""
-    assert _score("( B )", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+    assert (
+        _score("( B )", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+    )
 
 
 def test_ignore_whitespace_resolves_edge_whitespace():
     """FIX: leading/trailing/inner whitespace no longer causes mismatches."""
-    assert _score(" (B) ", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
-    assert _score("( B ) ", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+    assert (
+        _score(" (B) ", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+    )
+    assert (
+        _score("( B ) ", "(B)", ignore_punctuation=True, ignore_whitespace=True) == 1.0
+    )
 
 
 def test_ignore_whitespace_collapses_multiple_internal_spaces():
     """FIX: runs of spaces collapse to one, so '(B)    (C)' style outputs
-    compare consistently with references."""
-    assert (
-        _score("a    b", "a b", ignore_whitespace=True) == 1.0
-    )
+    compare consistently with references.
+    """
+    assert _score("a    b", "a b", ignore_whitespace=True) == 1.0
 
 
 def test_ignore_whitespace_preserves_distinct_answers():
@@ -69,6 +78,9 @@ def test_ignore_whitespace_preserves_distinct_answers():
 
 def test_ignore_whitespace_is_opt_in_and_does_not_change_defaults():
     """BACKWARD COMPAT: without ignore_whitespace, the legacy mismatch behavior
-    is unchanged so existing task scores are not silently altered."""
+    is unchanged so existing task scores are not silently altered.
+    """
     assert _score("( B )", "(B)", ignore_punctuation=True) == 0.0
-    assert _score("( B )", "(B)", ignore_punctuation=True, ignore_whitespace=False) == 0.0
+    assert (
+        _score("( B )", "(B)", ignore_punctuation=True, ignore_whitespace=False) == 0.0
+    )


### PR DESCRIPTION
# Add `ignore_whitespace` option to `exact_match` metric

## Summary

Adds an **opt-in** `ignore_whitespace` flag to `exact_match_hf_evaluate` that
normalizes whitespace before comparison. This fixes a silent false-negative
scoring bug: when `ignore_punctuation` / `ignore_numbers` / `regexes_to_ignore`
strip characters, the whitespace left behind is never collapsed, so
semantically identical answers are scored as mismatches.

No default behavior changes.

## Background: the whitespace gap

`exact_match_hf_evaluate` compares `predictions == references` after applying
the requested normalization flags. But each flag strips *characters* without
touching whitespace:

```python
if ignore_punctuation:
    repl_table = string.punctuation.maketrans("", "", string.punctuation)
    predictions = np.char.translate(predictions, table=repl_table)
    references = np.char.translate(references, table=repl_table)
# ... then: score_list = predictions == references
```

`"( B )"` with `ignore_punctuation=True` becomes `" B "` — but the reference
`"(B)"` becomes `"B"`. They mismatch, even though both are unambiguously
answer **B**.

Verified against the real metric (`ignore_punctuation=True`, the config GPQA
uses):

| Prediction | Reference | Score | Correct? |
|---|---|---|---|
| `"(B)"` | `"(B)"` | 1.0 | ✓ baseline |
| `"( B )"` | `"(B)"` | **0.0** | ✗ whitespace gap |
| `"(B) "` | `"(B)"` | **0.0** | ✗ trailing space |
| `" (B)"` | `"(B)"` | **0.0** | ✗ leading space |
| `"(B)."` | `"(B)"` | 1.0 | ✓ period stripped |
| `"( B )."` | `"(B)"` | **0.0** | ✗ period stripped, whitespace remains |

Same pattern with `ignore_numbers=True`: `"4 2"` vs `"42"` mismatches.

This is a **scoring reliability** issue: legitimate answers with incidental
internal/edge spacing are silently scored wrong. It affects any task enabling
these flags (GPQA-style multiple-choice with `exact_match`).

## The fix

New `ignore_whitespace` flag (default `False`), applied *after* the other
normalizations, collapsing runs of whitespace to a single space and trimming
both ends:

```python
if ignore_whitespace:
    predictions = np.array([" ".join(str(x).split()) for x in predictions])
    references  = np.array([" ".join(str(x).split()) for x in references])
```

With the same cases:

| Prediction | Reference | Score (with `ignore_whitespace`) |
|---|---|---|
| `"( B )"` | `"(B)"` | **1.0** ✓ |
| `"(B) "` | `"(B)"` | **1.0** ✓ |
| `"( B )."` | `"(B)"` | **1.0** ✓ |

Distinct answers still don't match (`"(A)"` vs `"(B)"` → 0.0).

## Properties

- **Backward-compatible:** `ignore_whitespace` defaults to `False`, so
  existing task scores are unchanged. Verified by an explicit opt-in test.
- **Safe:** whitespace collapse via `" ".join(s.split())` is a standard,
  reversible-on-equivalent-strings normalization.
- **Opt-in per task:** tasks adopt it deliberately via
  `metric_list: - metric: exact_match, ignore_whitespace: true`.

## Usage

```yaml
metric_list:
  - metric: exact_match
    aggregation: mean
    higher_is_better: true
    ignore_case: true
    ignore_punctuation: true
    ignore_whitespace: true      # new
```

## Tests

9 tests in `tests/test_exact_match.py`, all passing:

- **Regression (gap exists):** `test_punctuation_strip_leaves_inner_whitespace_causing_mismatch`,
  `test_punctuation_strip_leaves_edge_whitespace_causing_mismatch`,
  `test_numbers_strip_leaves_inner_whitespace_causing_mismatch`.
- **Fix:** `test_ignore_whitespace_resolves_inner_whitespace_after_punct_strip`,
  `test_ignore_whitespace_resolves_edge_whitespace`,
  `test_ignore_whitespace_collapses_multiple_internal_spaces`.
- **Backward compat / sanity:** `test_baseline_identical_strings_still_match`,
  `test_ignore_whitespace_preserves_distinct_answers`,
  `test_ignore_whitespace_is_opt_in_and_does_not_change_defaults`.

```
$ python -m pytest tests/test_exact_match.py tests/test_metrics.py -v
============================== 14 passed in 0.03s ==============================
```

(9 new `test_exact_match.py` tests + 5 pre-existing `test_metrics.py` tests.
The latter passing unchanged is the no-op proof for the lint cleanup below.)

## Scope

Two related changes, both in `metrics.py`:
1. The new opt-in `ignore_whitespace` flag + its tests (the fix).
2. A mechanical lint cleanup of the **30 pre-existing `ruff` errors** in
   `metrics.py` (see below), so this PR passes the pre-commit `Linters` CI
   gate cleanly. Diff: +130 / −29 across 2 files.

No changes to any task YAML, filter, or scoring path beyond the metric itself.

## Pre-existing lint debt (cleaned up in this PR)

`lm_eval/api/metrics.py` carried **30 pre-existing `ruff` errors** on lines
unrelated to this change (`B905` `zip()` without `strict=`, `RUF015`, `C419`,
`RUF059`). These predate this PR — pristine `main` reports the same 30 errors.
Because the `Linters` CI job runs `ruff` on the whole file when it's touched
(it is **not** diff-scoped), leaving them in place would fail CI.

I cleaned them up in a **separate commit** within this PR (`style: mechanical
lint cleanup of metrics.py`). All changes are behavior-preserving:

- `zip(...)` → `zip(..., strict=False)` (matches plain `zip()` truncation
  semantics exactly — no behavior change).
- `zip(*x)[0]` → `next(zip(*x))` (equivalent, avoids building the full list).
- `sum([... for ...])` → `sum(... for ...)` (drop unnecessary list comp
  inside `sum`).
- Removed one unused unpacked variable.

**Proof of no behavior change:** all 14 metrics tests (5 pre-existing +
9 new) pass unchanged after the cleanup. If the maintainers prefer, I'm happy
to split the lint cleanup into its own PR — but bundling keeps the file
green in one shot.
