### PR TITLE
docs: document OpenAI-compatible multi-model gateway base_url example

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,15 @@ We also support using your own local inference server with servers that mirror t
 lm_eval --model local-completions --tasks gsm8k --model_args model=facebook/opt-125m,base_url=http://{yourip}:8000/v1/completions,num_concurrent=1,max_retries=3,tokenized_requests=False,batch_size=16
 ```
 
+The same `base_url` pattern works with any OpenAI-compatible multi-model gateway. For chat-completions style endpoints (for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`):
+
+```bash
+export OPENAI_API_KEY=YOUR_KEY_HERE
+lm_eval --model local-chat-completions \
+    --tasks gsm8k \
+    --model_args model=gpt-4o-mini,base_url=https://api.daoxe.com/v1/chat/completions,num_concurrent=1,max_retries=3,tokenized_requests=False
+```
+
 Note that for externally hosted models, configs such as `--device` which relate to where to place a local model should not be used and do not function. Just like you can use `--model_args` to pass arbitrary arguments to the model constructor for local models, you can use it to pass arbitrary arguments to the model API for hosted models. See the documentation of the hosting service for information on what arguments they support.
 
 | API or Inference Server                                                                                                   | Implemented?                                                                                            | `--model <xxx>` name                                  | Models supported:                                                                                                                                               | Request Types:                                                                 |

--- a/docs/API_guide.md
+++ b/docs/API_guide.md
@@ -2,6 +2,9 @@
 
 The `TemplateAPI` class is a versatile superclass designed to facilitate the integration of various API-based language models into the lm-evaluation-harness framework. This guide will explain how to use and extend the `TemplateAPI` class to implement your own API models. If your API implements the OpenAI API you can use the `local-completions` or the `local-chat-completions` (defined [here](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/models/openai_completions.py)) model types, which can also serve as examples of how to effectively subclass this template.
 
+
+> **Tip:** Any OpenAI-compatible multi-model gateway can be used via `local-completions` / `local-chat-completions` by setting `base_url` (for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1/chat/completions`).
+
 ## Overview
 
 The `TemplateAPI` class provides a template for creating API-based model implementations. It handles common functionalities such as:


### PR DESCRIPTION
## Summary

`local-completions` / `local-chat-completions` already accept `base_url` for any OpenAI-compatible server. The README showed a local server example but not a hosted multi-model gateway.

This PR adds a concrete `local-chat-completions` example using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) and a matching tip in `docs/API_guide.md`.

Docs only — no runtime behavior changes.

## Test plan

- [ ] Example flags match existing `local-chat-completions` model_args
- [ ] base_url path uses `/v1/chat/completions` consistently with other docs
- [ ] No code or dependency changes