### PR TITLE
fix(spanish_bench): load wnli_es without the removed dataset script

### DIFF
--- a/lm_eval/tasks/spanish_bench/wnli_es.yaml
+++ b/lm_eval/tasks/spanish_bench/wnli_es.yaml
@@ -1,6 +1,9 @@
 task: wnli_es
-dataset_path: PlanTL-GOB-ES/wnli-es
-dataset_name: null
+dataset_path: csv
+dataset_kwargs:
+  data_files:
+    train: hf://datasets/PlanTL-GOB-ES/wnli-es/wnli-train-es.csv
+    validation: hf://datasets/PlanTL-GOB-ES/wnli-es/wnli-dev-es.csv
 output_type: multiple_choice
 training_split: train
 validation_split: validation


### PR DESCRIPTION
## Summary

`wnli_es` fails on `datasets>=4`:

```
$ lm_eval --model hf --model_args pretrained=EleutherAI/pythia-14m --tasks wnli_es --limit 1
RuntimeError: Dataset scripts are no longer supported, but found wnli-es.py
```

`PlanTL-GOB-ES/wnli-es` still publishes one csv per split, so the config reads them directly:

```yaml
dataset_path: csv
dataset_kwargs:
  data_files:
    train: hf://datasets/PlanTL-GOB-ES/wnli-es/wnli-train-es.csv
    validation: hf://datasets/PlanTL-GOB-ES/wnli-es/wnli-dev-es.csv
```

The split mapping is taken from the script rather than guessed: it fed `wnli-dev-es.csv` to `Split.VALIDATION`, which is what the task's `validation_split` expects.

## Why the labels still line up

Worth spelling out, since this is where a change like this can silently go wrong. The csv already stores an integer label, and the script did not pass it through untouched:

```python
process_label = {0: "not_entailment", 1: "entailment", -1: -1}
...
"label": process_label[int(score)],
```

It converted the integer to a string, then declared the field as `ClassLabel(names=["not_entailment", "entailment"])`, which encodes it straight back to the same integer in the same order. The round trip is an identity, so reading the csv's integer directly gives the same gold index, and `doc_to_choice: ["Falso", "Verdadero"]` still indexes correctly. No `process_docs` shim needed.

## Verification

Loaded through the task on a clean install (`datasets` 5.0.0). The split sizes match GLUE WNLI, which this is a translation of:

```
splits: {'train': 635, 'validation': 71}      GLUE WNLI: train 635, dev 71
label: 0 (int)   choices: ['Falso', 'Verdadero']   doc_to_target: 0
```

The rendered prompt is unchanged:

```
El desagüe se ha atascado con pelo. Hay que limpiarlo.
Pregunta: Hay que limpiar el pelo. ¿Verdadero o Falso?
Respuesta:
```

Zero shot and few shot both run end to end, the latter exercising the train split through the fewshot sampler:

```
|wnli_es|      1|none  |     0|acc   |↑  | 0.65|±  |0.1094|     (limit 20)
|wnli_es|      1|none  |     2|acc   |↑  |  0.2|±  |   0.2 |     (limit 5, 2 shot)
```

pre-commit is clean over the diff range.

## The one expected red check

`test_download[wnli_es]` fails, and it is not this change. `test_download` calls `download()` with no arguments, dropping `dataset_kwargs`, so any task loading through `data_files` cannot be loaded by the test. I have proposed that two line fix separately in #3980; once it lands this goes green untouched. Everything else passes (15 passed, 1 failed).

Part of the #3171 cleanup, using the same approach as #3975, #3976 and #3977: the data is still published next to the script, so no mirror is required.

Written with AI assistance. The reproduction, the label round trip check against the script, the split counts, and the runs above are mine.
