### PR TITLE
fix(afrixnli): use Jinja braces in prompt_1 doc_to_text

### DIFF
--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_amh.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_amh.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_eng.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_eng.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ewe.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ewe.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_fra.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_fra.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_hau.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_hau.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ibo.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_ibo.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_kin.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_kin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lin.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lug.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_lug.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_orm.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_orm.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sna.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sna.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sot.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_sot.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_swa.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_swa.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_twi.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_twi.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_wol.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_wol.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_xho.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_xho.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_yor.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_yor.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_zul.yaml
+++ b/lm_eval/tasks/afrixnli/direct/prompt_1/afrixnli_zul.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/gen_utils.py
+++ b/lm_eval/tasks/afrixnli/gen_utils.py
@@ -12,7 +12,7 @@ class FunctionTag:
 def prompt_func(mode, lang):
     prompt_map = {
         "prompt_1": "Please identify whether the premise entails or contradicts the hypothesis in the following premise "
-        "and hypothesis. The answer should be exact entailment, contradiction, or neutral.\n\nPremise: {premise}\nHypothesis: {hypothesis}\n\n"
+        "and hypothesis. The answer should be exact entailment, contradiction, or neutral.\n\nPremise: {{premise}}\nHypothesis: {{hypothesis}}\n\n"
         "Is it entailment, contradiction, or neutral?",
         "prompt_3": f"Given the following premise and hypothesis in {lang}, identify if the premise entails, contradicts, "
         f"or is neutral towards the hypothesis. Please respond with exact 'entailment', 'contradiction', or 'neutral'. \n\n"

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_amh.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_amh.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ewe.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ewe.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_fra.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_fra.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_hau.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_hau.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ibo.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_ibo.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_kin.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_kin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lin.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lin.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lug.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_lug.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_orm.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_orm.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sna.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sna.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sot.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_sot.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_swa.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_swa.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_twi.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_twi.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_wol.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_wol.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_xho.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_xho.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_yor.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_yor.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'

--- a/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_zul.yaml
+++ b/lm_eval/tasks/afrixnli/translate/prompt_1/afrixnli_translate_zul.yaml
@@ -5,9 +5,9 @@ doc_to_text: 'Please identify whether the premise entails or contradicts the hyp
   contradiction, or neutral.
 
 
-  Premise: {premise}
+  Premise: {{premise}}
 
-  Hypothesis: {hypothesis}
+  Hypothesis: {{hypothesis}}
 
 
   Is it entailment, contradiction, or neutral?'


### PR DESCRIPTION
## Summary
`afrixnli_*_prompt_1` (direct + translate) declared `doc_to_text` with Python `.format()`-style single braces. `doc_to_text` is rendered by Jinja2, so `{premise}` / `{hypothesis}` were emitted literally and the model never saw the document fields. Accuracy collapses to chance because every example shares the same empty stem.

Root cause is `prompt_map["prompt_1"]` in `lm_eval/tasks/afrixnli/gen_utils.py` (introduced in #2825). Prompts 3–5 already use `{{premise}}` / `{{hypothesis}}`.

## Change
- Fix `prompt_1` in `gen_utils.py` to Jinja double braces
- Regenerate all 35 `prompt_1` YAML files under `direct/` and `translate/`

## Test plan
- [x] Confirmed no remaining single-brace `{premise}` / `{hypothesis}` in the 35 YAMLs
- [x] Jinja2 render of the fixed template substitutes Swahili premise/hypothesis; old single-brace template stays literal
- [ ] Optional: `lm_eval --model hf --model_args pretrained=EleutherAI/pythia-160m --tasks afrixnli_swa_prompt_1 --limit 1 --device cpu --log_samples` and inspect `arg_0` for real text

Fixes #3930
