### PR TITLE
fix(longbench): skip blank leading line in code_sim_score extraction

### DIFF
--- a/lm_eval/tasks/longbench/README.md
+++ b/lm_eval/tasks/longbench/README.md
@@ -110,3 +110,7 @@ v2.: fix doc_to_target; add vcsum
 v3: properly use all answers for metric calculation; trim whitespace from resps; fix stop sequences not parsing correctly.
 
 v4: fixed special characters in prompts; use greedy decoding by default.
+
+v5: added `longbench_*` task groups and their `_e` counterparts; standardized the reported metric as `score` alongside each task's native metric.
+
+v6 (`lcc`, `lcc_e`, `repobench-p`, `repobench-p_e` only): `code_sim_score` now skips blank/whitespace-only lines when selecting the first line of the completion.

--- a/lm_eval/tasks/longbench/lcc.yaml
+++ b/lm_eval/tasks/longbench/lcc.yaml
@@ -22,4 +22,4 @@ metric_list:
     aggregation: mean
     higher_is_better: True
 metadata:
-  version: 5.0
+  version: 6.0

--- a/lm_eval/tasks/longbench/lcc_e.yaml
+++ b/lm_eval/tasks/longbench/lcc_e.yaml
@@ -22,4 +22,4 @@ metric_list:
     aggregation: mean
     higher_is_better: True
 metadata:
-  version: 5.0
+  version: 6.0

--- a/lm_eval/tasks/longbench/metrics.py
+++ b/lm_eval/tasks/longbench/metrics.py
@@ -137,9 +137,11 @@ def get_retrieval_zh_score(doc: dict, results: list[str], **kwargs):
 
 
 def code_sim_score(prediction: str, ground_truth: str, **kwargs):
-    all_lines = prediction.lstrip("\n").split("\n")
+    all_lines = prediction.split("\n")
     prediction = ""
     for line in all_lines:
+        if line.strip() == "":
+            continue
         if ("`" not in line) and ("#" not in line) and ("//" not in line):
             prediction = line
             break

--- a/lm_eval/tasks/longbench/repobench-p.yaml
+++ b/lm_eval/tasks/longbench/repobench-p.yaml
@@ -22,4 +22,4 @@ metric_list:
     aggregation: mean
     higher_is_better: True
 metadata:
-  version: 5.0
+  version: 6.0

--- a/lm_eval/tasks/longbench/repobench-p_e.yaml
+++ b/lm_eval/tasks/longbench/repobench-p_e.yaml
@@ -22,4 +22,4 @@ metric_list:
     aggregation: mean
     higher_is_better: True
 metadata:
-  version: 5.0
+  version: 6.0


### PR DESCRIPTION
## Summary

`code_sim_score` (used by `longbench_lcc` / `longbench_repobench-p`) picks the first non-comment line of the model's completion to compare against the reference via `fuzz.ratio`:

```python
all_lines = prediction.lstrip("\n").split("\n")
prediction = ""
for line in all_lines:
    if ("`" not in line) and ("#" not in line) and ("//" not in line):
        prediction = line
        break
```

`.lstrip("\n")` only strips leading newline *characters*, not leading whitespace. In practice, vLLM completions for these tasks very often start with a leading space before the first newline (e.g. `' \n\t\t\tsome_code_line'`). When that happens, `.split("\n")` yields a bare space as the "first line," which gets picked (since it trivially satisfies the backtick/`#`/`//` check) and scored via `fuzz.ratio` against the real target — near-zero, regardless of whether the actual generated code was correct.

This fix skips blank/whitespace-only lines when hunting for the first real line, without altering the indentation of the line that's ultimately kept (so exact-match scoring against indented reference lines still works correctly).

## Motivation / evidence

Ran into this while reproducing TriAttentions's Qwen3-8B LongBench baseline (Table B in the appendix [here](https://arxiv.org/pdf/2604.04921)). QA/summarization/synthetic tasks reproduced closely once `apply_chat_template` + sampling settings were aligned with the original methodology, but `lcc`/`repobench-p` remained catastrophically low (~20-23) vs. the paper's ~60-65 regardless of generation settings — while manually inspecting `code_sim_score`'s output on raw samples showed it scoring exact-content matches near zero because of this line-extraction bug.

With this fix, on Qwen3-8B (`limit=20`, same model outputs before/after — only the scoring changed):

| Task | Before | After | Paper reference |
|---|---|---|---|
| `longbench_lcc` | 0.321 | **0.638** | ~64.9 |
| `longbench_repobench-p` | 0.125 | **0.4845** | ~60.0 |

## Test plan

- [x] Verified the extraction now correctly picks the real first code line instead of a blank fragment, by manually replaying `samples.jsonl` responses through both the old and new logic.
- [x] Re-ran `longbench_code` (lcc + repobench-p) end-to-end with the patched metric and confirmed scores moved from near-zero to roughly in line with expectations.