### PR TITLE
fix(tmmluplus): use ikala/tmmluplus so the task loads on datasets>=4

### DIFF
--- a/lm_eval/tasks/tmmluplus/default/_tmmluplus_template_yaml
+++ b/lm_eval/tasks/tmmluplus/default/_tmmluplus_template_yaml
@@ -1,4 +1,4 @@
-dataset_path: ZoneTwelve/tmmluplus # a copy of `ikala/tmmluplus`
+dataset_path: ikala/tmmluplus
 test_split: test
 fewshot_split: train
 fewshot_config:

--- a/lm_eval/tasks/tmmluplus/default/tmmluplus_linear_algebra.yaml
+++ b/lm_eval/tasks/tmmluplus/default/tmmluplus_linear_algebra.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "linear_algebra"
+"dataset_path": "csv"
+"dataset_name": null
+"dataset_kwargs":
+  "data_files":
+    "train": "hf://datasets/ikala/tmmluplus/data/linear_algebra_train.csv"
+    "test": "hf://datasets/ikala/tmmluplus/data/linear_algebra_test.csv"
 "description": "以下為線代的單選題，請提供正確答案的選項。\n\n"
 "tag": "tmmluplus_STEM_tasks"
 "include": "_tmmluplus_template_yaml"


### PR DESCRIPTION
`tmmluplus` points at `ZoneTwelve/tmmluplus`, which is a script dataset (`tmmluplus.py`), so on `datasets>=4.0` every subject fails with:

```
RuntimeError: Dataset scripts are no longer supported, but found tmmluplus.py
```

Part of #3171.

The template comment already notes ZoneTwelve is "a copy of `ikala/tmmluplus`", and the task README lists `ikala/tmmluplus` as the homepage. ikala's copy is parquet-native and loads fine on current `datasets`, so I repointed `dataset_path` to it in `_tmmluplus_template_yaml`. That fixes 66 of the 67 subjects in one line.

The exception is `linear_algebra`. ikala doesn't register it as a named config (`get_dataset_config_names("ikala/tmmluplus")` returns 66 without it) even though the CSVs are in the repo, so that subject loads its CSV directly with `data_files`.

On the data being unchanged: I compared the git blob OIDs for every file under `data/` in both repos. 266 of 267 match. The only difference is `tve_mathematics_dev.csv`, and the task never reads a dev/validation split (it uses `test` for eval and `train` for fewshot), so every split the task actually consumes is byte identical across all 67 subjects.

Checked locally on `datasets==5.0.0`:
- `ZoneTwelve/tmmluplus` raises the script error, `ikala/tmmluplus` loads
- built `tmmluplus_pharmacology` (named config), `tmmluplus_linear_algebra` (csv) and `tmmluplus_tve_mathematics` through the task manager; `process_docs` output looks right
- ran `lm_eval --model hf --tasks tmmluplus_linear_algebra,tmmluplus_pharmacology --limit 3` end to end and both return acc/acc_norm
- pre-commit passes on both changed files

If you'd rather source `linear_algebra` a different way (or drop it), happy to change it. This keeps the current 67-subject coverage.