### PR TITLE
fix(scrolls): load SCROLLS without the removed dataset script

### DIFF
--- a/lm_eval/tasks/scrolls/task.py
+++ b/lm_eval/tasks/scrolls/task.py
@@ -1,12 +1,13 @@
 import re
 from abc import abstractmethod
 from functools import reduce
+from typing import ClassVar
 
 import numpy as np
-import transformers.data.metrics.squad_metrics as squad_metrics
-from datasets import Dataset
+from datasets import Dataset, load_dataset
 from evaluate import load
 from transformers import AutoTokenizer
+from transformers.data.metrics import squad_metrics
 
 from lm_eval.api.instance import Instance
 from lm_eval.api.metrics import mean
@@ -86,7 +87,7 @@ def _drop_duplicates_in_input(untokenized_dataset):
     id_to_idx = {}
     outputs = []
     for i, (id_, output) in enumerate(
-        zip(untokenized_dataset["id"], untokenized_dataset["output"])
+        zip(untokenized_dataset["id"], untokenized_dataset["output"], strict=False)
     ):
         if id_ in id_to_idx:
             outputs[id_to_idx[id_]].append(output)
@@ -119,6 +120,10 @@ class _SCROLLSTask(ConfigurableTask):
     PRUNE_TOKENIZERS = None
     PRUNE_MAX_TOKENS = None
     PRUNE_NUM_PROC = None
+
+    # Each subtask ships as "<name>/<split>.jsonl" inside "<name>.zip", stored
+    # in the dataset repo alongside the loading script.
+    ZIP_URL = "https://huggingface.co/datasets/{path}/resolve/main/{name}.zip"
 
     def __init__(self, config=None):
         super().__init__(config={"metadata": {"version": self.VERSION}})
@@ -163,8 +168,18 @@ class _SCROLLSTask(ConfigurableTask):
         return doc["input"]
 
     def download(self, *args, **kwargs):
-        super().download(*args, **kwargs)
-        del self.dataset["test"]
+        # `datasets` no longer runs loading scripts, so read the zipped jsonl
+        # that the dataset repo already publishes rather than going through
+        # scrolls.py. Only train and validation carry labels upstream, so the
+        # held-out test split is not loaded at all.
+        zip_url = self.ZIP_URL.format(path=self.DATASET_PATH, name=self.DATASET_NAME)
+        self.dataset = load_dataset(
+            "json",
+            data_files={
+                split: f"zip://{self.DATASET_NAME}/{split}.jsonl::{zip_url}"
+                for split in ("train", "validation")
+            },
+        )
         for split in self.dataset:
             self.dataset[split] = _drop_duplicates_in_input(self.dataset[split])
         if self.PRUNE_TOKENIZERS is not None:
@@ -186,7 +201,7 @@ class _SCROLLSTask(ConfigurableTask):
 
         def _filter(sample):
             text = self._get_prune_text(sample)
-            cached = cache.get(text, None)
+            cached = cache.get(text)
             if cached is None:
                 for tokenizer in tokenizers:
                     if len(tokenizer(text).input_ids) > self.PRUNE_MAX_TOKENS:
@@ -214,7 +229,7 @@ class _SCROLLSTask(ConfigurableTask):
 
     def _make_compute_metrics(self, value):
         def compute_metrics(samples):
-            predictions, references = zip(*samples)  # unzip, if you will
+            predictions, references = zip(*samples, strict=False)  # unzip, if you will
             computed = self.metric.compute(
                 predictions=predictions, references=references
             )
@@ -245,7 +260,7 @@ class _SCROLLSMultipleChoiceTask(_SCROLLSTask):
     def process_results(self, doc, results):
         gold = doc["gold"]
 
-        lls, _ = zip(*results)
+        lls, _ = zip(*results, strict=False)
         acc = 1.0 if np.argmax(lls) == gold else 0.0
         completion_len = np.array([float(len(i)) for i in doc["choices"]])
         acc_norm = 1.0 if np.argmax(lls / completion_len) == gold else 0.0
@@ -263,9 +278,9 @@ class _SCROLLSMultipleChoiceTask(_SCROLLSTask):
             Instance(
                 request_type="loglikelihood",
                 doc=doc,
-                arguments=(ctx, " {}".format(choice))
+                arguments=(ctx, f" {choice}")
                 if not apply_chat_template
-                else (ctx, "{}".format(choice)),
+                else (ctx, f"{choice}"),
                 idx=i,
                 **kwargs,
             )
@@ -317,8 +332,9 @@ class Qasper(_SCROLLSTask):
     def _process_doc(self, doc):
         doc = _process_doc_prepended_question(doc)
         doc["is_yes_no"] = reduce(
-            lambda prev, cur: prev
-            and squad_metrics.normalize_answer(cur) in ["yes", "no"],
+            lambda prev, cur: (
+                prev and squad_metrics.normalize_answer(cur) in ["yes", "no"]
+            ),
             doc["outputs"],
             True,
         )
@@ -437,7 +453,7 @@ class ContractNLI(_SCROLLSMultipleChoiceTask):
     """
 
     DATASET_NAME = "contract_nli"
-    CHOICES = ["Not mentioned", "Entailment", "Contradiction"]
+    CHOICES: ClassVar[list[str]] = ["Not mentioned", "Entailment", "Contradiction"]
 
     def _process_doc(self, doc):
         doc = _process_doc_prepended_question(doc)


### PR DESCRIPTION
## Summary

All seven `scrolls_*` tasks fail on `datasets>=4`. Fixes #3859.

```
$ lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks scrolls_contractnli --limit 1
RuntimeError: Dataset scripts are no longer supported, but found scrolls.py
```

`tau/scrolls` has no parquet conversion (its `refs` endpoint reports `converts: []`) and there is no mirror, so the usual "repoint at parquet" fix is not available here. What the repo does still publish, next to the loading script, is the data itself: one `<name>.zip` per subtask, each containing `<name>/{train,validation,test}.jsonl` with exactly the `id` / `pid` / `input` / `output` fields the tasks already consume.

So this reads those members directly and skips `scrolls.py` entirely:

```python
zip_url = self.ZIP_URL.format(path=self.DATASET_PATH, name=self.DATASET_NAME)
self.dataset = load_dataset(
    "json",
    data_files={
        split: f"zip://{self.DATASET_NAME}/{split}.jsonl::{zip_url}"
        for split in ("train", "validation")
    },
)
```

`DATASET_NAME` already matches the zip basename for all seven subtasks, so this is one change in `_SCROLLSTask` rather than seven. No new dependency, and no vendored copy of the loading logic.

Only `train` and `validation` carry labels upstream, so the held out `test` split is simply not loaded. That replaces the old `del self.dataset["test"]`.

## Verification

The internal layout was confirmed for **all seven** subtasks by listing each zip remotely, so no subtask relies on a guessed path:

```
contract_nli:   ['contract_nli/test.jsonl', 'contract_nli/train.jsonl', 'contract_nli/validation.jsonl']
qasper:         ['qasper/test.jsonl', 'qasper/train.jsonl', 'qasper/validation.jsonl']
...same shape for qmsum, quality, summ_screen_fd, gov_report, narrative_qa
```

Six of the seven were then run end to end on a clean install (`datasets` 5.0.0), and the split sizes line up with the published SCROLLS numbers:

| task | train | validation |
|---|---|---|
| scrolls_contractnli | 7191 | 1037 |
| scrolls_quality | 2523 | 2086 |
| scrolls_qasper | 2490 | 984 |
| scrolls_qmsum | 1257 | 272 |
| scrolls_summscreenfd | 3673 | 338 |
| scrolls_govreport | 17457 | 972 |

```
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m \
  --tasks scrolls_contractnli,scrolls_quality,scrolls_qasper --limit 3

|       Tasks       |Version|Filter|n-shot| Metric |   | Value |   |Stderr |
|-------------------|------:|------|-----:|--------|---|------:|---|------:|
|scrolls_contractnli|      2|none  |     0|acc     |↑  | 0.0000|±  |      0|
|scrolls_qasper     |      2|none  |     0|f1      |↑  | 0.0000|±  |   N/A |
|scrolls_quality    |      2|none  |     0|acc     |↑  | 0.3333|±  | 0.3333|
```

pythia-14m scores at or near chance on long context tasks, as expected. The point is that every task now loads, builds requests, and scores, including the ROUGE and F1 metric paths.

**One caveat I want to be upfront about:** `scrolls_narrativeqa` is the only subtask I did not run, because its zip is 8.4 GB and I am on a CPU only laptop. Its internal paths were verified remotely and it takes the identical code path as the other six, but if someone with the bandwidth can confirm it, that would close the last gap.

## Lint note

`lm_eval/tasks/scrolls/task.py` carries eight pre existing ruff violations under the repo config. They stay invisible on `main` because pre-commit only inspects changed files, but touching this file surfaces all of them and turns the Linters job red. Three were auto fixed by the hook (`SIM910`, two `UP032`) and I fixed the remaining five by hand, all behaviour preserving: `PLR0402` on the `squad_metrics` import, three `B905` occurrences given an explicit `strict=False` to keep current semantics exactly, and `RUF012` on `ContractNLI.CHOICES` annotated as `ClassVar`. Happy to split those into a separate PR if you would rather keep this diff to the loader alone.

Relates to #3171, and supersedes the approach in the now closed #3872, which vendored the zip to jsonl loading into the task. Reading the published zips through `data_files` turned out to need far less code.

AI tooling helped me put this together. The reproduction, the remote zip listings, the split counts, and every eval run above are mine.
