### PR TITLE
Fix AGIEval few-shot crash and malformed target with list-valued gold

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1046,7 +1046,7 @@ class ConfigurableTask(Task):
         *,
         q: str | None = None,
         c: list[str] | None = None,
-        a: str | int | list[str] | None = None,
+        a: str | int | list[str] | list[int] | None = None,
         gen_prefix: str | None = None,
         tgt_delim=" ",
         few_delim="\n\n",
@@ -1063,8 +1063,10 @@ class ConfigurableTask(Task):
             q (str): The question or context text (required).
             c (list[str] | None): List of answer choices for multiple-choice tasks.
                 When provided with an integer `a`, indexes into this list to get the answer.
-            a (str | int | list[str] | None): The answer - can be a string, an index
-                into `c`, or a list of strings (for multiple targets).
+            a (str | int | list[str] | list[int] | None): The answer - can be a
+                string, an index into `c`, a list of choice indices (e.g. `[3]`,
+                as produced by AGIEval-style `gold` targets, indexes into `c`), or
+                a list of strings (for multiple targets).
             gen_prefix (str | None): A prefix to prepend to generated text (e.g., "Answer:").
             tgt_delim (str): Delimiter between question and answer (default: " ").
             few_delim (str): Delimiter after assistant response for few-shot separation
@@ -1092,6 +1094,10 @@ class ConfigurableTask(Task):
             answer_text = (
                 c[a]
                 if (c and isinstance(a, int))
+                # gold given as a list of choice indices (e.g. AGIEval's [3]):
+                # index into the choices so we render the choice text, not the index.
+                else c[a[0]]
+                if (c and isinstance(a, list) and a and isinstance(a[0], int))
                 # TODO: for multiple targets a is a list[str]. Fix this hack
                 else a[0]
                 if isinstance(a, list)

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1094,8 +1094,12 @@ class ConfigurableTask(Task):
             answer_text = (
                 c[a]
                 if (c and isinstance(a, int))
-                # gold given as a list of choice indices (e.g. AGIEval's [3]):
-                # index into the choices so we render the choice text, not the index.
+                # gold given as a list of choice indices (e.g. AGIEval's [3], or
+                # [0, 2] when several choices are acceptable): index into the choices
+                # so we render the choice text, not the index. For multi-element gold
+                # we deliberately take the first (lowest) acceptable index, matching the
+                # task metric (``argmax in gold`` scores any one acceptable choice as
+                # correct) -- do not "fix" this into joining all golds.
                 else c[a[0]]
                 if (c and isinstance(a, list) and a and isinstance(a[0], int))
                 # TODO: for multiple targets a is a list[str]. Fix this hack

--- a/tests/test_fewshot_context.py
+++ b/tests/test_fewshot_context.py
@@ -249,6 +249,27 @@ class TestBuildQaTurn:
 
         assert msgs[1].content == "first"
 
+    def test_choice_with_list_int_answer(self, task):
+        """Answer as a list of choice indices renders the choice text.
+
+        AGIEval-style MCQA tasks set ``doc_to_target: "{{gold}}"`` where ``gold``
+        is a list of indices (e.g. ``[2]``). With ``doc_to_choice`` set, this is
+        rendered to a Python list, so ``a`` reaches build_qa_turn as ``[2]``. It
+        should index into ``c`` and produce the choice text, not the bare index.
+        """
+        msgs = ConfigurableTask.build_qa_turn(
+            task,
+            q="Pick one:",
+            c=["Apple", "Banana", "Cherry"],
+            a=[2],
+            tgt_delim=" ",
+            few_delim="\n\n",
+        )
+
+        assert len(msgs) == 2
+        assert msgs[1].content == "Cherry"
+        assert messages_to_text(msgs) == "Pick one: Cherry\n\n"
+
     def test_gen_prefix_without_answer(self, task):
         """gen_prefix adds assistant message when no answer."""
         msgs = ConfigurableTask.build_qa_turn(
@@ -577,6 +598,38 @@ class TestFewshotContext:
 
         # Fewshot uses choices[0]="A", target question only (no answer)
         assert "A\n\n" in result
+        assert result.endswith("Pick a fruit:")
+
+    def test_fewshot_with_list_gold_renders_choice_text(self, mock_configurable_task):
+        """Fewshot MCQA with list-valued gold renders the choice text, not the index.
+
+        Regression test for AGIEval few-shot (issue #2323): ``doc_to_target``
+        returns a list of indices such as ``[1]``. The few-shot assistant turn
+        should contain the choice text (e.g. "B"), not the bare index "1".
+        """
+        mock_configurable_task.config.doc_to_choice = "choices"
+        mock_configurable_task.fewshot_cfg.doc_to_choice = "choices"
+
+        fs_doc = {"q": "Pick:", "a": [1]}
+        target_doc = {"q": "Pick a fruit:", "a": [0]}
+
+        mock_configurable_task.sampler.sample.return_value = [fs_doc]
+        mock_configurable_task.doc_to_text = Mock(side_effect=lambda d, *args: d["q"])
+        mock_configurable_task.doc_to_target = Mock(side_effect=lambda d, *args: d["a"])
+        mock_configurable_task.doc_to_choice = Mock(
+            side_effect=lambda d, *args: (
+                ["A", "B"] if d == fs_doc else ["Apple", "Banana"]
+            )
+        )
+
+        result = ConfigurableTask.fewshot_context(
+            mock_configurable_task, doc=target_doc, num_fewshot=1
+        )
+
+        # Fewshot assistant turn contains the choice text choices[1]="B",
+        # not the bare index "1", and the eval doc has no answer.
+        assert "Pick: B\n\n" in result
+        assert "1" not in result
         assert result.endswith("Pick a fruit:")
 
     def test_custom_delimiters(self, mock_configurable_task):

--- a/tests/test_fewshot_context.py
+++ b/tests/test_fewshot_context.py
@@ -270,6 +270,23 @@ class TestBuildQaTurn:
         assert msgs[1].content == "Cherry"
         assert messages_to_text(msgs) == "Pick one: Cherry\n\n"
 
+        # Multi-element gold (several acceptable choices, e.g. AGIEval jec_qa):
+        # render the first (lowest) acceptable choice, matching the ``argmax in gold``
+        # metric that scores any one acceptable answer as correct. Pinned here so the
+        # branch is not later "fixed" into joining all golds, which would diverge from
+        # how the task is actually scored.
+        multi = ConfigurableTask.build_qa_turn(
+            task,
+            q="Pick one:",
+            c=["Apple", "Banana", "Cherry"],
+            a=[0, 2],
+            tgt_delim=" ",
+            few_delim="\n\n",
+        )
+
+        assert multi[1].content == "Apple"
+        assert messages_to_text(multi) == "Pick one: Apple\n\n"
+
     def test_gen_prefix_without_answer(self, task):
         """gen_prefix adds assistant message when no answer."""
         msgs = ConfigurableTask.build_qa_turn(


### PR DESCRIPTION
## Problem

Running AGIEval multiple-choice tasks with `num_fewshot > 0` crashes, and even when it doesn't crash the few-shot targets are rendered as raw indices instead of the choice text.

The issue's original 2024 traceback pointed at `samplers.py`, but that code path has since been refactored. The live failure at HEAD is in `ConfigurableTask.build_qa_turn` (`lm_eval/api/task.py`):

```
  File ".../lm_eval/api/task.py", line 1100, in build_qa_turn
    assert isinstance(answer_text, str), f"Answer is not a string! : {a}"
AssertionError: Answer is not a string! : [2]
```

**Root cause.** AGIEval configs set `doc_to_target: "{{gold}}"`, where `gold` is a *list* of choice indices (e.g. `[3]`). Because `doc_to_choice` is also set, `doc_to_target` renders `"[3]"` and then `ast.literal_eval` turns it back into the Python list `[3]`, which is passed into `build_qa_turn` as the answer `a`.

The answer-text selection only handled two shapes:

```python
answer_text = (
    c[a]
    if (c and isinstance(a, int))       # scalar index -> choice text (arc_easy)
    else a[0]
    if isinstance(a, list)              # list of target strings -> first string
    else a
)
```

A list of *indices* falls through to the `a[0]` branch, yielding the bare int `3`. That trips the `assert isinstance(answer_text, str)` and crashes. On code paths that don't hit the assert, the few-shot prompt is silently corrupted — the target renders as the index rather than the choice, e.g.

```
Q: What value of $x$ satisfies the equation $3 x+3=27$ ? Answer Choices: (A)3 (B)8 (C)10 (D)27
A: Among A through D, the answer is 1        <-- should be "(B)8"
```

(This matches the malformed-prompt report from @yoonniverse in the issue thread.)

## Fix

Add one branch to the answer-text selection in `build_qa_turn`: when choices are present and `a` is a non-empty list whose first element is an int, index into the choices (`c[a[0]]`) so the choice *text* is rendered. This lands exactly on the existing `# TODO: for multiple targets a is a list[str]. Fix this hack` and fixes all list-of-index MCQA tasks generically, without touching any AGIEval YAML or bumping task versions.

```python
answer_text = (
    c[a]
    if (c and isinstance(a, int))
    # gold given as a list of choice indices (e.g. AGIEval's [3]):
    # index into the choices so we render the choice text, not the index.
    else c[a[0]]
    if (c and isinstance(a, list) and a and isinstance(a[0], int))
    # TODO: for multiple targets a is a list[str]. Fix this hack
    else a[0]
    if isinstance(a, list)
    else a
)
```

The branch is gated on `c` being present and `a[0]` being an int, so the existing list-of-string targets path (`a[0]`) and scalar-int path (`c[a]`, used by arc_easy) are unaffected.

## Testing

Two regression tests added to `tests/test_fewshot_context.py`:

- `TestBuildQaTurn::test_choice_with_list_int_answer` — `a=[2]` with choices now renders the choice text; fails pre-fix with the exact `AssertionError: Answer is not a string! : [2]`.
- `TestFewshotContext::test_fewshot_with_list_gold_renders_choice_text` — end-to-end few-shot context for a list-gold MCQA doc asserts the assistant turn contains the choice text and not the bare index.

```
$ python -m pytest tests/test_fewshot_context.py -q
...................................................                      [51 passed]
```

End-to-end with the built-in dummy model (crashes pre-fix, completes post-fix):

```
python -m lm_eval --model dummy --tasks agieval_sat_math --num_fewshot 3 --limit 5 --log_samples
python -m lm_eval --model dummy --tasks agieval_jec_qa_kd --num_fewshot 3 --limit 20
python -m lm_eval --model dummy --tasks arc_easy --num_fewshot 3 --limit 5   # scalar-int-gold regression check, unchanged
```

Inspecting the logged samples confirms the few-shot targets now render the choice text:

```
A: Among A through D, the answer is (B)8
```

instead of the previous `A: Among A through D, the answer is 1`.

## Note on the empty-gold row

@baberabb noted in the thread that one `agieval_jec_qa_kd` row is missing its answer field. That is a separate dataset-side issue: when `gold == []`, the new branch is skipped (it requires a non-empty list) and the existing `a[0]` fallback raises `IndexError`. This PR intentionally does not change the behavior for answerless few-shot docs; it should be handled separately (ideally on the dataset/loader side) rather than by silently fabricating a target.

Fixes #2323
