### PR TITLE
fix(tasks): use script-less parquet mirrors for mathqa, siqa, and moral_stories

### DIFF
--- a/lm_eval/tasks/mathqa/mathqa.yaml
+++ b/lm_eval/tasks/mathqa/mathqa.yaml
@@ -1,7 +1,7 @@
 tag:
   - math_word_problems
 task: mathqa
-dataset_path: math_qa
+dataset_path: regisss/math_qa
 output_type: multiple_choice
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/moral_stories/moral_stories.yaml
+++ b/lm_eval/tasks/moral_stories/moral_stories.yaml
@@ -1,6 +1,6 @@
 task: moral_stories
-dataset_path: demelin/moral_stories
-dataset_name: full
+dataset_path: LabHC/moral_stories
+dataset_name: null
 output_type: multiple_choice
 test_split: train
 process_docs: !function utils.process_docs

--- a/lm_eval/tasks/siqa/siqa.yaml
+++ b/lm_eval/tasks/siqa/siqa.yaml
@@ -1,5 +1,5 @@
 task: social_iqa
-dataset_path: allenai/social_i_qa
+dataset_path: lighteval/siqa
 dataset_name: null
 output_type: multiple_choice
 training_split: train


### PR DESCRIPTION
## Summary

Three more tasks from #3171 point at script-based HF datasets, which fail on the current stack (datasets 5.0.0 / huggingface_hub 1.24.0):

```
RuntimeError: Dataset scripts are no longer supported, but found math_qa.py
```

This swaps them to parquet mirrors, same pattern as #3870 and #3361:

| task | old path | new path |
|---|---|---|
| `mathqa` | `math_qa` | `regisss/math_qa` |
| `social_iqa` | `allenai/social_i_qa` | `lighteval/siqa` |
| `moral_stories` | `demelin/moral_stories` (config `full`) | `LabHC/moral_stories` |

`LabHC/moral_stories` has a single unnamed config, so `dataset_name: full` becomes `null`. It carries two extra columns (`guid`, `__index_level_0__`) that `process_docs` ignores.

## Provenance

I didn't want to swap in mirrors on vibes, so I verified content, not just row counts: loaded each original with datasets 3.6.0 (`trust_remote_code=True`), md5-hashed every split over the columns the task configs consume (sorted rows, order-independent), and did the same for the mirrors on datasets 5.0.0. All hashes match exactly:

- `regisss/math_qa` == `allenai/math_qa`: train 29837 / validation 4475 / test 2985, all seven columns
- `lighteval/siqa` == `allenai/social_i_qa`: train 33410 / validation 1954, all six used columns
- `LabHC/moral_stories` == `demelin/moral_stories` `full`: train 12000, all five fields `process_docs` reads

## Validation

- All three tasks run end to end on datasets 5.0.0 / hf_hub 1.24.0: `lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks mathqa,social_iqa,moral_stories --limit 5 --device cpu`
- On current main all three fail with the script RuntimeError before any request is built.
- The new paths also load on datasets 3.6.0, so users pinned below datasets 4 are unaffected.
- Simulated the "Tasks Modified" CI job locally (wrote the changed-files list and ran `pytest tests/test_tasks.py`): 42 passed.
- pre-commit is clean on the touched files.

## Not included (findings from verifying the rest of the #3171 list)

- `mc_taco` (`CogComp/mc_taco`) and `prost` (`corypaik/prost`): no faithful script-less mirror on the Hub that I could find. `corypaik/prost` ships its data as jsonl in the repo, so the simplest fix is upstream removal of `prost.py`.
- afrobench `mafand` (`masakhane/mafand`) still resolves to a script-based repo on the Hub, so it needs a Hub-side conversion rather than a config change here.

Closes nothing on its own; chips away at #3171.
