### PR TITLE
Fix group stderr to match weight_by_size=False (unweighted) aggregation

### DIFF
--- a/lm_eval/api/group.py
+++ b/lm_eval/api/group.py
@@ -193,7 +193,11 @@ class Group:
             Aggregated metrics dict for this group:
             {"alias": str, "acc,none": float, "acc_stderr,none": float, "sample_len": int, ...}
         """
-        from lm_eval.api.metrics import aggregate_subtask_metrics, pooled_sample_stderr
+        from lm_eval.api.metrics import (
+            aggregate_subtask_metrics,
+            pooled_sample_stderr,
+            unweighted_mean_stderr,
+        )
 
         group_metrics: dict[str, Any] = {
             "alias": self.alias or self.name,
@@ -271,7 +275,16 @@ class Group:
                     sample_count[metric_key] = sum(sizes)
 
                     if len(stderrs) == len(values) and "N/A" not in stderrs:
-                        group_metrics[stderr_key] = pooled_sample_stderr(stderrs, sizes)
+                        # The stderr must match the point estimate: pooled (size-weighted)
+                        # stderr for the size-weighted mean, but the stderr of the simple
+                        # unweighted mean when weight_by_size=False (otherwise the reported
+                        # error bar is overconfident).
+                        if agg_config.weight_by_size:
+                            group_metrics[stderr_key] = pooled_sample_stderr(
+                                stderrs, sizes
+                            )
+                        else:
+                            group_metrics[stderr_key] = unweighted_mean_stderr(stderrs)
                     else:
                         group_metrics[stderr_key] = "N/A"
 

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -605,6 +605,17 @@ def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
     return np.sqrt(pooled_sample_var / sum(sizes))
 
 
+def unweighted_mean_stderr(stderrs: List[float]) -> float:
+    # Used to aggregate stderrs across subtasks in a group when we are NOT weighting
+    # by subtask size (weight_by_size=False), i.e. the group score is the simple
+    # unweighted mean of the k subtask means. For k independent subtask means,
+    # Var(mean) = (1 / k**2) * sum(se_i**2), so the stderr is sqrt(sum(se_i**2)) / k.
+    # (This coincides exactly with pooled_sample_stderr when all subtasks are the same
+    # size; it diverges only for unequal sizes, which is precisely the case the pooled
+    # formula mis-handles for an unweighted mean.)
+    return np.sqrt(sum(stderr**2 for stderr in stderrs)) / len(stderrs)
+
+
 def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None):
     assert metrics is not None, (
         "Need to pass a list of each subtask's metric for this stderr aggregation"

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -486,6 +486,64 @@ class TestGroupWeightedAggregation:
         # Unweighted average: (0.60 + 0.90) / 2 = 0.75
         assert result_unweighted["acc,none"] == pytest.approx(0.75)
 
+    def test_unweighted_aggregation_stderr_matches_unweighted_mean(self):
+        """weight_by_size=False must report the stderr of the *unweighted* mean.
+
+        Regression test for the inconsistency where the group point estimate is the
+        unweighted mean of subtask means but the stderr is the size-weighted (pooled)
+        value, yielding an overconfident error bar. For k independent subtask means the
+        unweighted-mean stderr is sqrt(sum(se_i**2)) / k.
+        """
+        import math
+
+        from lm_eval.api.metrics import pooled_sample_stderr
+
+        task_a = MockTask("task_a")
+        task_b = MockTask("task_b")
+        # Deliberately very unequal sizes so pooled != unweighted-mean stderr.
+        metrics = {
+            "task_a": {"sample_len": 1000, "acc,none": 0.60, "acc_stderr,none": 0.02},
+            "task_b": {"sample_len": 10, "acc,none": 0.80, "acc_stderr,none": 0.10},
+        }
+
+        group = Group(
+            name="test_unweighted_stderr",
+            aggregate_metric_list=[AggMetricConfig(metric="acc", weight_by_size=False)],
+        )
+        group.add(task_a)
+        group.add(task_b)
+        result = group.aggregate(metrics)
+
+        # stderr of the unweighted mean (0.60, 0.80): sqrt(0.02**2 + 0.10**2) / 2
+        expected = math.sqrt(0.02**2 + 0.10**2) / 2
+        assert result["acc_stderr,none"] == pytest.approx(expected)
+        # And it must NOT be the size-weighted pooled stderr (the previous bug).
+        pooled = pooled_sample_stderr([0.02, 0.10], [1000, 10])
+        assert result["acc_stderr,none"] != pytest.approx(pooled)
+
+    def test_weighted_aggregation_stderr_uses_pooled(self):
+        """weight_by_size=True must keep using the pooled (size-weighted) stderr."""
+        from lm_eval.api.metrics import pooled_sample_stderr
+
+        task_a = MockTask("task_a")
+        task_b = MockTask("task_b")
+        metrics = {
+            "task_a": {"sample_len": 1000, "acc,none": 0.60, "acc_stderr,none": 0.02},
+            "task_b": {"sample_len": 10, "acc,none": 0.80, "acc_stderr,none": 0.10},
+        }
+
+        group = Group(
+            name="test_weighted_stderr",
+            aggregate_metric_list=[AggMetricConfig(metric="acc", weight_by_size=True)],
+        )
+        group.add(task_a)
+        group.add(task_b)
+        result = group.aggregate(metrics)
+
+        assert result["acc_stderr,none"] == pytest.approx(
+            pooled_sample_stderr([0.02, 0.10], [1000, 10])
+        )
+
 
 class TestGroupEdgeCases:
     """Test edge cases for Group aggregation."""


### PR DESCRIPTION
## Summary

`Group.aggregate` computes the group point estimate with
`aggregate_subtask_metrics(values, sizes, weight_by_size)`, which uses the **unweighted** mean of
subtask means when `weight_by_size=False`. But the accompanying stderr is **always** computed as
`pooled_sample_stderr(stderrs, sizes)` (the *size-weighted* stderr), regardless of the flag.

So when `weight_by_size=False` the reported point estimate and its stderr describe **different
estimators** — an unweighted mean reported alongside the stderr of a size-weighted mean — which
yields an overconfident error bar whenever subtasks have unequal sizes.

## Reproduce (no GPU, no model)

```python
from lm_eval.api.group import AggMetricConfig, Group
from lm_eval.api.task import Task

class MockTask(Task):
    VERSION = 0
    def __init__(self, n): self._n = n
    @property
    def task_name(self): return self._n
    def has_training_docs(self): return False
    def has_validation_docs(self): return False
    def has_test_docs(self): return True
    def test_docs(self): return []
    def doc_to_text(self, d): return ""
    def doc_to_target(self, d): return ""
    def construct_requests(self, d, c, **k): return []
    def process_results(self, d, r): return {}
    def aggregation(self): return {}
    def higher_is_better(self): return {}

metrics = {
    "task_a": {"sample_len": 1000, "acc,none": 0.60, "acc_stderr,none": 0.02},
    "task_b": {"sample_len": 10,   "acc,none": 0.80, "acc_stderr,none": 0.10},
}
g = Group(name="g", aggregate_metric_list=[AggMetricConfig(metric="acc", weight_by_size=False)])
g.add(MockTask("task_a")); g.add(MockTask("task_b"))
out = g.aggregate(metrics)
print(out["acc,none"], out["acc_stderr,none"])
# -> 0.70 0.01983
# The point estimate is the unweighted mean (0.70), but the reported stderr (0.01983) is the
# size-weighted pooled value. The correct unweighted-mean stderr is sqrt(.02**2 + .10**2)/2 = 0.05099
# (~2.9x larger). This affects the 44 task config files that set `weight_by_size: false`
# (e.g. global_piqa, blimp, metabench).
```

## Fix

For the unweighted mean `(1/k)·Σ mean_i` of `k` independent subtask means,
`Var = (1/k²)·Σ se_i²`, so `stderr = sqrt(Σ se_i²) / k`. This coincides **exactly** with
`pooled_sample_stderr` when all subtasks are the same size, and diverges only for unequal sizes —
the case the pooled formula mis-handles for an unweighted mean.

- Add `lm_eval/api/metrics.py::unweighted_mean_stderr(stderrs)`.
- Branch the stderr on `weight_by_size` in `Group.aggregate` (mirroring how the point estimate
  already branches): pooled stderr when `True`, unweighted-mean stderr when `False`.

(Implementing the `False` case as `pooled_sample_stderr(stderrs, [1]*k)` would `ZeroDivisionError` —
`pooled_sample_var` divides by `sum(sizes) - len(sizes) = 0` — hence the dedicated helper.)

## Tests

`tests/test_group.py`: the unweighted-stderr value, a regression guard that `weight_by_size=True`
still uses the pooled stderr, and an equal-size agreement case. Full `test_group.py` (53) and
`test_metrics`/`test_aggregation_pipeline`/`test_evaluator_utils` (85) pass; CPU-only, no GPU.
