### PR TITLE
Fix fewshot_config.split precedence in TaskConfig

### DIFF
--- a/lm_eval/config/task.py
+++ b/lm_eval/config/task.py
@@ -154,7 +154,7 @@ class TaskConfig(dict):
         self.fewshot_config = (
             FewshotConfig.from_dict(
                 self.fewshot_config or {},
-                split=self.fewshot_split,
+                fewshot_split=self.fewshot_split,
                 process_docs=self.process_docs,
                 fewshot_delimiter=self.fewshot_delimiter,
                 target_delimiter=self.target_delimiter,

--- a/tests/test_fewshot_context.py
+++ b/tests/test_fewshot_context.py
@@ -773,3 +773,32 @@ def test_mmlu_pro_fewshot_chat_template_split():
     assert user_text.endswith("Answer: Let's think step by step.")
     assert "Basic arithmetic" not in user_text
     assert assistant_text == "Basic arithmetic gives 4."
+
+
+def test_fewshot_config_split_precedence():
+    """Nested ``fewshot_config.split`` must override the inherited top-level ``fewshot_split``.
+
+    ``FewshotConfig``'s fields are documented to override the parent ``TaskConfig``
+    fields. Regression guard for ``__post_init__`` passing ``split=`` (an unknown
+    kwarg captured by ``**overloads`` at highest precedence), which inverted the
+    precedence so the top-level value clobbered the nested one.
+    """
+    from lm_eval.config.task import TaskConfig
+
+    # Nested value wins over the (None) inherited top-level split.
+    cfg = TaskConfig(
+        task="demo",
+        output_type="multiple_choice",
+        fewshot_split=None,
+        fewshot_config={"split": "train"},
+    )
+    assert cfg.fewshot_config.split == "train"
+
+    # Top-level split is still inherited when the nested value is absent.
+    cfg_inherit = TaskConfig(
+        task="demo",
+        output_type="multiple_choice",
+        fewshot_split="validation",
+        fewshot_config={"process_docs": None},
+    )
+    assert cfg_inherit.fewshot_config.split == "validation"


### PR DESCRIPTION
## What

`TaskConfig.__post_init__` builds its `FewshotConfig` via `FewshotConfig.from_dict(..., split=self.fewshot_split, ...)`, but `from_dict`'s parameter is named `fewshot_split`. The stray `split=` is captured by `**overloads`, which is spread **last** into `cfg_dict` (highest precedence). So the inherited top-level `fewshot_split` overrides an explicit nested `fewshot_config.split`, inverting the precedence that `FewshotConfig` documents ("these fields override the parent `TaskConfig` fields"). Only the `split` field is affected — the sibling fields (`process_docs`, delimiters, `doc_to_*`, …) are already passed with their correct kwarg names.

## Repro

```python
from lm_eval.config.task import TaskConfig

cfg = TaskConfig(
    task="demo", output_type="multiple_choice",
    fewshot_split=None,
    fewshot_config={"split": "train"},
)
print(cfg.fewshot_config.split)   # before: None   after: "train"
```

`ConfigurableTask.fewshot_docs()` branches on `self.fewshot_cfg.split`, so when it is wrongly `None` the few-shot examples are drawn from the fallback pool (and the "fewshot_split is None" warning fires).

## Fix

Pass `fewshot_split=` instead of `split=`, so a nested `fewshot_config.split` wins while the top-level value is still inherited when the nested one is absent.

## Scope / impact

This affects user task configs that set `fewshot_config.split`. No bundled task YAML uses `fewshot_config.split` (bundled configs use `sampler`/`samples`), so shipped-benchmark numbers are unchanged — this is a correctness fix for the documented `fewshot_config` API.

## Test

Added `test_fewshot_config_split_precedence` (`tests/test_fewshot_context.py`) covering nested-override and top-level-inheritance; it fails before the fix and passes after. Existing `test_fewshot_context.py` / `test_samplers.py` / `test_task_manager.py` (150 tests) still pass.
