### PR TITLE
fix(filters): POSFilter.apply returns a list, not a generator

### DIFF
--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -83,7 +83,9 @@ class POSFilter(Filter):
         self.group_select = group_select
         self.fallback = fallback
 
-    def apply(self, resps: Iterable[Sequence[str]], docs: Sequence[dict[str, Any]]):
+    def apply(
+        self, resps: Iterable[Sequence[str]], docs: Sequence[dict[str, Any]]
+    ) -> list[list]:
         def extract_tagged_tokens(text):
             # Extract tagged tokens list from text input using regex
             tokens = re.findall(r"\('([^']*)', '([^']*)'\)", text)
@@ -103,7 +105,7 @@ class POSFilter(Filter):
                 filtered.append(match)
             return filtered
 
-        return (filter_set(x) for x in resps)
+        return [filter_set(x) for x in resps]
 
 
 @register_filter("remove_whitespace")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -21,3 +21,31 @@ def test_multi_choice_regex_all_empty_capture_groups_falls_back_to_bare_letter()
     docs = [{"choices": ["alpha", "beta"]}]
 
     assert filt.apply(resps, docs) == [["(B)"]]
+
+
+def test_pos_filter_returns_list_not_generator():
+    """POSFilter.apply must return a concrete list, like every other filter.
+
+    Filter.apply is documented to return a list of per-instance results, and
+    FilterEnsemble chains filters by feeding one filter's output as the next
+    filter's input. POSFilter previously returned a generator, which violates
+    that contract and is silently consumed if the results are iterated twice.
+    """
+    from lm_eval.filters.extraction import POSFilter
+
+    f = POSFilter()
+    resps = [["[('the', 'DET'), ('cat', 'NOUN')]"]]
+    out = f.apply(resps, [{}])
+
+    assert isinstance(out, list)
+    assert out == [[["DET", "NOUN"]]]
+    # A generator would be empty on the second pass; a list is stable.
+    assert list(out) == list(out)
+
+
+def test_pos_filter_falls_back_when_no_tags():
+    from lm_eval.filters.extraction import POSFilter
+
+    f = POSFilter()
+    out = f.apply([["no tagged tokens here"]], [{}])
+    assert out == [[["invalid"]]]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -97,3 +97,31 @@ def test_bbh_multi_choice_regex_prefix_choice_does_not_shadow_longer_choice(vari
 
     assert filt.apply([["The answer is Batman Returns"]], docs) == [["(B)"]]
     assert filt.apply([["The answer is Batman"]], docs) == [["(A)"]]
+
+
+def test_pos_filter_returns_list_not_generator():
+    """POSFilter.apply must return a concrete list, like every other filter.
+
+    Filter.apply is documented to return a list of per-instance results, and
+    FilterEnsemble chains filters by feeding one filter's output as the next
+    filter's input. POSFilter previously returned a generator, which violates
+    that contract and is silently consumed if the results are iterated twice.
+    """
+    from lm_eval.filters.extraction import POSFilter
+
+    f = POSFilter()
+    resps = [["[('the', 'DET'), ('cat', 'NOUN')]"]]
+    out = f.apply(resps, [{}])
+
+    assert isinstance(out, list)
+    assert out == [[["DET", "NOUN"]]]
+    # A generator would be empty on the second pass; a list is stable.
+    assert list(out) == list(out)
+
+
+def test_pos_filter_falls_back_when_no_tags():
+    from lm_eval.filters.extraction import POSFilter
+
+    f = POSFilter()
+    out = f.apply([["no tagged tokens here"]], [{}])
+    assert out == [[["invalid"]]]


### PR DESCRIPTION
Filter.apply is documented to return a list of per-instance results, and FilterEnsemble chains filters by feeding one filter's output as the next filter's input. POSFilter was the only filter returning a generator, which violates that contract and is silently consumed if the results are ever iterated more than once. Return a list to match RegexFilter, WhitespaceFilter, and MultiChoiceRegexFilter.

Adds tests asserting POSFilter returns a stable, re-iterable list and that the no-match fallback path still works.