### PR TITLE
fix(afrixnli): use Jinja braces in prompt_1 doc_to_text so premise and hypothesis are substituted

### DIFF
--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_amh.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_amh.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_eng.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_eng.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ewe.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ewe.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_fra.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_fra.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_hau.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_hau.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ibo.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ibo.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_kin.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_kin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lin.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lug.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lug.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_orm.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_orm.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sna.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sna.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sot.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sot.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_swa.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_swa.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_twi.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_twi.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_wol.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_wol.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_xho.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_xho.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_yor.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_yor.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_zul.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_zul.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/gen_utils.py
+++ b/lm_eval/tasks/afrixnli/gen_utils.py
@@ -12,7 +12,7 @@ class FunctionTag:
 def prompt_func(mode, lang):
     prompt_map = {
         "prompt_1": "Please identify whether the premise entails or contradicts the hypothesis in the following premise "
-        "and hypothesis. The answer should be exact entailment, contradiction, or neutral.\n\nPremise: {premise}\nHypothesis: {hypothesis}\n\n"
+        "and hypothesis. The answer should be exact entailment, contradiction, or neutral.\n\nPremise: {{premise}}\nHypothesis: {{hypothesis}}\n\n"
         "Is it entailment, contradiction, or neutral?",
         "prompt_3": f"Given the following premise and hypothesis in {lang}, identify if the premise entails, contradicts, "
         f"or is neutral towards the hypothesis. Please respond with exact 'entailment', 'contradiction', or 'neutral'. \n\n"
@@ -56,7 +56,7 @@ def gen_lang_yamls(output_dir: str, overwrite: bool, mode: str) -> None:
         "swa": "Swahili",
     }
 
-    for lang in languages.keys():
+    for lang, lang_name in languages.items():
         try:
             file_name = f"afrixnli_{lang}.yaml"
             task_name = f"afrixnli_{lang}_{mode}"
@@ -70,7 +70,7 @@ def gen_lang_yamls(output_dir: str, overwrite: bool, mode: str) -> None:
                     "include": yaml_template,
                     "task": task_name,
                     "dataset_name": lang,
-                    "doc_to_text": prompt_func(mode, languages[lang]),
+                    "doc_to_text": prompt_func(mode, lang_name),
                 }
             else:
                 yaml_details = {

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_amh.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_amh.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ewe.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ewe.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_fra.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_fra.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_hau.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_hau.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ibo.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ibo.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_kin.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_kin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lin.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lug.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lug.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_orm.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_orm.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sna.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sna.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sot.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sot.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_swa.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_swa.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_twi.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_twi.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_wol.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_wol.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_xho.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_xho.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_yor.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_yor.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_zul.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_zul.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'


### PR DESCRIPTION
## What this fixes

`afrixnli` `prompt_1` declared an inline `doc_to_text` using Python `.format()` brace syntax (`{premise}`, `{hypothesis}`). `doc_to_text` is rendered through Jinja2, where single braces are literal. The premise and hypothesis were never substituted, so every document in the task produced the same constant prompt and the model scored a three-way multiple choice against an empty stem.

## Evidence

Run with `--log_samples` on `afrixnli_eng_prompt_1`, `Qwen/Qwen2.5-0.5B`, `--limit 200`, CPU. English is used as a control so that "the model does not know the language" cannot explain the result.

| | documents | distinct `doc_hash` | distinct `prompt_hash` |
|---|---|---|---|
| before | 200 | 200 | **1** |
| after | 200 | 200 | **200** |

Two hundred distinct documents rendered one identical prompt. After the fix they render two hundred distinct prompts.

The rendered `arg_0` before the fix:

## What does not change, stated up front

Accuracy and F1 are identical before and after: `acc 0.3300 (± 0.0333)`, `f1 0.1638`, on both `eng` and `swa`. Qwen2.5-0.5B collapses to a single label in both conditions, so the score cannot demonstrate the fix. A weighted F1 of 0.1638 is close to the 1/6 that always-predict-one-class yields on a balanced three-class set, which is what a constant prompt guarantees but is also what this model does anyway at this size.

Runtime is the independent confirmation that the prompts really did change: the same 200-document run took 3 seconds before and 38 minutes after, since the prompts now carry the actual premise and hypothesis.

I do not have GPU access to run a model large enough to show a score delta. If a maintainer can run this at around 7B, I would expect the fixed task to separate from chance and the broken one not to.

## Changes

- `lm_eval/tasks/afrixnli/gen_utils.py`: `prompt_1` now uses `{{premise}}` and `{{hypothesis}}`, matching how `prompt_3`, `prompt_4` and `prompt_5` already write them. `prompt_2` is unaffected as it has no inline `doc_to_text`.
- Regenerated the affected task YAMLs with the repo's own generator rather than editing them by hand:

```bash
python gen_utils.py --output-dir ./direct    --mode prompt_1 --overwrite
python gen_utils.py --output-dir ./translate --mode prompt_1 --overwrite
```

- 18 files under `direct/prompt_1/`, 17 under `translate/prompt_1/`, 35 tasks total.
- Also cleared a pre-existing `ruff PLC0206` in `gen_utils.py` (`for lang in languages.keys()` to `.items()`). This is unrelated to the bug, but the pre-commit hook fails on it and therefore blocks any change to that file. Regenerating after the lint fix produces byte-identical YAMLs.

## Notes for reviewers

1. **Alternative approach.** `lm_eval/tasks/afrixnli/direct/prompt_1/utils.py` already contains a correct `doc_to_text` function, but nothing references it, because the templates carry no `doc_to_text` key and the generated inline string is the only one in the chain. An alternative fix would be to add `doc_to_text: !function utils.doc_to_text` to the templates and drop the inline strings entirely, which would also revive that dead function. That is a larger change and would want the same treatment across all five prompts, so I kept this PR minimal. Happy to do it that way instead if you prefer.

2. **Separate generator issue, not fixed here.** Running `gen_utils.py` in translate mode emits `translate/prompt_1/afrixnli_translate_eng.yaml`, an English-to-English translate task that is not in the repo and was presumably removed deliberately. I deleted it after regenerating in order to preserve the committed state. The generator is not idempotent against the repo as committed. Worth a separate fix.

3. I make no claim about any published results. This PR describes only what the harness renders today.

## Testing

- `pytest --showlocals -s -vv -n=auto --ignore=tests/models/test_openvino.py`: 607 passed, 16 skipped, matching the baseline on `main`.
- `pre-commit run --files <the changed files>`: passing.
