### PR TITLE
fix(tasks): add missing task names to t0_eval group entries

### DIFF
--- a/lm_eval/tasks/benchmarks/t0_eval.yaml
+++ b/lm_eval/tasks/benchmarks/t0_eval.yaml
@@ -1,7 +1,8 @@
 group: t0_eval
 task:
   # Coreference Resolution
-  - dataset_path: aps/super_glue
+  - task: t0_wsc
+    dataset_path: aps/super_glue
     dataset_name: wsc.fixed
     use_prompt: promptsource:*
     training_split: train
@@ -14,7 +15,8 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Coreference Resolution
-  - dataset_path: winogrande
+  - task: t0_winogrande
+    dataset_path: winogrande
     dataset_name: winogrande_xl
     use_prompt: promptsource:*
     training_split: train
@@ -27,7 +29,8 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Natural Language Inference
-  - dataset_path: aps/super_glue
+  - task: t0_cb
+    dataset_path: aps/super_glue
     dataset_name: cb
     use_prompt: promptsource:*
     training_split: train
@@ -39,7 +42,8 @@ task:
         higher_is_better: true
         ignore_case: true
         ignore_punctuation: true
-  - dataset_path: aps/super_glue
+  - task: t0_rte
+    dataset_path: aps/super_glue
     dataset_name: rte
     use_prompt: promptsource:*
     training_split: train
@@ -88,7 +92,8 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Sentence Completion
-  - dataset_path: aps/super_glue
+  - task: t0_copa
+    dataset_path: aps/super_glue
     dataset_name: copa
     use_prompt: promptsource:*
     training_split: train
@@ -101,7 +106,8 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Natural Language Inference
-  - dataset_path: hellaswag
+  - task: t0_hellaswag
+    dataset_path: hellaswag
     use_prompt: promptsource:*
     training_split: train
     validation_split: validation
@@ -113,7 +119,8 @@ task:
         ignore_case: true
         ignore_punctuation: true
   # Word Sense Disambiguation
-  - dataset_path: aps/super_glue
+  - task: t0_wic
+    dataset_path: aps/super_glue
     dataset_name: wic
     use_prompt: promptsource:*
     training_split: train


### PR DESCRIPTION
Closes #3947

## Problem

The `t0_eval` benchmark cannot be loaded at all. Seven of the ten entries under the group's
`task:` list are inline task definitions with no `task` (name) key, and the group factory
rejects them:

```
ValueError: Dict entry in group 't0_eval' must have 'task' or 'group' key, got:
['dataset_path', 'dataset_name', 'use_prompt', 'training_split', 'validation_split', 'output_type', 'metric_list']
```

The three `anli_r*` entries already carry a `task` key, so the omission looks accidental.
As noted in the issue, this also makes the `new_tasks` CI workflow fail for any PR that
touches this file.

## Change

Give each of the seven unnamed entries an explicit `task` name.

The names are prefixed with `t0_` rather than reusing the plain dataset names, and that
choice matters. `_build_group_members` only treats an entry as an inline definition when its
name is **not** already in the registry:

```python
# lm_eval/tasks/_factory.py
if base_name not in registry:
    namespaced = f"{group_name}::{base_name}"
    task_cfg = {**item_overrides, "task": namespaced}
    children.append(ConfigurableTask(config=task_cfg))
    continue
```

`wsc`, `winogrande`, `cb`, `rte`, `copa`, `hellaswag` and `wic` are all registered task names
already. Using them here would resolve to those existing tasks and silently discard this
file's inline configuration (`use_prompt: promptsource:*`, `output_type: generate_until`,
the `exact_match` metric block). The `t0_`-prefixed names are unregistered, so each entry
stays an inline task and keeps its own config.

## Verification

Editable install on Python 3.12, CPU.

- Reproduced the reported failure on a clean checkout via `TaskManager().load(["t0_eval"])`,
  getting the exact `ValueError` above.
- After the change that `ValueError` is gone: the first member builds and starts resolving
  its dataset (`t0_eval::t0_wsc`).
- Checked every member resolves as intended - 0 entries missing a `task`/`group` key, no
  duplicate names, and all seven new names resolve as `INLINE` while `anli_r1/r2/r3` keep
  referencing their registered tasks.
- Scanned all 831 group YAMLs in `lm_eval/tasks/` for the same defect: 0 remaining entries
  missing a `task`/`group` key, so this file was the only one affected.

## Scope

This fixes only the group-loading error from #3947. The two further blockers listed in that
issue are still present and out of scope here:

1. Bare dataset ids (`winogrande`, `hellaswag`, `anli`) that newer `datasets`/`huggingface_hub`
   versions reject.
2. `use_prompt: promptsource:*` cannot resolve, because `promptsource` requires Python < 3.10
   and is no longer installable on supported versions. Worth noting separately: the error
   message in `lm_eval/prompts/__init__.py` still suggests `pip install lm-eval[promptsource]`,
   but that extra no longer exists in `pyproject.toml`.

So `t0_eval` still will not run end to end, but it now loads instead of failing immediately,
and the CI workflow is no longer blocked by this file.