### PR TITLE
Serialize all numpy scalar types in JSON output, not just int64/int32

### DIFF
--- a/lm_eval/loggers/utils.py
+++ b/lm_eval/loggers/utils.py
@@ -41,12 +41,16 @@ def _handle_non_serializable(o: Any) -> int | str | list:
         o (Any): The object to be handled.
 
     Returns:
-        Union[int, str, list]: The converted object. If the object is of type np.int64 or np.int32,
-            it will be converted to int. If the object is of type set, it will be converted
-            to a list. Otherwise, it will be converted to str.
+        Union[int, str, list]: The converted object. numpy booleans/integers/floats are
+            converted to the corresponding Python bool/int/float, a set is converted to a
+            list, and anything else is converted to str.
     """
-    if isinstance(o, (np.int64, np.int32)):
+    if isinstance(o, np.bool_):
+        return bool(o)
+    elif isinstance(o, np.integer):
         return int(o)
+    elif isinstance(o, np.floating):
+        return float(o)
     elif isinstance(o, set):
         return list(o)
     else:

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -197,8 +197,12 @@ def handle_arg_string(arg):
 
 
 def handle_non_serializable(o):
-    if isinstance(o, (np.int64, np.int32)):
+    if isinstance(o, np.bool_):
+        return bool(o)
+    elif isinstance(o, np.integer):
         return int(o)
+    elif isinstance(o, np.floating):
+        return float(o)
     elif isinstance(o, set):
         return list(o)
     else:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,32 @@
+import json
+
+import numpy as np
+
+from lm_eval.loggers.utils import _handle_non_serializable
+from lm_eval.utils import handle_non_serializable
+
+
+def test_handle_non_serializable_numpy_scalars():
+    """All numpy scalar types must serialize to JSON numbers/booleans, not quoted strings.
+
+    Regression: only np.int64/np.int32 were special-cased, so np.float32/float16,
+    np.int16/int8/uint8 and np.bool_ fell through to str(o) and were written to the
+    results/samples JSON as quoted strings (e.g. "0.5", "True", "5").
+    """
+    for handler in (handle_non_serializable, _handle_non_serializable):
+        # numpy floats -> JSON numbers
+        for f in (np.float16(0.5), np.float32(0.5), np.float64(0.5)):
+            val = json.loads(json.dumps(f, default=handler))
+            assert val == 0.5 and isinstance(val, float)
+
+        # numpy booleans -> JSON booleans
+        assert json.loads(json.dumps(np.bool_(True), default=handler)) is True
+        assert json.loads(json.dumps(np.bool_(False), default=handler)) is False
+
+        # numpy integers of every width -> JSON ints
+        for i in (np.int8(5), np.int16(5), np.int32(5), np.int64(5), np.uint8(5)):
+            val = json.loads(json.dumps(i, default=handler))
+            assert val == 5 and isinstance(val, int)
+
+        # sets still convert to lists
+        assert json.loads(json.dumps({1, 2}, default=handler)) == [1, 2]


### PR DESCRIPTION
## Summary

`handle_non_serializable` (in `lm_eval/utils.py`) and its copy `_handle_non_serializable`
(in `lm_eval/loggers/utils.py`) — the `default=` hooks used when writing results/samples to JSON —
only special-cased `np.int64`/`np.int32`:

```python
if isinstance(o, (np.int64, np.int32)):
    return int(o)
elif isinstance(o, set):
    return list(o)
else:
    return str(o)
```

Every other numpy scalar fell through to `str(o)`, so `np.float32`/`np.float16`, `np.int16`/`int8`/`uint8`,
and `np.bool_` were written into the JSON as **quoted strings** (`"0.5"`, `"True"`, `"5"`) rather than
numbers/booleans. (`np.float64` happened to work only because it subclasses Python `float`.) Anything
downstream that parses these result files then sees strings where it expects numbers.

## Reproduce

```python
import json, numpy as np
from lm_eval.utils import handle_non_serializable
print(json.dumps({"acc": np.float32(2/3)}, default=handle_non_serializable))  # {"acc": "0.6666667"}
print(json.dumps({"ok": np.bool_(True)},  default=handle_non_serializable))   # {"ok": "True"}
```

## Fix

Broaden the checks to the numpy abstract base types, which cover all widths:

```python
if isinstance(o, np.bool_):
    return bool(o)
elif isinstance(o, np.integer):
    return int(o)
elif isinstance(o, np.floating):
    return float(o)
elif isinstance(o, set):
    return list(o)
else:
    return str(o)
```

Applied to both copies (docstring updated too).

## Tests

`tests/test_serialization.py` — round-trips every numpy scalar width through `json.dumps(..., default=)`
and asserts floats/ints/bools come back as `float`/`int`/`bool` (not `str`), for both handlers.
CPU-only, no GPU. (Placed in a new torch-free test file because `tests/test_utils.py` imports torch.)
