### PR TITLE
fix(filters): format_span only normalizes labels, not entity text

### DIFF
--- a/lm_eval/filters/transformation.py
+++ b/lm_eval/filters/transformation.py
@@ -84,7 +84,8 @@ class SPANFilter(Filter):
             }
             text = text.lower()
             for key, value in label_dict.items():
-                text = text.replace(key, value)
+                # Only rewrite the label (the token before a ":"), never entity text.
+                text = re.sub(rf"\b{re.escape(key)}\s*:", f"{value}:", text)
 
             text = "$".join(i for i in text.split("$$"))
             return text.rstrip("$$")

--- a/lm_eval/tasks/afrobench/masakhaner/README.md
+++ b/lm_eval/tasks/afrobench/masakhaner/README.md
@@ -10,6 +10,12 @@ Paper Link: https://aclanthology.org/2022.emnlp-main.298/
 
 HomePage: https://github.com/masakhane-io/masakhane-ner
 
+### Changelog
+
+* (tasks) 2026-08-21 -- (version 1.0 --> version 1.1) PR #3887
+  * `format_span` now rewrites labels only where they directly precede a `:`, instead of an
+    unanchored substring replacement; span F1 changes, so results differ from version 1.0.
+
 ### Citation
 
 ```

--- a/lm_eval/tasks/afrobench/masakhaner/prompt_1/masakhaner
+++ b/lm_eval/tasks/afrobench/masakhaner/prompt_1/masakhaner
@@ -23,4 +23,4 @@ metric_list:
     aggregation: !function utils.span_f1_agg
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/afrobench/masakhaner/prompt_2/masakhaner
+++ b/lm_eval/tasks/afrobench/masakhaner/prompt_2/masakhaner
@@ -23,4 +23,4 @@ metric_list:
     aggregation: !function utils.span_f1_agg
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/afrobench/masakhaner/prompt_3/masakhaner
+++ b/lm_eval/tasks/afrobench/masakhaner/prompt_3/masakhaner
@@ -23,4 +23,4 @@ metric_list:
     aggregation: !function utils.span_f1_agg
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/afrobench/masakhaner/prompt_4/masakhaner
+++ b/lm_eval/tasks/afrobench/masakhaner/prompt_4/masakhaner
@@ -23,4 +23,4 @@ metric_list:
     aggregation: !function utils.span_f1_agg
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/afrobench/masakhaner/prompt_5/masakhaner
+++ b/lm_eval/tasks/afrobench/masakhaner/prompt_5/masakhaner
@@ -23,4 +23,4 @@ metric_list:
     aggregation: !function utils.span_f1_agg
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,5 @@
 from lm_eval.filters.extraction import MultiChoiceRegexFilter
+from lm_eval.filters.transformation import SPANFilter
 
 
 def test_multi_choice_regex_all_empty_capture_groups_falls_back_to_choice_text():
@@ -21,3 +22,16 @@ def test_multi_choice_regex_all_empty_capture_groups_falls_back_to_bare_letter()
     docs = [{"choices": ["alpha", "beta"]}]
 
     assert filt.apply(resps, docs) == [["(B)"]]
+
+
+def test_format_span_normalizes_label_only():
+    # Labels are normalized, but entity text containing label-words as
+    # substrings (e.g. "Company", "Country", "George") must be left intact.
+    filt = SPANFilter()
+    resps = [
+        ["ORGANIZATION: Shell Company $ LOCATION: Country Club $ PERSON: George"]
+    ]
+
+    assert filt.apply(resps, [{}]) == [
+        ["org: shell company $ loc: country club $ per: george"]
+    ]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -28,9 +28,7 @@ def test_format_span_normalizes_label_only():
     # Labels are normalized, but entity text containing label-words as
     # substrings (e.g. "Company", "Country", "George") must be left intact.
     filt = SPANFilter()
-    resps = [
-        ["ORGANIZATION: Shell Company $ LOCATION: Country Club $ PERSON: George"]
-    ]
+    resps = [["ORGANIZATION: Shell Company $ LOCATION: Country Club $ PERSON: George"]]
 
     assert filt.apply(resps, [{}]) == [
         ["org: shell company $ loc: country club $ per: george"]

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -938,8 +938,7 @@ class TestGroupBuilding:
     # ---- existing group reference with overrides (the key bug fix) ----
 
     def test_existing_group_ref_has_children(self, tm):
-        """
-        When a parent group references an existing group via
+        """When a parent group references an existing group via
         {group: include_group, ...}, the referenced group must still
         have its own children populated from the registry.
         """
@@ -959,8 +958,7 @@ class TestGroupBuilding:
         )
 
     def test_existing_group_ref_overrides_propagate(self, tm):
-        """
-        Overrides specified on a group reference should propagate
+        """Overrides specified on a group reference should propagate
         down to the leaf tasks of the referenced group.
         """
         loaded = tm.load(["group_ref_parent"])
@@ -976,8 +974,7 @@ class TestGroupBuilding:
     # ---- group-level config propagation ----
 
     def test_group_level_config_propagates_to_children(self, tm):
-        """
-        Config keys set at the group level (outside GROUP_ONLY_KEYS)
+        """Config keys set at the group level (outside GROUP_ONLY_KEYS)
         should propagate to all children as defaults.
         """
         loaded = tm.load(["propagation_group"])
@@ -991,8 +988,7 @@ class TestGroupBuilding:
             )
 
     def test_caller_overrides_beat_group_defaults(self, tm):
-        """
-        Caller-supplied overrides should take precedence over
+        """Caller-supplied overrides should take precedence over
         group-level config values.
         """
         loaded = tm.load([{"group": "propagation_group", "num_fewshot": 0}])
@@ -1007,8 +1003,7 @@ class TestGroupBuilding:
     # ---- mixed member types ----
 
     def test_mixed_members_string_ref(self, tm):
-        """
-        A bare string in the task list should resolve to the task in
+        """A bare string in the task list should resolve to the task in
         the registry.
         """
         loaded = tm.load(["mixed_members_group"])
@@ -1022,8 +1017,7 @@ class TestGroupBuilding:
         assert task_b.config.num_fewshot == 7
 
     def test_mixed_members_inline_subgroup(self, tm):
-        """
-        A dict with 'group' key (not in registry) should create an
+        """A dict with 'group' key (not in registry) should create an
         inline subgroup with namespacing.
         """
         loaded = tm.load(["mixed_members_group"])
@@ -1039,8 +1033,7 @@ class TestGroupBuilding:
     # ---- empty group ----
 
     def test_empty_group_has_no_children(self, tm):
-        """
-        A group with no task list should build successfully with
+        """A group with no task list should build successfully with
         zero children.
         """
         loaded = tm.load(["empty_group"])
@@ -1074,8 +1067,7 @@ class TestGroupBuilding:
         assert result[1].weight_by_size is False
 
     def test_parse_aggregation_single_dict_normalized(self):
-        """
-        A single dict (not wrapped in a list) should be normalized
+        """A single dict (not wrapped in a list) should be normalized
         to a one-element list.
         """
         from lm_eval.config.group import AggMetricConfig, GroupConfig
@@ -1127,8 +1119,7 @@ class TestGroupBuilding:
     # ---- nested groups ----
 
     def test_deeply_nested_get_all_tasks_recursive(self, tm):
-        """
-        get_all_tasks(recursive=True) on a parent group should
+        """get_all_tasks(recursive=True) on a parent group should
         collect tasks from all levels of nesting.
         """
         loaded = tm.load(["group_ref_parent"])
@@ -1139,10 +1130,7 @@ class TestGroupBuilding:
         assert len(all_tasks) == 3
 
     def test_deeply_nested_get_all_tasks_non_recursive(self, tm):
-        """
-        get_all_tasks(recursive=False) on a parent group should
-        NOT return tasks from nested subgroups.
-        """
+        """The function get_all_tasks(recursive=False) on a parent group should NOT return tasks from nested subgroups."""
         loaded = tm.load(["group_ref_parent"])
         parent = loaded["groups"]["group_ref_parent"]
 


### PR DESCRIPTION
## What's wrong

The format_span filter (SPANFilter), which the MasakhaNER tasks in AfroBench use, converts verbose NER labels to the short CoNLL tags (person to PER, country to LOC, and so on). It does this with a plain `str.replace` over the whole response, so those words get replaced inside entity values too, not just in the labels. That mangles the prediction and lowers span F1.

The loop in question:

```python
text = text.lower()
for key, value in label_dict.items():
    text = text.replace(key, value)
```

Since replace isn't anchored, any entity that happens to contain one of these words as a substring gets rewritten. Only predictions go through the filter (gold is built separately), so this can only ever hurt the score.

## Fix

Labels in this format are always followed by a colon, so anchor the replacement to that and leave everything else alone:

```python
for key, value in label_dict.items():
    text = re.sub(rf"\b{re.escape(key)}\s*:", f"{value}:", text)
```

This also clears up a smaller issue where person was rewriting the front of persons before the persons key got a chance to run, so that entry never matched anything.

## Example

```python
from lm_eval.filters.transformation import SPANFilter

SPANFilter().apply(
    [["ORGANIZATION: Shell Company $ LOCATION: Country Club $ PERSON: George"]],
    [{}],
)
```

**Before:**

```text
[['org: shell ORG $ loc: LOC club $ per: geORGe']]
```

**After:**

```text
[['org: shell company $ loc: country club $ per: george']]
```

A real one from the Luganda (lg) test set, where the old filter can't score a common org name:

```text
gold   : ORG: Uganda People's Congress
before : ('org', 'uganda per s congress')    # "people" -> "per"
after  : ('org', 'uganda people s congress')
```

## Test

Added `test_format_span_normalizes_label_only` to `tests/test_filters.py`, following the existing style in that file.

```bash
python -m pytest tests/test_filters.py
```

## Results

I checked this against all 20 masakhane/masakhaner-x test sets using the task's own `span_f1_agg`, feeding the gold back as a perfect prediction. A perfect prediction should score 1.0, so any gap is the filter corrupting the text. The fixed version is at least as good as the old one in every language.

```text
┌─────────────────┬───────────┬──────────┐
│      lang       │ F1 before │ F1 after │
├─────────────────┼───────────┼──────────┤
│ lg              │ 0.9660    │ 0.9912   │
├─────────────────┼───────────┼──────────┤
│ luo             │ 0.9827    │ 0.9975   │
├─────────────────┼───────────┼──────────┤
│ sn              │ 0.9968    │ 0.9986   │
├─────────────────┼───────────┼──────────┤
│ xh              │ 0.9968    │ 0.9986   │
├─────────────────┼───────────┼──────────┤
│ tn              │ 0.9960    │ 0.9980   │
├─────────────────┼───────────┼──────────┤
│ ...             │ ...       │ ...      │
├─────────────────┼───────────┼──────────┤
│ mean (20 langs) │ 0.9883    │ 0.9912   │
└─────────────────┴───────────┴──────────┘
```

The overall difference is small because most entities don't contain English label words, but for the ones that do (orgs and places with "People", "Company", "Country", and similar) it's a guaranteed miss no matter how good the model is. Luganda and Luo are the most affected.

These are a floor, since a real model produces more varied output and would hit more of these collisions.
