### PR TITLE
Add LooGLE long-context generation tasks

### DIFF
--- a/lm_eval/tasks/loogle/README.md
+++ b/lm_eval/tasks/loogle/README.md
@@ -1,0 +1,81 @@
+# LooGLE
+
+### Paper
+
+Title: `LooGLE: Can Long-Context Language Models Understand Long Contexts?`
+
+Abstract: `LooGLE is a benchmark for long-context understanding built from documents
+published after 2022 (average ~20k words). It contains short-dependency tasks (short-
+dependency QA and cloze) and long-dependency tasks (long-dependency QA and summarization),
+where answering requires aggregating evidence spread across the document.`
+
+Homepage: `https://github.com/bigai-nlco/LooGLE`
+
+Paper: `https://arxiv.org/abs/2311.04939`
+
+### Citation
+
+```
+@inproceedings{li-etal-2024-loogle,
+    title = "{L}oo{GLE}: Can Long-Context Language Models Understand Long Contexts?",
+    author = "Li, Jiaqi and Wang, Mengmeng and Zheng, Zilong and Zhang, Muhan",
+    booktitle = "Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = aug,
+    year = "2024",
+    address = "Bangkok, Thailand",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2024.acl-long.859",
+    pages = "16304--16333",
+}
+```
+
+### Scope
+
+This directory implements the three **free-text generation** sub-tasks of LooGLE, scored
+with ROUGE and needing no judge model (mirroring how LongBench is integrated). The
+`shortdep_cloze` sub-task (entity fill-in, scored by exact/partial entity match) is
+intentionally left for a follow-up.
+
+The data is loaded from the Hugging Face hub (`bigai-nlco/LooGLE`, MIT-licensed). The
+prompts are reproduced from the benchmark's `config/task2prompt.json`; ROUGE is
+re-implemented in `utils.py` using only the standard library, so no extra dependency is
+required.
+
+### Groups, Tags, and Tasks
+
+#### Tags
+
+* `loogle`: The three LooGLE generation sub-tasks; run them together with `--tasks loogle`.
+
+#### Tasks
+
+* `loogle_shortdep_qa`: Short-dependency question answering — the answer relies on a single span in the document.
+* `loogle_longdep_qa`: Long-dependency question answering — the answer requires aggregating evidence from multiple, distant parts of the document.
+* `loogle_summarization`: Abstractive summarization of a long scientific paper.
+
+### Metric
+
+Each task reports `rouge_l` (primary), `rouge_1` and `rouge_2`, as F-measure in `[0, 1]`.
+ROUGE is computed over lowercased, punctuation-stripped whitespace tokens (LCS for
+ROUGE-L, n-gram overlap for ROUGE-1/2). The LooGLE paper additionally reports the recall
+variant of ROUGE alongside BLEU, METEOR, BERTScore and a GPT-4 judge; only the
+dependency-free n-gram metric is implemented here.
+
+### Notes / deviations
+
+* Documents are passed through as-is; truncation to the model's context window is left to
+  the model wrapper.
+* `until` is empty, so generation stops at `max_gen_toks` (300 for `shortdep_qa`, 500 for
+  `longdep_qa` and `summarization`, matching `config/task2maxlen.json`).
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/loogle/loogle_longdep_qa.yaml
+++ b/lm_eval/tasks/loogle/loogle_longdep_qa.yaml
@@ -1,0 +1,27 @@
+tag:
+  - loogle
+task: loogle_longdep_qa
+dataset_path: bigai-nlco/LooGLE
+dataset_name: longdep_qa
+test_split: test
+output_type: generate_until
+doc_to_text: "Please answer the question based on the long texts below. \n{{context}}\nQuestion: {{question}}\nAnswer:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+generation_kwargs:
+  max_gen_toks: 500
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: rouge_l
+    aggregation: mean
+    higher_is_better: true
+  - metric: rouge_1
+    aggregation: mean
+    higher_is_better: true
+  - metric: rouge_2
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/loogle/loogle_shortdep_qa.yaml
+++ b/lm_eval/tasks/loogle/loogle_shortdep_qa.yaml
@@ -1,0 +1,27 @@
+tag:
+  - loogle
+task: loogle_shortdep_qa
+dataset_path: bigai-nlco/LooGLE
+dataset_name: shortdep_qa
+test_split: test
+output_type: generate_until
+doc_to_text: "Please answer the question based on the long texts below. \n{{context}}\nQuestion: {{question}}\nAnswer:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+generation_kwargs:
+  max_gen_toks: 300
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: rouge_l
+    aggregation: mean
+    higher_is_better: true
+  - metric: rouge_1
+    aggregation: mean
+    higher_is_better: true
+  - metric: rouge_2
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/loogle/loogle_summarization.yaml
+++ b/lm_eval/tasks/loogle/loogle_summarization.yaml
@@ -1,0 +1,27 @@
+tag:
+  - loogle
+task: loogle_summarization
+dataset_path: bigai-nlco/LooGLE
+dataset_name: summarization
+test_split: test
+output_type: generate_until
+doc_to_text: "Please generate a summary of the below paper. \n{{context}}\n Summarization:"
+doc_to_target: "{{answer}}"
+process_results: !function utils.process_results
+generation_kwargs:
+  max_gen_toks: 500
+  do_sample: false
+  temperature: 0.0
+  until: []
+metric_list:
+  - metric: rouge_l
+    aggregation: mean
+    higher_is_better: true
+  - metric: rouge_1
+    aggregation: mean
+    higher_is_better: true
+  - metric: rouge_2
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/loogle/utils.py
+++ b/lm_eval/tasks/loogle/utils.py
@@ -1,0 +1,76 @@
+"""Scoring for the LooGLE long-context generation tasks.
+
+LooGLE: Can Long-Context Language Models Understand Long Contexts?
+Jiaqi Li et al., ACL 2024 — https://arxiv.org/abs/2311.04939
+Benchmark: https://github.com/bigai-nlco/LooGLE (MIT)
+Data:      https://huggingface.co/datasets/bigai-nlco/LooGLE (MIT)
+
+Covers the three free-text generation sub-tasks (shortdep_qa, longdep_qa,
+summarization), scored with ROUGE. The cloze sub-task (entity fill-in, scored
+by exact/partial entity match) is left for a follow-up.
+
+ROUGE is re-implemented here in the standard library (LCS for ROUGE-L, n-gram
+overlap for ROUGE-1/2) so the task needs no extra dependencies. F-measure is
+reported; the LooGLE paper additionally reports the recall variant.
+"""
+
+from __future__ import annotations
+
+import string
+from collections import Counter
+
+
+_PUNCT = str.maketrans("", "", string.punctuation)
+
+
+def _tokens(text: str) -> list[str]:
+    """Lowercase, drop punctuation, split on whitespace."""
+    return text.lower().translate(_PUNCT).split()
+
+
+def _f_measure(overlap: int, pred_total: int, gold_total: int) -> float:
+    if overlap == 0 or pred_total == 0 or gold_total == 0:
+        return 0.0
+    precision = overlap / pred_total
+    recall = overlap / gold_total
+    return 2 * precision * recall / (precision + recall)
+
+
+def _rouge_n(pred: list[str], gold: list[str], n: int) -> float:
+    if len(pred) < n or len(gold) < n:
+        return 0.0
+    pred_ngrams = Counter(tuple(pred[i : i + n]) for i in range(len(pred) - n + 1))
+    gold_ngrams = Counter(tuple(gold[i : i + n]) for i in range(len(gold) - n + 1))
+    overlap = sum((pred_ngrams & gold_ngrams).values())
+    return _f_measure(overlap, sum(pred_ngrams.values()), sum(gold_ngrams.values()))
+
+
+def _lcs_length(a: list[str], b: list[str]) -> int:
+    prev = [0] * (len(b) + 1)
+    for token_a in a:
+        curr = [0]
+        for j, token_b in enumerate(b, start=1):
+            if token_a == token_b:
+                curr.append(prev[j - 1] + 1)
+            else:
+                curr.append(max(prev[j], curr[j - 1]))
+        prev = curr
+    return prev[-1]
+
+
+def _rouge_l(pred: list[str], gold: list[str]) -> float:
+    if not pred or not gold:
+        return 0.0
+    lcs = _lcs_length(pred, gold)
+    return _f_measure(lcs, len(pred), len(gold))
+
+
+def process_results(doc: dict, results: list[str]) -> dict:
+    prediction = _tokens(results[0])
+    reference = _tokens(doc["answer"])
+    rouge_l = _rouge_l(prediction, reference)
+    return {
+        "rouge_l": rouge_l,
+        "rouge_1": _rouge_n(prediction, reference, 1),
+        "rouge_2": _rouge_n(prediction, reference, 2),
+    }


### PR DESCRIPTION
## What

Adds the three **free-text generation** sub-tasks of LooGLE (ACL 2024) as new tasks under a `loogle` tag:

`loogle_shortdep_qa`, `loogle_longdep_qa`, `loogle_summarization` — run them all with `--tasks loogle`.

They are scored with ROUGE and need no judge model, mirroring how LongBench is integrated. The `shortdep_cloze` sub-task (entity fill-in, scored by exact/partial entity match) is left for a follow-up.

## Notes for reviewers

- **Data / licensing.** Loads from the Hugging Face hub (`bigai-nlco/LooGLE`), which is MIT-licensed and stored as JSONL (no loading script), so it works with `datasets >= 4` directly.
- **Metric.** ROUGE-1/2/L (F-measure) is re-implemented in `utils.py` using only the standard library (LCS for ROUGE-L, n-gram overlap for ROUGE-1/2), so the task needs no extra dependency. The LooGLE paper additionally reports the recall variant alongside BLEU / METEOR / BERTScore and a GPT-4 judge; only the dependency-free n-gram metric is included here. Prompts and `max_gen_toks` are reproduced from the benchmark's `config/task2prompt.json` / `config/task2maxlen.json`.
- **Tag, not a group.** The three tasks share a `loogle` tag rather than a group (a group config trips the `new_tasks` CI's duplicate check when a group and its members are all new in one PR).

## Verification

- `pytest tests/test_tasks.py` — **42 passed** for the three new tasks (download, doc_to_text, build_all_requests, construct_requests, …).
- `ruff check` / `ruff format` clean.
- ROUGE spot-checked against the real data (identical → 1.0, disjoint → 0.0, partial in between).

## Task Validity Checklist

- [x] Is the task an existing benchmark in the literature?
  - [x] Have you referenced the original paper that introduced the task?
  - [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
- [x] New subfolder `lm_eval/tasks/loogle` with a README describing each sub-task and the metric.
