### PR TITLE
Fix request cache key ignoring generation_kwargs (#3881)

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import ast
+import json
 import logging
 import random
 import re
@@ -265,6 +266,50 @@ class Task(abc.ABC):
     def doc_to_prefix(self, doc):
         return ""
 
+    @staticmethod
+    def _build_request_cache_key(
+        *,
+        task: str,
+        num_fewshot: int | None,
+        rank: int,
+        world_size: int,
+        apply_chat_template: bool,
+        fewshot_as_multiturn: bool,
+        system_instruction: str | None,
+        tokenizer_name: str,
+        generation_kwargs: dict | None = None,
+    ) -> str:
+        """Build the request-cache key for a task.
+
+        The key reflects everything that changes which instances get built:
+        task, fewshot count, rank/world size, chat-template and system-prompt
+        settings, tokenizer, and the sampling configuration. Folding
+        ``generation_kwargs`` in means that changing a sampling parameter
+        (temperature, top_p, max_gen_toks, until, ...) between two
+        ``--cache_requests`` runs produces a cache miss instead of silently
+        reusing instances built for the previous settings (see issue #3881).
+        """
+        cache_key = (
+            f"requests-{task}-{num_fewshot}shot-rank{rank}-world_size{world_size}"
+        )
+        cache_key += "-chat_template" if apply_chat_template else ""
+        cache_key += "-fewshot_as_multiturn" if fewshot_as_multiturn else ""
+        cache_key += (
+            f"-system_prompt_hash{utils.hash_string(system_instruction)}"
+            if system_instruction is not None
+            else ""
+        )
+        cache_key += f"-tokenizer{tokenizer_name}"
+        # generate_until tasks bake generation_kwargs into each instance's
+        # arguments, so the same docs at different sampling settings are not
+        # interchangeable; hash the sampling config into the key. multiple_choice
+        # tasks carry no generation_kwargs and keep their previous (suffix-free)
+        # key, so this is backward compatible for them.
+        if generation_kwargs:
+            gen_repr = json.dumps(generation_kwargs, sort_keys=True, default=str)
+            cache_key += f"-gen_kwargs{utils.hash_string(gen_repr)}"
+        return cache_key
+
     def build_all_requests(
         self,
         *,
@@ -285,15 +330,17 @@ class Task(abc.ABC):
         # used with caching
         og_limit = limit
 
-        cache_key = f"requests-{self._config.task}-{self.config.num_fewshot}shot-rank{rank}-world_size{world_size}"
-        cache_key += "-chat_template" if apply_chat_template else ""
-        cache_key += "-fewshot_as_multiturn" if fewshot_as_multiturn else ""
-        cache_key += (
-            f"-system_prompt_hash{utils.hash_string(system_instruction)}"
-            if system_instruction is not None
-            else ""
+        cache_key = self._build_request_cache_key(
+            task=self._config.task,
+            num_fewshot=self.config.num_fewshot,
+            rank=rank,
+            world_size=world_size,
+            apply_chat_template=apply_chat_template,
+            fewshot_as_multiturn=fewshot_as_multiturn,
+            system_instruction=system_instruction,
+            tokenizer_name=tokenizer_name,
+            generation_kwargs=self.config.generation_kwargs,
         )
-        cache_key += f"-tokenizer{tokenizer_name}"
 
         cached_instances = load_from_cache(file_name=cache_key, cache=cache_requests)
 

--- a/tests/test_request_cache_key.py
+++ b/tests/test_request_cache_key.py
@@ -1,0 +1,66 @@
+"""Regression tests for the request-cache key (issue #3881).
+
+The request cache key must incorporate ``generation_kwargs`` so that changing a
+sampling parameter (temperature, top_p, max_gen_toks, until, ...) between two
+``--cache_requests`` runs produces a cache miss instead of silently reusing the
+instances that were built for the previous sampling settings.
+"""
+
+from lm_eval.api.task import Task
+
+
+BASE = {
+    "task": "gsm8k",
+    "num_fewshot": 5,
+    "rank": 0,
+    "world_size": 1,
+    "apply_chat_template": False,
+    "fewshot_as_multiturn": False,
+    "system_instruction": None,
+    "tokenizer_name": "meta-llama/Llama-3-8B",
+}
+
+
+def key(**overrides):
+    return Task._build_request_cache_key(**{**BASE, **overrides})
+
+
+def test_temperature_change_produces_different_key():
+    greedy = key(generation_kwargs={"until": ["\n\n"], "do_sample": False})
+    sampled = key(
+        generation_kwargs={"until": ["\n\n"], "do_sample": True, "temperature": 0.7}
+    )
+    assert greedy != sampled
+
+
+def test_max_gen_toks_change_produces_different_key():
+    short = key(generation_kwargs={"until": ["\n\n"], "max_gen_toks": 64})
+    long = key(generation_kwargs={"until": ["\n\n"], "max_gen_toks": 256})
+    assert short != long
+
+
+def test_identical_generation_kwargs_produce_identical_key():
+    gk = {"until": ["\n\n"], "temperature": 0.7, "top_p": 0.95}
+    assert key(generation_kwargs=gk) == key(generation_kwargs=dict(gk))
+
+
+def test_key_is_insensitive_to_dict_order():
+    a = key(generation_kwargs={"temperature": 0.7, "top_p": 0.95, "until": ["\n\n"]})
+    b = key(generation_kwargs={"until": ["\n\n"], "top_p": 0.95, "temperature": 0.7})
+    assert a == b
+
+
+def test_multiple_choice_key_has_no_gen_kwargs_suffix():
+    # multiple_choice tasks carry no generation_kwargs; their key must stay
+    # unchanged by this fix (backward compatibility / no spurious cache miss).
+    mc = key(generation_kwargs=None)
+    assert "gen_kwargs" not in mc
+    assert mc.endswith("-tokenizermeta-llama/Llama-3-8B")
+
+
+def test_run_config_components_still_reflected():
+    # the pre-existing run-config components must still change the key
+    assert key(rank=0) != key(rank=1)
+    assert key(tokenizer_name="a") != key(tokenizer_name="b")
+    # with no generation_kwargs the key is the original (suffix-free) form
+    assert "gen_kwargs" not in key()


### PR DESCRIPTION
Fixes #3881

When --cache_requests is on, the request cache key was built from task name, fewshot count, rank/world size, chat-template flags, system prompt, and tokenizer, but not from generation_kwargs. Two runs of the same generate_until task with different sampling params (temperature, top_p, max_gen_toks, until) got the same key, so the second run loaded the first run's cached instances. Since generate_until bakes generation_kwargs into each instance's arguments, the second run silently evaluated at the first run's settings.

This folds a stable hash of generation_kwargs into the key, so a changed sampling param is a cache miss instead of a stale hit. The key construction is pulled into a small static method so it can be unit tested. multiple_choice tasks have no generation_kwargs, so their key is unchanged; generate_until tasks get a -gen_kwargs suffix and take a one-time cache miss the first run after this change, which is correct.

Added tests/test_request_cache_key.py covering different sampling params giving different keys, identical params giving identical keys, dict-key order independence, max_gen_toks detection, multiple_choice keys staying suffix free, and the existing run-config components still affecting the key.
