### PR TITLE
fix: prevent ValueError when batch_size="auto:N" is passed to API models

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -167,11 +167,14 @@ class TemplateAPI(TemplateLM):
             eval_logger.warning(
                 "Automatic batch size is not supported for API models. Defaulting to batch size 1."
             )
+            self._batch_size = 1
         elif int(batch_size) > 1:
             eval_logger.warning(
                 "Batch size > 1 detected. Ensure your API supports batched requests with varying total sequence lengths."
             )
-        self._batch_size = int(batch_size) if batch_size != "auto" else 1
+            self._batch_size = int(batch_size)
+        else:
+            self._batch_size = int(batch_size)
         self._truncate = truncate
         self._max_gen_toks = int(max_gen_toks)
         self._seed = int(seed)


### PR DESCRIPTION
## Bug

`APIMixin.__init__` (and all models that inherit from it: `LocalCompletionsAPI`, `LocalChatCompletion`, etc.) crashes with a `ValueError` when the standard lm-eval `--batch_size auto:4` syntax is used.

### Reproduction

```bash
lm_eval --model local-completions         --model_args base_url=http://localhost:8080/v1         --batch_size auto:4         --tasks hellaswag
```

Traceback:
```
ValueError: invalid literal for int() with base 10: 'auto:4'
```

### Root cause

The code path in `api_models.py`:

```python
if not isinstance(batch_size, int) and "auto" in batch_size:
    eval_logger.warning(
        "Automatic batch size is not supported for API models. Defaulting to batch size 1."
    )
elif int(batch_size) > 1:
    ...
self._batch_size = int(batch_size) if batch_size != "auto" else 1   # <-- BUG
```

When `batch_size = "auto:4"`:
1. The `if` branch fires and logs the warning (correctly).
2. The final assignment evaluates `"auto:4" != "auto"` → `True`, so it calls `int("auto:4")` → **`ValueError`**.

The warning message already says "Defaulting to batch size 1", but the code never actually does that for the `auto:N` form.

## Fix

Move the `_batch_size` assignment into each branch of the conditional so the auto-detected case correctly sets `_batch_size = 1`:

```python
if not isinstance(batch_size, int) and "auto" in batch_size:
    eval_logger.warning(...)
    self._batch_size = 1          # honours the warning message
elif int(batch_size) > 1:
    eval_logger.warning(...)
    self._batch_size = int(batch_size)
else:
    self._batch_size = int(batch_size)
```