### PR TITLE
Include generation_kwargs in the request cache key

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import ast
+import json
 import logging
 import random
 import re
@@ -265,6 +266,40 @@ class Task(abc.ABC):
     def doc_to_prefix(self, doc):
         return ""
 
+    def request_cache_key(
+        self,
+        *,
+        rank: int = 0,
+        world_size: int = 1,
+        system_instruction: str | None = None,
+        apply_chat_template: bool = False,
+        fewshot_as_multiturn: bool = False,
+        tokenizer_name: str = "",
+    ) -> str:
+        """Build the request-cache file name for this task under a given run config.
+
+        Every input that changes the resulting Instances has to be folded in, otherwise
+        a cached run is silently reused under settings it was never built for.
+        """
+        cache_key = f"requests-{self._config.task}-{self.config.num_fewshot}shot-rank{rank}-world_size{world_size}"
+        cache_key += "-chat_template" if apply_chat_template else ""
+        cache_key += "-fewshot_as_multiturn" if fewshot_as_multiturn else ""
+        cache_key += (
+            f"-system_prompt_hash{utils.hash_string(system_instruction)}"
+            if system_instruction is not None
+            else ""
+        )
+        cache_key += f"-tokenizer{tokenizer_name}"
+        # `generate_until` bakes `generation_kwargs` into every Instance's arguments, so
+        # runs that differ only in sampling parameters must not share a cache entry.
+        # Left out when unset so existing caches for non-generative tasks stay valid.
+        if self.config.generation_kwargs is not None:
+            gen_kwargs_repr = json.dumps(
+                self.config.generation_kwargs, sort_keys=True, default=str
+            )
+            cache_key += f"-gen_kwargs_hash{utils.hash_string(gen_kwargs_repr)}"
+        return cache_key
+
     def build_all_requests(
         self,
         *,
@@ -285,15 +320,14 @@ class Task(abc.ABC):
         # used with caching
         og_limit = limit
 
-        cache_key = f"requests-{self._config.task}-{self.config.num_fewshot}shot-rank{rank}-world_size{world_size}"
-        cache_key += "-chat_template" if apply_chat_template else ""
-        cache_key += "-fewshot_as_multiturn" if fewshot_as_multiturn else ""
-        cache_key += (
-            f"-system_prompt_hash{utils.hash_string(system_instruction)}"
-            if system_instruction is not None
-            else ""
+        cache_key = self.request_cache_key(
+            rank=rank,
+            world_size=world_size,
+            system_instruction=system_instruction,
+            apply_chat_template=apply_chat_template,
+            fewshot_as_multiturn=fewshot_as_multiturn,
+            tokenizer_name=tokenizer_name,
         )
-        cache_key += f"-tokenizer{tokenizer_name}"
 
         cached_instances = load_from_cache(file_name=cache_key, cache=cache_requests)
 

--- a/tests/test_request_cache_key.py
+++ b/tests/test_request_cache_key.py
@@ -1,0 +1,117 @@
+"""Tests for the request-cache key built by `Task.request_cache_key`.
+
+The key names the file that `--cache_requests` reads back. Any run setting that
+changes the resulting Instances has to be part of it, otherwise a later run
+silently reuses instances that were built under different settings.
+"""
+
+from lm_eval.api.task import ConfigurableTask
+from lm_eval.config.task import TaskConfig
+
+
+def make_task(**overrides) -> ConfigurableTask:
+    """Build a `generate_until` task without touching the network or datasets."""
+    config = {
+        "task": "test_task",
+        "output_type": "generate_until",
+        "doc_to_text": "Question: {{question}}",
+        "doc_to_target": "{{answer}}",
+        "num_fewshot": 5,
+        "generation_kwargs": {"until": ["\n"], "do_sample": False, "temperature": 0.0},
+    }
+    config.update(overrides)
+
+    task = ConfigurableTask.__new__(ConfigurableTask)
+    task._config = TaskConfig(**config)
+    task.OUTPUT_TYPE = config["output_type"]
+    return task
+
+
+RUN_CONFIG = {
+    "rank": 0,
+    "world_size": 1,
+    "system_instruction": None,
+    "apply_chat_template": False,
+    "fewshot_as_multiturn": False,
+    "tokenizer_name": "meta-llama/Llama-3-8B",
+}
+
+
+def test_generation_kwargs_change_the_cache_key():
+    """Two runs differing only in sampling parameters must not share a cache entry.
+
+    `generate_until` bakes `generation_kwargs` into each Instance's arguments, so
+    reusing the greedy run's cache for a temperature=0.7 run would silently evaluate
+    at the old sampling settings.
+    """
+    greedy = make_task(
+        generation_kwargs={"until": ["\n"], "do_sample": False, "temperature": 0.0}
+    )
+    sampled = make_task(
+        generation_kwargs={"until": ["\n"], "do_sample": True, "temperature": 0.7}
+    )
+
+    assert greedy.request_cache_key(**RUN_CONFIG) != sampled.request_cache_key(
+        **RUN_CONFIG
+    )
+
+
+def test_max_gen_toks_and_until_change_the_cache_key():
+    """`until` and `max_gen_toks` also reach the model, so they belong in the key."""
+    base = make_task(generation_kwargs={"until": ["\n"], "max_gen_toks": 30})
+    longer = make_task(generation_kwargs={"until": ["\n"], "max_gen_toks": 256})
+    other_stop = make_task(generation_kwargs={"until": ["\n\n"], "max_gen_toks": 30})
+
+    keys = {
+        base.request_cache_key(**RUN_CONFIG),
+        longer.request_cache_key(**RUN_CONFIG),
+        other_stop.request_cache_key(**RUN_CONFIG),
+    }
+    assert len(keys) == 3
+
+
+def test_cache_key_is_stable_across_key_order():
+    """The same kwargs written in a different order describe the same run."""
+    one = make_task(
+        generation_kwargs={"until": ["\n"], "do_sample": True, "temperature": 0.7}
+    )
+    two = make_task(
+        generation_kwargs={"temperature": 0.7, "until": ["\n"], "do_sample": True}
+    )
+
+    assert one.request_cache_key(**RUN_CONFIG) == two.request_cache_key(**RUN_CONFIG)
+
+
+def test_cache_key_is_deterministic():
+    """Repeated calls on the same task give the same key."""
+    task = make_task()
+    assert task.request_cache_key(**RUN_CONFIG) == task.request_cache_key(**RUN_CONFIG)
+
+
+def test_cache_key_unchanged_when_generation_kwargs_unset():
+    """Tasks without `generation_kwargs` keep their previous key, so caches stay valid."""
+    task = make_task(output_type="multiple_choice", generation_kwargs=None)
+    key = task.request_cache_key(**RUN_CONFIG)
+
+    assert key == (
+        "requests-test_task-5shot-rank0-world_size1-tokenizermeta-llama/Llama-3-8B"
+    )
+    assert "gen_kwargs_hash" not in key
+
+
+def test_existing_run_settings_still_change_the_cache_key():
+    """The settings the key already covered must keep working."""
+    task = make_task()
+    base = task.request_cache_key(**RUN_CONFIG)
+
+    assert task.request_cache_key(**{**RUN_CONFIG, "rank": 1}) != base
+    assert task.request_cache_key(**{**RUN_CONFIG, "world_size": 2}) != base
+    assert task.request_cache_key(**{**RUN_CONFIG, "apply_chat_template": True}) != base
+    assert (
+        task.request_cache_key(**{**RUN_CONFIG, "fewshot_as_multiturn": True}) != base
+    )
+    assert (
+        task.request_cache_key(**{**RUN_CONFIG, "system_instruction": "be terse"})
+        != base
+    )
+    assert task.request_cache_key(**{**RUN_CONFIG, "tokenizer_name": "gpt2"}) != base


### PR DESCRIPTION
## What this fixes

The `--cache_requests` key in `build_all_requests` was built from task name, fewshot count, rank, world size, system prompt, chat-template flags and tokenizer — but not from `generation_kwargs`:

```python
cache_key = f"requests-{self._config.task}-{self.config.num_fewshot}shot-rank{rank}-world_size{world_size}"
cache_key += "-chat_template" if apply_chat_template else ""
cache_key += "-fewshot_as_multiturn" if fewshot_as_multiturn else ""
cache_key += f"-system_prompt_hash{...}" if system_instruction is not None else ""
cache_key += f"-tokenizer{tokenizer_name}"
```

For `generate_until` tasks that matters, because `construct_requests` bakes the kwargs into every `Instance` (`lm_eval/api/task.py:1408`):

```python
arguments = (ctx, deepcopy(self.config.generation_kwargs))
```

So two runs of the same task that differ only in `temperature`, `do_sample`, `until` or `max_gen_toks` produce **identical** keys. The second run loads the first run's cached instances and silently evaluates at the *first* run's sampling settings.

Both of these collide today:

```
requests-mmlu-5shot-rank0-world_size1-tokenizermeta-llama/Llama-3-8B   # temperature=0.0
requests-mmlu-5shot-rank0-world_size1-tokenizermeta-llama/Llama-3-8B   # temperature=0.7
```

There is no crash and no warning — an evaluator who reruns a task at a new temperature over a warm cache just gets numbers that do not correspond to the config they asked for. It is a reproducibility problem rather than a failure, which is what makes it easy to miss.

Scope: opt-in only (`--cache_requests` is off by default) and only affects `generate_until` tasks.

## The change

- Fold a stable hash of `generation_kwargs` into the key. `json.dumps(..., sort_keys=True, default=str)` keeps it order-independent and tolerant of non-serializable values.
- Move key construction out of `build_all_requests` into `Task.request_cache_key(...)` so it can be tested without building instances or touching the network. `build_all_requests` now just calls it — no behaviour change there.

**Backwards compatibility:** the hash is appended only when `generation_kwargs is not None`. Keys for loglikelihood / multiple-choice tasks are byte-identical to before, so existing caches stay valid. `generate_until` caches are invalidated once, which is the point.

## Tests

Added `tests/test_request_cache_key.py` (6 tests, no network or model downloads — the task is built by setting `_config` directly, following the `MockConfigurableTask` pattern in `tests/test_metrics.py`):

- `test_generation_kwargs_change_the_cache_key` — the reported collision: greedy vs `temperature=0.7`
- `test_max_gen_toks_and_until_change_the_cache_key` — `until` and `max_gen_toks` produce three distinct keys
- `test_cache_key_is_stable_across_key_order` — reordering the same kwargs gives the same key
- `test_cache_key_is_deterministic`
- `test_cache_key_unchanged_when_generation_kwargs_unset` — pins the exact legacy key string, guarding the compatibility claim above
- `test_existing_run_settings_still_change_the_cache_key` — rank, world size, chat template, multiturn, system prompt and tokenizer all still affect the key

The first two fail without the fix and pass with it:

```
# before
FAILED tests/test_request_cache_key.py::test_generation_kwargs_change_the_cache_key
FAILED tests/test_request_cache_key.py::test_max_gen_toks_and_until_change_the_cache_key
2 failed, 4 passed

# after
6 passed
```

`tests/test_metrics.py`, `tests/test_misc.py`, `tests/test_janitor.py` and `tests/test_filters.py` all still pass. `tests/test_evaluator.py` fails identically before and after my change in this environment (no `torch` installed), so it is unrelated.

Note on lint: `ruff check lm_eval/api/task.py` reports 17 errors on a clean `main` too (see #3900), so I left those alone and kept the diff to three hunks.

Fixes #3881.
