### PR TITLE
feat: add SimpleQA factuality benchmark task (#3666)

### DIFF
--- a/lm_eval/tasks/simpleqa/simpleqa.yaml
+++ b/lm_eval/tasks/simpleqa/simpleqa.yaml
@@ -1,0 +1,51 @@
+tag:
+  - factuality
+  - knowledge
+
+task: simpleqa
+dataset_path: basicv8vc/SimpleQA
+output_type: generate_until
+
+# SimpleQA has only a test split; zero-shot matches the original paper setup.
+test_split: test
+num_fewshot: 0
+
+# The instruction mirrors OpenAI's original prompt, nudging models toward
+# short, direct answers rather than hedged paragraphs.
+doc_to_text: "Answer the following question in a single brief, direct answer.\n\nQuestion: {{problem}}\nAnswer:"
+doc_to_target: "{{answer}}"
+
+generation_kwargs:
+  # Stop at newline — answers should be one line.
+  until:
+    - "\n"
+    - "</s>"
+    - "<|im_end|>"
+    - "<|eot_id|>"
+    - "<|end_of_text|>"
+  do_sample: false
+  temperature: 0.0
+  # 64 tokens is generous for the typically short factual answers in SimpleQA.
+  max_gen_toks: 64
+
+process_results: !function utils.process_results
+
+metric_list:
+  # Fraction of questions answered CORRECTLY.
+  - metric: correct
+    aggregation: mean
+    higher_is_better: true
+
+  # Fraction of questions where the model declined to answer (NOT_ATTEMPTED).
+  - metric: not_attempted
+    aggregation: mean
+    higher_is_better: false
+
+  # Harmonic mean of accuracy-given-attempted and overall-correct-rate.
+  # This is the primary SimpleQA metric from the original paper.
+  - metric: f1
+    aggregation: !function utils.simpleqa_f1_agg
+    higher_is_better: true
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/simpleqa/test_simpleqa.py
+++ b/lm_eval/tasks/simpleqa/test_simpleqa.py
@@ -1,0 +1,238 @@
+"""
+Tests for SimpleQA scoring utilities.
+
+Run with:  pytest tests/simpleqa/test_simpleqa.py -v
+or from the repo root: python -m pytest lm_eval/tasks/simpleqa/test_simpleqa.py -v
+"""
+import pytest
+
+# When running from the repo root the import path is:
+#   from lm_eval.tasks.simpleqa.utils import ...
+# For standalone testing adjust as needed.
+from utils import (
+    classify_answer,
+    normalize_answer,
+    process_results,
+    simpleqa_f1_agg,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_answer
+# ---------------------------------------------------------------------------
+
+class TestNormalizeAnswer:
+    def test_lowercase(self):
+        assert normalize_answer("Barack Obama") == "barack obama"
+
+    def test_removes_articles(self):
+        assert normalize_answer("The White House") == "white house"
+        assert normalize_answer("a cat sat on an mat") == "cat sat on mat"
+
+    def test_removes_punctuation(self):
+        assert normalize_answer("1,200") == "1200"
+        assert normalize_answer("San Francisco, California") == "san francisco california"
+
+    def test_collapses_whitespace(self):
+        assert normalize_answer("  hello   world  ") == "hello world"
+
+    def test_empty_string(self):
+        assert normalize_answer("") == ""
+
+
+# ---------------------------------------------------------------------------
+# classify_answer — CORRECT cases
+# ---------------------------------------------------------------------------
+
+class TestClassifyCorrect:
+    """
+    These cases mirror the CORRECT examples from the original SimpleQA grader
+    prompt and from the paper's grading guidelines.
+    """
+
+    def test_exact_match(self):
+        assert classify_answer("Malia and Sasha", "Malia and Sasha") == "correct"
+
+    def test_case_insensitive(self):
+        assert classify_answer("malia and sasha obama", "Malia Obama and Sasha Obama") == "correct"
+
+    def test_prediction_subset_of_gold(self):
+        # "Michelle" is correct when gold is "Michelle Obama"
+        # because the last name is implied by the question.
+        assert classify_answer("Michelle", "Michelle Obama") == "correct"
+
+    def test_prediction_superset_of_gold(self):
+        # Model says "San Francisco, California"; gold is "San Francisco"
+        assert classify_answer("San Francisco, California", "San Francisco") == "correct"
+
+    def test_unit_in_gold_not_prediction(self):
+        # Gold "1.73 m"; prediction "1.73" — unit implied in the question
+        assert classify_answer("1.73", "1.73 m") == "correct"
+
+    def test_hedged_but_correct(self):
+        # Hedging is OK if the gold is present (original paper rule)
+        assert classify_answer(
+            "I believe the answer is Malia and Sasha Obama",
+            "Malia and Sasha",
+        ) == "correct"
+
+    def test_award_suffix_omitted(self):
+        # "Outstanding Paper" vs "Outstanding Paper Award" — award implied in question
+        assert classify_answer("Outstanding Paper", "Outstanding Paper Award") == "correct"
+
+    def test_article_difference(self):
+        assert classify_answer("White House", "The White House") == "correct"
+
+    def test_refusal_phrase_but_answer_present(self):
+        # Unusual but should still be CORRECT if gold appears in output
+        assert classify_answer(
+            "I'm not sure, but I think it's Sasha and Malia Obama",
+            "Malia and Sasha",
+        ) == "correct"
+
+
+# ---------------------------------------------------------------------------
+# classify_answer — INCORRECT cases
+# ---------------------------------------------------------------------------
+
+class TestClassifyIncorrect:
+    def test_wrong_name(self):
+        assert classify_answer("Malia.", "Malia and Sasha") == "incorrect"
+
+    def test_extra_wrong_name(self):
+        assert classify_answer("Malia, Sasha, and Susan", "Malia and Sasha") == "incorrect"
+
+    def test_negation(self):
+        assert classify_answer(
+            "Barack Obama does not have any children.",
+            "Malia and Sasha",
+        ) == "incorrect"
+
+    def test_wrong_count(self):
+        assert classify_answer(
+            "Barack Obama has three children.",
+            "Malia and Sasha",
+        ) == "incorrect"
+
+    def test_completely_wrong(self):
+        assert classify_answer("Paris", "London") == "incorrect"
+
+
+# ---------------------------------------------------------------------------
+# classify_answer — NOT_ATTEMPTED cases
+# ---------------------------------------------------------------------------
+
+class TestClassifyNotAttempted:
+    def test_i_dont_know(self):
+        assert classify_answer("I don't know.", "Malia and Sasha") == "not_attempted"
+
+    def test_i_do_not_know(self):
+        assert classify_answer("I do not know.", "Malia and Sasha") == "not_attempted"
+
+    def test_need_more_context(self):
+        assert classify_answer(
+            "I need more context about which Obama you are talking about.",
+            "Malia and Sasha",
+        ) == "not_attempted"
+
+    def test_cannot_answer_without_web(self):
+        assert classify_answer(
+            "Without researching the web, I cannot answer this question.",
+            "Malia and Sasha",
+        ) == "not_attempted"
+
+    def test_partial_then_unsure(self):
+        # "I know one but not the other" → NOT_ATTEMPTED (gold not fully present)
+        assert classify_answer(
+            "Barack Obama has two children. I know that one of them is Malia, "
+            "but I'm not sure about the other one.",
+            "Malia and Sasha",
+        ) == "not_attempted"
+
+    def test_i_cannot(self):
+        assert classify_answer("I cannot answer this.", "42") == "not_attempted"
+
+    def test_i_am_unable(self):
+        assert classify_answer("I am unable to provide that information.", "42") == "not_attempted"
+
+
+# ---------------------------------------------------------------------------
+# process_results
+# ---------------------------------------------------------------------------
+
+class TestProcessResults:
+    def _doc(self, answer):
+        return {"problem": "...", "answer": answer}
+
+    def test_correct_returns_correct_1(self):
+        result = process_results(self._doc("Malia and Sasha"), ["Malia and Sasha Obama"])
+        assert result["correct"] == 1
+        assert result["not_attempted"] == 0
+        assert result["f1"] == (1, 0, 0)
+
+    def test_incorrect_returns_correct_0(self):
+        result = process_results(self._doc("Paris"), ["London"])
+        assert result["correct"] == 0
+        assert result["not_attempted"] == 0
+        assert result["f1"] == (0, 1, 0)
+
+    def test_not_attempted(self):
+        result = process_results(self._doc("Malia and Sasha"), ["I don't know."])
+        assert result["correct"] == 0
+        assert result["not_attempted"] == 1
+        assert result["f1"] == (0, 0, 1)
+
+
+# ---------------------------------------------------------------------------
+# simpleqa_f1_agg
+# ---------------------------------------------------------------------------
+
+class TestSimpleQAF1Agg:
+    def test_all_correct(self):
+        # accuracy_given_attempted = 1.0, overall = 1.0  → F1 = 1.0
+        items = [(1, 0, 0)] * 10
+        assert simpleqa_f1_agg(items) == pytest.approx(1.0)
+
+    def test_all_incorrect(self):
+        # accuracy_given_attempted = 0.0 → F1 = 0.0
+        items = [(0, 1, 0)] * 10
+        assert simpleqa_f1_agg(items) == pytest.approx(0.0)
+
+    def test_all_not_attempted(self):
+        # No attempts → F1 = 0.0
+        items = [(0, 0, 1)] * 10
+        assert simpleqa_f1_agg(items) == pytest.approx(0.0)
+
+    def test_half_correct_half_not_attempted(self):
+        # correct=5, incorrect=0, not_attempted=5, total=10
+        # acc_given_attempted = 5/5 = 1.0
+        # overall_correct = 5/10 = 0.5
+        # F1 = 2 * 1.0 * 0.5 / (1.0 + 0.5) = 1.0 / 1.5 ≈ 0.6667
+        items = [(1, 0, 0)] * 5 + [(0, 0, 1)] * 5
+        assert simpleqa_f1_agg(items) == pytest.approx(2 / 3, rel=1e-4)
+
+    def test_half_correct_half_incorrect(self):
+        # correct=5, incorrect=5, not_attempted=0, total=10
+        # acc_given_attempted = 5/10 = 0.5
+        # overall_correct = 5/10 = 0.5
+        # F1 = 2 * 0.5 * 0.5 / (0.5 + 0.5) = 0.5
+        items = [(1, 0, 0)] * 5 + [(0, 1, 0)] * 5
+        assert simpleqa_f1_agg(items) == pytest.approx(0.5)
+
+    def test_empty(self):
+        assert simpleqa_f1_agg([]) == pytest.approx(0.0)
+
+    def test_realistic_scores(self):
+        # Simulate a model with ~40% correct, ~10% not_attempted, ~50% incorrect
+        # (roughly what a mid-tier model might score)
+        n = 100
+        items = (
+            [(1, 0, 0)] * 40
+            + [(0, 1, 0)] * 50
+            + [(0, 0, 1)] * 10
+        )
+        f1 = simpleqa_f1_agg(items)
+        # acc_given_attempted = 40/90 ≈ 0.444
+        # overall_correct = 40/100 = 0.400
+        # F1 = 2 * 0.444 * 0.4 / (0.444 + 0.4) ≈ 0.421
+        assert 0.40 < f1 < 0.45

--- a/lm_eval/tasks/simpleqa/utils.py
+++ b/lm_eval/tasks/simpleqa/utils.py
@@ -1,0 +1,106 @@
+"""
+SimpleQA scoring utilities for lm-evaluation-harness.
+"""
+
+import re
+import string
+
+_NOT_ATTEMPTED_RE = re.compile(
+    r"\b("
+    r"i don'?t know|i do not know"
+    r"|i'?m not sure|i am not sure"
+    r"|i'?m not certain|i am not certain"
+    r"|i cannot|i can'?t"
+    r"|i'?m unable|i am unable"
+    r"|i'?m not aware|i am not aware"
+    r"|i have no (?:idea|information|knowledge)"
+    r"|i don'?t have|i do not have"
+    r"|cannot be determined"
+    r"|i cannot answer|i can'?t answer"
+    r"|i need more (?:information|context|data)"
+    r"|i'?d need (?:more|additional)"
+    r"|not (?:enough|sufficient) (?:information|context|data)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_ARTICLES_RE = re.compile(r"\b(a|an|the)\b", re.UNICODE | re.IGNORECASE)
+
+
+def normalize_answer(text):
+    text = text.lower()
+    text = _ARTICLES_RE.sub(" ", text)
+    text = text.translate(str.maketrans("", "", string.punctuation))
+    text = " ".join(text.split())
+    return text
+
+
+def classify_answer(prediction, gold):
+    pred_norm = normalize_answer(prediction)
+    gold_norm = normalize_answer(gold)
+
+    if not gold_norm:
+        return "not_attempted"
+
+    gold_tokens = set(gold_norm.split())
+    pred_tokens = set(pred_norm.split())
+
+    def _gold_is_present():
+        if gold_norm in pred_norm:
+            return True
+        if gold_tokens == pred_tokens:
+            return True
+        if pred_norm in gold_norm and len(pred_tokens) >= max(1, len(gold_tokens) - 1):
+            return True
+        if gold_tokens and gold_tokens.issubset(pred_tokens):
+            return True
+        return False
+
+    if _NOT_ATTEMPTED_RE.search(prediction):
+        return "correct" if _gold_is_present() else "not_attempted"
+
+    if gold_norm in pred_norm:
+        return "correct"
+
+    if gold_tokens == pred_tokens:
+        return "correct"
+
+    if pred_norm in gold_norm and len(pred_tokens) >= max(1, len(gold_tokens) - 1):
+        return "correct"
+
+    return "incorrect"
+
+
+def process_results(doc, results):
+    prediction = results[0]
+    gold = doc["answer"]
+    grade = classify_answer(prediction, gold)
+
+    is_correct = int(grade == "correct")
+    is_incorrect = int(grade == "incorrect")
+    is_not_attempted = int(grade == "not_attempted")
+
+    return {
+        "correct": is_correct,
+        "not_attempted": is_not_attempted,
+        "f1": (is_correct, is_incorrect, is_not_attempted),
+    }
+
+
+def simpleqa_f1_agg(items):
+    correct = sum(t[0] for t in items)
+    incorrect = sum(t[1] for t in items)
+    not_attempted = sum(t[2] for t in items)
+    total = correct + incorrect + not_attempted
+
+    if total == 0:
+        return 0.0
+
+    overall_correct = correct / total
+    attempted = correct + incorrect
+    acc_given_attempted = correct / attempted if attempted > 0 else 0.0
+
+    denom = acc_given_attempted + overall_correct
+    if denom == 0.0:
+        return 0.0
+    return 2.0 * acc_given_attempted * overall_correct / denom


### PR DESCRIPTION
## Notes on grading

The original SimpleQA paper uses GPT-4o as the judge. This implementation
uses a string-matching approximation so the task runs without a secondary
model call. It handles exact matches, word-order differences, and partial
answers where the missing word is implied by the question (e.g. "Michelle"
is accepted for "Michelle Obama").

Known limitations vs. LLM grading:
- Paraphrases / synonyms without token overlap → graded INCORRECT
- Numeric ranges (e.g. "~120k" for "124,000") → graded INCORRECT
- Decimal numbers lose their dot after punctuation removal

Closes #3666 