### PR TITLE
fix(mmlusr): restore dataset loading for all 171 MMLU-SR tasks

### DIFF
--- a/lm_eval/tasks/mmlusr/answer_only/_mmlusr_a_yml
+++ b/lm_eval/tasks/mmlusr/answer_only/_mmlusr_a_yml
@@ -1,6 +1,4 @@
 dataset_path: NiniCat/MMLU-SR
-dataset_kwargs:
-  revision: bd6827d2542e9d6cf1d58ce262ce0b9ad7742754
 test_split: test
 fewshot_split: train
 fewshot_config:

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_abstract_algebra.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_abstract_algebra.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_abstract_algebra"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_abstract_algebra_dev.csv"
+    "test": "answer_only_test/answer_only_abstract_algebra_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about abstract\
   \ algebra.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_anatomy.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_anatomy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_anatomy"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_anatomy_dev.csv"
+    "test": "answer_only_test/answer_only_anatomy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about anatomy.\n\
   \n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_astronomy.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_astronomy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_astronomy"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_astronomy_dev.csv"
+    "test": "answer_only_test/answer_only_astronomy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about astronomy.\n\
   \n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_business_ethics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_business_ethics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_business_ethics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_business_ethics_dev.csv"
+    "test": "answer_only_test/answer_only_business_ethics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about business\
   \ ethics.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_clinical_knowledge.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_clinical_knowledge.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_clinical_knowledge"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_clinical_knowledge_dev.csv"
+    "test": "answer_only_test/answer_only_clinical_knowledge_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about clinical\
   \ knowledge.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_college_biology.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_college_biology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_college_biology"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_college_biology_dev.csv"
+    "test": "answer_only_test/answer_only_college_biology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ biology.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_college_chemistry.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_college_chemistry.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_college_chemistry"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_college_chemistry_dev.csv"
+    "test": "answer_only_test/answer_only_college_chemistry_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ chemistry.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_college_computer_science.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_college_computer_science.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_college_computer_science"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_college_computer_science_dev.csv"
+    "test": "answer_only_test/answer_only_college_computer_science_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ computer science.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_college_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_college_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_college_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_college_mathematics_dev.csv"
+    "test": "answer_only_test/answer_only_college_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ mathematics.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_college_medicine.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_college_medicine.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_college_medicine"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_college_medicine_dev.csv"
+    "test": "answer_only_test/answer_only_college_medicine_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ medicine.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_college_physics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_college_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_college_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_college_physics_dev.csv"
+    "test": "answer_only_test/answer_only_college_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ physics.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_computer_security.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_computer_security.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_computer_security"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_computer_security_dev.csv"
+    "test": "answer_only_test/answer_only_computer_security_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about computer\
   \ security.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_conceptual_physics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_conceptual_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_conceptual_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_conceptual_physics_dev.csv"
+    "test": "answer_only_test/answer_only_conceptual_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about conceptual\
   \ physics.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_econometrics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_econometrics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_econometrics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_econometrics_dev.csv"
+    "test": "answer_only_test/answer_only_econometrics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about econometrics.\n\
   \n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_electrical_engineering.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_electrical_engineering.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_electrical_engineering"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_electrical_engineering_dev.csv"
+    "test": "answer_only_test/answer_only_electrical_engineering_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about electrical\
   \ engineering.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_elementary_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_elementary_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_elementary_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_elementary_mathematics_dev.csv"
+    "test": "answer_only_test/answer_only_elementary_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about elementary\
   \ mathematics.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_formal_logic.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_formal_logic.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_formal_logic"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_formal_logic_dev.csv"
+    "test": "answer_only_test/answer_only_formal_logic_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about formal\
   \ logic.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_global_facts.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_global_facts.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_global_facts"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_global_facts_dev.csv"
+    "test": "answer_only_test/answer_only_global_facts_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about global\
   \ facts.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_biology.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_biology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_biology"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_biology_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_biology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school biology.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_chemistry.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_chemistry.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_chemistry"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_chemistry_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_chemistry_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school chemistry.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_computer_science.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_computer_science.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_computer_science"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_computer_science_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_computer_science_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school computer science.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_european_history.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_european_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_european_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_european_history_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_european_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school european history.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_geography.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_geography.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_geography"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_geography_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_geography_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school geography.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_government_and_politics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_government_and_politics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_government_and_politics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_government_and_politics_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_government_and_politics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school government and politics.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_macroeconomics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_macroeconomics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_macroeconomics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_macroeconomics_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_macroeconomics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school macroeconomics.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_mathematics_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school mathematics.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_microeconomics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_microeconomics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_microeconomics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_microeconomics_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_microeconomics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school microeconomics.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_physics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_physics_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school physics.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_psychology.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_psychology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_psychology"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_psychology_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_psychology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school psychology.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_statistics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_statistics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_statistics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_statistics_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_statistics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school statistics.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_us_history.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_us_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_us_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_us_history_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_us_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school us history.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_world_history.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_high_school_world_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_high_school_world_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_high_school_world_history_dev.csv"
+    "test": "answer_only_test/answer_only_high_school_world_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school world history.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_human_aging.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_human_aging.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_human_aging"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_human_aging_dev.csv"
+    "test": "answer_only_test/answer_only_human_aging_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about human\
   \ aging.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_human_sexuality.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_human_sexuality.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_human_sexuality"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_human_sexuality_dev.csv"
+    "test": "answer_only_test/answer_only_human_sexuality_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about human\
   \ sexuality.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_international_law.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_international_law.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_international_law"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_international_law_dev.csv"
+    "test": "answer_only_test/answer_only_international_law_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about international\
   \ law.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_jurisprudence.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_jurisprudence.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_jurisprudence"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_jurisprudence_dev.csv"
+    "test": "answer_only_test/answer_only_jurisprudence_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about jurisprudence.\n\
   \n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_logical_fallacies.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_logical_fallacies.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_logical_fallacies"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_logical_fallacies_dev.csv"
+    "test": "answer_only_test/answer_only_logical_fallacies_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about logical\
   \ fallacies.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_machine_learning.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_machine_learning.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_machine_learning"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_machine_learning_dev.csv"
+    "test": "answer_only_test/answer_only_machine_learning_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about machine\
   \ learning.\n\n"
 "tag": "mmlusr_answer_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_management.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_management.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_management"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_management_dev.csv"
+    "test": "answer_only_test/answer_only_management_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about management.\n\
   \n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_marketing.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_marketing.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_marketing"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_marketing_dev.csv"
+    "test": "answer_only_test/answer_only_marketing_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about marketing.\n\
   \n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_medical_genetics.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_medical_genetics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_medical_genetics"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_medical_genetics_dev.csv"
+    "test": "answer_only_test/answer_only_medical_genetics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about medical\
   \ genetics.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_miscellaneous.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_miscellaneous.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_miscellaneous"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_miscellaneous_dev.csv"
+    "test": "answer_only_test/answer_only_miscellaneous_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about miscellaneous.\n\
   \n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_moral_disputes.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_moral_disputes.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_moral_disputes"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_moral_disputes_dev.csv"
+    "test": "answer_only_test/answer_only_moral_disputes_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about moral\
   \ disputes.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_moral_scenarios.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_moral_scenarios.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_moral_scenarios"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_moral_scenarios_dev.csv"
+    "test": "answer_only_test/answer_only_moral_scenarios_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about moral\
   \ scenarios.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_nutrition.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_nutrition.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_nutrition"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_nutrition_dev.csv"
+    "test": "answer_only_test/answer_only_nutrition_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about nutrition.\n\
   \n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_philosophy.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_philosophy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_philosophy"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_philosophy_dev.csv"
+    "test": "answer_only_test/answer_only_philosophy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about philosophy.\n\
   \n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_prehistory.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_prehistory.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_prehistory"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_prehistory_dev.csv"
+    "test": "answer_only_test/answer_only_prehistory_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about prehistory.\n\
   \n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_accounting.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_accounting.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_professional_accounting"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_professional_accounting_dev.csv"
+    "test": "answer_only_test/answer_only_professional_accounting_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ accounting.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_law.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_law.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_professional_law"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_professional_law_dev.csv"
+    "test": "answer_only_test/answer_only_professional_law_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ law.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_medicine.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_medicine.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_professional_medicine"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_professional_medicine_dev.csv"
+    "test": "answer_only_test/answer_only_professional_medicine_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ medicine.\n\n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_psychology.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_professional_psychology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_professional_psychology"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_professional_psychology_dev.csv"
+    "test": "answer_only_test/answer_only_professional_psychology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ psychology.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_public_relations.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_public_relations.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_public_relations"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_public_relations_dev.csv"
+    "test": "answer_only_test/answer_only_public_relations_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about public\
   \ relations.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_security_studies.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_security_studies.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_security_studies"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_security_studies_dev.csv"
+    "test": "answer_only_test/answer_only_security_studies_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about security\
   \ studies.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_sociology.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_sociology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_sociology"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_sociology_dev.csv"
+    "test": "answer_only_test/answer_only_sociology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about sociology.\n\
   \n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_us_foreign_policy.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_us_foreign_policy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_us_foreign_policy"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_us_foreign_policy_dev.csv"
+    "test": "answer_only_test/answer_only_us_foreign_policy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about us\
   \ foreign policy.\n\n"
 "tag": "mmlusr_answer_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_virology.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_virology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_virology"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_virology_dev.csv"
+    "test": "answer_only_test/answer_only_virology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about virology.\n\
   \n"
 "tag": "mmlusr_answer_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/answer_only_world_religions.yaml
+++ b/lm_eval/tasks/mmlusr/answer_only/answer_only_world_religions.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "answer_only_world_religions"
+"dataset_kwargs":
+  "data_files":
+    "train": "answer_only_dev/answer_only_world_religions_dev.csv"
+    "test": "answer_only_test/answer_only_world_religions_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about world\
   \ religions.\n\n"
 "tag": "mmlusr_answer_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/answer_only/utils.py
+++ b/lm_eval/tasks/mmlusr/answer_only/utils.py
@@ -3,16 +3,18 @@ import datasets
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     def _helper(doc):
-        # Assuming that the 'answer' field in the dataset now contains numbers 0-3 instead of 'A', 'B', 'C', 'D'
-        answer_list = ["A", "B", "C", "D"]
-        # Convert numeric index to corresponding letter
-        answer_index = int(doc["answer"])  # Make sure the answer is an integer
-        answer_letter = answer_list[answer_index]
-
+        # The published CSVs carry no header row and store the answer as a
+        # letter, so the columns are named in the task config and used as-is.
+        # A handful of rows upstream have an empty choice, which the CSV
+        # reader hands back as None.
         out_doc = {
-            "questions": doc["question"],
-            "choices": [doc["choice1"], doc["choice2"], doc["choice3"], doc["choice4"]],
-            "answer": answer_letter,  # Include the letter for clarity
+            "choices": [
+                doc["choice1"] or "",
+                doc["choice2"] or "",
+                doc["choice3"] or "",
+                doc["choice4"] or "",
+            ],
+            "answer": (doc["answer"] or "").strip(),
         }
         return out_doc
 

--- a/lm_eval/tasks/mmlusr/config.py
+++ b/lm_eval/tasks/mmlusr/config.py
@@ -73,7 +73,7 @@ SUBJECTS = {
     "world_religions": "humanities",
 }
 
-GROUPS = ["question_and_answer"]
+GROUPS = ["answer_only", "question_only", "question_and_answer"]
 
 
 def parse_args():
@@ -101,6 +101,10 @@ def parse_args():
     # Optional prefix to add to group names in the YAML files
     parser.add_argument("--group_prefix", default="")
 
+    # Which MMLU-SR variant to generate. Each one lives in its own directory
+    # and reads its own base YAML.
+    parser.add_argument("--group", choices=GROUPS, default=None)
+
     return parser.parse_args()
 
 
@@ -108,9 +112,9 @@ if __name__ == "__main__":
     args = parse_args()
 
     # Load base YAML configuration
+    # Only the file name is needed, for the "include" key. Parsing the base
+    # YAML here used to fail anyway, since it carries a !function tag.
     base_yaml_name = os.path.basename(args.base_yaml_path)
-    with open(args.base_yaml_path, "r", encoding="utf-8") as f:
-        base_yaml = yaml.full_load(f)
 
     if args.cot_prompt_path is not None:
         import json
@@ -118,7 +122,7 @@ if __name__ == "__main__":
         with open(args.cot_prompt_path, encoding="utf-8") as f:
             cot_file = json.load(f)
 
-    for group in GROUPS:
+    for group in [args.group] if args.group else GROUPS:
         for subject, category in tqdm(SUBJECTS.items()):
             if args.cot_prompt_path is not None:
                 description = cot_file[subject]
@@ -135,7 +139,24 @@ if __name__ == "__main__":
                 else f"mmlusr_{group}_{subject}",
                 "task_alias": subject.replace("_", " "),
                 "description": description,
-                "dataset_name": f"{group}_{subject}",
+                # The Hub repo no longer exposes a config per subject, so each
+                # task reads that subject's CSVs directly. They have no header
+                # row, hence the explicit column names.
+                "dataset_kwargs": {
+                    "data_files": {
+                        "train": f"{group}_dev/{group}_{subject}_dev.csv",
+                        "test": f"{group}_test/{group}_{subject}_test.csv",
+                    },
+                    "column_names": [
+                        "question",
+                        "choice1",
+                        "choice2",
+                        "choice3",
+                        "choice4",
+                        "answer",
+                    ],
+                    "header": None,
+                },
             }
 
             # File path for saving the generated YAML file

--- a/lm_eval/tasks/mmlusr/question_and_answer/_mmlusr_qna_yml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/_mmlusr_qna_yml
@@ -1,6 +1,4 @@
 dataset_path: NiniCat/MMLU-SR
-dataset_kwargs:
-  revision: bd6827d2542e9d6cf1d58ce262ce0b9ad7742754
 test_split: test
 fewshot_split: train
 fewshot_config:

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_abstract_algebra.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_abstract_algebra.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_abstract_algebra"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_abstract_algebra_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_abstract_algebra_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about abstract\
   \ algebra.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_anatomy.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_anatomy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_anatomy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_anatomy_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_anatomy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about anatomy.\n\
   \n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_astronomy.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_astronomy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_astronomy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_astronomy_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_astronomy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about astronomy.\n\
   \n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_business_ethics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_business_ethics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_business_ethics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_business_ethics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_business_ethics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about business\
   \ ethics.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_clinical_knowledge.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_clinical_knowledge.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_clinical_knowledge"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_clinical_knowledge_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_clinical_knowledge_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about clinical\
   \ knowledge.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_biology.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_biology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_college_biology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_college_biology_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_college_biology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ biology.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_chemistry.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_chemistry.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_college_chemistry"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_college_chemistry_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_college_chemistry_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ chemistry.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_computer_science.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_computer_science.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_college_computer_science"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_college_computer_science_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_college_computer_science_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ computer science.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_college_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_college_mathematics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_college_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ mathematics.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_medicine.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_medicine.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_college_medicine"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_college_medicine_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_college_medicine_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ medicine.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_physics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_college_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_college_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_college_physics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_college_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ physics.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_computer_security.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_computer_security.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_computer_security"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_computer_security_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_computer_security_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about computer\
   \ security.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_conceptual_physics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_conceptual_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_conceptual_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_conceptual_physics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_conceptual_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about conceptual\
   \ physics.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_econometrics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_econometrics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_econometrics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_econometrics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_econometrics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about econometrics.\n\
   \n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_electrical_engineering.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_electrical_engineering.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_electrical_engineering"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_electrical_engineering_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_electrical_engineering_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about electrical\
   \ engineering.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_elementary_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_elementary_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_elementary_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_elementary_mathematics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_elementary_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about elementary\
   \ mathematics.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_formal_logic.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_formal_logic.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_formal_logic"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_formal_logic_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_formal_logic_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about formal\
   \ logic.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_global_facts.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_global_facts.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_global_facts"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_global_facts_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_global_facts_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about global\
   \ facts.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_biology.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_biology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_biology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_biology_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_biology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school biology.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_chemistry.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_chemistry.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_chemistry"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_chemistry_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_chemistry_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school chemistry.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_computer_science.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_computer_science.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_computer_science"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_computer_science_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_computer_science_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school computer science.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_european_history.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_european_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_european_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_european_history_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_european_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school european history.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_geography.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_geography.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_geography"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_geography_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_geography_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school geography.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_government_and_politics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_government_and_politics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_government_and_politics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_government_and_politics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_government_and_politics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school government and politics.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_macroeconomics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_macroeconomics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_macroeconomics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_macroeconomics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_macroeconomics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school macroeconomics.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_mathematics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school mathematics.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_microeconomics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_microeconomics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_microeconomics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_microeconomics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_microeconomics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school microeconomics.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_physics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_physics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school physics.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_psychology.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_psychology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_psychology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_psychology_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_psychology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school psychology.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_statistics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_statistics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_statistics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_statistics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_statistics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school statistics.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_us_history.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_us_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_us_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_us_history_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_us_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school us history.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_world_history.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_high_school_world_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_high_school_world_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_high_school_world_history_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_high_school_world_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school world history.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_human_aging.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_human_aging.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_human_aging"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_human_aging_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_human_aging_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about human\
   \ aging.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_human_sexuality.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_human_sexuality.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_human_sexuality"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_human_sexuality_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_human_sexuality_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about human\
   \ sexuality.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_international_law.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_international_law.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_international_law"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_international_law_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_international_law_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about international\
   \ law.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_jurisprudence.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_jurisprudence.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_jurisprudence"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_jurisprudence_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_jurisprudence_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about jurisprudence.\n\
   \n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_logical_fallacies.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_logical_fallacies.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_logical_fallacies"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_logical_fallacies_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_logical_fallacies_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about logical\
   \ fallacies.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_machine_learning.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_machine_learning.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_machine_learning"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_machine_learning_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_machine_learning_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about machine\
   \ learning.\n\n"
 "tag": "mmlusr_question_and_answer_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_management.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_management.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_management"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_management_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_management_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about management.\n\
   \n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_marketing.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_marketing.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_marketing"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_marketing_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_marketing_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about marketing.\n\
   \n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_medical_genetics.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_medical_genetics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_medical_genetics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_medical_genetics_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_medical_genetics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about medical\
   \ genetics.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_miscellaneous.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_miscellaneous.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_miscellaneous"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_miscellaneous_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_miscellaneous_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about miscellaneous.\n\
   \n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_moral_disputes.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_moral_disputes.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_moral_disputes"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_moral_disputes_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_moral_disputes_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about moral\
   \ disputes.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_moral_scenarios.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_moral_scenarios.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_moral_scenarios"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_moral_scenarios_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_moral_scenarios_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about moral\
   \ scenarios.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_nutrition.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_nutrition.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_nutrition"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_nutrition_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_nutrition_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about nutrition.\n\
   \n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_philosophy.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_philosophy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_philosophy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_philosophy_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_philosophy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about philosophy.\n\
   \n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_prehistory.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_prehistory.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_prehistory"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_prehistory_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_prehistory_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about prehistory.\n\
   \n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_accounting.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_accounting.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_professional_accounting"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_professional_accounting_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_professional_accounting_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ accounting.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_law.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_law.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_professional_law"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_professional_law_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_professional_law_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ law.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_medicine.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_medicine.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_professional_medicine"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_professional_medicine_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_professional_medicine_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ medicine.\n\n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_psychology.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_professional_psychology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_professional_psychology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_professional_psychology_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_professional_psychology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ psychology.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_public_relations.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_public_relations.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_public_relations"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_public_relations_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_public_relations_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about public\
   \ relations.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_security_studies.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_security_studies.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_security_studies"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_security_studies_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_security_studies_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about security\
   \ studies.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_sociology.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_sociology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_sociology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_sociology_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_sociology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about sociology.\n\
   \n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_us_foreign_policy.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_us_foreign_policy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_us_foreign_policy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_us_foreign_policy_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_us_foreign_policy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about us\
   \ foreign policy.\n\n"
 "tag": "mmlusr_question_and_answer_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_virology.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_virology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_virology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_virology_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_virology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about virology.\n\
   \n"
 "tag": "mmlusr_question_and_answer_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_world_religions.yaml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/question_and_answer_world_religions.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_and_answer_world_religions"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_and_answer_dev/question_and_answer_world_religions_dev.csv"
+    "test": "question_and_answer_test/question_and_answer_world_religions_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about world\
   \ religions.\n\n"
 "tag": "mmlusr_question_and_answer_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_and_answer/utils.py
+++ b/lm_eval/tasks/mmlusr/question_and_answer/utils.py
@@ -3,16 +3,18 @@ import datasets
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     def _helper(doc):
-        # Assuming that the 'answer' field in the dataset now contains numbers 0-3 instead of 'A', 'B', 'C', 'D'
-        answer_list = ["A", "B", "C", "D"]
-        # Convert numeric index to corresponding letter
-        answer_index = int(doc["answer"])  # Make sure the answer is an integer
-        answer_letter = answer_list[answer_index]
-
+        # The published CSVs carry no header row and store the answer as a
+        # letter, so the columns are named in the task config and used as-is.
+        # A handful of rows upstream have an empty choice, which the CSV
+        # reader hands back as None.
         out_doc = {
-            "questions": doc["question"],
-            "choices": [doc["choice1"], doc["choice2"], doc["choice3"], doc["choice4"]],
-            "answer": answer_letter,  # Include the letter for clarity
+            "choices": [
+                doc["choice1"] or "",
+                doc["choice2"] or "",
+                doc["choice3"] or "",
+                doc["choice4"] or "",
+            ],
+            "answer": (doc["answer"] or "").strip(),
         }
         return out_doc
 

--- a/lm_eval/tasks/mmlusr/question_only/_mmlusr_q_yml
+++ b/lm_eval/tasks/mmlusr/question_only/_mmlusr_q_yml
@@ -1,6 +1,4 @@
 dataset_path: NiniCat/MMLU-SR
-dataset_kwargs:
-  revision: bd6827d2542e9d6cf1d58ce262ce0b9ad7742754
 test_split: test
 fewshot_split: train
 fewshot_config:

--- a/lm_eval/tasks/mmlusr/question_only/question_only_abstract_algebra.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_abstract_algebra.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_abstract_algebra"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_abstract_algebra_dev.csv"
+    "test": "question_only_test/question_only_abstract_algebra_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about abstract\
   \ algebra.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_anatomy.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_anatomy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_anatomy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_anatomy_dev.csv"
+    "test": "question_only_test/question_only_anatomy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about anatomy.\n\
   \n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_astronomy.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_astronomy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_astronomy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_astronomy_dev.csv"
+    "test": "question_only_test/question_only_astronomy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about astronomy.\n\
   \n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_business_ethics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_business_ethics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_business_ethics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_business_ethics_dev.csv"
+    "test": "question_only_test/question_only_business_ethics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about business\
   \ ethics.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_clinical_knowledge.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_clinical_knowledge.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_clinical_knowledge"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_clinical_knowledge_dev.csv"
+    "test": "question_only_test/question_only_clinical_knowledge_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about clinical\
   \ knowledge.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_college_biology.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_college_biology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_college_biology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_college_biology_dev.csv"
+    "test": "question_only_test/question_only_college_biology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ biology.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_college_chemistry.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_college_chemistry.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_college_chemistry"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_college_chemistry_dev.csv"
+    "test": "question_only_test/question_only_college_chemistry_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ chemistry.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_college_computer_science.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_college_computer_science.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_college_computer_science"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_college_computer_science_dev.csv"
+    "test": "question_only_test/question_only_college_computer_science_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ computer science.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_college_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_college_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_college_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_college_mathematics_dev.csv"
+    "test": "question_only_test/question_only_college_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ mathematics.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_college_medicine.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_college_medicine.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_college_medicine"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_college_medicine_dev.csv"
+    "test": "question_only_test/question_only_college_medicine_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ medicine.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_college_physics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_college_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_college_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_college_physics_dev.csv"
+    "test": "question_only_test/question_only_college_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about college\
   \ physics.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_computer_security.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_computer_security.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_computer_security"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_computer_security_dev.csv"
+    "test": "question_only_test/question_only_computer_security_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about computer\
   \ security.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_conceptual_physics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_conceptual_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_conceptual_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_conceptual_physics_dev.csv"
+    "test": "question_only_test/question_only_conceptual_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about conceptual\
   \ physics.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_econometrics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_econometrics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_econometrics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_econometrics_dev.csv"
+    "test": "question_only_test/question_only_econometrics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about econometrics.\n\
   \n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_electrical_engineering.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_electrical_engineering.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_electrical_engineering"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_electrical_engineering_dev.csv"
+    "test": "question_only_test/question_only_electrical_engineering_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about electrical\
   \ engineering.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_elementary_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_elementary_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_elementary_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_elementary_mathematics_dev.csv"
+    "test": "question_only_test/question_only_elementary_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about elementary\
   \ mathematics.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_formal_logic.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_formal_logic.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_formal_logic"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_formal_logic_dev.csv"
+    "test": "question_only_test/question_only_formal_logic_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about formal\
   \ logic.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_global_facts.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_global_facts.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_global_facts"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_global_facts_dev.csv"
+    "test": "question_only_test/question_only_global_facts_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about global\
   \ facts.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_biology.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_biology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_biology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_biology_dev.csv"
+    "test": "question_only_test/question_only_high_school_biology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school biology.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_chemistry.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_chemistry.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_chemistry"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_chemistry_dev.csv"
+    "test": "question_only_test/question_only_high_school_chemistry_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school chemistry.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_computer_science.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_computer_science.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_computer_science"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_computer_science_dev.csv"
+    "test": "question_only_test/question_only_high_school_computer_science_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school computer science.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_european_history.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_european_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_european_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_european_history_dev.csv"
+    "test": "question_only_test/question_only_high_school_european_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school european history.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_geography.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_geography.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_geography"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_geography_dev.csv"
+    "test": "question_only_test/question_only_high_school_geography_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school geography.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_government_and_politics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_government_and_politics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_government_and_politics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_government_and_politics_dev.csv"
+    "test": "question_only_test/question_only_high_school_government_and_politics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school government and politics.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_macroeconomics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_macroeconomics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_macroeconomics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_macroeconomics_dev.csv"
+    "test": "question_only_test/question_only_high_school_macroeconomics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school macroeconomics.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_mathematics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_mathematics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_mathematics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_mathematics_dev.csv"
+    "test": "question_only_test/question_only_high_school_mathematics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school mathematics.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_microeconomics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_microeconomics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_microeconomics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_microeconomics_dev.csv"
+    "test": "question_only_test/question_only_high_school_microeconomics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school microeconomics.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_physics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_physics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_physics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_physics_dev.csv"
+    "test": "question_only_test/question_only_high_school_physics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school physics.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_psychology.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_psychology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_psychology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_psychology_dev.csv"
+    "test": "question_only_test/question_only_high_school_psychology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school psychology.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_statistics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_statistics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_statistics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_statistics_dev.csv"
+    "test": "question_only_test/question_only_high_school_statistics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school statistics.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_us_history.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_us_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_us_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_us_history_dev.csv"
+    "test": "question_only_test/question_only_high_school_us_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school us history.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_high_school_world_history.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_high_school_world_history.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_high_school_world_history"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_high_school_world_history_dev.csv"
+    "test": "question_only_test/question_only_high_school_world_history_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about high\
   \ school world history.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_human_aging.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_human_aging.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_human_aging"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_human_aging_dev.csv"
+    "test": "question_only_test/question_only_human_aging_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about human\
   \ aging.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_human_sexuality.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_human_sexuality.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_human_sexuality"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_human_sexuality_dev.csv"
+    "test": "question_only_test/question_only_human_sexuality_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about human\
   \ sexuality.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_international_law.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_international_law.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_international_law"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_international_law_dev.csv"
+    "test": "question_only_test/question_only_international_law_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about international\
   \ law.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_jurisprudence.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_jurisprudence.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_jurisprudence"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_jurisprudence_dev.csv"
+    "test": "question_only_test/question_only_jurisprudence_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about jurisprudence.\n\
   \n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_logical_fallacies.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_logical_fallacies.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_logical_fallacies"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_logical_fallacies_dev.csv"
+    "test": "question_only_test/question_only_logical_fallacies_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about logical\
   \ fallacies.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_machine_learning.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_machine_learning.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_machine_learning"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_machine_learning_dev.csv"
+    "test": "question_only_test/question_only_machine_learning_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about machine\
   \ learning.\n\n"
 "tag": "mmlusr_question_only_stem_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_management.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_management.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_management"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_management_dev.csv"
+    "test": "question_only_test/question_only_management_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about management.\n\
   \n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_marketing.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_marketing.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_marketing"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_marketing_dev.csv"
+    "test": "question_only_test/question_only_marketing_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about marketing.\n\
   \n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_medical_genetics.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_medical_genetics.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_medical_genetics"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_medical_genetics_dev.csv"
+    "test": "question_only_test/question_only_medical_genetics_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about medical\
   \ genetics.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_miscellaneous.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_miscellaneous.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_miscellaneous"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_miscellaneous_dev.csv"
+    "test": "question_only_test/question_only_miscellaneous_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about miscellaneous.\n\
   \n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_moral_disputes.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_moral_disputes.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_moral_disputes"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_moral_disputes_dev.csv"
+    "test": "question_only_test/question_only_moral_disputes_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about moral\
   \ disputes.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_moral_scenarios.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_moral_scenarios.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_moral_scenarios"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_moral_scenarios_dev.csv"
+    "test": "question_only_test/question_only_moral_scenarios_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about moral\
   \ scenarios.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_nutrition.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_nutrition.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_nutrition"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_nutrition_dev.csv"
+    "test": "question_only_test/question_only_nutrition_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about nutrition.\n\
   \n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_philosophy.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_philosophy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_philosophy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_philosophy_dev.csv"
+    "test": "question_only_test/question_only_philosophy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about philosophy.\n\
   \n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_prehistory.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_prehistory.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_prehistory"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_prehistory_dev.csv"
+    "test": "question_only_test/question_only_prehistory_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about prehistory.\n\
   \n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_professional_accounting.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_professional_accounting.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_professional_accounting"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_professional_accounting_dev.csv"
+    "test": "question_only_test/question_only_professional_accounting_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ accounting.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_professional_law.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_professional_law.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_professional_law"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_professional_law_dev.csv"
+    "test": "question_only_test/question_only_professional_law_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ law.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_professional_medicine.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_professional_medicine.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_professional_medicine"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_professional_medicine_dev.csv"
+    "test": "question_only_test/question_only_professional_medicine_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ medicine.\n\n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_professional_psychology.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_professional_psychology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_professional_psychology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_professional_psychology_dev.csv"
+    "test": "question_only_test/question_only_professional_psychology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about professional\
   \ psychology.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_public_relations.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_public_relations.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_public_relations"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_public_relations_dev.csv"
+    "test": "question_only_test/question_only_public_relations_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about public\
   \ relations.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_security_studies.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_security_studies.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_security_studies"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_security_studies_dev.csv"
+    "test": "question_only_test/question_only_security_studies_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about security\
   \ studies.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_sociology.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_sociology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_sociology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_sociology_dev.csv"
+    "test": "question_only_test/question_only_sociology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about sociology.\n\
   \n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_us_foreign_policy.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_us_foreign_policy.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_us_foreign_policy"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_us_foreign_policy_dev.csv"
+    "test": "question_only_test/question_only_us_foreign_policy_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about us\
   \ foreign policy.\n\n"
 "tag": "mmlusr_question_only_social_sciences_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_virology.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_virology.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_virology"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_virology_dev.csv"
+    "test": "question_only_test/question_only_virology_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about virology.\n\
   \n"
 "tag": "mmlusr_question_only_other_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/question_only_world_religions.yaml
+++ b/lm_eval/tasks/mmlusr/question_only/question_only_world_religions.yaml
@@ -1,4 +1,9 @@
-"dataset_name": "question_only_world_religions"
+"dataset_kwargs":
+  "data_files":
+    "train": "question_only_dev/question_only_world_religions_dev.csv"
+    "test": "question_only_test/question_only_world_religions_test.csv"
+  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
+  "header": null
 "description": "The following are multiple choice questions (with answers) about world\
   \ religions.\n\n"
 "tag": "mmlusr_question_only_humanities_tasks"

--- a/lm_eval/tasks/mmlusr/question_only/utils.py
+++ b/lm_eval/tasks/mmlusr/question_only/utils.py
@@ -3,16 +3,18 @@ import datasets
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
     def _helper(doc):
-        # Assuming that the 'answer' field in the dataset now contains numbers 0-3 instead of 'A', 'B', 'C', 'D'
-        answer_list = ["A", "B", "C", "D"]
-        # Convert numeric index to corresponding letter
-        answer_index = int(doc["answer"])  # Make sure the answer is an integer
-        answer_letter = answer_list[answer_index]
-
+        # The published CSVs carry no header row and store the answer as a
+        # letter, so the columns are named in the task config and used as-is.
+        # A handful of rows upstream have an empty choice, which the CSV
+        # reader hands back as None.
         out_doc = {
-            "questions": doc["question"],
-            "choices": [doc["choice1"], doc["choice2"], doc["choice3"], doc["choice4"]],
-            "answer": answer_letter,  # Include the letter for clarity
+            "choices": [
+                doc["choice1"] or "",
+                doc["choice2"] or "",
+                doc["choice3"] or "",
+                doc["choice4"] or "",
+            ],
+            "answer": (doc["answer"] or "").strip(),
         }
         return out_doc
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,7 +22,6 @@ def get_new_tasks_else_default():
     Check if any modifications have been made to built-in tasks and return
     the list, otherwise return the default task list
     """
-    global TASKS
     # CI: new_tasks checks if any modifications have been made
     task_list = new_tasks()
     # Check if task_classes is empty
@@ -57,7 +56,9 @@ class BaseTasks:
     """
 
     def test_download(self, task_class: ConfigurableTask):
-        task_class.download()
+        # Pass the task's own dataset_kwargs, the same way __init__ does.
+        # Without them a task that relies on e.g. data_files cannot be loaded.
+        task_class.download(task_class.config.dataset_kwargs)
         assert task_class.dataset is not None
 
     def test_has_training_docs(self, task_class: ConfigurableTask):


### PR DESCRIPTION
## Summary

Every `mmlusr_*` task (171 of them) fails to load on current main. Fixes #3289.

```
$ lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks mmlusr_answer_only_anatomy --limit 1
RuntimeError: Dataset scripts are no longer supported, but found MMLU-SR.py
```

There are two separate reasons, and both need fixing:

1. The configs pin `revision: bd6827d2`, which is a loading-script revision of `NiniCat/MMLU-SR`. `datasets>=4` will not run dataset scripts, so the pin added in #3350 no longer loads at all.
2. The Hub repo no longer publishes one config per subject. It now has three (`answer_only`, `question_only`, `question_and_answer`), so the existing `dataset_name` values such as `answer_only_abstract_algebra` do not resolve either:

```
ValueError: BuilderConfig 'answer_only_abstract_algebra' not found.
Available: ['answer_only', 'question_only', 'question_and_answer']
```

## What this changes

Each task now reads its own subject CSV through `data_files`, which is the one addressing scheme the repo still exposes per subject:

```yaml
"dataset_kwargs":
  "data_files":
    "train": "answer_only_dev/answer_only_anatomy_dev.csv"
    "test": "answer_only_test/answer_only_anatomy_test.csv"
  "column_names": ["question", "choice1", "choice2", "choice3", "choice4", "answer"]
  "header": null
```

Those CSVs have no header row, hence the explicit `column_names`. `process_docs` now uses the published answer letter directly instead of converting from an index, since the letter is what the files contain. The stale `revision` pin is dropped from the three base YAMLs, and `config.py` generates the new form (it also gained a `--group` flag, and no longer parses the base YAML just to read its filename, which was failing on the `!function` tag).

I deliberately did not use the `*_parquet/` directories. They are lossy: `question_only_college_physics` has 101 rows there against 102 in the CSV, and the parquet rows carry nulls where the CSV has real text.

## Verification

Row counts for all 171 subjects were compared against `cais/mmlu`:

**171/171 match canonical MMLU on both the test and dev splits.** Anatomy is 135 test / 5 dev, college_physics 102 / 5, and so on. Before this change, none of them loaded.

All three variants run end to end, zero-shot and few-shot:

```
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m \
  --tasks mmlusr_answer_only_anatomy,mmlusr_question_only_college_physics,mmlusr_question_and_answer_professional_law \
  --limit 5 --num_fewshot 2

|     Tasks      |Version|Filter|n-shot|Metric|   |Value|   |Stderr|
|----------------|------:|------|-----:|------|---|----:|---|-----:|
|anatomy         |      1|none  |     2|acc   |↑  |  0.0|±  |   0.0|
|professional law|      1|none  |     2|acc   |↑  |  0.0|±  |   0.0|
|college physics |      1|none  |     2|acc   |↑  |  0.2|±  |   0.2|
```

pythia-14m scores at chance, as expected; the point is that prompts assemble and all docs score. A rendered few-shot prompt keeps the symbol-replacement wording intact and ends with the shot's gold letter, and all 342 declared `data_files` paths were confirmed to exist on the Hub.

`tests/test_tasks.py` passes with the full changed-task list: **2226 passed**. pre-commit is clean over the diff range.

## Two things worth flagging

**`test_download` needed a one line change.** It called `task_class.download()` with no arguments, so `dataset_kwargs` was dropped and any task depending on `data_files` could not be loaded by the test. It now passes the task's own kwargs, the same way `__init__` does. This is not specific to mmlusr; `c4` and `med_text_classification` already use `data_files` and would hit the same thing whenever they land in a changed-task set.

**Small overlap with #3942.** Touching `tests/test_tasks.py` surfaces a pre-existing `PLW0602` on the unused `global TASKS`, which fails the lint job on the whole file. I removed it here so CI is green. My open PR #3942 removes the same line, so whichever merges second will need a trivial conflict resolution, or I can drop it from one of them, whichever you prefer.

The upstream CSVs have 10 rows across 4 subjects with an empty choice field. Those are left as published, just coerced to an empty string so they do not render as the literal text `None`.

I used AI assistance while putting this together. Every command, count comparison, and eval run above I ran and checked myself.
