### PR TITLE
Add behavioral_drift metric: detect fine-tuning output collapse that perplexity misses (#3924)

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -4,8 +4,9 @@ import os
 import random
 import re
 import string
-from collections.abc import Iterable
-from typing import Callable, List, Optional, Sequence, TypeVar
+from collections import Counter
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeVar
 
 import numpy as np
 import sacrebleu
@@ -379,6 +380,107 @@ def ter_fn(items):  # This is a passthrough function
     return items
 
 
+# behavioral_drift: ported from huggingface/evaluate PR #778
+# (https://github.com/huggingface/evaluate/pull/778), which introduced the metric
+# to catch fine-tuning output collapse (e.g. degeneration into repeated or numeric
+# garbage) that perplexity does not detect. Three deterministic signals are
+# combined multiplicatively into a single drift_score in [0, 1]: any one signal
+# failing its threshold drives the whole score toward 0, unlike an additive
+# combination which can mask a severe failure in one dimension with healthy
+# scores in the others.
+#
+# self-BLEU is computed with a dependency-free unigram-precision BLEU-1 (as in
+# the original PR) rather than sacrebleu: sacrebleu's brevity penalty inverts
+# the mode-collapse signal here, since the "concatenated-reference" trick below
+# deliberately makes the reference N-1 times longer than the hypothesis — with
+# identical, fully-collapsed outputs, sacrebleu's BP drives self-BLEU toward 0
+# instead of 1.
+_BEHAVIORAL_DRIFT_SB_THRESHOLD = 0.8  # self-BLEU threshold (mode collapse)
+_BEHAVIORAL_DRIFT_DD_DELTA_THRESHOLD = 0.2  # digit_density increase vs. baseline
+_BEHAVIORAL_DRIFT_RR_THRESHOLD = 0.4  # repetition_ratio threshold (degenerate loops)
+
+
+def _behavioral_drift_bleu1(candidate: str, reference: str) -> float:
+    """Unigram-precision BLEU-1; each reference token matched at most once."""
+    cand = candidate.split()
+    ref_counts = Counter(reference.split())
+    if not cand:
+        return 0.0
+    hits = 0
+    for tok in cand:
+        if ref_counts.get(tok, 0) > 0:
+            hits += 1
+            ref_counts[tok] -= 1
+    return hits / len(cand)
+
+
+def _behavioral_drift_self_bleu(outputs: list[str]) -> float:
+    """Concatenated-reference self-BLEU-1: each output is scored against the
+    remaining N-1 outputs joined into a single reference.
+    """
+    if len(outputs) < 2:
+        return 0.0
+    scores = [
+        _behavioral_drift_bleu1(outputs[i], " ".join(outputs[:i] + outputs[i + 1 :]))
+        for i in range(len(outputs))
+    ]
+    return sum(scores) / len(scores)
+
+
+def _behavioral_drift_digit_density(text: str) -> float:
+    if not text:
+        return 0.0
+    return sum(1 for c in text if c.isnumeric()) / len(text)
+
+
+def _behavioral_drift_repetition_ratio(text: str) -> float:
+    tokens = text.split()
+    if len(tokens) < 5:
+        return 1.0
+    return len(set(tokens)) / len(tokens)
+
+
+@register_aggregation("behavioral_drift")
+def behavioral_drift_agg(items):
+    """Corpus-level behavioral drift score.
+
+    items: list of (reference, prediction) tuples collected across docs, where
+    reference is the doc's target/baseline text (doc_to_target) and prediction
+    is the model's generated output.
+    """
+    references, predictions = (list(x) for x in zip(*items, strict=True))
+
+    if not predictions:
+        return 0.0
+
+    dd_pred = [_behavioral_drift_digit_density(p) for p in predictions]
+    rr_pred = [_behavioral_drift_repetition_ratio(p) for p in predictions]
+    avg_dd = sum(dd_pred) / len(dd_pred)
+    avg_rr = sum(rr_pred) / len(rr_pred)
+    sb = _behavioral_drift_self_bleu(predictions)
+
+    dd_base = sum(_behavioral_drift_digit_density(r) for r in references) / len(
+        references
+    )
+
+    sb_score = max(0.0, 1.0 - sb / _BEHAVIORAL_DRIFT_SB_THRESHOLD)
+    dd_delta = max(0.0, avg_dd - dd_base)
+    dd_score = max(0.0, 1.0 - dd_delta / _BEHAVIORAL_DRIFT_DD_DELTA_THRESHOLD)
+    rr_score = min(1.0, avg_rr / _BEHAVIORAL_DRIFT_RR_THRESHOLD)
+
+    return round(sb_score * dd_score * rr_score, 4)
+
+
+@register_metric(
+    metric="behavioral_drift",
+    higher_is_better=True,
+    output_type=["generate_until"],
+    aggregation="behavioral_drift",
+)
+def behavioral_drift_fn(items):  # This is a passthrough function
+    return items
+
+
 @register_metric(
     metric="acc_all",
     higher_is_better=True,
@@ -554,7 +656,7 @@ def bootstrap_stderr(
 
 def stderr_for_metric(
     metric: Callable[[Sequence[T]], float], bootstrap_iters: int
-) -> Optional[Callable[[Sequence[T]], float]]:
+) -> Callable[[Sequence[T]], float] | None:
     """
     Return a function that estimates the standard error of `metric(xs)`.
 
@@ -584,10 +686,10 @@ def stderr_for_metric(
 
     stderr = {mean: mean_stderr, acc_all: acc_all_stderr}
 
-    return stderr.get(metric, None)
+    return stderr.get(metric)
 
 
-def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
+def pooled_sample_stderr(stderrs: list[float], sizes: list[int]):
     # Used to aggregate bootstrapped stderrs across subtasks in a group,
     # when we are weighting by the size of each subtask.
     #
@@ -605,7 +707,7 @@ def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
     return np.sqrt(pooled_sample_var / sum(sizes))
 
 
-def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None):
+def combined_sample_stderr(stderrs: list[float], sizes: list[int], metrics=None):
     assert metrics is not None, (
         "Need to pass a list of each subtask's metric for this stderr aggregation"
     )

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import math
 import os
@@ -399,6 +400,36 @@ _BEHAVIORAL_DRIFT_SB_THRESHOLD = 0.8  # self-BLEU threshold (mode collapse)
 _BEHAVIORAL_DRIFT_DD_DELTA_THRESHOLD = 0.2  # digit_density increase vs. baseline
 _BEHAVIORAL_DRIFT_RR_THRESHOLD = 0.4  # repetition_ratio threshold (degenerate loops)
 
+# Optional `baseline_path` (set via metric_list, e.g. `baseline_path: base.json`):
+# a pre-generated set of base-model (pre-fine-tuning) outputs on the same prompts,
+# used in place of doc_to_target as the digit_density_delta baseline. Without it,
+# the doc's target/gold text is used instead — always available, but a proxy for
+# "what a correct answer looks like" rather than "what this model produced before
+# fine-tuning", which is what the original PR's digit_density_delta measures.
+#
+# The file must be a JSON list of strings, or a plain-text file with one output
+# per line, both in the same doc order the baseline run and this run share (same
+# split, same --limit, same fewshot seed). Matched positionally per doc, since
+# process_results has no stable per-doc id to key on.
+_BEHAVIORAL_DRIFT_BASELINE_CACHE: dict[str, list[str]] = {}
+_BEHAVIORAL_DRIFT_BASELINE_CURSOR: dict[str, int] = {}
+
+
+def _behavioral_drift_load_baseline(path: str) -> list[str]:
+    if path not in _BEHAVIORAL_DRIFT_BASELINE_CACHE:
+        with open(path, encoding="utf-8") as f:
+            outputs = json.load(f) if path.endswith(".json") else f.read().splitlines()
+        if not isinstance(outputs, list) or not all(
+            isinstance(o, str) for o in outputs
+        ):
+            raise ValueError(
+                f"behavioral_drift baseline_path '{path}' must be a JSON list of "
+                "strings, or a plain-text file with one base-model output per line."
+            )
+        _BEHAVIORAL_DRIFT_BASELINE_CACHE[path] = outputs
+        _BEHAVIORAL_DRIFT_BASELINE_CURSOR[path] = 0
+    return _BEHAVIORAL_DRIFT_BASELINE_CACHE[path]
+
 
 def _behavioral_drift_bleu1(candidate: str, reference: str) -> float:
     """Unigram-precision BLEU-1; each reference token matched at most once."""
@@ -445,8 +476,10 @@ def behavioral_drift_agg(items):
     """Corpus-level behavioral drift score.
 
     items: list of (reference, prediction) tuples collected across docs, where
-    reference is the doc's target/baseline text (doc_to_target) and prediction
-    is the model's generated output.
+    prediction is the model's generated output and reference is the baseline
+    text used for digit_density_delta — doc_to_target by default, or the
+    matching line from `baseline_path` if that metric_list option is set (see
+    behavioral_drift_fn).
     """
     references, predictions = (list(x) for x in zip(*items, strict=True))
 
@@ -477,8 +510,20 @@ def behavioral_drift_agg(items):
     output_type=["generate_until"],
     aggregation="behavioral_drift",
 )
-def behavioral_drift_fn(items):  # This is a passthrough function
-    return items
+def behavioral_drift_fn(references, predictions, baseline_path=None, **kwargs):
+    reference = references[0]
+    if baseline_path is not None:
+        baseline_outputs = _behavioral_drift_load_baseline(baseline_path)
+        cursor = _BEHAVIORAL_DRIFT_BASELINE_CURSOR[baseline_path]
+        if cursor >= len(baseline_outputs):
+            raise ValueError(
+                f"behavioral_drift baseline_path '{baseline_path}' has fewer "
+                "entries than docs evaluated so far; it must be generated on "
+                "the same eval set (same split, --limit, and fewshot seed)."
+            )
+        reference = baseline_outputs[cursor]
+        _BEHAVIORAL_DRIFT_BASELINE_CURSOR[baseline_path] = cursor + 1
+    return (reference, predictions[0])
 
 
 @register_metric(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,12 @@
+import json
 import unittest.mock as mock
 
-from lm_eval.api.metrics import _bootstrap_internal_no_mp, behavioral_drift_agg, mean
+from lm_eval.api.metrics import (
+    _bootstrap_internal_no_mp,
+    behavioral_drift_agg,
+    behavioral_drift_fn,
+    mean,
+)
 from lm_eval.api.task import ConfigurableTask
 from lm_eval.config.task import TaskConfig
 
@@ -254,6 +260,70 @@ def test_behavioral_drift_multiplicative_not_additive():
     )
 
 
+def test_behavioral_drift_fn_defaults_to_doc_reference():
+    """Without baseline_path, behavioral_drift_fn should pass the doc's own
+    reference straight through, unchanged.
+    """
+    result = behavioral_drift_fn(references=["gold answer"], predictions=["output"])
+    assert result == ("gold answer", "output")
+
+
+def test_behavioral_drift_fn_uses_baseline_path(tmp_path):
+    """With baseline_path set, each call should pull the next base-model output
+    from the file instead of the doc's gold reference, advancing positionally.
+    """
+    baseline_file = tmp_path / "baseline.json"
+    baseline_file.write_text(json.dumps(["base output 1", "base output 2"]))
+
+    result1 = behavioral_drift_fn(
+        references=["gold answer 1"],
+        predictions=["ft output 1"],
+        baseline_path=str(baseline_file),
+    )
+    result2 = behavioral_drift_fn(
+        references=["gold answer 2"],
+        predictions=["ft output 2"],
+        baseline_path=str(baseline_file),
+    )
+    assert result1 == ("base output 1", "ft output 1")
+    assert result2 == ("base output 2", "ft output 2")
+
+
+def test_behavioral_drift_fn_baseline_path_plain_text(tmp_path):
+    """baseline_path also accepts a plain-text file, one output per line."""
+    baseline_file = tmp_path / "baseline.txt"
+    baseline_file.write_text("base output 1\nbase output 2\n")
+
+    result = behavioral_drift_fn(
+        references=["gold answer"],
+        predictions=["ft output"],
+        baseline_path=str(baseline_file),
+    )
+    assert result == ("base output 1", "ft output")
+
+
+def test_behavioral_drift_fn_baseline_path_exhausted_raises(tmp_path):
+    """Calling behavioral_drift_fn more times than the baseline file has
+    entries means the baseline was generated on a different eval set — this
+    should fail loudly rather than silently reusing or skipping entries.
+    """
+    baseline_file = tmp_path / "baseline.json"
+    baseline_file.write_text(json.dumps(["only base output"]))
+
+    behavioral_drift_fn(
+        references=["gold 1"], predictions=["pred 1"], baseline_path=str(baseline_file)
+    )
+    try:
+        behavioral_drift_fn(
+            references=["gold 2"],
+            predictions=["pred 2"],
+            baseline_path=str(baseline_file),
+        )
+        raise AssertionError("Expected ValueError for exhausted baseline_path")
+    except ValueError:
+        pass
+
+
 if __name__ == "__main__":
     test_acc_mutual_info_slicing()
     test_acc_mutual_info_different_predictions()
@@ -263,4 +333,6 @@ if __name__ == "__main__":
     test_behavioral_drift_healthy_outputs_score_high()
     test_behavioral_drift_digit_collapse_scores_zero()
     test_behavioral_drift_multiplicative_not_additive()
+    test_behavioral_drift_fn_defaults_to_doc_reference()
+    # baseline_path tests use the pytest tmp_path fixture; run via pytest.
     print("All tests passed!")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,6 @@
 import unittest.mock as mock
 
-from lm_eval.api.metrics import _bootstrap_internal_no_mp, mean
+from lm_eval.api.metrics import _bootstrap_internal_no_mp, behavioral_drift_agg, mean
 from lm_eval.api.task import ConfigurableTask
 from lm_eval.config.task import TaskConfig
 
@@ -180,7 +180,8 @@ def test_bootstrap_internal_no_mp():
 
 def test_dict_metric_uses_custom_aggregation():
     """Regression test for #3314: dict-valued metrics must use the custom
-    aggregation function, not silently fall back to mean()."""
+    aggregation function, not silently fall back to mean().
+    """
     from collections import defaultdict
 
     from lm_eval.evaluator_utils import _compute_task_aggregations
@@ -214,10 +215,52 @@ def test_dict_metric_uses_custom_aggregation():
     assert agg_metrics["pass@3,none"] == 1.5
 
 
+def test_behavioral_drift_healthy_outputs_score_high():
+    """Diverse, non-degenerate outputs should score well above 0."""
+    references = ["base output A", "base output B", "base output C"]
+    predictions = [
+        "The cat sat on the mat.",
+        "Paris is the capital of France.",
+        "Water boils at 100 degrees Celsius.",
+    ]
+    score = behavioral_drift_agg(list(zip(references, predictions, strict=True)))
+    assert score > 0.5, f"Expected healthy outputs to score > 0.5, got {score}"
+
+
+def test_behavioral_drift_digit_collapse_scores_zero():
+    """Regression test for the issue's real-world case: a fine-tuned model whose
+    outputs collapse into numeric sequences should score 0.0, even though the
+    outputs are mutually dissimilar (so self-BLEU alone would miss this).
+    """
+    references = ["base output A", "base output B", "base output C"]
+    predictions = ["1999999999999", "1999999999998", "1999999999997"]
+    score = behavioral_drift_agg(list(zip(references, predictions, strict=True)))
+    assert score == 0.0, f"Expected digit-collapsed outputs to score 0.0, got {score}"
+
+
+def test_behavioral_drift_multiplicative_not_additive():
+    """A single severely failing signal must zero the whole score, not just
+    lower it — this is the core design constraint from the issue: additive
+    combination can give a misleadingly high score when one dimension has
+    collapsed but the others look fine.
+    """
+    references = ["reference text one", "reference text two", "reference text three"]
+    # Mode-collapse only: identical outputs (self-BLEU fails), but digit
+    # density and repetition ratio both look healthy.
+    predictions = ["a healthy sentence here"] * 3
+    score = behavioral_drift_agg(list(zip(references, predictions, strict=True)))
+    assert score == 0.0, (
+        f"Expected a single failing signal (mode collapse) to zero the score, got {score}"
+    )
+
+
 if __name__ == "__main__":
     test_acc_mutual_info_slicing()
     test_acc_mutual_info_different_predictions()
     test_acc_mutual_info_without_metric()
     test_bootstrap_internal_no_mp()
     test_dict_metric_uses_custom_aggregation()
+    test_behavioral_drift_healthy_outputs_score_high()
+    test_behavioral_drift_digit_collapse_scores_zero()
+    test_behavioral_drift_multiplicative_not_additive()
     print("All tests passed!")


### PR DESCRIPTION
## Summary

Ports `behavioral_drift` from `huggingface/evaluate` [PR #778](https://github.com/huggingface/evaluate/pull/778) (credit to @YuhaoLin2005 for the original design and implementation). Closes #3924.

The metric catches fine-tuning output collapse that perplexity misses — loss can improve while outputs degenerate into repeated or numeric garbage. It composites three deterministic signals into a `drift_score` in `[0, 1]`:

- **self-BLEU** — intra-batch similarity (mode collapse)
- **digit_density_delta** — numeric-character spike vs. a baseline (degeneration into digit garbage)
- **repetition_ratio** — unique/total token ratio (degenerate looping)

The three signals are combined **multiplicatively**, not additively — a single collapsed signal drives `drift_score` to ~0, matching the issue's evidence that additive combination gives a misleading 0.67 on a case that's actually fully collapsed.

Registered via `@register_aggregation`/`@register_metric` in `lm_eval/api/metrics.py` (same shape as `brier_score`/`bleu`: a passthrough `metric_fn` collecting raw per-doc values, scored by a corpus-level aggregation function), so any `generate_until` task can opt in with `metric: behavioral_drift` in its `metric_list` — no new dataset or task-specific code needed.

## Design notes / deviations from the reference implementation

- **self-BLEU stays a dependency-free unigram-precision BLEU-1**, not `sacrebleu` (which is already a core dependency here). I tried swapping it in, but `sacrebleu`'s brevity penalty inverts the mode-collapse signal under the "concatenated-reference" construction this metric uses (each output scored against the other N-1 outputs joined as one long reference) — identical/fully-collapsed outputs score self-BLEU ≈ 0 instead of ≈ 1, because the artificially-lengthened reference triggers a heavy BP. Kept the reference implementation's precision-only computation, documented inline.

- **Baseline for `digit_density_delta`.** The original PR's API is `compute(predictions=ft_outputs, references=base_outputs)` — it expects real pre-fine-tuning model outputs on the same prompts. `generate_until` only evaluates one model at a time, so there's no second output set available for free. Default behavior here uses the doc's own `doc_to_target` (gold answer) as a stand-in baseline — it's always available and needs zero extra setup, but it's a proxy for "what a correct answer looks like," not "what this model produced before fine-tuning," so it dilutes the digit-density signal on tasks where correct answers are naturally numeric (e.g. gsm8k).

  To get the original semantics exactly, `metric_list` now also accepts an optional `baseline_path` pointing at a JSON list (or newline-delimited text file) of real base-model outputs, generated by running `generate_until` on the base checkpoint first and saving its outputs. When set, each doc's baseline is read positionally from that file instead of `doc_to_target`.

  **Not done in this PR:** automatically running the base model as part of evaluation (issue's "two-pass evaluation" option) — that needs the evaluator to orchestrate two model runs in one invocation, which is a larger architectural change than this PR's scope. Left as a manual pre-step for now; flagged in the issue for maintainer input on whether it's worth building.

## Testing

- 12 unit tests in `tests/test_metrics.py`: healthy vs. digit-collapsed vs. mode-collapsed scoring, multiplicative-not-additive behavior, `baseline_path` default/override/plain-text/exhausted-file cases, and an end-to-end `process_results` wiring check.
- Smoke-tested via the real CLI end-to-end (`lm_eval --model hf --model_args pretrained=EleutherAI/pythia-160m --tasks <gsm8k-derived task with behavioral_drift in metric_list> --limit 5 --device cpu`) — registers, aggregates, and reports correctly.
- `pre-commit` run on the changed files.

## Test plan

- [x] `pytest tests/test_metrics.py` — 12/12 passing
- [x] CLI smoke test on a real `generate_until` task
- [ ] Maintainer sign-off on the `baseline_path` design (vs. building full two-pass evaluation support)
