### PR TITLE
fix(prost): load PROST without the removed dataset script

### DIFF
--- a/lm_eval/tasks/prost/corypaik_prost.yaml
+++ b/lm_eval/tasks/prost/corypaik_prost.yaml
@@ -1,6 +1,8 @@
 task: prost
-dataset_path: corypaik/prost
-dataset_name: null
+dataset_path: json
+dataset_kwargs:
+  data_files:
+    test: hf://datasets/corypaik/prost/data/default.jsonl
 output_type: multiple_choice
 test_split: test
 doc_to_text: "{{context}}\nQuestion: {{ex_question}}\nAnswer:"


### PR DESCRIPTION
## Summary

The `prost` task fails on `datasets>=4`:

```
$ lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks prost --limit 1
RuntimeError: Dataset scripts are no longer supported, but found prost.py
```

`corypaik/prost` still publishes the data itself as `data/default.jsonl`, so the config reads that file directly instead of going through the script. Four lines changed, one file.

```yaml
dataset_path: json
dataset_kwargs:
  data_files:
    test: hf://datasets/corypaik/prost/data/default.jsonl
```

## Why no field normalisation is needed here

Worth stating explicitly, because it is not automatically true when replacing a loading script. `prost.py` yields each line untouched:

```python
def _generate_examples(self, path):
  with open(path, 'r') as f:
    for _id, line in enumerate(f.readlines()):
      yield _id, json.loads(line)
```

The one thing that could have changed behaviour is `label`, which the script declared as `datasets.ClassLabel(names=list('ABCD'))`. If the raw file stored letters, reading it as plain json would have handed `doc_to_target` a string while `doc_to_choice` produced option text, and scoring would have quietly gone wrong. It does not: `label` is already an integer in the file, distributed across 0 to 3, so the encoding was a no op and the gold index is unchanged.

## Verification

Loaded through the task itself on a clean install (`datasets` 5.0.0):

- **18736 test documents**, matching the 18,736 examples published for PROST
- `label` arrives as `int`, and indexes correctly into the choices

```
label: 2   choices: ['apple', 'ball', 'block', 'bottle']   doc_to_target: 2
```

The rendered prompt is unchanged in shape:

```
A person is trying to roll an apple, a ball, a block, and a bottle.
Question: Which is the hardest to roll?
Answer:
```

End to end:

```
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks prost --limit 20

|Tasks|Version|Filter|n-shot| Metric |   |Value|   |Stderr|
|-----|------:|------|-----:|--------|---|----:|---|-----:|
|prost|      1|none  |     0|acc     |↑  |  0.1|±  |0.0688|
|     |       |none  |     0|acc_norm|↑  |  0.1|±  |0.0688|
```

pre-commit is clean over the diff range.

## One expected test failure, and why I left it alone

`tests/test_tasks.py::test_download[prost]` fails, and it is not this change. `test_download` calls `task_class.download()` with no arguments, which discards `dataset_kwargs`, so `data_files` never reaches the loader. The json builder then falls back to scanning the working directory, which produces this rather telling error:

```
Failed to load JSON from file '.../lm_eval/tasks/e2lmc/mmlu_early_training/custom_metrics.py'
```

The task config itself is fine:

```
dataset_kwargs: {'data_files': {'test': 'hf://datasets/corypaik/prost/data/default.jsonl'}}
```

Every other test passes (15 passed, 1 failed). This affects any task relying on `data_files`, including `c4` and `med_text_classification` today, and I have already proposed the one line fix in #3972 and #3976. I deliberately did not include it a third time here, since three copies of the same two lines would just create conflicts between my own PRs. Merge any one of those and this goes green; alternatively I am happy to pull that fix out into its own small PR so it can land independently, which is probably the tidiest option.

Part of the #3171 cleanup. I mentioned on that thread that I was not working on the remaining datasets, so to be transparent: I picked this one up afterwards and have said so there, to avoid anyone duplicating it.

Built with AI assistance. The reproduction, the label check against the script, the document count, and the runs above are mine.
