### PR TITLE
Exclude eval docs from first-n few-shot samples

### DIFF
--- a/lm_eval/api/samplers.py
+++ b/lm_eval/api/samplers.py
@@ -99,10 +99,11 @@ class FirstNSampler(ContextSampler):
         Draw the first `n` samples in order from the specified split.
         Used for tasks with "canonical" ordered fewshot examples, such as MMLU and CMMLU.
         """
-        assert n <= len(self.df), (
-            f"Error: number of fewshot samples requested exceeds the {len(self.df)} that are available."
+        pool = self.rm_eval_doc(eval_doc, self.df) if eval_doc is not None else self.df
+        assert n <= len(pool), (
+            f"Error: number of fewshot samples requested exceeds the {len(pool)} that are available."
         )
-        return self.df[:n]
+        return pool[:n]
 
 
 class BalancedSampler(ContextSampler):
@@ -117,7 +118,6 @@ class BalancedSampler(ContextSampler):
 
 class ManualSampler(ContextSampler):
     def sample(self, n: int, eval_doc=None, df=None, **kwargs):
-        """ """
         raise NotImplementedError
 
 

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -254,15 +254,16 @@ class TestFirstNSampler:
         with pytest.raises(AssertionError, match="exceeds"):
             sampler.sample(n=10)
 
-    def test_ignores_eval_doc(self, sample_docs):
-        """FirstNSampler ignores eval_doc parameter (returns first n regardless)."""
+    def test_excludes_eval_doc_preserving_order(self, sample_docs):
+        """Excludes eval_doc while preserving the order of remaining documents."""
         sampler = FirstNSampler(sample_docs)
         eval_doc = sample_docs[0]
 
         result = sampler.sample(n=3, eval_doc=eval_doc)
 
-        # FirstNSampler doesn't exclude eval_doc - it just returns first n
-        assert result == sample_docs[:3]
+        assert result == sample_docs[1:4]
+        assert len(result) == 3
+        assert eval_doc not in result
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

`FirstNSampler.sample` ignored `eval_doc` and always sliced the unfiltered pool. When a task uses its test split for few-shot examples, this can put an evaluation document and its target in its own prompt.

## Reproduction

At `f4d4b3de3ee6741a7151a9fe74945ee515262f4c`:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=lm_eval/api python3 -c 'from samplers import FirstNSampler; docs=[{"id":0,"answer":"secret0"},{"id":1,"answer":"secret1"},{"id":2,"answer":"secret2"}]; eval_doc=docs[0]; shots=FirstNSampler(docs).sample(2, eval_doc=eval_doc); print(shots); assert eval_doc not in shots'
```

The command includes document 0 in its own samples and exits with `AssertionError`.

## Fix

Filter the ordered pool with `ContextSampler.rm_eval_doc` before checking availability and taking its first `n` documents. The regression test now verifies that exclusion preserves the remaining order. The empty `ManualSampler` docstring was also removed because Ruff reports it when checking the touched sampler file.

## Tests

- `python -m pytest tests/test_samplers.py -q` — 34 passed
- `python -m pytest tests/test_fewshot_context.py -q` — 49 passed
- `API=true python -m pytest -x -s -vv -n=auto tests/test_tasks.py` — 55 passed
- `python -m pytest -x --showlocals -s -vv -n=2 --ignore=tests/models/test_openvino.py --ignore=tests/models/test_hf_steered.py --ignore=tests/scripts/test_zeno_visualize.py` — 607 passed, 14 skipped
- `pre-commit run --files lm_eval/api/samplers.py tests/test_samplers.py` — passed
