### PR TITLE
Fix acc_mutual_info crash on multiple_target tasks

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1572,7 +1572,11 @@ class ConfigurableTask(Task):
                     ll_c - ll_u
                     for ll_c, ll_u in zip(lls, lls_unconditional, strict=True)
                 ]
-                acc_mutual_info = 1.0 if np.argmax(lls_mutual_info) == gold else 0.0
+                pred_mutual_info = np.argmax(lls_mutual_info)
+                if self.multiple_target:
+                    acc_mutual_info = 1.0 if pred_mutual_info in gold else 0.0
+                else:
+                    acc_mutual_info = 1.0 if pred_mutual_info == gold else 0.0
                 result_dict["acc_mutual_info"] = acc_mutual_info
 
         elif self.OUTPUT_TYPE == "generate_until":

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -153,6 +153,39 @@ def test_acc_mutual_info_without_metric():
     assert result_dict["acc"] == 1.0
 
 
+class MockMultiTargetTask(MockConfigurableTask):
+    """Mock multiple-choice task with multiple correct answers (multiple_target)."""
+
+    def __init__(self):
+        super().__init__()
+        self.multiple_target = 2  # gold is a list of correct indices
+
+    def doc_to_target(self, doc):
+        return [0, 2]  # choices A and C are both correct
+
+
+def test_acc_mutual_info_multiple_target():
+    """acc_mutual_info must handle multiple_target tasks (gold is a list), not crash.
+
+    Regression: `1.0 if np.argmax(lls_mutual_info) == gold else 0.0` builds a numpy
+    bool array when gold is a list, so the truth test raised ValueError.
+    """
+    task = MockMultiTargetTask()
+    # conditional lls favor choice C (index 2); unconditional flat -> mutual-info argmax = 2.
+    results = [
+        (-3.0, False),
+        (-2.0, False),
+        (-1.0, True),  # conditional
+        (-2.0, False),
+        (-2.0, False),
+        (-2.0, False),  # unconditional
+    ]
+    result_dict = task.process_results({}, results)
+    assert "acc_mutual_info" in result_dict
+    # mutual-info argmax index 2 is one of the gold answers [0, 2]
+    assert result_dict["acc_mutual_info"] == 1.0
+
+
 def test_bootstrap_internal_no_mp():
     """Test basic functionality of _bootstrap_internal_no_mp"""
 


### PR DESCRIPTION
## Summary

For multiple-choice tasks with **multiple correct answers** (`multiple_target`), `doc_to_target`
returns a list, so `gold` is a list of indices. The `acc_mutual_info` branch in
`ConfigurableTask.process_results` computed:

```python
acc_mutual_info = 1.0 if np.argmax(lls_mutual_info) == gold else 0.0
```

When `gold` is a list, `np.argmax(...) == gold` builds a numpy bool array, and the `1.0 if <array> else 0.0`
truth test raises `ValueError: The truth value of an array with more than one element is ambiguous`.

The sibling `acc` / `acc_norm` branches already special-case `multiple_target` via `pred in gold`;
`acc_mutual_info` was missed.

## Reproduce

A `multiple_choice` task with `multiple_target` (gold = `[0, 2]`) and `acc_mutual_info` in its metric
list raises `ValueError` from `process_results` instead of scoring the example.

## Fix

```python
pred_mutual_info = np.argmax(lls_mutual_info)
if self.multiple_target:
    acc_mutual_info = 1.0 if pred_mutual_info in gold else 0.0
else:
    acc_mutual_info = 1.0 if pred_mutual_info == gold else 0.0
```

## Tests

`tests/test_metrics.py::test_acc_mutual_info_multiple_target` — fail-before: `ValueError`;
pass-after: `acc_mutual_info == 1.0` when the mutual-info argmax index is one of the gold answers.
All `test_metrics.py` tests pass. CPU-only, no GPU.
