### PR TITLE
fix(tasks): use namespaced dataset paths for webqs, medmcqa, and wmt16

### DIFF
--- a/lm_eval/tasks/medmcqa/medmcqa.yaml
+++ b/lm_eval/tasks/medmcqa/medmcqa.yaml
@@ -1,5 +1,5 @@
 task: medmcqa
-dataset_path: medmcqa
+dataset_path: openlifescienceai/medmcqa
 output_type: multiple_choice
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/webqs/webqs.yaml
+++ b/lm_eval/tasks/webqs/webqs.yaml
@@ -1,7 +1,7 @@
 tag:
   - freebase
 task: webqs
-dataset_path: web_questions
+dataset_path: stanfordnlp/web_questions
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/wmt2016/ro_en-t5_prompt.yaml
+++ b/lm_eval/tasks/wmt2016/ro_en-t5_prompt.yaml
@@ -1,5 +1,5 @@
 task: wmt-ro-en-t5-prompt
-dataset_path: wmt16
+dataset_path: wmt/wmt16
 dataset_name: ro-en
 training_split: train
 validation_split: validation

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,7 +22,6 @@ def get_new_tasks_else_default():
     Check if any modifications have been made to built-in tasks and return
     the list, otherwise return the default task list
     """
-    global TASKS
     # CI: new_tasks checks if any modifications have been made
     task_list = new_tasks()
     # Check if task_classes is empty
@@ -133,7 +132,12 @@ class BaseTasks:
         _array_target = [task.doc_to_target(doc) for doc in arr]
         if task._config.output_type == "multiple_choice":
             # TODO<baber>: label can be string or int; add better test conditions
-            assert all(isinstance(label, (int, str)) for label in _array_target)
+            for label in _array_target:
+                if isinstance(label, list):
+                    # tasks with multiple gold answers (e.g. webqs) return a list of indices
+                    assert all(isinstance(x, int) for x in label)
+                else:
+                    assert isinstance(label, (int, str))
 
     def test_build_all_requests(self, task_class, limit):
         task_class.build_all_requests(rank=1, limit=limit, world_size=1)


### PR DESCRIPTION
## Summary

Three task configs still point at bare (un-namespaced) HF dataset IDs. With the current HF stack (datasets 5.0.0 / huggingface_hub 1.24) these fail before task loading:

```
huggingface_hub.errors.HfUriError: Invalid HF URI 'hf://datasets/web_questions@0e473cbe.../.huggingface.yaml'. Repository id must be 'namespace/name', got 'web_questions'.
```

This is the same failure class that #3870 fixed for xnli/xcopa/paws-x/xquad. This PR updates the remaining ones I could fully verify:

| task | old path | new path |
|---|---|---|
| `webqs` | `web_questions` | `stanfordnlp/web_questions` |
| `medmcqa` | `medmcqa` | `openlifescienceai/medmcqa` |
| `wmt-ro-en-t5-prompt` | `wmt16` | `wmt/wmt16` |

The new paths are exactly the canonical repos the Hub 307-redirects the bare IDs to, so the underlying data is unchanged.

Two small test changes were needed so CI stays green on the touched files:

- `test_doc_to_target` assumed `multiple_choice` targets are `int` or `str`. `webqs` returns a list of gold answer indices (it has several accepted answers per question), which the evaluator already handles fine. The test now accepts a list of ints too.
- removed a `global TASKS` declaration that has no assignment. ruff flags it (PLW0602) as soon as the file is included in a changed-files lint run, which would have blocked this PR's CI.

## Validation

- All three tasks run end to end with the new paths on datasets 5.0.0 / huggingface_hub 1.24:
  `lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks webqs,medmcqa --limit 2` and the same for `wmt-ro-en-t5-prompt` (needs jiwer for the wer metric).
- On current main, all three fail with the HfUriError above before any request is built.
- The namespaced paths also load on the older stack (datasets 4.5.0 / huggingface_hub 1.8), so users pinned below datasets 5 are unaffected.
- Simulated the "Tasks Modified" CI job locally (wrote `.github/outputs/tasks_all_changed_and_modified_files.txt` with the three yamls and ran `pytest tests/test_tasks.py`): 42 passed.
- pre-commit is clean on all touched files.

Note: `benchmarks/t0_eval.yaml` also carries bare `anli`/`hellaswag`/`winogrande` paths, but that config currently fails to load for an unrelated reason (its group entries have no `task` key), so I left it out of this PR and will mention it in #3171 instead.

---

quick disclosure: i'm a freshman in college trying to contribute something genuinely useful to open source. i used Claude Code to help me script the dataset probing and sanity check my reasoning, but i ran every validation command above myself and read through the whole diff. if i got anything wrong i would honestly love to hear it so i can learn :)
