### PR TITLE
fix: Add better test coverage for models

### DIFF
--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -214,6 +214,148 @@ def test_create_image_prompt_uses_content_parts_without_top_level_type(
     }
 
 
+def test_parse_logplikelihood_greedy_and_non_greedy():
+    outputs = {
+        "choices": [
+            {
+                "index": 0,
+                "logprobs": {
+                    "token_logprobs": [None, -0.1, -0.2, -0.3],
+                    "top_logprobs": [
+                        {},
+                        {"a": -0.1, "b": -5.0},
+                        {"c": -0.2, "d": -5.0},
+                        {"e": -1.0, "f": -0.5},
+                    ],
+                },
+            }
+        ]
+    }
+    # ctxlen=1 means the first token is context, slice is [1:-1] -> indices 1 and 2
+    result = LocalCompletionsAPI.parse_logprobs(outputs, ctxlens=[1])
+
+    assert len(result) == 1
+    logprob, is_greedy = result[0]
+    assert logprob == pytest.approx(-0.1 + -0.2)
+    # both sampled tokens match the max of their top_logprobs, so greedy
+    assert is_greedy is True
+
+
+def test_parse_logplikelihood_detects_non_greedy():
+    outputs = {
+        "choices": [
+            {
+                "index": 0,
+                "logprobs": {
+                    "token_logprobs": [None, -2.0, -0.5],
+                    "top_logprobs": [
+                        {},
+                        {"a": -0.1, "b": -2.0},
+                        {"c": -0.5, "d": -5.0},
+                    ],
+                },
+            }
+        ]
+    }
+    result = LocalCompletionsAPI.parse_logprobs(outputs, ctxlens=[1])
+
+    _, is_greedy = result[0]
+    # first sampled token (-2.0) is not the max (-0.1), so not greedy
+    assert is_greedy is False
+
+
+def test_parse_logplikelihood_orders_choices_by_index():
+    outputs = {
+        "choices": [
+            {
+                "index": 1,
+                "logprobs": {
+                    "token_logprobs": [None, -0.5, -0.1],
+                    "top_logprobs": [{}, {"a": -0.5}, {"b": -0.1}],
+                },
+            },
+            {
+                "index": 0,
+                "logprobs": {
+                    "token_logprobs": [None, -0.2, -0.3],
+                    "top_logprobs": [{}, {"a": -0.2}, {"b": -0.3}],
+                },
+            },
+        ]
+    }
+    result = LocalCompletionsAPI.parse_logprobs(outputs, ctxlens=[1, 1])
+
+    # choices are sorted by index before being zipped with ctxlens
+    assert result[0][0] == pytest.approx(-0.2)
+    assert result[1][0] == pytest.approx(-0.5)
+
+
+def test_parse_generations_orders_by_index():
+    outputs = {
+        "choices": [
+            {"index": 1, "text": "world"},
+            {"index": 0, "text": "hello"},
+        ]
+    }
+    result = LocalCompletionsAPI.parse_generations(outputs)
+
+    assert result == ["hello", "world"]
+
+
+def test_chat_parse_generations_reads_message_content():
+    from lm_eval.models.openai_completions import LocalChatCompletion
+
+    outputs = {
+        "choices": [
+            {"index": 0, "message": {"content": "hello"}},
+            {"index": 1, "message": {"content": "world"}},
+        ]
+    }
+    result = LocalChatCompletion.parse_generations(outputs)
+
+    assert result == ["hello", "world"]
+
+
+def test_chat_parse_generations_handles_content_filter():
+    from lm_eval.models.openai_completions import LocalChatCompletion
+
+    # missing "content" simulates a response blocked by a content filter
+    outputs = {"choices": [{"index": 0, "message": {}}]}
+    result = LocalChatCompletion.parse_generations(outputs)
+
+    assert result == [""]
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["o1-mini", "o3-mini", "o4-mini", "gpt-5"],
+)
+def test_openai_chat_payload_drops_stop_for_reasoning_models(model_name):
+    from lm_eval.models.openai_completions import OpenAIChatCompletion
+
+    model = OpenAIChatCompletion(base_url="http://test-url.com", model=model_name)
+    messages = [{"role": "user", "content": "hi"}]
+    payload = model._create_payload(messages, generate=True, gen_kwargs={})
+
+    assert "stop" not in payload
+    assert payload["temperature"] == 1
+    assert payload["model"] == model_name
+
+
+def test_openai_chat_payload_keeps_stop_for_standard_models():
+    from lm_eval.models.openai_completions import OpenAIChatCompletion
+
+    model = OpenAIChatCompletion(base_url="http://test-url.com", model="gpt-4")
+    messages = [{"role": "user", "content": "hi"}]
+    payload = model._create_payload(
+        messages, generate=True, gen_kwargs={"until": ["END"], "temperature": 0.5}
+    )
+
+    assert payload["stop"] == ["END", "<|endoftext|>"]
+    assert payload["temperature"] == 0.5
+    assert payload["max_completion_tokens"] == model._max_gen_toks
+
+
 class DummyAsyncContextManager:
     def __init__(self, result):
         self.result = result


### PR DESCRIPTION
## Summary

This is a test-coverage gap rather than a bug. The API model classes in `lm_eval/models/openai_completions.py` contain pure logic that runs without any network access, but several of these paths had no direct unit tests: `LocalCompletionsAPI.parse_logprobs` (summing logprobs, greedy detection, ordering choices by...


## Root cause

This is a test-coverage gap rather than a bug. The API model classes in
`lm_eval/models/openai_completions.py` contain pure logic that runs without any
network access, but several of these paths had no direct unit tests:

- `LocalCompletionsAPI.parse_logprobs` (summing logprobs, greedy detection,
 ordering choices by index).
- `LocalCompletionsAPI.parse_generations` and
 `LocalChatCompletion.parse_generations` (ordering by index and the
 content-filter fallback that returns `[""]`).
- `OpenAIChatCompletion._create_payload` special-casing for reasoning/gpt-5
 models, which drops `stop` and forces `temperature = 1`.

These are exactly the kind of model behaviors the issue asks to cover, and they
can be tested by feeding in dummy response dicts instead of calling a real API.


## What changed

- `tests/models/test_api.py`: added 11 new tests covering the methods above.
 All tests use plain dummy response payloads, so no real API calls are made.
 - `test_parse_logplikelihood_greedy_and_non_greedy`
 - `test_parse_logplikelihood_detects_non_greedy`
 - `test_parse_logplikelihood_orders_choices_by_index`
 - `test_parse_generations_orders_by_index`
 - `test_chat_parse_generations_reads_message_content`
 - `test_chat_parse_generations_handles_content_filter`
 - `test_openai_chat_payload_drops_stop_for_reasoning_models`
 (parametrized over `o1-mini`, `o3-mini`, `o4-mini`, `gpt-5`)
 - `test_openai_chat_payload_keeps_stop_for_standard_models`

No production code was changed. The fix is intentionally limited to extending
test coverage, matching the issue scope.


## Issue

Fixes #1613

Issue: https://github.com/EleutherAI/lm-evaluation-harness/issues/1613


## Diffstat

```
tests/models/test_api.py | 142 +++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 142 insertions(+)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.