### PR TITLE
fix(tests): pass dataset_kwargs in test_download

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,7 +22,6 @@ def get_new_tasks_else_default():
     Check if any modifications have been made to built-in tasks and return
     the list, otherwise return the default task list
     """
-    global TASKS
     # CI: new_tasks checks if any modifications have been made
     task_list = new_tasks()
     # Check if task_classes is empty
@@ -57,7 +56,9 @@ class BaseTasks:
     """
 
     def test_download(self, task_class: ConfigurableTask):
-        task_class.download()
+        # Pass the task's own dataset_kwargs, the same way __init__ does.
+        # Without them a task that relies on e.g. data_files cannot be loaded.
+        task_class.download(task_class.config.dataset_kwargs)
         assert task_class.dataset is not None
 
     def test_has_training_docs(self, task_class: ConfigurableTask):


### PR DESCRIPTION
## Summary

`tests/test_tasks.py::test_download` calls `download()` with no arguments:

```python
def test_download(self, task_class: ConfigurableTask):
    task_class.download()
```

But `ConfigurableTask.download` takes `dataset_kwargs` as its first parameter, and `__init__` passes the task's own:

```python
self.download(self.config.dataset_kwargs)
```

So under the test those kwargs are silently dropped. For most tasks that makes no difference, but any task that depends on them, for instance one loading through `data_files`, cannot be loaded by the test at all. The packaged builder receives no files, falls back to scanning the working directory, and fails.

Two lines, isolated deliberately so it can land on its own.

## Reproduction

```python
from lm_eval.api.task import ConfigurableTask

cfg = {
    "task": "demo",
    "dataset_path": "json",
    "dataset_kwargs": {"data_files": {"test": "hf://datasets/corypaik/prost/data/default.jsonl"}},
    "test_split": "test",
    "doc_to_text": "{{context}}",
    "doc_to_target": "label",
    "output_type": "multiple_choice",
    "doc_to_choice": "{{[A, B, C, D]}}",
}
t = ConfigurableTask(config=cfg)     # works, 18736 rows
t.download()                          # what the test does
```

Run from the repo root:

```
Downloading data: 100%|##########| 15217/15217 [00:00<00:00, 59543.54files/s]
DatasetGenerationError: An error occurred while generating the dataset
```

It tries to ingest all 15,217 files in the checkout as the dataset. In CI that surfaces as a confusing parse error against whatever file it reaches first, for example:

```
Failed to load JSON from file '.../lm_eval/tasks/e2lmc/mmlu_early_training/custom_metrics.py'
```

Run from a larger working directory it can hang instead of failing, since the scan is recursive.

With the kwargs passed, the same task loads its 18736 rows normally.

## Scope

This is not hypothetical or specific to anything I am working on. `c4` and `med_text_classification` already use `data_files` on `main` today, so they hit this whenever they land in a changed-task set. It stays invisible the rest of the time only because the CI test list is derived from changed files.

`tests/test_tasks.py` passes with the default task set (16 passed), and pre-commit is clean over the diff range.

## Why it is a separate PR

Three of my open PRs restore dataset loading via `data_files` and need this to go green: #3972, #3976, and #3977. Rather than carry the same two lines in all three, it is duplicated in #3972 and #3976 and deliberately left out of #3977, which is why that one currently shows a single red `test_download`.

Landing this on its own is the cleanest path: #3977 goes green with no change, and I will drop the duplicate lines from #3972 and #3976 so they stop conflicting with each other. Happy to reorder that however suits your review queue.

The second line removes an unused `global TASKS`. It is unrelated, but the lint job checks the whole file once touched, so leaving it in place fails `PLW0602`. Glad to drop it if you would rather keep this to a single line.

Assembled with AI assistance; the reproduction above and the test runs are mine.
