### PR TITLE
fix(tasks): validate duplicate tasks in legacy loader

### DIFF
--- a/lm_eval/tasks/manager.py
+++ b/lm_eval/tasks/manager.py
@@ -275,9 +275,12 @@ class TaskManager:
                 return {cg: nested}
             return {obj.task_name: obj}
 
-        return dict(
-            collections.ChainMap(*[_to_nested(self._load_spec(s)) for s in task_list])
+        built = [self._load_spec(s) for s in task_list]
+        self._check_duplicates(
+            [item for obj in built for item in (obj if isinstance(obj, list) else [obj])]
         )
+
+        return dict(collections.ChainMap(*[_to_nested(obj) for obj in built]))
 
     @staticmethod
     def _check_duplicates(built: list[Task | Group]) -> None:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -917,6 +917,22 @@ metadata:
 
         assert set(new["tasks"].keys()) == _leaf_names(old)
 
+    def test_legacy_load_rejects_duplicate_top_level_tasks(
+        self, test_configs_task_manager
+    ):
+        """Deprecated load_task_or_group should not silently drop duplicate tasks.
+
+        This preserves the duplicate-task validation used by load() for callers
+        that still use the legacy nested-dict API.
+        """
+        with (
+            pytest.warns(DeprecationWarning),
+            pytest.raises(ValueError, match="include_task_fs0"),
+        ):
+            test_configs_task_manager.load_task_or_group(
+                ["include_group", "include_task_fs0"]
+            )
+
 
 # =============================================================================
 # Group Building & Factory Tests


### PR DESCRIPTION
## Summary

Fixes #1436 for the deprecated `TaskManager.load_task_or_group()` API by applying the same duplicate-task validation used by `TaskManager.load()` before converting loaded specs into the legacy nested-dict shape.

Previously, overlapping top-level selections such as a group plus one of its child tasks could be silently collapsed by the legacy `ChainMap` conversion. Now the legacy path raises an explicit `ValueError` instead of dropping/overwriting one occurrence.

## Test Plan

- [x] `python -m pytest tests/test_task_manager.py::TestTaskManagerLoad::test_legacy_load_rejects_duplicate_top_level_tasks -q`
- [x] `python -m pytest tests/test_task_manager.py::TestTaskManagerLoad::test_load_returns_same_tasks_as_legacy -q`
- [x] `uvx ruff check lm_eval/tasks/manager.py`

Note: full `tests/test_task_manager.py` timed out locally after 600s. Full-file ruff on `tests/test_task_manager.py` has pre-existing `FURB148` findings unrelated to this PR.
