### PR TITLE
Add README.md for medmcqa and medqa tasks

### DIFF
--- a/lm_eval/tasks/medmcqa/README.md
+++ b/lm_eval/tasks/medmcqa/README.md
@@ -1,0 +1,35 @@
+# MedMCQA
+
+### Paper
+Title: MedMCQA: A Large-scale Multi-Subject Multi-Choice Dataset for Medical domain Question Answering
+
+Abstract: https://arxiv.org/abs/2203.14371
+
+MedMCQA is a large-scale Multiple-Choice Question Answering dataset designed to address real-world medical entrance exam questions. It contains more than 194k high-quality AIIMS & NEET PG entrance exam MCQs covering 2.4k healthcare topics and 21 medical subjects. Each sample contains a question, correct answer(s), and other options which requires deeper language understanding as it tests 10+ reasoning abilities of a model across a wide range of medical subjects and topics.
+
+Homepage: https://medmcqa.github.io
+
+### Citation
+
+```bibtex
+@InProceedings{pmlr-v174-pal22a,
+  title={MedMCQA: A Large-scale Multi-Subject Multi-Choice Dataset for Medical domain Question Answering},
+  author={Pal, Ankit and Umapathi, Logesh Kumar and Sankarasubbu, Malaikannan},
+  booktitle={Proceedings of the Conference on Health, Inference, and Learning},
+  pages={248--260},
+  year={2022},
+  volume={174},
+  series={Proceedings of Machine Learning Research},
+  publisher={PMLR}
+}
+```
+
+### Groups and Tasks
+
+#### Tasks
+- `medmcqa`: Medical multiple choice questions sourced from AIIMS & NEET PG entrance exams covering 21 medical subjects and 2.4k healthcare topics.
+
+### Checklist
+- [x] Is the task an existing benchmark in the literature?
+  - [x] Have you referenced the original paper that introduces the task?
+  - [x] If yes, does the original paper provide a reference implementation?

--- a/lm_eval/tasks/medqa/README.md
+++ b/lm_eval/tasks/medqa/README.md
@@ -1,0 +1,33 @@
+# MedQA
+
+### Paper
+Title: What Disease does this Patient Have? A Large-scale Open Domain Question Answering Dataset from Medical Exams
+
+Abstract: https://arxiv.org/abs/2009.13081
+
+MedQA is a multiple-choice question answering dataset collected from professional medical board exams, specifically the United States Medical Licensing Examination (USMLE). It comprises 12,723 questions sourced from 18 English medical textbooks covering a wide range of clinical medicine topics. Questions require professional expertise and complex multi-hop reasoning across multiple pieces of evidence.
+
+Homepage: https://github.com/jind11/MedQA
+
+### Citation
+
+```bibtex
+@article{jin2020disease,
+  title={What Disease does this Patient Have? A Large-scale Open Domain Question Answering Dataset from Medical Exams},
+  author={Jin, Di and Pan, Eileen and Oufattole, Nassim and Weng, Wei-Hung and Fang, Hanyi and Szolovits, Peter},
+  journal={arXiv preprint arXiv:2009.13081},
+  year={2020}
+}
+```
+
+### Groups and Tasks
+
+#### Tasks
+- `medqa_en`: USMLE-based medical question answering in English (12,723 questions).
+- `medqa_zh`: Medical licensing exam questions in simplified Chinese.
+- `medqa_tw`: Medical licensing exam questions in traditional Chinese.
+
+### Checklist
+- [x] Is the task an existing benchmark in the literature?
+  - [x] Have you referenced the original paper that introduces the task?
+  - [x] If yes, does the original paper provide a reference implementation?


### PR DESCRIPTION
Both `medmcqa` and `medqa` task folders were missing README.md documentation files.

This PR adds README.md for both tasks following the existing format used across other task folders, including:
- Paper title and abstract link
- Dataset description
- Citation in bibtex format
- Groups and Tasks breakdown
- Checklist

References:
- MedMCQA: https://arxiv.org/abs/2203.14371
- MedQA: https://arxiv.org/abs/2009.13081