### PR TITLE
Add L-Eval closed-ended long-context tasks

### DIFF
--- a/lm_eval/tasks/leval/README.md
+++ b/lm_eval/tasks/leval/README.md
@@ -1,0 +1,90 @@
+# L-Eval
+
+### Paper
+
+Title: `L-Eval: Instituting Standardized Evaluation for Long Context Language Models`
+
+Abstract: `L-Eval is a long-context benchmark with 20 sub-tasks, 508 long documents, and
+over 2,000 human-labeled query-response pairs covering diverse question styles, domains,
+and input lengths (3k~200k tokens). It splits tasks into closed-ended groups (scored with
+exact match) and open-ended groups (scored with n-gram metrics or an LLM judge).`
+
+Homepage: `https://github.com/OpenLMLab/LEval`
+
+Paper: `https://arxiv.org/abs/2307.11088`
+
+### Citation
+
+```
+@inproceedings{an-etal-2024-l,
+    title = "{L}-{E}val: Instituting Standardized Evaluation for Long Context Language Models",
+    author = "An, Chenxin and Gong, Shansan and Zhong, Ming and Zhao, Xingjian and Li, Mukai and Zhang, Jun and Kong, Lingpeng and Qiu, Xipeng",
+    booktitle = "Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = aug,
+    year = "2024",
+    address = "Bangkok, Thailand",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2024.acl-long.776",
+    pages = "14388--14411",
+}
+```
+
+### Scope
+
+This directory implements the **7 closed-ended (exam / exact-match) sub-tasks** of L-Eval.
+These need no judge model, matching how LongBench is already integrated. The 13 open-ended
+sub-tasks (scored by an LLM judge or n-gram metrics) are intentionally left for a follow-up
+contribution.
+
+The data is read straight from the benchmark's closed-ended `*.jsonl` files, pinned to a
+fixed upstream commit (the original `L4NLP/LEval` Hugging Face dataset ships a loading
+script, which `datasets >= 4` no longer executes). The task instructions are reproduced from
+the benchmark so scores stay comparable with the paper; the answer extraction and
+exact-match scoring in `utils.py` are an independent re-implementation of the behaviour of
+L-Eval's `Evaluation/auto_eval.py` exam path (no code is copied from that GPL-3.0 project
+into this MIT-licensed repository).
+
+### Groups, Tags, and Tasks
+
+#### Tags
+
+* `leval`: All seven L-Eval closed-ended sub-tasks; run them together with `--tasks leval`.
+
+#### Tasks
+
+* `leval_coursera`: Multiple-choice questions (single **or** multiple correct options) over Coursera lecture transcripts.
+* `leval_quality`: Single-answer multiple-choice reading comprehension (QuALITY).
+* `leval_tpo`: Single-answer multiple-choice listening comprehension (TOEFL TPO).
+* `leval_gsm100`: 100 harder grade-school math word problems answered with a long chain-of-thought prompt (GSM).
+* `leval_codeu`: Predict the output of a function call after reading a long code base (CodeU).
+* `leval_sci_fi`: `True`/`False` claims that must be judged against a science-fiction story.
+* `leval_topic_retrieval`: Recover the 1st/2nd/3rd discussed topic from a long multi-topic conversation.
+
+### Metric
+
+Every sub-task reports `exact_match` in `[0, 1]`; the L-Eval paper reports the same quantity
+multiplied by 100. Scoring follows the benchmark: exact set match for multiple choice (with
+0.25 partial credit for coursera's multi-answer questions), numeric equality for `gsm100`,
+and case-insensitive containment of the gold string for `codeU` / `sci_fi` / `topic_retrieval`.
+
+### Notes / deviations
+
+* `leval_sci_fi` scores only the in-document (loyalty) `True`/`False` verdict. L-Eval's
+  optional second pass, which re-asks the model to contrast the story with real-world facts,
+  is not reproduced because the harness generates a single completion per request.
+* Documents are passed through as-is; L-Eval's original fixed-budget left/right truncation is
+  left to the model wrapper's own context handling.
+* `until` is empty, so generation stops at `max_gen_toks`. The extraction functions parse the
+  answer out of the raw generation, matching the benchmark.
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/leval/codeu.yaml
+++ b/lm_eval/tasks/leval/codeu.yaml
@@ -1,0 +1,25 @@
+tag:
+  - leval
+task: leval_codeu
+dataset_path: ""
+custom_dataset: !function utils.load_leval
+dataset_kwargs:
+  data_files:
+    test: "https://raw.githubusercontent.com/OpenLMLab/LEval/cd34b050269148aed75acbbe4a599873ad0f37e9/LEval-data/Closed-ended-tasks/codeU.jsonl"
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process_docs_codeu
+doc_to_text: "{{text}}"
+doc_to_target: "{{gold}}"
+process_results: !function utils.process_results_codeu
+generation_kwargs:
+  max_gen_toks: 100
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/leval/coursera.yaml
+++ b/lm_eval/tasks/leval/coursera.yaml
@@ -1,0 +1,25 @@
+tag:
+  - leval
+task: leval_coursera
+dataset_path: ""
+custom_dataset: !function utils.load_leval
+dataset_kwargs:
+  data_files:
+    test: "https://raw.githubusercontent.com/OpenLMLab/LEval/cd34b050269148aed75acbbe4a599873ad0f37e9/LEval-data/Closed-ended-tasks/coursera.jsonl"
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process_docs_coursera
+doc_to_text: "{{text}}"
+doc_to_target: "{{gold}}"
+process_results: !function utils.process_results_coursera
+generation_kwargs:
+  max_gen_toks: 32
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/leval/gsm100.yaml
+++ b/lm_eval/tasks/leval/gsm100.yaml
@@ -1,0 +1,25 @@
+tag:
+  - leval
+task: leval_gsm100
+dataset_path: ""
+custom_dataset: !function utils.load_leval
+dataset_kwargs:
+  data_files:
+    test: "https://raw.githubusercontent.com/OpenLMLab/LEval/cd34b050269148aed75acbbe4a599873ad0f37e9/LEval-data/Closed-ended-tasks/gsm100.jsonl"
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process_docs_gsm100
+doc_to_text: "{{text}}"
+doc_to_target: "{{gold}}"
+process_results: !function utils.process_results_gsm100
+generation_kwargs:
+  max_gen_toks: 512
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/leval/quality.yaml
+++ b/lm_eval/tasks/leval/quality.yaml
@@ -1,0 +1,25 @@
+tag:
+  - leval
+task: leval_quality
+dataset_path: ""
+custom_dataset: !function utils.load_leval
+dataset_kwargs:
+  data_files:
+    test: "https://raw.githubusercontent.com/OpenLMLab/LEval/cd34b050269148aed75acbbe4a599873ad0f37e9/LEval-data/Closed-ended-tasks/quality.jsonl"
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process_docs_quality
+doc_to_text: "{{text}}"
+doc_to_target: "{{gold}}"
+process_results: !function utils.process_results_quality
+generation_kwargs:
+  max_gen_toks: 32
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/leval/sci_fi.yaml
+++ b/lm_eval/tasks/leval/sci_fi.yaml
@@ -1,0 +1,25 @@
+tag:
+  - leval
+task: leval_sci_fi
+dataset_path: ""
+custom_dataset: !function utils.load_leval
+dataset_kwargs:
+  data_files:
+    test: "https://raw.githubusercontent.com/OpenLMLab/LEval/cd34b050269148aed75acbbe4a599873ad0f37e9/LEval-data/Closed-ended-tasks/sci_fi.jsonl"
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process_docs_sci_fi
+doc_to_text: "{{text}}"
+doc_to_target: "{{gold}}"
+process_results: !function utils.process_results_sci_fi
+generation_kwargs:
+  max_gen_toks: 32
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/leval/topic_retrieval.yaml
+++ b/lm_eval/tasks/leval/topic_retrieval.yaml
@@ -1,0 +1,25 @@
+tag:
+  - leval
+task: leval_topic_retrieval
+dataset_path: ""
+custom_dataset: !function utils.load_leval
+dataset_kwargs:
+  data_files:
+    test: "https://raw.githubusercontent.com/OpenLMLab/LEval/cd34b050269148aed75acbbe4a599873ad0f37e9/LEval-data/Closed-ended-tasks/topic_retrieval_longchat.jsonl"
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process_docs_topic
+doc_to_text: "{{text}}"
+doc_to_target: "{{gold}}"
+process_results: !function utils.process_results_topic
+generation_kwargs:
+  max_gen_toks: 32
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/leval/tpo.yaml
+++ b/lm_eval/tasks/leval/tpo.yaml
@@ -1,0 +1,25 @@
+tag:
+  - leval
+task: leval_tpo
+dataset_path: ""
+custom_dataset: !function utils.load_leval
+dataset_kwargs:
+  data_files:
+    test: "https://raw.githubusercontent.com/OpenLMLab/LEval/cd34b050269148aed75acbbe4a599873ad0f37e9/LEval-data/Closed-ended-tasks/tpo.jsonl"
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process_docs_tpo
+doc_to_text: "{{text}}"
+doc_to_target: "{{gold}}"
+process_results: !function utils.process_results_tpo
+generation_kwargs:
+  max_gen_toks: 32
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/leval/utils.py
+++ b/lm_eval/tasks/leval/utils.py
@@ -1,0 +1,317 @@
+"""Helpers for the L-Eval closed-ended (exam / exact-match) tasks.
+
+L-Eval: Instituting Standardized Evaluation for Long Context Language Models.
+Chenxin An et al., 2023 — https://arxiv.org/abs/2307.11088
+Benchmark: https://github.com/OpenLMLab/LEval
+Data:      the benchmark's LEval-data/Closed-ended-tasks/*.jsonl (pinned to a commit;
+           the L4NLP/LEval HF dataset ships a loading script that datasets>=4 rejects)
+
+Only the seven closed-ended subtasks are covered here (coursera, quality, tpo,
+gsm100, codeU, sci_fi, topic_retrieval_longchat). They are scored with exact
+match and need no judge model, mirroring the way LongBench is already integrated.
+The thirteen open-ended subtasks (LLM-as-judge / n-gram) are left for a follow-up.
+
+The task *instructions* below are reproduced verbatim from the benchmark so that
+scores stay comparable with the paper. The answer extraction and exact-match
+scoring are an independent re-implementation of the behaviour of LEval's
+``Evaluation/auto_eval.py`` exam path; no code is copied from that (GPL-3.0)
+project into this MIT-licensed repository.
+"""
+
+from __future__ import annotations
+
+import re
+import string
+
+import datasets
+
+
+# --------------------------------------------------------------------------- #
+# System instructions (reproduced from the benchmark for faithful prompting)
+# --------------------------------------------------------------------------- #
+_PROMPT_COURSERA = (
+    "Now you are given a very long document. Please follow the instruction based "
+    "on this document. For multi-choice questions, there could be a single correct "
+    "option or multiple correct options. Please only provide the letter "
+    "corresponding to the answer (like A or AB) when answering. "
+)
+_PROMPT_MC_SINGLE = (
+    "Now you are given a very long document. Please follow the instruction based "
+    "on this document. For multi-choice questions, there is only a single correct "
+    "option. Please only provide the letter corresponding to the answer (like A or "
+    "B) when answering. For other questions, please directly give the concise and "
+    "accurate answer. "
+)
+_PROMPT_GSM = (
+    "Given several question answer pairs, you need to follow a similar format to "
+    "answer the last question. Make sure the response is end with The answer is _ . "
+)
+_PROMPT_CODEU = (
+    "Now you are given a code base consisting of a large amount of functions and "
+    "the corresponding comments. In the end, I will call some functions defined in "
+    "the code base. Please carefully read these codes and comments and answer the "
+    "question."
+)
+_PROMPT_SCIFI = (
+    "Now you are given a scientific fiction. I will ask you some questions and the "
+    'answer should be "True" or "False". Notice that you should answer the question '
+    "based on the evidence in the document instead of your background knowledge."
+)
+_PROMPT_TOPIC = (
+    "Below is a record of our previous conversation on many different topics. You "
+    "are the ASSISTANT, and I am the USER. At the beginning of each topic, the USER "
+    "will say 'I would like to discuss the topic of <TOPIC>'. Memorize each <TOPIC>. "
+    "At the end of the record, I will ask you to retrieve the first/second/third "
+    "topic names. Now the record start. "
+)
+
+# Wrapper used for every closed-ended task except gsm100 / codeU, which append the
+# question directly after the document.
+_QUESTION_TEMPLATE = (
+    "Document is as follows. {document} Question: {instruction} \n"
+    "Please directly give answer without any additional output or explanation\n"
+    " Answer: "
+)
+
+
+def load_leval(**kwargs):
+    """Load a closed-ended L-Eval split from its pinned upstream jsonl.
+
+    Wired through ``custom_dataset`` (rather than ``dataset_path: json``) so that
+    ``download()`` still finds ``data_files`` when it is called without arguments,
+    as the task test-suite does. ``data_files`` comes from the task's
+    ``dataset_kwargs``; returns a ``DatasetDict`` keyed by the split name.
+    """
+    return datasets.load_dataset("json", data_files=kwargs.get("data_files"))
+
+
+def _build(dataset, system_prompt, *, raw_concat=False, scifi=False):
+    """Explode each row (many questions per document) into one doc per question."""
+    rows = []
+    for doc in dataset:
+        document = doc["input"]
+        for instruction, answer in zip(
+            doc["instructions"], doc["outputs"], strict=True
+        ):
+            if raw_concat:
+                body = document + "\n\n" + instruction
+            else:
+                body = _QUESTION_TEMPLATE.format(
+                    document=document, instruction=instruction
+                )
+            if scifi:
+                # gold looks like 'True [fact: False]'; keep the in-document verdict.
+                answer = answer.split("[fact:")[0].strip()
+            # rstrip so doc_to_text does not end in whitespace (harness convention).
+            text = (system_prompt + "\n" + body).rstrip()
+            rows.append({"text": text, "gold": answer})
+    return datasets.Dataset.from_list(rows)
+
+
+def process_docs_coursera(dataset):
+    return _build(dataset, _PROMPT_COURSERA)
+
+
+def process_docs_quality(dataset):
+    return _build(dataset, _PROMPT_MC_SINGLE)
+
+
+def process_docs_tpo(dataset):
+    return _build(dataset, _PROMPT_MC_SINGLE)
+
+
+def process_docs_gsm100(dataset):
+    return _build(dataset, _PROMPT_GSM, raw_concat=True)
+
+
+def process_docs_codeu(dataset):
+    return _build(dataset, _PROMPT_CODEU, raw_concat=True)
+
+
+def process_docs_sci_fi(dataset):
+    return _build(dataset, _PROMPT_SCIFI, scifi=True)
+
+
+def process_docs_topic(dataset):
+    return _build(dataset, _PROMPT_TOPIC)
+
+
+# --------------------------------------------------------------------------- #
+# Answer normalisation and exact match (re-implemented from the paper's rules)
+# --------------------------------------------------------------------------- #
+_PUNCT = str.maketrans("", "", string.punctuation)
+_ARTICLES = re.compile(r"\b(a|an|the)\b")
+
+
+def _normalize(text: str) -> str:
+    """Drop punctuation and articles, collapse whitespace (case preserved)."""
+    text = text.translate(_PUNCT)
+    text = _ARTICLES.sub(" ", text)
+    return " ".join(text.split())
+
+
+def _exact_match(prediction: str, ground_truth: str) -> float:
+    """Return 1.0 / 0.25 / 0.0 following LEval's exam scoring.
+
+    - Multiple-choice gold (only letters A-D): 1.0 on an exact set match, 0.25 when
+      the predicted letters are a subset of the gold letters (partial credit for
+      coursera's multi-answer questions).
+    - Numeric gold (gsm100): 1.0 when the two values are numerically equal.
+    - Everything else (codeU / sci_fi / topic): 1.0 when the whitespace-stripped
+      gold string is contained in the prediction (case-insensitive).
+    """
+    gold_norm = _normalize(ground_truth)
+    letters_only = gold_norm != "" and all(ch in "ABCD" for ch in gold_norm)
+
+    if letters_only:
+        pred_norm = _normalize(prediction)
+        if pred_norm == gold_norm:
+            return 1.0
+        if set(pred_norm) <= set(gold_norm):
+            return 0.25
+        return 0.0
+
+    try:
+        return 1.0 if float(prediction) == float(ground_truth) else 0.0
+    except ValueError:
+        needle = ground_truth.lower().replace(" ", "")
+        haystack = prediction.lower().replace(" ", "")
+        return 1.0 if needle in haystack else 0.0
+
+
+def _extract_letters(response: str, *, multi: bool) -> str:
+    """Pull the option letter(s) out of a multiple-choice generation."""
+    response = response.strip()
+    if not response:
+        return "None"
+    if not multi:
+        for ch in response:
+            if ch in "ABCD":
+                return ch
+        return "None"
+
+    # multi-answer (coursera): collect the leading run of option letters, else scan
+    # for isolated "A." / "B)" style options.
+    leading = ""
+    for ch in response:
+        if ch in "ABCD":
+            leading += ch
+        else:
+            break
+    if len(leading) > 1:
+        return "".join(sorted(set(leading)))
+
+    head = response.split("Question")[0]
+    options = re.findall(r"\s*[A-Z](?=[\s.)])", head)
+    letters = re.sub(r"[^A-D]", "", leading + "".join(options))
+    letters = "".join(sorted(set(letters)))
+    if not letters:
+        for ch in head:
+            if ch in "ABCD":
+                letters += ch
+    return letters or "A"
+
+
+def _extract_number(response: str) -> str:
+    """Grab the final numeric answer from a gsm100 generation."""
+    match = re.search(r"The answer is (\S+)", response)
+    token = match.group(1) if match else ""
+    if not token:
+        for word in reversed(response.split("\n\n")[0].split(" ")):
+            if any(ch.isdigit() for ch in word):
+                token = word
+                break
+    digits = ""
+    for ch in token:
+        if ch.isdigit():
+            digits += ch
+        elif ch == ".":
+            break
+    return digits
+
+
+def _clean_code(text: str) -> str:
+    text = re.sub(r"\s+", " ", text)
+    for old, new in (
+        (",", ""),
+        ("'", ""),
+        ("\\", ""),
+        (".0", ""),
+        ("] [", "]["),
+        ("[ [", "[["),
+        ("] ]", "]]"),
+    ):
+        text = text.replace(old, new)
+    return text
+
+
+def _extract_code_output(response: str, gold: str) -> str:
+    """Trim a codeU generation down to the reported output tokens."""
+    span = len(gold.split()) + 3
+    text = _clean_code(response)
+    for phrase in (
+        "will be",
+        "of the code",
+        "is",
+        "would be",
+        "the value of",
+        "the result of",
+        "printed",
+    ):
+        text = text.replace(phrase, "")
+    if "the final output" in text:
+        tokens = re.split(r"\s+", text.split("the final output")[-1])[:span]
+    else:
+        tokens = re.split(r"\s+", text)[-span:]
+    return " ".join(tokens)
+
+
+# --------------------------------------------------------------------------- #
+# process_results entry points (one per task)
+# --------------------------------------------------------------------------- #
+def _result(score: float) -> dict:
+    return {"exact_match": score}
+
+
+def _gold_letters(gold: str) -> str:
+    """Reduce a gold answer to its option letters (LEval's process_gt_mc)."""
+    first = gold.split()[0] if gold.split() else ""
+    return re.sub(r"[^A-D]", "", first) or "A"
+
+
+def process_results_coursera(doc, results):
+    pred = _extract_letters(results[0], multi=True)
+    return _result(_exact_match(pred, _gold_letters(doc["gold"])))
+
+
+def _process_results_mc_single(doc, results):
+    pred = _extract_letters(results[0], multi=False)
+    return _result(_exact_match(pred, _gold_letters(doc["gold"])))
+
+
+def process_results_quality(doc, results):
+    return _process_results_mc_single(doc, results)
+
+
+def process_results_tpo(doc, results):
+    return _process_results_mc_single(doc, results)
+
+
+def process_results_gsm100(doc, results):
+    pred = _extract_number(results[0])
+    gold = _extract_number(doc["gold"]) or doc["gold"].strip()
+    return _result(_exact_match(pred, gold))
+
+
+def process_results_codeu(doc, results):
+    pred = _extract_code_output(results[0], doc["gold"])
+    gold = _clean_code(doc["gold"])
+    return _result(_exact_match(pred, gold))
+
+
+def process_results_sci_fi(doc, results):
+    return _result(_exact_match(results[0], doc["gold"]))
+
+
+def process_results_topic(doc, results):
+    return _result(_exact_match(results[0], doc["gold"]))


### PR DESCRIPTION
## What

Adds the **closed-ended (exam / exact-match) half of L-Eval** as new tasks, under a `leval` tag:

`leval_coursera`, `leval_quality`, `leval_tpo`, `leval_gsm100`, `leval_codeu`, `leval_sci_fi`, `leval_topic_retrieval` — run them all with `--tasks leval`.

They are scored with exact match and need no judge model, mirroring how LongBench is already integrated. Towards #2180 (LongBench already landed; this adds L-Eval's closed-ended tasks). The 13 open-ended subtasks (LLM-judge / n-gram) are left for a follow-up.

## Notes for reviewers

- **Tag, not a group.** The seven tasks share a `leval` tag (so `--tasks leval` runs them all) rather than a `group`. A group config tripped the `new_tasks` CI: when every file is new, `new_tasks()` hands `load()` both the group name *and* its members, which `_check_duplicates` rejects. Glad to add a `leval` group with an aggregate score if you have a preferred way around that.
- **Data loading.** The original `L4NLP/LEval` HF dataset ships a loading script (`LEval.py`) that `datasets >= 4` refuses to run, so the tasks read the benchmark's closed-ended `*.jsonl` from the upstream repo, pinned to a fixed commit (wired via `custom_dataset` so `download()` still finds `data_files` when called with no arguments, as the task tests do). Happy to point at a parquet mirror instead if you'd prefer one.
- **Scoring / licensing.** L-Eval is GPL-3.0, so no code is copied from it. The prompts are reproduced (they are the benchmark's own task instructions, needed to stay comparable with the paper) and the answer extraction + exact-match scoring in `utils.py` are re-implemented independently: exact set match for multiple choice (with 0.25 partial credit for coursera's multi-answer items), numeric equality for `gsm100`, and case-insensitive containment for `codeU` / `sci_fi` / `topic_retrieval`.
- **sci_fi** scores only the in-document (loyalty) `True`/`False` verdict; L-Eval's optional second pass that contrasts the story with real-world facts isn't reproduced, since the harness generates one completion per request.
- Each document holds several questions, so `process_docs` explodes rows into one doc per question.

## Verification

- `pytest tests/test_tasks.py` → **94 passed** for the seven new tasks (download, doc_to_text, build_all_requests, construct_requests, …).
- `ruff check` / `ruff format` clean.
- Spot-checked loading + exact-match scoring against the real data for all seven subtasks.

## Task Validity Checklist

- [x] Is the task an existing benchmark in the literature?
  - [x] Have you referenced the original paper that introduced the task?
  - [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
- [x] New subfolder `lm_eval/tasks/leval` with a README describing each subtask and the metric.
