### PR TITLE
HiToM, DynToM, and FANToM

### DIFF
--- a/lm_eval/tasks/dyntom/README.md
+++ b/lm_eval/tasks/dyntom/README.md
@@ -1,0 +1,65 @@
+# DynToM — lm-eval adapter
+
+Faithful adaptation of the DynToM benchmark (arXiv 2505.17663) for `lm-evaluation-harness`.
+
+## Tasks
+
+| Task | Prompt style | `max_gen_toks` |
+|------|-------------|----------------|
+| `dyntom` | Vanilla (Fig 17) | 2048 |
+| `dyntom_cot` | Chain-of-Thought (Fig 17) | 4096 |
+
+## Architecture
+
+- **doc = one trial (story).** All questions for a trial are batched into a single prompt.
+- **Output:** the model returns a JSON dict `{question_id: letter}`.
+- **Scoring:** `process_results` parses the JSON and emits 11 per-trial metrics, aggregated by `mean`.
+- **Data source:** HF dataset `YangXiao-nlp/DynToM` (`DynToM.json`), fetched via `hf_hub_download`.
+
+## Metrics (11)
+
+| Metric | Questions/trial | Definition |
+|--------|----------------|------------|
+| `acc` | 71 | **Faithful headline AVG** — all questions incl. type_c. Reproduces paper Table-3 AVG. |
+| `acc_core` | 56 | **Ours (not paper):** type_a + type_d only, sans influence. |
+| `acc_influence` | 15 | type_c questions only. |
+| `acc_belief_u` | 5 | type_a, subject = belief. |
+| `acc_belief_t` | 9 | type_d, subject = belief. |
+| `acc_emotion_u` | 5 | type_a, subject = emotion. |
+| `acc_emotion_t` | 9 | type_d, subject = emotion. |
+| `acc_intention_u` | 5 | type_a, subject = intention. |
+| `acc_intention_t` | 9 | type_d, subject = intention. |
+| `acc_action_u` | 5 | type_a, subject = action. |
+| `acc_action_t` | 9 | type_d, subject = action. |
+
+Sanity identity: `acc = (56 * acc_core + 15 * acc_influence) / 71`.
+
+## Running
+
+```bash
+# Vanilla
+lm-eval run --model hf --model_args pretrained=<model> \
+    --tasks dyntom --limit 5 --log_samples --output_path out/
+
+# CoT
+lm-eval run --model hf --model_args pretrained=<model> \
+    --tasks dyntom_cot --limit 5 --log_samples --output_path out/
+```
+
+**Context window requirement:** measured across all 1,111 trials, prompts range from ~10k to ~23k tokens (min 41k chars, max 91k chars at ~4 chars/token). The model must support at least a **24k-token context**; 32k+ is recommended. Smaller models will silently left-truncate the prompt, dropping early questions and tanking scores in a way that resembles a model failure rather than a config issue.
+
+Recommended model for the smoke test: `Qwen/Qwen3-1.7B` (32k context, ~1.7B params):
+
+```bash
+lm-eval run --model hf --model_args pretrained=Qwen/Qwen3-1.7B \
+    --tasks dyntom --limit 5 --log_samples --output_path out/
+```
+
+## Deviations from the paper
+
+1. **Trial set is 1,111 trials (78,881 Q), not 1,100 / 78,100.** The paper filtered by an unrecoverable quality step; we filter by `scenario numbers == 5` directly from the HF release (~1% gap).
+2. **Reconstructed prompt serialization.** The paper's Fig 17 prompt wording is reproduced verbatim; however, the exact stringification of `{story}` and `{questions_new}` is a reconstruction (eval code was not released). This adapter uses `json.dumps(..., indent=2)` for both slots.
+3. **Reconstructed JSON extraction.** Lenient `json.loads` + `type_X_*_N: letter` regex fallback. Missing or unparseable answers are scored wrong (faithful to no-answer behavior).
+4. **Sampled decoding → non-deterministic `acc`** (temperature=0.7, top_p=0.9). The paper reports a single run; run-to-run variance is expected.
+5. **`acc_core` is not a paper metric.** It excludes type_c (influence) questions. The faithful reproduction number is `acc`.
+6. CoT over 71 answers is long; small models may truncate before the closing `}`, causing those answers to score wrong. This matches the paper's observed score collapse on small models.

--- a/lm_eval/tasks/dyntom/_dyntom_partition_template_yaml
+++ b/lm_eval/tasks/dyntom/_dyntom_partition_template_yaml
@@ -1,0 +1,15 @@
+custom_dataset: !function utils.load
+test_split: train
+output_type: generate_until
+doc_to_target: "{{target}}"
+doc_to_text: !function utils.doc_to_text
+generation_kwargs:
+  do_sample: true
+  temperature: 0.7
+  top_p: 0.9
+  until:
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 512
+metadata:
+  version: 0

--- a/lm_eval/tasks/dyntom/_dyntom_partitions.yaml
+++ b/lm_eval/tasks/dyntom/_dyntom_partitions.yaml
@@ -1,0 +1,14 @@
+group: dyntom_partitions
+tag: [theory_of_mind]
+task:
+  - dyntom_belief_u
+  - dyntom_belief_t
+  - dyntom_emotion_u
+  - dyntom_emotion_t
+  - dyntom_intention_u
+  - dyntom_intention_t
+  - dyntom_action_u
+  - dyntom_action_t
+  - dyntom_influence
+metadata:
+  version: 0

--- a/lm_eval/tasks/dyntom/_dyntom_template_yaml
+++ b/lm_eval/tasks/dyntom/_dyntom_template_yaml
@@ -1,0 +1,19 @@
+custom_dataset: !function utils.load
+test_split: train
+output_type: generate_until
+doc_to_target: "{{target}}"
+process_results: !function utils.process_results
+metric_list:
+  - {metric: acc,            aggregation: mean, higher_is_better: true}
+  - {metric: acc_core,       aggregation: mean, higher_is_better: true}
+  - {metric: acc_influence,  aggregation: mean, higher_is_better: true}
+  - {metric: acc_belief_u,   aggregation: mean, higher_is_better: true}
+  - {metric: acc_belief_t,   aggregation: mean, higher_is_better: true}
+  - {metric: acc_emotion_u,  aggregation: mean, higher_is_better: true}
+  - {metric: acc_emotion_t,  aggregation: mean, higher_is_better: true}
+  - {metric: acc_intention_u, aggregation: mean, higher_is_better: true}
+  - {metric: acc_intention_t, aggregation: mean, higher_is_better: true}
+  - {metric: acc_action_u,   aggregation: mean, higher_is_better: true}
+  - {metric: acc_action_t,   aggregation: mean, higher_is_better: true}
+metadata:
+  version: 0

--- a/lm_eval/tasks/dyntom/dyntom.yaml
+++ b/lm_eval/tasks/dyntom/dyntom.yaml
@@ -1,0 +1,12 @@
+include: _dyntom_template_yaml
+task: dyntom
+tag: [theory_of_mind]
+doc_to_text: !function utils.doc_to_text
+generation_kwargs:
+  do_sample: true
+  temperature: 0.7
+  top_p: 0.9
+  until:
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 2048

--- a/lm_eval/tasks/dyntom/dyntom_action_t.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_action_t.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_action_t
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_action_t
+process_results: !function utils.process_results_action_t
+metric_list:
+  - {metric: acc_action_t, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_action_u.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_action_u.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_action_u
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_action_u
+process_results: !function utils.process_results_action_u
+metric_list:
+  - {metric: acc_action_u, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_belief_t.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_belief_t.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_belief_t
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_belief_t
+process_results: !function utils.process_results_belief_t
+metric_list:
+  - {metric: acc_belief_t, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_belief_u.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_belief_u.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_belief_u
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_belief_u
+process_results: !function utils.process_results_belief_u
+metric_list:
+  - {metric: acc_belief_u, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_cot.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_cot.yaml
@@ -1,0 +1,12 @@
+include: _dyntom_template_yaml
+task: dyntom_cot
+tag: [theory_of_mind]
+doc_to_text: !function utils.doc_to_text_cot
+generation_kwargs:
+  do_sample: true
+  temperature: 0.7
+  top_p: 0.9
+  until:
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 4096

--- a/lm_eval/tasks/dyntom/dyntom_emotion_t.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_emotion_t.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_emotion_t
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_emotion_t
+process_results: !function utils.process_results_emotion_t
+metric_list:
+  - {metric: acc_emotion_t, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_emotion_u.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_emotion_u.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_emotion_u
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_emotion_u
+process_results: !function utils.process_results_emotion_u
+metric_list:
+  - {metric: acc_emotion_u, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_influence.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_influence.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_influence
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_influence
+process_results: !function utils.process_results_influence
+metric_list:
+  - {metric: acc_influence, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_intention_t.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_intention_t.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_intention_t
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_intention_t
+process_results: !function utils.process_results_intention_t
+metric_list:
+  - {metric: acc_intention_t, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/dyntom_intention_u.yaml
+++ b/lm_eval/tasks/dyntom/dyntom_intention_u.yaml
@@ -1,0 +1,7 @@
+include: _dyntom_partition_template_yaml
+task: dyntom_intention_u
+tag: [theory_of_mind]
+process_docs: !function utils.process_docs_intention_u
+process_results: !function utils.process_results_intention_u
+metric_list:
+  - {metric: acc_intention_u, aggregation: mean, higher_is_better: true}

--- a/lm_eval/tasks/dyntom/utils.py
+++ b/lm_eval/tasks/dyntom/utils.py
@@ -1,0 +1,195 @@
+import functools
+import json
+import re
+
+import datasets
+from huggingface_hub import hf_hub_download
+
+SUBJECTS = ("belief", "emotion", "intention", "action")
+_SUBJ_RE = re.compile(r"\bthe (belief|emotion|intention|action) of\b", re.I)
+
+# ---------- LOADER (cache-once; one doc per 5-scenario trial) ----------
+
+@functools.lru_cache(maxsize=1)
+def _build_docs():
+    path = hf_hub_download("YangXiao-nlp/DynToM", "DynToM.json", repo_type="dataset")
+    data = json.load(open(path, encoding="utf-8"))
+    docs = []
+    for tid, trial in data.items():
+        stage = trial["stage"]
+        if stage.get("scenario numbers") != 5:
+            continue
+        questions = trial["question"]
+        meta = []
+        prompt_qs = {}
+        for qid, q in questions.items():
+            family = re.sub(r"_\d+$", "", qid)
+            dim, subject = _classify(family, q["question"])
+            meta.append({
+                "id": qid,
+                "gold": q["true answer"].strip().lower(),
+                "family": family,
+                "dim": dim,
+                "subject": subject,
+            })
+            prompt_qs[qid] = {"question": q["question"], "options": q["options"]}
+        docs.append({
+            "trial_id": tid,
+            "characters_information": stage["characters information"],
+            "story": json.dumps(stage["story"], ensure_ascii=False, indent=2),
+            "questions_new": json.dumps(prompt_qs, ensure_ascii=False, indent=2),
+            # meta stored as JSON string to avoid Arrow nested-schema issues (subject is sometimes None)
+            "meta": json.dumps(meta),
+            # gold dict for logging only — never used in scoring
+            "target": json.dumps({m["id"]: m["gold"] for m in meta}),
+        })
+    return docs
+
+
+def load(**kwargs):
+    return {"train": datasets.Dataset.from_list(_build_docs())}
+
+
+def _classify(family, text):
+    if family == "type_c_how":
+        return "influence", None
+    m = _SUBJ_RE.search(text)
+    if not m:
+        raise ValueError(f"no subject parsed from: {text!r}")
+    subj = m.group(1).lower()
+    return ("u" if family == "type_a_what" else "t"), subj
+
+
+# ---------- PROMPT FUNCTIONS (verbatim Fig 17; shared tail) ----------
+
+_VANILLA = "Answer the questions based on the story. "
+_COT = (
+    "Answer the questions based on the story; first, think step by step, analyze the answers "
+    "to the questions, and finally, output the most likely answers. "
+)
+_TAIL = (
+    ". Answer the question, and response in JSON format:"
+    '{[question_id]:[a, b, c or d]}. for example: {"type_d_how_1":"a"}'
+)
+
+
+def _render(doc, head):
+    return (
+        f'{head}{doc["characters_information"]} \n'
+        f'{doc["story"]} \n'
+        f'{doc["questions_new"]}{_TAIL}'
+    )
+
+
+def doc_to_text(doc):
+    return _render(doc, _VANILLA)
+
+
+def doc_to_text_cot(doc):
+    return _render(doc, _COT)
+
+
+# ---------- ANSWER EXTRACTION + SCORING ----------
+
+# Matches bare or quoted key:value pairs — handles JSON and CoT prose
+_PAIR_RE = re.compile(
+    r'["\']?(type_[a-z_]+\d+)["\']?\s*:\s*["\']?([a-zA-Z])["\']?'
+)
+# Isolates the first {...} block (strips markdown fences and surrounding prose)
+_JSON_OBJ_RE = re.compile(r"\{[^{}]*\}", re.S)
+
+
+def _parse_answers(gen):
+    out = {}
+    # Try outermost JSON-like object first
+    m = _JSON_OBJ_RE.search(gen)
+    if m:
+        try:
+            obj = json.loads(m.group(0))
+            if isinstance(obj, dict):
+                out = {k: str(v).strip().lower()[:1] for k, v in obj.items()}
+        except Exception:
+            pass
+    # Regex fallback fills gaps (CoT models often emit prose alongside JSON)
+    for qid, letter in _PAIR_RE.findall(gen):
+        out.setdefault(qid, letter.strip().lower())
+    return out
+
+
+def process_results(doc, results):
+    pred = _parse_answers(results[0])
+    buckets = {}  # name -> [correct, total]
+
+    def bump(name, ok):
+        b = buckets.setdefault(name, [0, 0])
+        b[0] += ok
+        b[1] += 1
+
+    for m in json.loads(doc["meta"]):
+        ok = 1 if pred.get(m["id"]) == m["gold"] else 0
+        bump("acc", ok)
+        if m["dim"] == "influence":
+            bump("acc_influence", ok)
+        else:
+            bump("acc_core", ok)
+            bump(f"acc_{m['subject']}_{m['dim']}", ok)
+
+    return {name: c / t for name, (c, t) in buckets.items()}
+
+
+# ---------- PARTITION SUPPORT (per-bucket tasks) ----------
+# Each partition task asks only one bucket's questions per trial (5-15 Q vs 71),
+# so prompts are ~4-7x shorter. These are diagnostic — the model no longer reasons
+# over all questions together. The faithful task is dyntom/dyntom_cot.
+
+def _make_process_docs(subject, dim):
+    """Return a process_docs fn that filters each trial doc to one question bucket."""
+    def _process(dataset):
+        def _transform(doc):
+            full_meta = json.loads(doc["meta"])
+            if dim == "influence":
+                bucket_meta = [m for m in full_meta if m["dim"] == "influence"]
+            else:
+                bucket_meta = [m for m in full_meta
+                               if m["subject"] == subject and m["dim"] == dim]
+            full_qs = json.loads(doc["questions_new"])
+            filtered_qs = {m["id"]: full_qs[m["id"]] for m in bucket_meta}
+            return {
+                "trial_id": doc["trial_id"],
+                "characters_information": doc["characters_information"],
+                "story": doc["story"],
+                "questions_new": json.dumps(filtered_qs, ensure_ascii=False, indent=2),
+                "meta": json.dumps(bucket_meta),
+                "target": json.dumps({m["id"]: m["gold"] for m in bucket_meta}),
+            }
+        return dataset.map(_transform)
+    return _process
+
+
+def _make_process_results(metric_name):
+    """Return a process_results fn that emits only the single named metric."""
+    def _pr(doc, results):
+        return {metric_name: process_results(doc, results).get(metric_name, 0.0)}
+    return _pr
+
+
+# Named functions for !function references in partition YAMLs
+process_docs_belief_u    = _make_process_docs("belief",    "u")
+process_docs_belief_t    = _make_process_docs("belief",    "t")
+process_docs_emotion_u   = _make_process_docs("emotion",   "u")
+process_docs_emotion_t   = _make_process_docs("emotion",   "t")
+process_docs_intention_u = _make_process_docs("intention", "u")
+process_docs_intention_t = _make_process_docs("intention", "t")
+process_docs_action_u    = _make_process_docs("action",    "u")
+process_docs_action_t    = _make_process_docs("action",    "t")
+process_docs_influence   = _make_process_docs(None,        "influence")
+
+process_results_belief_u    = _make_process_results("acc_belief_u")
+process_results_belief_t    = _make_process_results("acc_belief_t")
+process_results_emotion_u   = _make_process_results("acc_emotion_u")
+process_results_emotion_t   = _make_process_results("acc_emotion_t")
+process_results_intention_u = _make_process_results("acc_intention_u")
+process_results_intention_t = _make_process_results("acc_intention_t")
+process_results_action_u    = _make_process_results("acc_action_u")
+process_results_action_t    = _make_process_results("acc_action_t")
+process_results_influence   = _make_process_results("acc_influence")

--- a/lm_eval/tasks/fantom/README.md
+++ b/lm_eval/tasks/fantom/README.md
@@ -1,0 +1,109 @@
+# FANToM — lm-eval adapter
+
+Faithful adaptation of the FANToM benchmark (Kim et al., EMNLP 2023; arXiv:2310.15421)
+for `lm-evaluation-harness`. Scoring **vendors FANToM's own** `setup_fantom` /
+per-QA scorers / `score_and_analyze` logic from the read-only submodule
+(`benchmarks/fantom/`), invoked through lm-eval's `process_results` + custom
+`aggregation` hooks so the headline numbers are reported live, in-harness.
+
+## Task
+
+| Task | Context | Prompting | Aggregation target |
+|------|---------|-----------|--------------------|
+| `fantom` | `short` | direct (non-CoT) | `set` |
+
+`full`-context and CoT are deferred (see Deviations).
+
+## Architecture
+
+- **doc = one flattened QA.** FANToM prompts each question separately (a *per-item*
+  protocol), so 870 sets explode into **12,832 docs** (`short`). Question types are NOT
+  split into separate tasks — the headline ALL\*/ALL scores are set-level conjunctions
+  over *every* question type in a set, so they must all be scored together.
+- **`output_type: generate_until`**, prompt = the exact string `setup_fantom` builds.
+- **`process_results`** scores the QA with the vendored per-type scorers (token-F1 for
+  fact; RoBERTa cosine for BeliefQ[Dist.]; letter-match for BeliefQ[Choice]; set
+  membership for list; yes/no mapping for binary) and emits a rich per-QA payload.
+- **Aggregation** (one custom `!function` per metric) rebuilds the corpus DataFrame from
+  the emitted payloads and runs vendored `score_and_analyze` for **both** the
+  `inaccessible` (FANToM) and `accessible` (control) scenarios.
+
+## Metrics (23, reported as percentages ×100)
+
+The 12 FANToM headline numbers (the paper's results table) for the main task, plus the
+same 12 for the mandated **control** task (`control_*`, the `accessible` scenario; fact
+F1 is shared so it appears once).
+
+| Metric | Paper column | Notes |
+|--------|--------------|-------|
+| `all_star` | All\* | set-level conjunction incl. BeliefQ[Dist.] (the headline) |
+| `all` | All | set-level conjunction using BeliefQ[Choice] |
+| `belief_choice` | BeliefQ [Choice] | MC letter match |
+| `belief_dist` | BeliefQ [Dist.] | embedder: closer to correct than wrong |
+| `belief_tokenf1` | BeliefQ token-F1 | token-F1 on the matched view (correct only) |
+| `answerability_all` | All AnswerabilityQ | set-level conjunction over answerability |
+| `answerability_list` | AnswerabilityQ [List] | set membership |
+| `answerability_binary_f1` | AnswerabilityQ [Y/N] | corpus weighted-F1 |
+| `infoaccess_all` | All Info-AccessQ | set-level conjunction over info-access |
+| `infoaccess_list` | Info-AccessQ [List] | set membership |
+| `infoaccess_binary_f1` | Info-AccessQ [Y/N] | corpus weighted-F1 |
+| `fact_tokenf1` | FactQ token-F1 | token-F1 |
+
+`control_*` = the same numbers on the `accessible` (no information-asymmetry) subset.
+**The paper asks reporters to confirm the control scores stay stable** — check the
+`control_*` columns alongside the headline `all_star`/`all`.
+
+## Running
+
+Run inside the harness env (Python 3.13). On Windows set `PYTHONIOENCODING=utf-8` so the
+results table prints. The first run downloads the RoBERTa embedder (~1.4 GB) and the
+FANToM data (to `~/.cache/fantom`, not committed — eval-only license).
+
+```bash
+PYTHONIOENCODING=utf-8 lm-eval --model hf --model_args pretrained=<model> \
+    --tasks fantom --include_path lm-evaluation-harness/lm_eval/tasks \
+    --limit 30 --log_samples --output_path out/
+```
+
+For instruction-tuned/chat models add `--apply_chat_template` (FANToM's own chat agents
+apply the chat template; base models do not).
+
+> **`--limit` inflates set-level metrics.** Docs are emitted set-by-set, so a limited run
+> usually ends mid-set; that partial set's `all`/`all_star` (and the list/binary means) are
+> computed over fewer questions and are not comparable to a full run. Use `--limit` only for
+> plumbing smoke tests; report numbers only from a full-corpus run.
+
+## Deviations from the paper
+
+1. **In-harness embedder.** BeliefQ[Dist.] uses `sentence-transformers/all-roberta-large-v1`
+   loaded inside the eval process (adds `sentence-transformers` as a runtime dep; slower).
+   This is faithful to the metric, just relocated into the harness.
+2. **Sampled decoding → non-deterministic scores.** `do_sample=True, max_new_tokens=365`
+   mirrors FANToM's HuggingFace agent (`agents/huggingface.py`). The agent does **not** set
+   a temperature (it inherits each model's `generation_config`); lm-eval requires a positive
+   temperature under `do_sample`, so we force `temperature=1.0`. For any model whose config
+   ships a non-1.0 default this is a (small) deviation. The paper's headline numbers were
+   produced with API models under different decoding; run-to-run variance is expected on HF
+   models.
+3. **v1 scope = `short` + direct, `aggregation_target=set`.** `full`-context (which
+   relabels some `missed_info_accessibility` values in `setup_fantom`) and the two-pass
+   CoT protocol (lm-eval cannot do single-shot two-pass) are deferred.
+4. **Headline scalars only.** The error-analysis diagnostics (`wrong_reasons` frequency
+   dicts) and the character-tracking analyses (`set:ALL_character`,
+   `character_answer_consistency`) from `score_and_analyze` are not exposed as lm-eval
+   metrics (they are dict-valued / diagnostic, not headline numbers).
+5. **Control task as metrics, not a second run.** The original dumps a separate
+   `control_task` report; here it is the `control_*` metric columns from the same run
+   (equally faithful, more convenient).
+
+## Faithfulness validation
+
+Validated against the **actual original** `eval_fantom` code (imported with its unused
+heavy/SDK deps stubbed; no model/embedder load), under the same pandas:
+
+- **Prompt assembly:** `utils._flatten` matches the real `setup_fantom` on all 12,832 docs —
+  byte-exact `input_text` *and* identical MC `choices_text` + gold index (so the seed-99 RNG
+  consumption order matches too).
+- **Scoring:** `utils._score_report` matches the real `run_reports`/`score_and_analyze` on
+  all 23 headline numbers (set-conjunctions, accessible-set filtering, binary weighted-F1,
+  the `no:long` short-input drop).

--- a/lm_eval/tasks/fantom/README.md
+++ b/lm_eval/tasks/fantom/README.md
@@ -6,13 +6,13 @@ per-QA scorers / `score_and_analyze` logic from the read-only submodule
 (`benchmarks/fantom/`), invoked through lm-eval's `process_results` + custom
 `aggregation` hooks so the headline numbers are reported live, in-harness.
 
-## Task
+## Tasks
 
 | Task | Context | Prompting | Aggregation target |
 |------|---------|-----------|--------------------|
-| `fantom` | `short` | direct (non-CoT) | `set` |
-
-`full`-context and CoT are deferred (see Deviations).
+| `fantom` | `short` | direct | `set` |
+| `fantom_full` | `full` | direct | `set` |
+| `fantom_cot` | `short` | zero-shot CoT (single-pass) | `set` |
 
 ## Architecture
 
@@ -85,9 +85,18 @@ apply the chat template; base models do not).
    ships a non-1.0 default this is a (small) deviation. The paper's headline numbers were
    produced with API models under different decoding; run-to-run variance is expected on HF
    models.
-3. **v1 scope = `short` + direct, `aggregation_target=set`.** `full`-context (which
-   relabels some `missed_info_accessibility` values in `setup_fantom`) and the two-pass
-   CoT protocol (lm-eval cannot do single-shot two-pass) are deferred.
+3. **`fantom_full` uses `full_context`.** The stored `missed_info_accessibility` labels
+   on answerability/info-access QAs are re-derived at flatten time (the raw labels were
+   computed for the short excerpt): a list QA is forced `inaccessible` if `wrong_answer`
+   is non-empty; binary QAs for a set are all stamped `inaccessible` if any character
+   answers "no". Belief and fact QAs are not touched. Scores are expected to be lower
+   than `fantom` (harder: more context, more noise).
+4. **`fantom_cot` is a single-pass CoT approximation.** FANToM's original protocol is
+   two model calls: (1) "Let's think step by step." → reasoning; (2) reasoning +
+   "Therefore, the answer is:" → answer. lm-eval has no two-pass mechanism. Instead,
+   both cues are baked into the prompt in one shot and the answer is parsed from after
+   "Therefore, the answer is:" in the response (falling back to the full response if the
+   string is absent). This is the same pattern as `gpqa_cot_zeroshot` in the harness.
 4. **Headline scalars only.** The error-analysis diagnostics (`wrong_reasons` frequency
    dicts) and the character-tracking analyses (`set:ALL_character`,
    `character_answer_consistency`) from `score_and_analyze` are not exposed as lm-eval

--- a/lm_eval/tasks/fantom/_fantom_template_yaml
+++ b/lm_eval/tasks/fantom/_fantom_template_yaml
@@ -1,0 +1,47 @@
+custom_dataset: !function utils.load
+test_split: train
+output_type: generate_until
+doc_to_text: !function utils.doc_to_text
+doc_to_target: "{{target}}"        # logging only; scoring lives in process_results
+process_results: !function utils.process_results
+generation_kwargs:
+  # Mirror FANToM's HuggingFace agent (agents/huggingface.py): max_new_tokens=365,
+  # do_sample=True, no stop sequence (response parsed afterwards). Sampled => results
+  # are run-to-run non-deterministic (documented in README). No "\n"/"\n\n" stop so a
+  # multi-line free-text / list answer is not truncated mid-answer.
+  do_sample: true
+  temperature: 1.0   # the transformers/agent default under do_sample=True (agent sets no temp)
+  max_gen_toks: 365
+  until:
+    - "</s>"
+    - "<|im_end|>"
+# Each metric is a faithful FANToM headline number; the value comes from a custom
+# !function aggregation that rebuilds the corpus DataFrame from the emitted per-QA
+# payloads and runs vendored score_and_analyze. Reported as percentages (x100).
+# `inaccessible:*` = the FANToM task; `control_*` = the mandated `accessible` control.
+metric_list:
+  - {metric: all_star,                 aggregation: !function utils.agg_all_star,                 higher_is_better: true}
+  - {metric: all,                      aggregation: !function utils.agg_all,                      higher_is_better: true}
+  - {metric: belief_choice,            aggregation: !function utils.agg_belief_choice,            higher_is_better: true}
+  - {metric: belief_dist,              aggregation: !function utils.agg_belief_dist,              higher_is_better: true}
+  - {metric: belief_tokenf1,           aggregation: !function utils.agg_belief_tokenf1,           higher_is_better: true}
+  - {metric: answerability_all,        aggregation: !function utils.agg_answerability_all,        higher_is_better: true}
+  - {metric: answerability_list,       aggregation: !function utils.agg_answerability_list,       higher_is_better: true}
+  - {metric: answerability_binary_f1,  aggregation: !function utils.agg_answerability_binary_f1,  higher_is_better: true}
+  - {metric: infoaccess_all,           aggregation: !function utils.agg_infoaccess_all,           higher_is_better: true}
+  - {metric: infoaccess_list,          aggregation: !function utils.agg_infoaccess_list,          higher_is_better: true}
+  - {metric: infoaccess_binary_f1,     aggregation: !function utils.agg_infoaccess_binary_f1,     higher_is_better: true}
+  - {metric: fact_tokenf1,             aggregation: !function utils.agg_fact_tokenf1,             higher_is_better: true}
+  - {metric: control_all_star,                aggregation: !function utils.agg_control_all_star,                higher_is_better: true}
+  - {metric: control_all,                     aggregation: !function utils.agg_control_all,                     higher_is_better: true}
+  - {metric: control_belief_choice,           aggregation: !function utils.agg_control_belief_choice,           higher_is_better: true}
+  - {metric: control_belief_dist,             aggregation: !function utils.agg_control_belief_dist,             higher_is_better: true}
+  - {metric: control_belief_tokenf1,          aggregation: !function utils.agg_control_belief_tokenf1,          higher_is_better: true}
+  - {metric: control_answerability_all,       aggregation: !function utils.agg_control_answerability_all,       higher_is_better: true}
+  - {metric: control_answerability_list,      aggregation: !function utils.agg_control_answerability_list,      higher_is_better: true}
+  - {metric: control_answerability_binary_f1, aggregation: !function utils.agg_control_answerability_binary_f1, higher_is_better: true}
+  - {metric: control_infoaccess_all,          aggregation: !function utils.agg_control_infoaccess_all,          higher_is_better: true}
+  - {metric: control_infoaccess_list,         aggregation: !function utils.agg_control_infoaccess_list,         higher_is_better: true}
+  - {metric: control_infoaccess_binary_f1,    aggregation: !function utils.agg_control_infoaccess_binary_f1,    higher_is_better: true}
+metadata:
+  version: 0

--- a/lm_eval/tasks/fantom/fantom.yaml
+++ b/lm_eval/tasks/fantom/fantom.yaml
@@ -1,0 +1,3 @@
+include: _fantom_template_yaml
+task: fantom
+tag: [theory_of_mind]

--- a/lm_eval/tasks/fantom/fantom_cot.yaml
+++ b/lm_eval/tasks/fantom/fantom_cot.yaml
@@ -1,0 +1,5 @@
+include: _fantom_template_yaml
+task: fantom_cot
+tag: [theory_of_mind]
+doc_to_text: !function utils.doc_to_text_cot
+process_results: !function utils.process_results_cot

--- a/lm_eval/tasks/fantom/fantom_full.yaml
+++ b/lm_eval/tasks/fantom/fantom_full.yaml
@@ -1,0 +1,4 @@
+include: _fantom_template_yaml
+task: fantom_full
+tag: [theory_of_mind]
+custom_dataset: !function utils.load_full

--- a/lm_eval/tasks/fantom/utils.py
+++ b/lm_eval/tasks/fantom/utils.py
@@ -212,6 +212,134 @@ def load(**kwargs):
     return {"train": datasets.Dataset.from_list(_build_docs())}
 
 
+# ---------------------------------------------------------------------------
+# FULL-CONTEXT LOADER — same flatten but uses full_context and re-derives
+# missed_info_accessibility for the 4 answerability/info-access QA types.
+# ---------------------------------------------------------------------------
+
+def _flatten_full(df):
+    """Vendored from eval_fantom.setup_fantom (conversation_input_type='full').
+    Identical to _flatten except: uses full_context, and overwrites the stored
+    missed_info_accessibility on answerability/info-access QAs with values
+    re-derived from the answer data (the stored labels were computed for short)."""
+    random.seed(RANDOM_SEED)
+    qas = []
+    for _, _set in df.iterrows():
+        context = _set["full_context"].strip()   # ← the only prompt change
+        set_id = _set["set_id"]
+        fact_q = _set["factQA"]["question"]
+        fact_a = _set["factQA"]["correct_answer"]
+
+        # Fact Question — unchanged
+        fact = dict(_set["factQA"])
+        fact["context"] = context
+        fact["input_text"] = "{}\n\nQuestion: {}\nAnswer:".format(context, fact_q)
+        fact["set_id"] = set_id
+        qas.append(fact)
+
+        # Belief Questions — unchanged (missed_info_accessibility not touched)
+        for _belief_qa in _set["beliefQAs"]:
+            belief = dict(_belief_qa)
+            belief["context"] = context
+            belief["input_text"] = "{}\n\nQuestion: {}\nAnswer:".format(context, belief["question"])
+            belief["set_id"] = set_id
+            qas.append(belief)
+
+            mc = dict(_belief_qa)
+            choices_text, answer = _set_beliefQA_multiple_choices(mc)
+            mc_question = "{}\n{}\n\nChoose an answer from above:".format(
+                _belief_qa["question"], choices_text.strip()
+            )
+            mc["question"] = mc_question
+            mc["question_type"] = mc["question_type"] + ":multiple-choice"
+            mc["choices_text"] = choices_text
+            mc["correct_answer"] = answer
+            mc["context"] = context
+            mc["input_text"] = "{}\n\nQuestion: {}".format(context, mc_question)
+            mc["set_id"] = set_id
+            qas.append(mc)
+
+        # Answerability List — overwrite missed_info_accessibility if wrong_answer non-empty
+        alist = dict(_set["answerabilityQA_list"])
+        alist["fact_question"] = fact_q
+        alist["context"] = context
+        alist["input_text"] = "{}\n\nTarget: {}\nQuestion: {}\nAnswer:".format(
+            context, fact_q, alist["question"]
+        )
+        alist["set_id"] = set_id
+        if len(alist.get("wrong_answer") or []) > 0:
+            alist["missed_info_accessibility"] = "inaccessible"
+        qas.append(alist)
+
+        # Answerability Binary — pre-scan to derive label, then stamp each copy
+        full_mia = _set["answerabilityQAs_binary"][0]["missed_info_accessibility"]
+        for _ab in _set["answerabilityQAs_binary"]:
+            if _ab["correct_answer"] != "yes":
+                full_mia = "inaccessible"
+        for _ab in _set["answerabilityQAs_binary"]:
+            ab = dict(_ab)
+            ab["fact_question"] = fact_q
+            ab["context"] = context
+            ab["input_text"] = "{}\n\nTarget: {}\nQuestion: {} Answer yes or no.\nAnswer:".format(
+                context, fact_q, ab["question"]
+            )
+            ab["set_id"] = set_id
+            ab["missed_info_accessibility"] = full_mia
+            qas.append(ab)
+
+        # Info-Accessibility List — same rule as answerability list
+        ilist = dict(_set["infoAccessibilityQA_list"])
+        ilist["fact_question"] = fact_q
+        ilist["fact_answer"] = fact_a
+        ilist["context"] = context
+        ilist["input_text"] = "{}\n\nInformation: {} {}\nQuestion: {}\nAnswer:".format(
+            context, fact_q, fact_a, ilist["question"]
+        )
+        ilist["set_id"] = set_id
+        if len(ilist.get("wrong_answer") or []) > 0:
+            ilist["missed_info_accessibility"] = "inaccessible"
+        qas.append(ilist)
+
+        # Info-Accessibility Binary — same pattern as answerability binary
+        full_mia = _set["infoAccessibilityQAs_binary"][0]["missed_info_accessibility"]
+        for _ib in _set["infoAccessibilityQAs_binary"]:
+            if _ib["correct_answer"] != "yes":
+                full_mia = "inaccessible"
+        for _ib in _set["infoAccessibilityQAs_binary"]:
+            ib = dict(_ib)
+            ib["fact_question"] = fact_q
+            ib["fact_answer"] = fact_a
+            ib["context"] = context
+            ib["input_text"] = "{}\n\nInformation: {} {}\nQuestion: {} Answer yes or no.\nAnswer:".format(
+                context, fact_q, fact_a, ib["question"]
+            )
+            ib["set_id"] = set_id
+            ib["missed_info_accessibility"] = full_mia
+            qas.append(ib)
+
+    return qas
+
+
+@functools.lru_cache(maxsize=1)
+def _build_docs_full():
+    json_path = _download_and_unzip()
+    df = pd.read_json(json_path)
+    docs = []
+    for qa in _flatten_full(df):
+        docs.append({
+            "input_text": qa["input_text"],
+            "set_id": qa["set_id"],
+            "question_type": qa["question_type"],
+            "target": str(qa.get("correct_answer")),
+            "qa": json.dumps(qa, ensure_ascii=False),
+        })
+    return docs
+
+
+def load_full(**kwargs):
+    return {"train": datasets.Dataset.from_list(_build_docs_full())}
+
+
 def doc_to_text(doc):
     return doc["input_text"]
 
@@ -324,6 +452,69 @@ def parse_response(response):
 def process_results(doc, results):
     qa = json.loads(doc["qa"])
     pred = parse_response(results[0])
+    qt = qa["question_type"]
+
+    payload = {
+        "set_id": qa["set_id"],
+        "question_type": qt,
+        "correct_answer": qa.get("correct_answer"),
+        "missed_info_accessibility": qa.get("missed_info_accessibility"),
+        "tom_type": qa.get("tom_type"),
+        "question": qa.get("question"),
+        "prediction": pred,
+        "word_overlap": None,
+        "binarized_model_answer": None,
+        "excluded_aware_character": None,
+        "included_unaware_character": None,
+    }
+
+    if qt.startswith("tom:belief:"):
+        if qt.endswith(":multiple-choice"):
+            result = bool(evaluate_mc_belief_q(qa, pred))
+        else:
+            result, word_overlap = evaluate_belief_q(qa, pred)
+            result = bool(result)
+            payload["word_overlap"] = word_overlap
+    elif qt.endswith(":list"):
+        result, excl, incl = evaluate_list_q(qa, pred)
+        result = bool(result)
+        payload["excluded_aware_character"] = excl
+        payload["included_unaware_character"] = incl
+    elif qt.endswith(":binary"):
+        _bin = map_binary_answer_to_int(pred)
+        result = bool(yesno_to_int(qa["correct_answer"]) == _bin)
+        payload["binarized_model_answer"] = _bin
+    elif qt.startswith("fact"):
+        result = float(evaluate_fact_q(qa, pred))
+    else:
+        raise NotImplementedError(qt)
+
+    payload["result"] = result
+    return {name: payload for name, _ in METRICS}
+
+
+# ---------------------------------------------------------------------------
+# CoT variants — zero-shot single-pass approximation of FANToM's two-pass CoT.
+# The prompt is extended with the CoT cue; the answer is parsed from after
+# "Therefore, the answer is:" in the model's output.
+# ---------------------------------------------------------------------------
+
+def doc_to_text_cot(doc):
+    text = doc["input_text"]
+    if text.endswith("Answer:"):
+        text = text[: -len("Answer:")]
+    return text + "Let's think step by step.\n\nTherefore, the answer is:"
+
+
+def parse_response_cot(response):
+    if "Therefore, the answer is:" in response:
+        return response.split("Therefore, the answer is:")[-1].strip()
+    return response.strip()
+
+
+def process_results_cot(doc, results):
+    qa = json.loads(doc["qa"])
+    pred = parse_response_cot(results[0])
     qt = qa["question_type"]
 
     payload = {

--- a/lm_eval/tasks/fantom/utils.py
+++ b/lm_eval/tasks/fantom/utils.py
@@ -1,0 +1,520 @@
+"""lm-eval adapter for FANToM (Kim et al., EMNLP 2023; arXiv:2310.15421).
+
+Faithfulness over convenience: this file **vendors** FANToM's own loader, prompt
+assembly, and scoring logic from the read-only submodule under
+`benchmarks/fantom/` (never imported — submodules are not importable as packages).
+Provenance of each vendored block is noted inline:
+
+  - download/unzip      ← benchmarks/fantom/task/dataset_loader.py
+  - prompt flatten       ← benchmarks/fantom/eval_fantom.py: setup_fantom / set_beliefQA_multiple_choices
+  - per-QA scorers       ← benchmarks/fantom/eval_fantom.py: compute_f1, evaluate_*_q,
+                            map_binary_answer_to_int, yesno_to_int, parse_response
+  - corpus report        ← benchmarks/fantom/eval_fantom.py: run_reports / score_and_analyze
+
+Architecture (see outputs/recon/fantom.md and the plan):
+  doc = ONE flattened QA  (FANToM prompts each QA separately — a per-item protocol).
+  process_results  scores the QA (vendored scorers, incl. the RoBERTa embedder for
+                   BeliefQ[Dist.]) and emits a rich payload under EVERY report metric.
+  aggregation      (one custom !function per metric) rebuilds a DataFrame from the
+                   emitted payloads and runs vendored score_and_analyze for both the
+                   `inaccessible` (FANToM) and `accessible` (control) scenarios.
+
+v1 scope: short context, direct (non-CoT), aggregation_target = set.
+"""
+
+import functools
+import hashlib
+import json
+import random
+import tarfile
+from collections import Counter
+from pathlib import Path
+
+import datasets
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+RANDOM_SEED = 99  # ← eval_fantom.py:29 — drives the MC-belief option shuffle
+_FANTOM_URL = "https://storage.googleapis.com/ai2-mosaic-public/projects/fantom/fantom.tar.gz"
+_FANTOM_SHA256 = "1d08dfa0ea474c7f83b9bc7e3a7b466eab25194043489dd618b4c5223e1253a4"
+_CACHE_DIR = Path.home() / ".cache" / "fantom"   # writable; NOT benchmarks/ (read-only)
+_VERSION = "1.0"
+
+CONVERSATION_INPUT_TYPE = "short"   # v1: short only
+AGGREGATION_TARGET = "set"          # v1: set-level ALL/ALL* (README table setting)
+
+
+# ---------------------------------------------------------------------------
+# LOADER — download + unzip (vendored from task/dataset_loader.py, retargeted)
+# ---------------------------------------------------------------------------
+
+def _download_and_unzip():
+    """Ensure fantom_v1.json exists under the cache dir; download+unpack once.
+    Mirrors dataset_loader.build_data (hash-checked tar.gz → fantom/fantom_v1.json)."""
+    target_dir = _CACHE_DIR / "fantom"
+    json_path = target_dir / "fantom_v1.json"
+    built_marker = target_dir / ".built"
+    if json_path.exists() and built_marker.exists():
+        return json_path
+
+    import requests  # local import: only needed on first download
+
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    resp = requests.get(_FANTOM_URL, stream=True)
+    data = b""
+    for chunk in resp.iter_content(chunk_size=1024 * 1024 * 10):
+        data += chunk
+    if hashlib.sha256(data).hexdigest() != _FANTOM_SHA256:
+        raise RuntimeError("FANToM download hash mismatch")
+    tgz = _CACHE_DIR / "fantom.tar.gz"
+    tgz.write_bytes(data)
+    with tarfile.open(tgz) as tar:
+        tar.extractall(target_dir)
+    tgz.unlink()
+    built_marker.write_text(_VERSION)
+    return json_path
+
+
+# ---------------------------------------------------------------------------
+# RESHAPER + PROMPT — flatten sets → one doc per QA  (vendored setup_fantom)
+# MC-belief options are shuffled ONCE here, sequentially, under seed 99 — exactly
+# as eval_fantom seeds at module load and consumes the RNG in setup_fantom order.
+# ---------------------------------------------------------------------------
+
+def _set_beliefQA_multiple_choices(qa):
+    """Vendored from eval_fantom.set_beliefQA_multiple_choices (uses module `random`)."""
+    option_a = qa["wrong_answer"]
+    option_b = qa["correct_answer"]
+    answer_goes_last = random.choice([True, False])
+    if answer_goes_last:
+        choices = [option_a, option_b]
+        answer = 1
+    else:
+        choices = [option_b, option_a]
+        answer = 0
+    option_letters = ["(" + chr(x) + ")" for x in range(ord("a"), len(choices) + ord("a"))]
+    choices_text = ""
+    for letter, option in zip(option_letters, choices):
+        choices_text += "{} {}\n".format(letter, option)
+    return choices_text, answer
+
+
+def _flatten(df):
+    """Vendored from eval_fantom.setup_fantom (conversation_input_type='short').
+    Returns a list of QA dicts, each becoming one lm-eval doc."""
+    random.seed(RANDOM_SEED)  # ← reproduce the shuffle deterministically, once
+    qas = []
+    for _, _set in df.iterrows():
+        context = _set["short_context"].strip()
+        set_id = _set["set_id"]
+        fact_q = _set["factQA"]["question"]
+        fact_a = _set["factQA"]["correct_answer"]
+
+        # Fact Question
+        fact = dict(_set["factQA"])
+        fact["context"] = context
+        fact["input_text"] = "{}\n\nQuestion: {}\nAnswer:".format(context, fact_q)
+        fact["set_id"] = set_id
+        qas.append(fact)
+
+        for _belief_qa in _set["beliefQAs"]:
+            belief = dict(_belief_qa)
+            belief["context"] = context
+            belief["input_text"] = "{}\n\nQuestion: {}\nAnswer:".format(context, belief["question"])
+            belief["set_id"] = set_id
+            qas.append(belief)
+
+            # Multiple-choice belief (shuffle consumed here, in order)
+            mc = dict(_belief_qa)
+            choices_text, answer = _set_beliefQA_multiple_choices(mc)
+            mc_question = "{}\n{}\n\nChoose an answer from above:".format(
+                _belief_qa["question"], choices_text.strip()
+            )
+            mc["question"] = mc_question
+            mc["question_type"] = mc["question_type"] + ":multiple-choice"
+            mc["choices_text"] = choices_text
+            mc["correct_answer"] = answer
+            mc["context"] = context
+            mc["input_text"] = "{}\n\nQuestion: {}".format(context, mc_question)
+            mc["set_id"] = set_id
+            qas.append(mc)
+
+        # Answerability List
+        alist = dict(_set["answerabilityQA_list"])
+        alist["fact_question"] = fact_q
+        alist["context"] = context
+        alist["input_text"] = "{}\n\nTarget: {}\nQuestion: {}\nAnswer:".format(
+            context, fact_q, alist["question"]
+        )
+        alist["set_id"] = set_id
+        qas.append(alist)
+
+        # Answerability Binary
+        for _ab in _set["answerabilityQAs_binary"]:
+            ab = dict(_ab)
+            ab["fact_question"] = fact_q
+            ab["context"] = context
+            ab["input_text"] = "{}\n\nTarget: {}\nQuestion: {} Answer yes or no.\nAnswer:".format(
+                context, fact_q, ab["question"]
+            )
+            ab["set_id"] = set_id
+            qas.append(ab)
+
+        # Info-Accessibility List
+        ilist = dict(_set["infoAccessibilityQA_list"])
+        ilist["fact_question"] = fact_q
+        ilist["fact_answer"] = fact_a
+        ilist["context"] = context
+        ilist["input_text"] = "{}\n\nInformation: {} {}\nQuestion: {}\nAnswer:".format(
+            context, fact_q, fact_a, ilist["question"]
+        )
+        ilist["set_id"] = set_id
+        qas.append(ilist)
+
+        # Info-Accessibility Binary
+        for _ib in _set["infoAccessibilityQAs_binary"]:
+            ib = dict(_ib)
+            ib["fact_question"] = fact_q
+            ib["fact_answer"] = fact_a
+            ib["context"] = context
+            ib["input_text"] = "{}\n\nInformation: {} {}\nQuestion: {} Answer yes or no.\nAnswer:".format(
+                context, fact_q, fact_a, ib["question"]
+            )
+            ib["set_id"] = set_id
+            qas.append(ib)
+
+    return qas
+
+
+@functools.lru_cache(maxsize=1)
+def _build_docs():
+    """Parse + flatten once. Heterogeneous QA dicts (correct_answer is str/int/list
+    across types) are stored as a single JSON string `qa` to avoid Arrow schema
+    clashes (the dyntom pattern); flat fields are exposed for doc_to_text / logging."""
+    json_path = _download_and_unzip()
+    df = pd.read_json(json_path)
+    docs = []
+    for qa in _flatten(df):
+        docs.append({
+            "input_text": qa["input_text"],
+            "set_id": qa["set_id"],
+            "question_type": qa["question_type"],
+            "target": str(qa.get("correct_answer")),  # logging only
+            "qa": json.dumps(qa, ensure_ascii=False),
+        })
+    return docs
+
+
+def load(**kwargs):
+    return {"train": datasets.Dataset.from_list(_build_docs())}
+
+
+def doc_to_text(doc):
+    return doc["input_text"]
+
+
+# ---------------------------------------------------------------------------
+# Per-QA scorers — vendored verbatim from eval_fantom.py (self → module funcs)
+# ---------------------------------------------------------------------------
+
+@functools.lru_cache(maxsize=1)
+def _get_embedder():
+    """Lazy RoBERTa-large singleton (BeliefQ[Dist.] cosine). Heavy: loads only when
+    a belief-distance QA is actually scored."""
+    import torch
+    from sentence_transformers import SentenceTransformer
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    return SentenceTransformer("sentence-transformers/all-roberta-large-v1").to(device)
+
+
+def compute_f1(ground_truth, model_response):
+    ground_truth = ground_truth.split()
+    model_response = model_response.split()
+    common = Counter(ground_truth) & Counter(model_response)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return 0
+    precision = 1.0 * num_same / len(model_response)
+    recall = 1.0 * num_same / len(ground_truth)
+    return (2 * precision * recall) / (precision + recall)
+
+
+def evaluate_belief_q(qa, model_response):
+    from sklearn.metrics.pairwise import cosine_similarity
+    embedder = _get_embedder()
+    wrong_tom_view = qa["wrong_answer"]
+    wrong_emb = embedder.encode(wrong_tom_view)
+    personx_emb = embedder.encode(qa["correct_answer"])
+    resp_emb = embedder.encode(model_response)
+    sim_wrong = cosine_similarity(resp_emb.reshape(1, -1), wrong_emb.reshape(1, -1))[0][0]
+    sim_personx = cosine_similarity(resp_emb.reshape(1, -1), personx_emb.reshape(1, -1))[0][0]
+    if sim_wrong >= sim_personx:
+        return False, compute_f1(wrong_tom_view, model_response)
+    return True, compute_f1(qa["correct_answer"], model_response)
+
+
+def evaluate_mc_belief_q(qa, model_response):
+    int_to_alphabet = {0: "a", 1: "b", 2: "c", 3: "d"}
+    answer = int_to_alphabet[qa["correct_answer"]]
+    response = model_response.lower()
+    return (
+        response.startswith("(" + answer + ")")
+        or response.startswith(answer + ")")
+        or response.startswith(answer + ".")
+        or response.startswith(answer + ":")
+        or response.startswith(answer + ",")
+        or "({})".format(answer) in response
+        or answer == response
+    )
+
+
+def evaluate_list_q(qa, model_response):
+    excluded_aware_character = False
+    included_unaware_character = False
+    for character in qa["correct_answer"]:
+        if character.lower() not in model_response.lower():
+            excluded_aware_character = True
+            break
+    for character in qa["wrong_answer"]:
+        if character.lower() in model_response.lower():
+            included_unaware_character = True
+            break
+    return (
+        not (excluded_aware_character or included_unaware_character),
+        excluded_aware_character,
+        included_unaware_character,
+    )
+
+
+def map_binary_answer_to_int(model_response):
+    a = model_response.lower().strip("'").strip('"')
+    if (" yes," in a or " yes " in a or a.startswith("yes") or " yes." in a
+            or " knows " in a or a.lower().startswith("true")):
+        return 1
+    elif (" no," in a or " no " in a or a.startswith("no") or " no." in a
+          or " does not know " in a or " doesn't know " in a or a.lower().startswith("false")):
+        return 0
+    return -1
+
+
+def evaluate_fact_q(qa, model_response):
+    return compute_f1(qa["correct_answer"].lower(), model_response.lower())
+
+
+def yesno_to_int(yesno_str):
+    return {"yes": 1, "no": 0, "no:long": 0, "error": -1}[yesno_str]
+
+
+def parse_response(response):
+    if "Answer:" in response:
+        response = response.split("Answer:")[-1].strip()
+    elif "Choose an answer from above:" in response:
+        response = response.split("Choose an answer from above:")[-1].strip()
+    return response
+
+
+# ---------------------------------------------------------------------------
+# process_results — score one QA (vendored evaluate_response branching) and emit
+# the SAME rich payload under every report metric (each agg consumes the full list).
+# ---------------------------------------------------------------------------
+
+def process_results(doc, results):
+    qa = json.loads(doc["qa"])
+    pred = parse_response(results[0])
+    qt = qa["question_type"]
+
+    payload = {
+        "set_id": qa["set_id"],
+        "question_type": qt,
+        "correct_answer": qa.get("correct_answer"),
+        "missed_info_accessibility": qa.get("missed_info_accessibility"),
+        "tom_type": qa.get("tom_type"),
+        "question": qa.get("question"),
+        "prediction": pred,
+        "word_overlap": None,
+        "binarized_model_answer": None,
+        "excluded_aware_character": None,
+        "included_unaware_character": None,
+    }
+
+    if qt.startswith("tom:belief:"):
+        if qt.endswith(":multiple-choice"):
+            result = bool(evaluate_mc_belief_q(qa, pred))
+        else:
+            result, word_overlap = evaluate_belief_q(qa, pred)
+            result = bool(result)
+            payload["word_overlap"] = word_overlap
+    elif qt.endswith(":list"):
+        result, excl, incl = evaluate_list_q(qa, pred)
+        result = bool(result)
+        payload["excluded_aware_character"] = excl
+        payload["included_unaware_character"] = incl
+    elif qt.endswith(":binary"):
+        _bin = map_binary_answer_to_int(pred)
+        result = bool(yesno_to_int(qa["correct_answer"]) == _bin)
+        payload["binarized_model_answer"] = _bin
+    elif qt.startswith("fact"):
+        result = float(evaluate_fact_q(qa, pred))
+    else:
+        raise NotImplementedError(qt)
+
+    payload["result"] = result
+    return {name: payload for name, _ in METRICS}
+
+
+# ---------------------------------------------------------------------------
+# Corpus report — vendored run_reports + score_and_analyze (headline scalars).
+# Returns BOTH the `inaccessible` (FANToM) and `accessible` (control) numbers.
+# ---------------------------------------------------------------------------
+
+_F1 = None
+_REPORT_COLS = [
+    "set_id", "question_type", "correct_answer", "missed_info_accessibility",
+    "result", "word_overlap", "binarized_model_answer", "prediction",
+]
+
+
+def _f1_metric():
+    global _F1
+    if _F1 is None:
+        import evaluate
+        _F1 = evaluate.load("f1")
+    return _F1
+
+
+def _score_scenario(df, target_scenario, agg_col):
+    """Vendored headline portion of eval_fantom.score_and_analyze (one scenario)."""
+    report = {}
+    tom_df = df[df["question_type"].str.startswith("tom")].copy()
+    target_df = tom_df[tom_df["missed_info_accessibility"] == target_scenario].copy()
+
+    if target_scenario == "accessible":
+        # Keep only sets whose every tom question is `accessible` (else ALL/ALL* inflate)
+        set_ids = target_df["set_id"].unique()
+        target_sets = [
+            sid for sid in set_ids
+            if tom_df[tom_df["set_id"] == sid]["missed_info_accessibility"].eq(target_scenario).all()
+        ]
+    else:
+        target_sets = target_df["set_id"].unique()
+
+    s = target_scenario
+    report[s + ":set:ALL*"] = (
+        target_df[target_df["set_id"].isin(target_sets)].groupby(agg_col)["result"].all().mean()
+    )
+    qfa = ["tom:belief:" + s + ":multiple-choice", "tom:answerability:list",
+           "tom:answerability:binary", "tom:info_accessibility:list", "tom:info_accessibility:binary"]
+    report[s + ":set:ALL"] = (
+        target_df[target_df["question_type"].isin(qfa) & target_df["set_id"].isin(target_sets)]
+        .groupby(agg_col)["result"].all().mean()
+    )
+    report[s + ":belief:multiple-choice"] = (
+        target_df[target_df["question_type"].str.endswith(":multiple-choice")]["result"].mean()
+    )
+    report[s + ":belief:distance"] = (
+        target_df[target_df["question_type"] == "tom:belief:" + s]["result"].mean()
+    )
+    report[s + ":belief_true_word-f1"] = (
+        target_df[(target_df["question_type"] == "tom:belief:" + s) & (target_df["result"] == True)]
+        ["word_overlap"].mean()
+    )
+    report[s + ":answerability:set:ALL"] = (
+        target_df[target_df["question_type"].str.startswith("tom:answerability")]
+        .groupby(agg_col)["result"].all().mean()
+    )
+    report[s + ":answerability:list"] = (
+        target_df[target_df["question_type"] == "tom:answerability:list"]["result"].mean()
+    )
+    ans_pred = target_df[target_df["question_type"] == "tom:answerability:binary"]["binarized_model_answer"].to_list()
+    ans_ref = target_df[target_df["question_type"] == "tom:answerability:binary"]["correct_answer"].map(yesno_to_int).to_list()
+    report[s + ":answerability:binary-f1"] = (
+        _f1_metric().compute(predictions=ans_pred, references=ans_ref, pos_label=0, average="weighted")["f1"]
+        if ans_pred else float("nan")
+    )
+    report[s + ":info_accessibility:set:ALL"] = (
+        target_df[target_df["question_type"].str.startswith("tom:info_accessibility")]
+        .groupby(agg_col)["result"].all().mean()
+    )
+    report[s + ":info_accessibility:list"] = (
+        target_df[target_df["question_type"] == "tom:info_accessibility:list"]["result"].mean()
+    )
+    acc_pred = target_df[target_df["question_type"] == "tom:info_accessibility:binary"]["binarized_model_answer"].to_list()
+    acc_ref = target_df[target_df["question_type"] == "tom:info_accessibility:binary"]["correct_answer"].map(yesno_to_int).to_list()
+    report[s + ":info_accessibility:binary-f1"] = (
+        _f1_metric().compute(predictions=acc_pred, references=acc_ref, pos_label=0, average="weighted")["f1"]
+        if acc_pred else float("nan")
+    )
+    report["fact_word-f1"] = df[df["question_type"].str.startswith("fact")]["result"].mean()
+
+    for k, v in report.items():
+        if isinstance(v, float):
+            report[k] = round(v, 3) * 100
+    return report
+
+
+def _score_report(payloads):
+    """Vendored run_reports: build df, drop short-input `no:long` binaries, then
+    score both scenarios. Recomputed per metric (cheap; headline-only scoring)."""
+    df = pd.DataFrame(list(payloads))
+    for col in _REPORT_COLS:
+        if col not in df.columns:
+            df[col] = pd.NA
+    # short input: drop binary questions with no:long answer (run_reports)
+    df = df.drop(
+        df[(df["question_type"].str.endswith(":binary")) & (df["correct_answer"] == "no:long")].index
+    )
+    agg_col = AGGREGATION_TARGET + "_id"  # v1: "set_id"
+    if agg_col not in df.columns:
+        # run_reports derives these from set_id; we only need set_id for v1
+        df["conversation_id"] = df["set_id"].map(lambda x: x.split("-")[0])
+        df["part_id"] = df["set_id"].map(lambda x: "-".join(x.split("-")[:2]))
+    report = _score_scenario(df, "inaccessible", agg_col)
+    control = _score_scenario(df, "accessible", agg_col)
+    return {**report, **control}
+
+
+# ---------------------------------------------------------------------------
+# Metric registry — (lm-eval metric name, score_and_analyze report key).
+# process_results emits the payload under every name; each agg returns its key.
+# ---------------------------------------------------------------------------
+
+METRICS = [
+    # inaccessible (the FANToM task)
+    ("all_star",                 "inaccessible:set:ALL*"),
+    ("all",                      "inaccessible:set:ALL"),
+    ("belief_choice",            "inaccessible:belief:multiple-choice"),
+    ("belief_dist",              "inaccessible:belief:distance"),
+    ("belief_tokenf1",           "inaccessible:belief_true_word-f1"),
+    ("answerability_all",        "inaccessible:answerability:set:ALL"),
+    ("answerability_list",       "inaccessible:answerability:list"),
+    ("answerability_binary_f1",  "inaccessible:answerability:binary-f1"),
+    ("infoaccess_all",           "inaccessible:info_accessibility:set:ALL"),
+    ("infoaccess_list",          "inaccessible:info_accessibility:list"),
+    ("infoaccess_binary_f1",     "inaccessible:info_accessibility:binary-f1"),
+    ("fact_tokenf1",             "fact_word-f1"),
+    # accessible (the mandated control task)
+    ("control_all_star",                "accessible:set:ALL*"),
+    ("control_all",                     "accessible:set:ALL"),
+    ("control_belief_choice",           "accessible:belief:multiple-choice"),
+    ("control_belief_dist",             "accessible:belief:distance"),
+    ("control_belief_tokenf1",          "accessible:belief_true_word-f1"),
+    ("control_answerability_all",       "accessible:answerability:set:ALL"),
+    ("control_answerability_list",      "accessible:answerability:list"),
+    ("control_answerability_binary_f1", "accessible:answerability:binary-f1"),
+    ("control_infoaccess_all",          "accessible:info_accessibility:set:ALL"),
+    ("control_infoaccess_list",         "accessible:info_accessibility:list"),
+    ("control_infoaccess_binary_f1",    "accessible:info_accessibility:binary-f1"),
+]
+
+
+def _make_agg(report_key):
+    def _agg(items):
+        return _score_report(items).get(report_key, float("nan"))
+    return _agg
+
+
+for _name, _key in METRICS:
+    globals()["agg_" + _name] = _make_agg(_key)

--- a/lm_eval/tasks/hitom/_hitom.yaml
+++ b/lm_eval/tasks/hitom/_hitom.yaml
@@ -1,0 +1,18 @@
+group: hitom
+task:
+  - hitom_cotp_order_0
+  - hitom_cotp_order_1
+  - hitom_cotp_order_2
+  - hitom_cotp_order_3
+  - hitom_cotp_order_4
+  - hitom_vp_order_0
+  - hitom_vp_order_1
+  - hitom_vp_order_2
+  - hitom_vp_order_3
+  - hitom_vp_order_4
+aggregate_metric_list:
+  - metric: acc
+    aggregation: mean
+    weight_by_size: true
+metadata:
+  version: 0

--- a/lm_eval/tasks/hitom/_hitom_cotp.yaml
+++ b/lm_eval/tasks/hitom/_hitom_cotp.yaml
@@ -1,0 +1,13 @@
+group: hitom_cotp
+task:
+  - hitom_cotp_order_0
+  - hitom_cotp_order_1
+  - hitom_cotp_order_2
+  - hitom_cotp_order_3
+  - hitom_cotp_order_4
+aggregate_metric_list:
+  - metric: acc
+    aggregation: mean
+    weight_by_size: true
+metadata:
+  version: 0

--- a/lm_eval/tasks/hitom/_hitom_cotp_template_yaml
+++ b/lm_eval/tasks/hitom/_hitom_cotp_template_yaml
@@ -1,0 +1,24 @@
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+  data_files: C:/Users/hmark/WPI/ToM-and-Jerry/benchmarks/Hi-ToM_dataset/Hi-ToM_data/Hi-ToM_data.json
+  field: data
+test_split: train
+output_type: generate_until
+# The `prompt` field is the authentic Hi-ToM prompt (paper Table 8); feed it verbatim.
+doc_to_text: "{{prompt}}"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+generation_kwargs:
+  until:
+    - "</s>"
+    - "<|im_end|>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 512
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0

--- a/lm_eval/tasks/hitom/_hitom_cotp_template_yaml
+++ b/lm_eval/tasks/hitom/_hitom_cotp_template_yaml
@@ -1,8 +1,4 @@
-dataset_path: json
-dataset_name: null
-dataset_kwargs:
-  data_files: C:/Users/hmark/WPI/ToM-and-Jerry/benchmarks/Hi-ToM_dataset/Hi-ToM_data/Hi-ToM_data.json
-  field: data
+custom_dataset: !function utils.load
 test_split: train
 output_type: generate_until
 # The `prompt` field is the authentic Hi-ToM prompt (paper Table 8); feed it verbatim.

--- a/lm_eval/tasks/hitom/_hitom_vp.yaml
+++ b/lm_eval/tasks/hitom/_hitom_vp.yaml
@@ -1,0 +1,13 @@
+group: hitom_vp
+task:
+  - hitom_vp_order_0
+  - hitom_vp_order_1
+  - hitom_vp_order_2
+  - hitom_vp_order_3
+  - hitom_vp_order_4
+aggregate_metric_list:
+  - metric: acc
+    aggregation: mean
+    weight_by_size: true
+metadata:
+  version: 0

--- a/lm_eval/tasks/hitom/_hitom_vp_template_yaml
+++ b/lm_eval/tasks/hitom/_hitom_vp_template_yaml
@@ -1,0 +1,25 @@
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+  data_files: C:/Users/hmark/WPI/ToM-and-Jerry/benchmarks/Hi-ToM_dataset/Hi-ToM_data/Hi-ToM_data.json
+  field: data
+test_split: train
+output_type: generate_until
+# The `prompt` field is the authentic Hi-ToM prompt (paper Table 8); feed it verbatim.
+doc_to_text: "{{prompt}}"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+generation_kwargs:
+  until:
+    - "</s>"
+    - "<|im_end|>"
+    - "\n\n"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 64
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 0

--- a/lm_eval/tasks/hitom/_hitom_vp_template_yaml
+++ b/lm_eval/tasks/hitom/_hitom_vp_template_yaml
@@ -1,8 +1,4 @@
-dataset_path: json
-dataset_name: null
-dataset_kwargs:
-  data_files: C:/Users/hmark/WPI/ToM-and-Jerry/benchmarks/Hi-ToM_dataset/Hi-ToM_data/Hi-ToM_data.json
-  field: data
+custom_dataset: !function utils.load
 test_split: train
 output_type: generate_until
 # The `prompt` field is the authentic Hi-ToM prompt (paper Table 8); feed it verbatim.

--- a/lm_eval/tasks/hitom/hitom_cotp_order_0.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_0.yaml
@@ -1,0 +1,3 @@
+include: _hitom_cotp_template_yaml
+task: hitom_cotp_order_0
+process_docs: !function utils.process_docs_cotp_order_0

--- a/lm_eval/tasks/hitom/hitom_cotp_order_0.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_0.yaml
@@ -1,3 +1,5 @@
 include: _hitom_cotp_template_yaml
 task: hitom_cotp_order_0
-process_docs: !function utils.process_docs_cotp_order_0
+dataset_kwargs:
+  prompting_type: CoTP
+  question_order: 0

--- a/lm_eval/tasks/hitom/hitom_cotp_order_1.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_1.yaml
@@ -1,3 +1,5 @@
 include: _hitom_cotp_template_yaml
 task: hitom_cotp_order_1
-process_docs: !function utils.process_docs_cotp_order_1
+dataset_kwargs:
+  prompting_type: CoTP
+  question_order: 1

--- a/lm_eval/tasks/hitom/hitom_cotp_order_1.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_1.yaml
@@ -1,0 +1,3 @@
+include: _hitom_cotp_template_yaml
+task: hitom_cotp_order_1
+process_docs: !function utils.process_docs_cotp_order_1

--- a/lm_eval/tasks/hitom/hitom_cotp_order_2.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_2.yaml
@@ -1,0 +1,3 @@
+include: _hitom_cotp_template_yaml
+task: hitom_cotp_order_2
+process_docs: !function utils.process_docs_cotp_order_2

--- a/lm_eval/tasks/hitom/hitom_cotp_order_2.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_2.yaml
@@ -1,3 +1,5 @@
 include: _hitom_cotp_template_yaml
 task: hitom_cotp_order_2
-process_docs: !function utils.process_docs_cotp_order_2
+dataset_kwargs:
+  prompting_type: CoTP
+  question_order: 2

--- a/lm_eval/tasks/hitom/hitom_cotp_order_3.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_3.yaml
@@ -1,3 +1,5 @@
 include: _hitom_cotp_template_yaml
 task: hitom_cotp_order_3
-process_docs: !function utils.process_docs_cotp_order_3
+dataset_kwargs:
+  prompting_type: CoTP
+  question_order: 3

--- a/lm_eval/tasks/hitom/hitom_cotp_order_3.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_3.yaml
@@ -1,0 +1,3 @@
+include: _hitom_cotp_template_yaml
+task: hitom_cotp_order_3
+process_docs: !function utils.process_docs_cotp_order_3

--- a/lm_eval/tasks/hitom/hitom_cotp_order_4.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_4.yaml
@@ -1,3 +1,5 @@
 include: _hitom_cotp_template_yaml
 task: hitom_cotp_order_4
-process_docs: !function utils.process_docs_cotp_order_4
+dataset_kwargs:
+  prompting_type: CoTP
+  question_order: 4

--- a/lm_eval/tasks/hitom/hitom_cotp_order_4.yaml
+++ b/lm_eval/tasks/hitom/hitom_cotp_order_4.yaml
@@ -1,0 +1,3 @@
+include: _hitom_cotp_template_yaml
+task: hitom_cotp_order_4
+process_docs: !function utils.process_docs_cotp_order_4

--- a/lm_eval/tasks/hitom/hitom_vp_order_0.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_0.yaml
@@ -1,0 +1,3 @@
+include: _hitom_vp_template_yaml
+task: hitom_vp_order_0
+process_docs: !function utils.process_docs_vp_order_0

--- a/lm_eval/tasks/hitom/hitom_vp_order_0.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_0.yaml
@@ -1,3 +1,5 @@
 include: _hitom_vp_template_yaml
 task: hitom_vp_order_0
-process_docs: !function utils.process_docs_vp_order_0
+dataset_kwargs:
+  prompting_type: VP
+  question_order: 0

--- a/lm_eval/tasks/hitom/hitom_vp_order_1.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_1.yaml
@@ -1,3 +1,5 @@
 include: _hitom_vp_template_yaml
 task: hitom_vp_order_1
-process_docs: !function utils.process_docs_vp_order_1
+dataset_kwargs:
+  prompting_type: VP
+  question_order: 1

--- a/lm_eval/tasks/hitom/hitom_vp_order_1.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_1.yaml
@@ -1,0 +1,3 @@
+include: _hitom_vp_template_yaml
+task: hitom_vp_order_1
+process_docs: !function utils.process_docs_vp_order_1

--- a/lm_eval/tasks/hitom/hitom_vp_order_2.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_2.yaml
@@ -1,0 +1,3 @@
+include: _hitom_vp_template_yaml
+task: hitom_vp_order_2
+process_docs: !function utils.process_docs_vp_order_2

--- a/lm_eval/tasks/hitom/hitom_vp_order_2.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_2.yaml
@@ -1,3 +1,5 @@
 include: _hitom_vp_template_yaml
 task: hitom_vp_order_2
-process_docs: !function utils.process_docs_vp_order_2
+dataset_kwargs:
+  prompting_type: VP
+  question_order: 2

--- a/lm_eval/tasks/hitom/hitom_vp_order_3.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_3.yaml
@@ -1,0 +1,3 @@
+include: _hitom_vp_template_yaml
+task: hitom_vp_order_3
+process_docs: !function utils.process_docs_vp_order_3

--- a/lm_eval/tasks/hitom/hitom_vp_order_3.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_3.yaml
@@ -1,3 +1,5 @@
 include: _hitom_vp_template_yaml
 task: hitom_vp_order_3
-process_docs: !function utils.process_docs_vp_order_3
+dataset_kwargs:
+  prompting_type: VP
+  question_order: 3

--- a/lm_eval/tasks/hitom/hitom_vp_order_4.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_4.yaml
@@ -1,0 +1,3 @@
+include: _hitom_vp_template_yaml
+task: hitom_vp_order_4
+process_docs: !function utils.process_docs_vp_order_4

--- a/lm_eval/tasks/hitom/hitom_vp_order_4.yaml
+++ b/lm_eval/tasks/hitom/hitom_vp_order_4.yaml
@@ -1,3 +1,5 @@
 include: _hitom_vp_template_yaml
 task: hitom_vp_order_4
-process_docs: !function utils.process_docs_vp_order_4
+dataset_kwargs:
+  prompting_type: VP
+  question_order: 4

--- a/lm_eval/tasks/hitom/utils.py
+++ b/lm_eval/tasks/hitom/utils.py
@@ -1,0 +1,61 @@
+import re
+
+
+def _parse_doc(doc):
+    # choices arrives as "A. foo, B. bar, ..."; answer is the text value, not the letter
+    choices = [c.split(". ", 1)[1].strip() for c in doc["choices"].split(", ")]
+    return {**doc, "choices_list": choices, "gold": choices.index(doc["answer"])}
+
+
+def process_docs(dataset):
+    return dataset.map(_parse_doc)
+
+
+def _make_filter(style, order):
+    def _process(dataset):
+        return dataset.filter(
+            lambda d: d["prompting_type"] == style and d["question_order"] == order
+        ).map(_parse_doc)
+
+    return _process
+
+
+# Per (prompting_type x question_order) doc processors, e.g. process_docs_cotp_order_0
+for _style in ("CoTP", "VP"):
+    for _order in range(5):
+        globals()["process_docs_%s_order_%d" % (_style.lower(), _order)] = _make_filter(
+            _style, _order
+        )
+
+
+def _extract_index(gen, choices):
+    """Letter-first, value-fallback extraction (Hi-ToM answers come first in the output)."""
+    n = len(choices)
+    last = chr(ord("A") + n - 1)
+    lc = "A-%sa-%s" % (last, last.lower())
+    letter_patterns = [
+        r"^\s*\(?([%s])[\.\):]" % lc,            # leading "A." "A)" "A:" "(A)"
+        r"^\s*\(?([%s])\)?\s*$" % lc,            # whole (stripped) output is just a letter
+        r"answer\s*(?:is|:)\s*\(?([%s])\b" % lc,  # "the answer is A" / "answer: A"
+        r"\(([%s])\)" % lc,                       # "(A)" anywhere
+    ]
+    g = gen.strip()
+    for pat in letter_patterns:
+        m = re.search(pat, g, flags=re.IGNORECASE | re.MULTILINE)
+        if m:
+            idx = ord(m.group(1).upper()) - ord("A")
+            if 0 <= idx < n:
+                return idx
+    # fallback: earliest-appearing choice value (case-insensitive)
+    low = gen.lower()
+    best = None
+    for i, v in enumerate(choices):
+        pos = low.find(v.lower())
+        if pos != -1 and (best is None or pos < best[0]):
+            best = (pos, i)
+    return best[1] if best else None
+
+
+def process_results(doc, results):
+    pred = _extract_index(results[0], doc["choices_list"])
+    return {"acc": 1.0 if pred == doc["gold"] else 0.0}

--- a/lm_eval/tasks/hitom/utils.py
+++ b/lm_eval/tasks/hitom/utils.py
@@ -1,31 +1,41 @@
 import re
+from pathlib import Path
+
+import datasets
+
+
+def _data_file():
+    # Resolve THIS repo's own Hi-ToM submodule copy, relative to this file, so the
+    # task is portable across clones/machines (no hardcoded absolute path).
+    for parent in Path(__file__).resolve().parents:
+        cand = parent / "benchmarks/Hi-ToM_dataset/Hi-ToM_data/Hi-ToM_data.json"
+        if cand.exists():
+            return str(cand)
+    raise FileNotFoundError(
+        "Hi-ToM_data.json not found under any parent's benchmarks/ directory"
+    )
 
 
 def _parse_doc(doc):
-    # choices arrives as "A. foo, B. bar, ..."; answer is the text value, not the letter
+    # choices arrives as "A. foo, B. bar, ..."; answer is the text value, not the letter.
+    # Contract: answer appears verbatim among the choice values, else .index raises (fail loud).
     choices = [c.split(". ", 1)[1].strip() for c in doc["choices"].split(", ")]
     return {**doc, "choices_list": choices, "gold": choices.index(doc["answer"])}
 
 
-def process_docs(dataset):
-    return dataset.map(_parse_doc)
-
-
-def _make_filter(style, order):
-    def _process(dataset):
-        return dataset.filter(
-            lambda d: d["prompting_type"] == style and d["question_order"] == order
-        ).map(_parse_doc)
-
-    return _process
-
-
-# Per (prompting_type x question_order) doc processors, e.g. process_docs_cotp_order_0
-for _style in ("CoTP", "VP"):
-    for _order in range(5):
-        globals()["process_docs_%s_order_%d" % (_style.lower(), _order)] = _make_filter(
-            _style, _order
-        )
+def load(prompting_type=None, question_order=None, **kwargs):
+    """LOADER: read the verbatim Hi-ToM JSON, parse choices/gold, and optionally
+    filter to one (prompting_type, question_order) partition. The partition
+    selectors arrive from each leaf task's `dataset_kwargs`; with neither set this
+    returns the whole corpus."""
+    ds = datasets.load_dataset(
+        "json", data_files=_data_file(), field="data", split="train"
+    ).map(_parse_doc)
+    if prompting_type is not None:
+        ds = ds.filter(lambda d: d["prompting_type"] == prompting_type)
+    if question_order is not None:
+        ds = ds.filter(lambda d: d["question_order"] == question_order)
+    return {"train": ds}
 
 
 def _extract_index(gen, choices):


### PR DESCRIPTION
Includes three benchmark adaptations/task conversions: HiToM (low-C), DynToM (med-C), and FANToM (high-C). The goal was to use our existing references for task adapting on progressively harder/more complex benchmarks, stress-testing our approach and adding what we learned as refinements, rules, and references.

## HiToM |
This was a low complexity adaptation and was mainly yaml files. Here are the issues and the associated revisions to our approach:
- The AI took a shortcut on the accuracy initially, doing log-likelihood instead of acc.
- **Revision**: emphasized faithfulness throughout documents; any and all faithfulness deviations must be carefully noted.
- The initial solution was over-engineered because it didn't know to use `dataset-kwargs` for input extraction arguments.
- **Revision**: added some guidelines for following lm-evaluation-harness's `new_task_guide.md` more closely.

The adapter guidelines were added right around the end of HiToM/beginning of DynToM.

## DynToM
The DynToM adaptation was more complex, with a very inelegant original prompting process. What we learned:
- The .json data file was ~6 million lines, with individual scenarios being ~5000 lines each, which requires loads of VRAM.
- **Revision**: added a max-faithfulness mode with 1 task that did everything and a second mode, which atomized all of the tasks and could be run individually (running all of them this way is inefficient). This sets standard for the MATRIX adapter module: max faithfulness as an option, second option documents deviations.
- There was a mystery question category that didn't seem to fit in any of the other categories.
- **Revision**: referencing the paper itself combined with human input and careful rechecking showed which category to fold it into. The sets the standard for the AGG-FN module.

The DynToM build took multiple steps. The intermediate period was recorded in DynToM-build-notes.md and is the first build reference--later to be used as an example (in what is almost few-shot prompting).

## FANToM
FANToM was the most complex, involving many custom metrics as well as very different input and output formats. Fortunately, the codebase and datasets were very clean.
- The metrics were all custom (except f1). All of the code was in eval_fantom.py
- **Revision**: the metrics were put in the utils.py of the new task. This became the standard for METRIC-FN: move over as much code as possible, using existing code whenever possible.
- The inputs varied widely, especially CoT questions which did a two-pass process; lm-eval does not support this.
- **Revision**: most of the inputs were successfully converted; after human judgment, the two-pass CoT process was condensed into a single-pass prompt. This shows a good combination of autonomous conversion as well as human judgment on deviating areas--a good standard for PROMPT-FN.

The process for FANToM was put into FANToM-build-notes.md, which serves as another useful reference.