### PR TITLE
fix: prevent ValueError when batch_size="auto" is passed to neuronx model

### DIFF
--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -164,8 +164,15 @@ class NEURON_HF(TemplateLM):
         assert isinstance(pretrained, str)
         assert isinstance(batch_size, (int, str))
 
-        self.batch_size_per_gpu = int(batch_size)
-        batch_size = int(batch_size)
+        if isinstance(batch_size, str) and batch_size.startswith("auto"):
+            logger.warning(
+                "neuronx requires a static batch size compiled into the model graph; "
+                "'auto' batch size is not supported. Defaulting to batch_size=1."
+            )
+            batch_size = 1
+        else:
+            batch_size = int(batch_size)
+        self.batch_size_per_gpu = batch_size
 
         self._config = transformers.AutoConfig.from_pretrained(
             pretrained,


### PR DESCRIPTION
## Summary

`NEURON_HF.__init__` in `lm_eval/models/neuron_optimum.py` explicitly asserts
`isinstance(batch_size, (int, str))`, signalling that string values are
expected inputs, but then calls `int(batch_size)` unconditionally. Passing
`--batch_size auto` or `--batch_size auto:4` via the CLI therefore raises:

```
ValueError: invalid literal for int() with base 10: 'auto'
```

The neuronx backend compiles the model graph for a fixed batch size, so
adaptive batch sizing (`auto`) is not meaningful. The fix replaces the bare
`int()` calls with an explicit check: strings starting with `"auto"` now emit
a `logger.warning` and fall back to `batch_size=1`, consistent with the
pattern used by `trtllm` and `sglang` backends that also cannot support
adaptive batching.

## Changes

- `lm_eval/models/neuron_optimum.py`: guard the `int(batch_size)` conversion
  with an `"auto"` prefix check; log a warning and default to `1` when `auto`
  is passed.

## Before / After

```python
# Before — crashes for batch_size="auto" or "auto:4"
assert isinstance(batch_size, (int, str))
self.batch_size_per_gpu = int(batch_size)
batch_size = int(batch_size)

# After — accepted, warned, and clamped to 1
assert isinstance(batch_size, (int, str))
if isinstance(batch_size, str) and batch_size.startswith("auto"):
    logger.warning(
        "neuronx requires a static batch size compiled into the model graph; "
        "'auto' batch size is not supported. Defaulting to batch_size=1."
    )
    batch_size = 1
else:
    batch_size = int(batch_size)
self.batch_size_per_gpu = batch_size
```