### PR TITLE
fix(infinitebench): convert feature spec to datasets.Features and correct split names

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -615,6 +615,28 @@ class Task(abc.ABC):
         return getattr(self.config, "task", None) or random_task_id()
 
 
+def _features_from_dict(features: dict) -> datasets.Features:
+    """Convert a YAML feature spec into a `datasets.Features` instance.
+
+    Task YAMLs declare `dataset_kwargs.features` as a plain mapping, e.g.
+
+        features:
+          id:     {dtype: int64}
+          answer: {dtype: string, sequence: true}
+
+    A leaf carrying a `dtype` becomes a `Value`, wrapped in a `Sequence` when
+    `sequence: true`; any other mapping is treated as a nested struct.
+    """
+
+    def parse(spec: dict):
+        if "dtype" in spec:
+            value = datasets.Value(spec["dtype"])
+            return datasets.Sequence(value) if spec.get("sequence") else value
+        return {name: parse(sub) for name, sub in spec.items()}
+
+    return datasets.Features(parse(features))
+
+
 class ConfigurableTask(Task):
     VERSION = "Yaml"
     OUTPUT_TYPE = None
@@ -858,15 +880,9 @@ class ConfigurableTask(Task):
         if dataset_kwargs and vparse(datasets.__version__) >= vparse("4.0.0"):
             dataset_kwargs.pop("trust_remote_code", None)
         feats = dataset_kwargs.get("features") if dataset_kwargs else None
+        # `Features` subclasses `dict`, so an already-converted spec must not be reparsed.
         if isinstance(feats, dict) and not isinstance(feats, datasets.Features):
-
-            def _parse(d: dict):
-                if "dtype" in d:
-                    val = datasets.Value(d["dtype"])
-                    return datasets.Sequence(val) if d.get("sequence") else val
-                return {k: _parse(v) for k, v in d.items()}
-
-            dataset_kwargs["features"] = datasets.Features(_parse(feats))
+            dataset_kwargs["features"] = _features_from_dict(feats)
         if isinstance(self.config.custom_dataset, Callable):
             eval_logger.warning(
                 f"{self.config.task}: Custom kwargs can be passed to `--metadata` in console (as json string) or to the TaskManager."

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -857,6 +857,16 @@ class ConfigurableTask(Task):
 
         if dataset_kwargs and vparse(datasets.__version__) >= vparse("4.0.0"):
             dataset_kwargs.pop("trust_remote_code", None)
+        feats = dataset_kwargs.get("features") if dataset_kwargs else None
+        if isinstance(feats, dict) and not isinstance(feats, datasets.Features):
+
+            def _parse(d: dict):
+                if "dtype" in d:
+                    val = datasets.Value(d["dtype"])
+                    return datasets.Sequence(val) if d.get("sequence") else val
+                return {k: _parse(v) for k, v in d.items()}
+
+            dataset_kwargs["features"] = datasets.Features(_parse(feats))
         if isinstance(self.config.custom_dataset, Callable):
             eval_logger.warning(
                 f"{self.config.task}: Custom kwargs can be passed to `--metadata` in console (as json string) or to the TaskManager."

--- a/lm_eval/tasks/infinitebench/infinitebench_longbook_choice_en.yaml
+++ b/lm_eval/tasks/infinitebench/infinitebench_longbook_choice_en.yaml
@@ -1,6 +1,6 @@
 include: _infinitebench_common_yaml
 task: infinitebench_longbook_choice_en
-test_split: longbook_choice_en
+test_split: longbook_choice_eng
 process_results: !function utils.process_results_choice
 doc_to_text: !function utils.doc_to_text_longbook_choice
 generation_kwargs:

--- a/lm_eval/tasks/infinitebench/infinitebench_longbook_qa_en.yaml
+++ b/lm_eval/tasks/infinitebench/infinitebench_longbook_qa_en.yaml
@@ -1,6 +1,6 @@
 include: _infinitebench_common_yaml
 task: infinitebench_longbook_qa_en
-test_split: longbook_qa_en
+test_split: longbook_qa_eng
 process_results: !function utils.process_results_qa_en
 description: "Read the book below and answer a question.\n\n"
 doc_to_text: "{{context}}\n\nQuestion: {{input}}\n\nBe very concise."

--- a/lm_eval/tasks/infinitebench/infinitebench_longbook_sum_en.yaml
+++ b/lm_eval/tasks/infinitebench/infinitebench_longbook_sum_en.yaml
@@ -1,6 +1,6 @@
 include: _infinitebench_common_yaml
 task: infinitebench_longbook_sum_en
-test_split: longbook_sum_en
+test_split: longbook_sum_eng
 process_results: !function utils.process_results_rouge
 description: "Summarize the following book.\n\n"
 doc_to_text: "{{context}}"

--- a/lm_eval/tasks/infinitebench/infinitebench_longdialogue_qa_en.yaml
+++ b/lm_eval/tasks/infinitebench/infinitebench_longdialogue_qa_en.yaml
@@ -1,6 +1,6 @@
 include: _infinitebench_common_yaml
 task: infinitebench_longdialogue_qa_en
-test_split: longdialogue_qa_en
+test_split: longdialogue_qa_eng
 doc_to_text: !function utils.doc_to_text_longdialogue
 generation_kwargs:
   do_sample: false

--- a/tests/test_task_features.py
+++ b/tests/test_task_features.py
@@ -1,0 +1,46 @@
+import datasets
+
+from lm_eval.api.task import _features_from_dict
+
+
+def test_infinitebench_schema():
+    """The spec shipped in `_infinitebench_common_yaml`."""
+    features = _features_from_dict(
+        {
+            "id": {"dtype": "int64"},
+            "context": {"dtype": "string"},
+            "input": {"dtype": "string"},
+            "answer": {"dtype": "string", "sequence": True},
+            "options": {"dtype": "string", "sequence": True},
+        }
+    )
+    assert features == datasets.Features(
+        {
+            "id": datasets.Value("int64"),
+            "context": datasets.Value("string"),
+            "input": datasets.Value("string"),
+            "answer": datasets.Sequence(datasets.Value("string")),
+            "options": datasets.Sequence(datasets.Value("string")),
+        }
+    )
+
+
+def test_sequence_false_stays_scalar():
+    features = _features_from_dict({"answer": {"dtype": "string", "sequence": False}})
+    assert features == datasets.Features({"answer": datasets.Value("string")})
+
+
+def test_nested_struct():
+    features = _features_from_dict(
+        {"meta": {"source": {"dtype": "string"}, "page": {"dtype": "int32"}}}
+    )
+    assert features == datasets.Features(
+        {"meta": {"source": datasets.Value("string"), "page": datasets.Value("int32")}}
+    )
+
+
+def test_returns_features_instance():
+    """`download()` guards on this to avoid reparsing an already-converted spec."""
+    assert isinstance(
+        _features_from_dict({"id": {"dtype": "int64"}}), datasets.Features
+    )


### PR DESCRIPTION
Fixes #3895

Two independent bugs prevent InfiniteBench tasks from running on a clean install.

**Bug 1 - features dict not converted to datasets.Features**

`_infinitebench_common_yaml` declares the dataset schema under
`dataset_kwargs.features` using a `{dtype, sequence}` mini-schema, but
`ConfigurableTask.download()` forwards `dataset_kwargs` verbatim to
`datasets.load_dataset()`. The `datasets` library requires `features` to be a
`datasets.Features` instance, not a plain dict, raising
`AttributeError: 'str' object has no attribute 'items'`.

Fix: `download()` now converts the YAML feature spec into `Value`/`Sequence`
objects before the `load_dataset()` call. The guard uses
`not isinstance(feats, datasets.Features)` because `Features` is a `dict`
subclass - a bare `isinstance(feats, dict)` check would incorrectly re-parse
an already-converted object.

**Bug 2 - test_split uses _en, dataset exposes _eng keys**

Four English subtask YAMLs set `test_split` to `longbook_choice_en`,
`longbook_qa_en`, `longbook_sum_en`, and `longdialogue_qa_en`. The
`xinrongzhang2022/InfiniteBench` dataset exposes these splits under the `_eng`
suffix, causing a `KeyError` at evaluation time. The task/file names are kept
as-is (cosmetic); only the `test_split` values are corrected.