### PR TITLE
fix(arithmetic): load arithmetic tasks without the removed dataset script

### DIFF
--- a/lm_eval/tasks/arithmetic/arithmetic_1dc.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_1dc.yaml
@@ -1,11 +1,14 @@
 tag:
   - arithmetic
 task: arithmetic_1dc
-dataset_path: EleutherAI/arithmetic
-dataset_name: arithmetic_1dc
+dataset_path: json
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/single_digit_three_ops.jsonl
 output_type: loglikelihood
 validation_split: validation
 test_split: null
+process_docs: !function utils.process_docs
 doc_to_text: "{{context}}"
 doc_to_target: "{{completion}}"
 target_delimiter: ""

--- a/lm_eval/tasks/arithmetic/arithmetic_2da.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_2da.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_2da
-dataset_name: arithmetic_2da
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/two_digit_addition.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_2dm.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_2dm.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_2dm
-dataset_name: arithmetic_2dm
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/two_digit_multiplication.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_2ds.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_2ds.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_2ds
-dataset_name: arithmetic_2ds
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/two_digit_subtraction.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_3da.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_3da.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_3da
-dataset_name: arithmetic_3da
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/three_digit_addition.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_3ds.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_3ds.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_3ds
-dataset_name: arithmetic_3ds
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/three_digit_subtraction.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_4da.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_4da.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_4da
-dataset_name: arithmetic_4da
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/four_digit_addition.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_4ds.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_4ds.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_4ds
-dataset_name: arithmetic_4ds
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/four_digit_subtraction.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_5da.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_5da.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_5da
-dataset_name: arithmetic_5da
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/five_digit_addition.jsonl

--- a/lm_eval/tasks/arithmetic/arithmetic_5ds.yaml
+++ b/lm_eval/tasks/arithmetic/arithmetic_5ds.yaml
@@ -1,3 +1,5 @@
 include: arithmetic_1dc.yaml
 task: arithmetic_5ds
-dataset_name: arithmetic_5ds
+dataset_kwargs:
+  data_files:
+    validation: hf://datasets/EleutherAI/arithmetic/data/five_digit_subtraction.jsonl

--- a/lm_eval/tasks/arithmetic/utils.py
+++ b/lm_eval/tasks/arithmetic/utils.py
@@ -1,0 +1,18 @@
+import datasets
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _helper(doc):
+        # The dataset's own loading script normalised the raw context before
+        # yielding it, and the prompts depend on that exact shape, so keep the
+        # same four steps here now that the script is read as plain jsonl.
+        return {
+            "context": doc["context"]
+            .strip()
+            .replace("\n\n", "\n")
+            .replace("Q:", "Question:")
+            .replace("A:", "Answer:"),
+            "completion": doc["completion"],
+        }
+
+    return dataset.map(_helper)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,7 +22,6 @@ def get_new_tasks_else_default():
     Check if any modifications have been made to built-in tasks and return
     the list, otherwise return the default task list
     """
-    global TASKS
     # CI: new_tasks checks if any modifications have been made
     task_list = new_tasks()
     # Check if task_classes is empty
@@ -57,7 +56,9 @@ class BaseTasks:
     """
 
     def test_download(self, task_class: ConfigurableTask):
-        task_class.download()
+        # Pass the task's own dataset_kwargs, the same way __init__ does.
+        # Without them a task that relies on e.g. data_files cannot be loaded.
+        task_class.download(task_class.config.dataset_kwargs)
         assert task_class.dataset is not None
 
     def test_has_training_docs(self, task_class: ConfigurableTask):


### PR DESCRIPTION
## Summary

All ten `arithmetic_*` tasks fail on `datasets>=4`:

```
$ lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks arithmetic_2da --limit 1
RuntimeError: Dataset scripts are no longer supported, but found arithmetic.py
```

`EleutherAI/arithmetic` still publishes the data itself, one jsonl per subtask under `data/`, carrying the same `context` and `completion` fields the tasks already consume. So each config now reads its own file instead of going through `arithmetic.py`:

```yaml
dataset_path: json
dataset_kwargs:
  data_files:
    validation: hf://datasets/EleutherAI/arithmetic/data/two_digit_addition.jsonl
```

The config to file mapping is taken from the script's own `_URLS` table rather than guessed, so `arithmetic_1dc` reads `single_digit_three_ops.jsonl`, `arithmetic_2dm` reads `two_digit_multiplication.jsonl`, and so on.

## The part that needed care

The loading script did not yield the raw field. It normalised `context` first:

```python
context = (
    data["context"].strip().replace("\n\n", "\n").replace("Q:", "Question:").replace("A:", "Answer:")
)
```

Reading the jsonl directly would therefore have changed every prompt in these tasks, silently and without any error, which matters here given the spacing sensitivity fixed earlier in #2695. A raw record looks like this:

```
{"context": "\n\nQ: What is 98 plus 45?\n\nA:", "completion": " 143"}
```

`process_docs` now applies those same four steps, so the prompt the model sees is unchanged:

```
Question: What is 98 plus 45?
Answer:
```

## Verification

Each task loads its own correct file, with 2000 documents apiece as published, and the first rendered document confirms both the mapping and the normalisation:

| task | n | first context | target |
|---|---|---|---|
| arithmetic_1dc | 2000 | `Question: What is (9 + 8) * 2?\nAnswer:` | ` 34` |
| arithmetic_2da | 2000 | `Question: What is 98 plus 45?\nAnswer:` | ` 143` |
| arithmetic_2ds | 2000 | `Question: What is 17 minus 14?\nAnswer:` | ` 3` |
| arithmetic_2dm | 2000 | `Question: What is 95 times 45?\nAnswer:` | ` 4275` |
| arithmetic_3da | 2000 | `Question: What is 556 plus 497?\nAnswer:` | ` 1053` |
| arithmetic_3ds | 2000 | `Question: What is 509 minus 488?\nAnswer:` | ` 21` |
| arithmetic_4da | 2000 | `Question: What is 9923 plus 617?\nAnswer:` | ` 10540` |
| arithmetic_4ds | 2000 | `Question: What is 6209 minus 3365?\nAnswer:` | ` 2844` |
| arithmetic_5da | 2000 | `Question: What is 65360 plus 16204?\nAnswer:` | ` 81564` |
| arithmetic_5ds | 2000 | `Question: What is 40649 minus 78746?\nAnswer:` | ` -38097` |

End to end on a clean install with `datasets` 5.0.0:

```
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m \
  --tasks arithmetic_2da,arithmetic_2dm,arithmetic_5ds --limit 20

|    Tasks     |Version|Filter|n-shot|Metric|   |Value|   |Stderr|
|--------------|------:|------|-----:|------|---|----:|---|-----:|
|arithmetic_2da|      2|none  |     0|acc   |↑  |    0|±  |     0|
|arithmetic_2dm|      2|none  |     0|acc   |↑  |    0|±  |     0|
|arithmetic_5ds|      2|none  |     0|acc   |↑  |    0|±  |     0|
```

pythia-14m scoring zero on multi digit arithmetic is the expected result for a 14M parameter model; the point is that the tasks load, build requests, and score again.

`tests/test_tasks.py` passes with the full changed task list (133 passed), and pre-commit is clean over the diff range.

One caveat worth stating plainly: I could not diff my output against the original script's, because no installable `datasets` version will execute the script any more. The equivalence above rests on applying the script's own four normalisation steps verbatim, and on the rendered contexts matching the documented prompt format.

## Note on the two test file lines

`test_download` called `task_class.download()` with no arguments, which discards `dataset_kwargs`, so any task using `data_files` could not be loaded by the test at all. It now passes the task's own kwargs, exactly as `__init__` does. Without this the ten tasks here fail the download test for a reason unrelated to the fix. Touching that file also surfaces a pre existing `PLW0602` on an unused `global TASKS`, which fails lint on the whole file, so that line is removed too.

Both of those same two lines appear in my #3972, so whichever merges second will need a trivial conflict resolution. Happy to pull them out into their own PR if you would rather review them separately, since they are arguably a fix in their own right.

Related to #3171. Prepared with AI assistance; the reproduction, the mapping check against the script, the document counts, and the eval runs are all mine.
