### PR TITLE
Add NSINA Sinhala evaluation tasks (nsina_categories, nsina_media, nsina_headlines)

### DIFF
--- a/lm_eval/tasks/nsina/README.md
+++ b/lm_eval/tasks/nsina/README.md
@@ -1,0 +1,52 @@
+# NSINA
+
+### Paper
+
+Title: `NSINA: A News Corpus for Sinhala`
+
+Abstract: https://arxiv.org/abs/2403.16571
+
+NSINA is a collection of over 500,000 articles from popular Sinhala news websites, released alongside three benchmark tasks: news media identification, news category prediction, and news headline generation. Sinhala is a low-resource language spoken by over 20 million people, and NSINA provides the largest news corpus and benchmark suite available for it.
+
+Homepage: https://github.com/Sinhala-NLP/NSINA
+
+### Citation
+
+```
+@inproceedings{Nsina2024,
+author={Hettiarachchi, Hansi and Premasiri, Damith and Uyangodage, Lasitha and Ranasinghe, Tharindu},
+title={{NSINA: A News Corpus for Sinhala}},
+booktitle={The 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024)},
+year={2024},
+month={May},
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `nsina`: Runs all NSINA tasks.
+
+#### Tasks
+
+* `nsina_categories`: 4-way news category classification (multiple choice, scored with accuracy and macro-F1). Prompts and answer choices are in Sinhala.
+* `nsina_media`: 10-way news media source identification (multiple choice, scored with accuracy and macro-F1).
+* `nsina_headlines`: headline generation from article content, scored with chrF. chrF is used instead of the ROUGE metrics reported in the paper because the default ROUGE tokenizer discards non-Latin-script text, which makes it unsuitable for Sinhala.
+
+Note: the underlying datasets are gated on the Hugging Face Hub (automatic approval). You must be logged in with `hf auth login` and accept the terms on each dataset page before running these tasks.
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+    * The original paper evaluates fine-tuned encoder models (e.g. SinBERT); this implementation adapts the same data and splits for zero-/few-shot evaluation of autoregressive LMs, so scores are not directly comparable to the paper.
+
+If other tasks on this dataset are already supported:
+
+* [x] Is the "Main" variant of this task clearly denoted?
+* [x] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [x] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/nsina/nsina_categories.yaml
+++ b/lm_eval/tasks/nsina/nsina_categories.yaml
@@ -1,0 +1,21 @@
+tag: nsina
+task: nsina_categories
+dataset_path: sinhala-nlp/NSINA-Categories
+dataset_name: null
+output_type: multiple_choice
+training_split: train
+test_split: test
+fewshot_split: train
+process_docs: !function utils.process_docs_categories
+doc_to_text: "පුවත: {{text}}\nප්‍රශ්නය: ඉහත පුවත අයත් වන්නේ කුමන ප්‍රවර්ගයටද?\nපිළිතුර:"
+doc_to_target: label
+doc_to_choice: ["ව්‍යාපාරික පුවත්", "ජාත්‍යන්තර පුවත්", "දේශීය පුවත්", "ක්‍රීඩා පුවත්"]
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1
+    aggregation: !function utils.macro_f1_score
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/nsina/nsina_headlines.yaml
+++ b/lm_eval/tasks/nsina/nsina_headlines.yaml
@@ -1,0 +1,20 @@
+tag: nsina
+task: nsina_headlines
+dataset_path: sinhala-nlp/NSINA-Headlines
+dataset_name: null
+output_type: generate_until
+training_split: train
+test_split: test
+fewshot_split: train
+process_docs: !function utils.process_docs_headlines
+doc_to_text: "පුවත: {{text}}\nඉහත පුවත සඳහා සුදුසු සිරස්තලයක් ලියන්න.\nසිරස්තලය:"
+doc_to_target: "{{headline}}"
+generation_kwargs:
+  until:
+    - "\n"
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: chrf
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/nsina/nsina_media.yaml
+++ b/lm_eval/tasks/nsina/nsina_media.yaml
@@ -1,0 +1,31 @@
+tag: nsina
+task: nsina_media
+dataset_path: sinhala-nlp/NSINA-Media
+dataset_name: null
+output_type: multiple_choice
+training_split: train
+test_split: test
+fewshot_split: train
+process_docs: !function utils.process_docs_media
+doc_to_text: "පුවත: {{text}}\nප්‍රශ්නය: ඉහත පුවත පළ කළ මාධ්‍ය ආයතනය කුමක්ද?\nපිළිතුර:"
+doc_to_target: label
+doc_to_choice:
+  - "අද දෙරණ"
+  - "අයිටීඑන් නිවුස්"
+  - "ලංකාටෲත්"
+  - "සියත නිවුස්"
+  - "දිනමිණ"
+  - "දිවයින"
+  - "හිරු නිවුස්"
+  - "නිවුස්.එල්කේ"
+  - "ලංකාදීප"
+  - "විකල්ප"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1
+    aggregation: !function utils.macro_f1_score
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/nsina/utils.py
+++ b/lm_eval/tasks/nsina/utils.py
@@ -1,0 +1,88 @@
+import datasets
+
+
+CATEGORY_LABELS = ["Business", "International News", "Local News", "Sports"]
+
+# Raw `Source` values as they appear in the dataset, index-aligned with the
+# doc_to_choice list in nsina_media.yaml.
+MEDIA_LABELS = [
+    "Adaderana",
+    "ITN news",
+    "Lankatruth",
+    "Siyatha News",
+    "dinamina",
+    "divaina",
+    "hirunews",
+    "https://sinhala.news.lk",
+    "www.lankadeepa.lk",
+    "www.vikalpa.org",
+]
+
+
+def _truncate(text: str, max_chars: int = 2000) -> str:
+    """Truncate long articles to keep prompts within reasonable context."""
+    text = text.strip()
+    if len(text) > max_chars:
+        text = text[:max_chars].rsplit(" ", 1)[0]
+    return text
+
+
+def process_docs_categories(dataset: datasets.Dataset) -> datasets.Dataset:
+    # The reference implementation drops rows with missing values:
+    # https://github.com/Sinhala-NLP/Sinhala-News-Category-Prediction
+    dataset = dataset.filter(
+        lambda doc: doc["News Content"] is not None and doc["Category"] is not None
+    )
+
+    def _process_doc(doc):
+        return {
+            "text": _truncate(doc["News Content"]),
+            "label": CATEGORY_LABELS.index(doc["Category"]),
+        }
+
+    return dataset.map(_process_doc)
+
+
+def process_docs_media(dataset: datasets.Dataset) -> datasets.Dataset:
+    dataset = dataset.filter(
+        lambda doc: doc["News Content"] is not None and doc["Source"] is not None
+    )
+
+    def _process_doc(doc):
+        return {
+            "text": _truncate(doc["News Content"]),
+            "label": MEDIA_LABELS.index(doc["Source"]),
+        }
+
+    return dataset.map(_process_doc)
+
+
+def process_docs_headlines(dataset: datasets.Dataset) -> datasets.Dataset:
+    dataset = dataset.filter(
+        lambda doc: doc["News Content"] is not None and doc["Headline"] is not None
+    )
+
+    def _process_doc(doc):
+        return {
+            "text": _truncate(doc["News Content"]),
+            "headline": doc["Headline"].strip(),
+        }
+
+    return dataset.map(_process_doc)
+
+
+def macro_f1_score(items):
+    """Macro-averaged F1 over (gold, prediction) index pairs, dependency-free."""
+    golds, preds = zip(*items, strict=True)
+    scores = []
+    for label in set(golds):
+        pairs = list(zip(golds, preds, strict=True))
+        tp = sum(1 for g, p in pairs if g == label and p == label)
+        fp = sum(1 for g, p in pairs if g != label and p == label)
+        fn = sum(1 for g, p in pairs if g == label and p != label)
+        precision = tp / (tp + fp) if tp + fp else 0.0
+        recall = tp / (tp + fn) if tp + fn else 0.0
+        scores.append(
+            2 * precision * recall / (precision + recall) if precision + recall else 0.0
+        )
+    return sum(scores) / len(scores)


### PR DESCRIPTION
Description:

This PR adds the first Sinhala-language tasks to the harness, implementing the three
benchmark tasks from **NSINA** (Hettiarachchi et al., LREC-COLING 2024,
https://arxiv.org/abs/2403.16571), the largest news corpus and benchmark suite for
Sinhala. Which is a low-resource language spoken by ~20M people with no existing coverage
in the harness.

### Tasks

| Task | Type | Test docs | Metrics |
|---|---|---|---|
| `nsina_categories` | 4-way news category classification (multiple choice) | 7,755 | acc, macro-F1 |
| `nsina_media` | 10-way news source identification (multiple choice) | 18,189 | acc, macro-F1 |
| `nsina_headlines` | headline generation | 97,387 | chrF |

All prompts and answer verbalizers are in Sinhala (I'm a native speaker), following
the pattern of `basqueglue`. The `nsina` tag runs all three.

### Design notes

- **chrF instead of ROUGE for headlines**: the paper reports ROUGE, but the default
  `rouge_score` tokenizer discards non-Latin-script text, which would silently score
  all Sinhala output as ~0. chrF is character-based and script-agnostic. This
  divergence is documented in the task README.
- The original paper evaluates fine-tuned encoders (SinBERT etc.); this adapts the
  same data/splits for zero-/few-shot autoregressive LM evaluation, so scores are
  not directly comparable to the paper (noted in the README checklist).
- Datasets are gated on the HF Hub (automatic approval) under `sinhala-nlp`, licensed
  CC BY-SA 4.0; the README notes the login requirement. Rows with missing values are
  dropped in `process_docs`, matching the reference implementation.

### Verification

- Smoke-tested all three tasks end-to-end with `sshleifer/tiny-gpt2` (`--limit 8`):
  the random-weight model scores chance level on both classification tasks
  (acc 0.25 on 4-way, 0.125 on 10-way) and chrF ≈ 0 on generation, confirming the
  scoring plumbing.
- `pre-commit` hooks (ruff check/format etc.) pass on all added files.
- Macro-F1 aggregation verified against a hand-computed example.

### Disclosure

Built with AI assistance (Claude Code) for scaffolding and test plumbing; all
Sinhala prompt/verbalizer text was written and verified by me as a native speaker,
and the task design decisions are mine.