### PR TITLE
fix(tasks): use namespaced dataset path for wsc273

### DIFF
--- a/lm_eval/tasks/wsc273/default.yaml
+++ b/lm_eval/tasks/wsc273/default.yaml
@@ -1,5 +1,5 @@
 task: wsc273
-dataset_path: winograd_wsc
+dataset_path: lighteval/winograd_wsc
 dataset_name: wsc273
 output_type: multiple_choice
 test_split: test


### PR DESCRIPTION
## Summary

`wsc273` currently points at the bare `winograd_wsc` repo id, which is a script-based dataset. `datasets>=4.0` refuses to load it:

```
RuntimeError: Dataset scripts are no longer supported, but found winograd_wsc.py
```

This PR swaps the config to the `lighteval/winograd_wsc` parquet mirror, following the same pattern as #3870 and #3942. One line changed.

## Mirror parity verification

I compared every row of `lighteval/winograd_wsc` (config `wsc273`, split `test`) against Hugging Face's own auto-converted parquet of the original script dataset (`refs/convert/parquet` on the upstream repo):

- 273 rows in both, identical column sets (`text`, `pronoun`, `pronoun_loc`, `quote`, `quote_loc`, `options`, `label`, `source`)
- 0 row-level differences (full dict equality, all 273 rows)

## Test results

Fails on current `main` with the traceback above. After this change, the full task runs end to end on a clean install (datasets 5.0.0):

```
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks wsc273
|Tasks |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------|------:|------|-----:|------|---|-----:|---|-----:|
|wsc273|      1|none  |     0|acc   |↑  |0.5201|±  |0.0303|
```

(pythia-14m is at chance on WSC as expected; the run demonstrates the task loads, builds contexts, and scores all 273 docs.)

`tests/test_tasks.py` passes locally against the changed config, and pre-commit is clean on the diff range.

Related: #3171 (script-dataset breakage umbrella; wsc273 is one of the datasets tabled there).

This change was prepared with AI assistance (Claude); I reviewed and verified everything above by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)