### PR TITLE
Fix NVFP4 batch alignment in Megatron evaluation

### DIFF
--- a/lm_eval/models/megatron_lm.py
+++ b/lm_eval/models/megatron_lm.py
@@ -1188,9 +1188,7 @@ class MegatronLMEval(LM):
             # configured microbatch size (often 8) is not sufficient.
             target_batch_size = max(actual_batch_size, self.batch_size)
             if getattr(self._args, "fp4_format", None) is not None:
-                target_batch_size = (
-                    (target_batch_size + 15) // 16
-                ) * 16
+                target_batch_size = ((target_batch_size + 15) // 16) * 16
 
             # Duplicate one real row as padding. Only the first
             # actual_batch_size rows are decoded and returned below.

--- a/lm_eval/models/megatron_lm.py
+++ b/lm_eval/models/megatron_lm.py
@@ -54,6 +54,7 @@ Usage Examples:
 """
 
 import logging
+import math
 import os
 import sys
 from copy import deepcopy
@@ -944,8 +945,19 @@ class MegatronLMEval(LM):
                 contlens.append(len(continuation_enc))
                 inps.append(inp)
 
-            # Pad sequences
+            # Pad sequences. NVFP4 flattens [batch, sequence] before
+            # quantization and requires that dimension to be divisible by 16.
+            # Aligning the sequence length here also covers odd lengths for a
+            # full microbatch.
             max_len = max(len(inp) for inp in inps)
+            fp4_enabled = getattr(self._args, "fp4_format", None) is not None
+            target_batch_size = max(len(inps), self.batch_size)
+            if fp4_enabled:
+                sequence_alignment = 16 // math.gcd(target_batch_size, 16)
+                max_len = (
+                    (max_len + sequence_alignment - 1) // sequence_alignment
+                ) * sequence_alignment
+
             padded_inps = []
             attention_mask_list = []
             for inp in inps:
@@ -954,6 +966,17 @@ class MegatronLMEval(LM):
                 padded_inps.append(padded)
                 # Attention mask: 0 for padding, 1 for real tokens
                 attention_mask_list.append([0] * pad_len + [1] * len(inp))
+
+            # Collator leaves the final chunk smaller than the configured
+            # microbatch. Duplicate a real row to keep the model input shape
+            # full-sized; result processing below still only visits the
+            # original rows, so these dummy rows do not affect metrics.
+            missing_rows = target_batch_size - len(padded_inps)
+            if missing_rows > 0:
+                padded_inps.extend([padded_inps[0].copy() for _ in range(missing_rows)])
+                attention_mask_list.extend(
+                    [attention_mask_list[0].copy() for _ in range(missing_rows)]
+                )
 
             input_ids = torch.tensor(padded_inps, dtype=torch.long, device=self.device)
             attention_mask = torch.tensor(

--- a/lm_eval/models/megatron_lm.py
+++ b/lm_eval/models/megatron_lm.py
@@ -1182,6 +1182,27 @@ class MegatronLMEval(LM):
                 mask = [0] * pad_len + [1] * len(tokens)
                 attention_mask_list.append(mask)
 
+            # Keep generation batches aligned for low-precision Transformer
+            # Engine kernels. NVFP4 needs the flattened token dimension to be
+            # divisible by 16 on every decode step, so padding only to the
+            # configured microbatch size (often 8) is not sufficient.
+            target_batch_size = max(actual_batch_size, self.batch_size)
+            if getattr(self._args, "fp4_format", None) is not None:
+                target_batch_size = (
+                    (target_batch_size + 15) // 16
+                ) * 16
+
+            # Duplicate one real row as padding. Only the first
+            # actual_batch_size rows are decoded and returned below.
+            missing_rows = target_batch_size - actual_batch_size
+            if missing_rows > 0:
+                padded_input_ids.extend(
+                    [padded_input_ids[0].copy() for _ in range(missing_rows)]
+                )
+                attention_mask_list.extend(
+                    [attention_mask_list[0].copy() for _ in range(missing_rows)]
+                )
+
             input_ids = torch.tensor(
                 padded_input_ids, dtype=torch.long, device=self.device
             )
@@ -1312,7 +1333,7 @@ class MegatronLMEval(LM):
                         [
                             attention_mask,
                             torch.ones(
-                                (actual_batch_size, 1),
+                                (input_ids.shape[0], 1),
                                 dtype=torch.long,
                                 device=self.device,
                             ),


### PR DESCRIPTION
## Summary

- Align loglikelihood sequence lengths to satisfy NVFP4 block-size requirements.
- Pad incomplete loglikelihood batches to the configured microbatch size.
- Pad generation batches to multiples of 16 for stable NVFP4 decoding.
- Exclude padded samples from evaluation results.

## Motivation

Transformer Engine requires the flattened NVFP4 input dimension to be divisible by 16. Variable sequence lengths and incomplete final batches caused runtime alignment errors in both loglikelihood and generation evaluation.

## Validation

- Python syntax validation passed.
- No linter errors found.
- Padded samples are ignored during metric calculation.