### PR TITLE
feat(models): add raw onnxruntime backend for Model Builder ONNX exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,34 @@ The `pretrained` path is a Model Builder output directory (containing `genai_con
 > [!Note]
 > Supported architectures are whatever the Model Builder supports (Llama, Phi, Qwen, Gemma, Mistral, Granite, ChatGLM, …). Inference is batch-size 1 and runs one execution provider per run.
 
+### ONNX Runtime
+
+We also support running the *same* Model Builder export through a raw `onnxruntime.InferenceSession` instead of the GenAI loop. Use this backend when you want scores to come from the exact runtime a deployment uses, or when you need an execution provider that `onnxruntime-genai` does not build — notably **ROCm** and **MIGraphX** for AMD GPUs.
+
+```bash
+# CPU
+pip install "lm_eval[onnxruntime]"
+# CUDA / ROCm instead of the CPU wheel (mutually exclusive):
+#   pip install onnxruntime-gpu
+#   pip install onnxruntime-rocm
+```
+
+```bash
+lm_eval --model onnxruntime \
+    --model_args pretrained=/path/to/model_builder_output,execution_provider=rocm \
+    --tasks hellaswag,arc_easy,wikitext \
+    --batch_size 1
+```
+
+`execution_provider` accepts short aliases (`cpu`, `cuda`, `rocm`, `migraphx`, `dml`, `openvino`, `tensorrt`, `vitisai`, `webgpu`, `qnn`) as well as full ONNX Runtime provider names. As with the `onnxruntime-genai` backend, leaving it unset honors the providers declared in the export's `genai_config.json`, so an export built for a specific device runs there without extra flags. Non-CPU providers keep `CPUExecutionProvider` as a per-node fallback, since Model Builder graphs use contrib ops that not every provider implements.
+
+Because both ONNX backends share one scoring implementation and end up in the same ORT kernels, they agree on the same model and provider; `tests/models/test_onnxruntime_parity.py` enforces that as a standing check.
+
+> [!Note]
+> This backend currently covers `loglikelihood`, `multiple_choice`, and `loglikelihood_rolling` (hellaswag, arc, mmlu, wikitext, …). For generative tasks such as gsm8k, use `--model onnxruntime-genai` with the same model directory.
+>
+> The installed `onnxruntime` must be new enough to load the contrib-op schemas your Model Builder version emitted. An older runtime can reject the graph outright — for example a 12-input `GroupQueryAttention` fails to load on ONNX Runtime 1.22.
+
 ### Windows ML
 
 We support **Windows ML** for hardware-accelerated inference on Windows platforms. This enables evaluation on CPU, GPU, and **NPU (Neural Processing Unit)** devices.
@@ -585,6 +613,7 @@ Note that for externally hosted models, configs such as `--device` which relate 
 | NVIDIA Megatron-LM                                                                                                        | :heavy_check_mark:                                                                                      | `megatron_lm`                                         | [Megatron-LM GPT models](https://github.com/NVIDIA/Megatron-LM) (standard and distributed checkpoints)                                                          | `generate_until`, `loglikelihood`, `loglikelihood_rolling`                     |
 | Watsonx.ai                                                                                                                | :heavy_check_mark:                                                                                      | `watsonx_llm`                                         | [Supported Watsonx.ai Engines](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx)                                      | `generate_until` `loglikelihood`                                               |
 | ONNX Runtime GenAI                                                                                                        | :heavy_check_mark:                                                                                      | `onnxruntime-genai`                                   | [ONNX models in GenAI format](https://onnxruntime.ai/docs/genai/howto/build-model.html) (cross-platform: CPU/CUDA/DirectML/NPU)                                  | `generate_until`, `loglikelihood`, `loglikelihood_rolling`                     |
+| ONNX Runtime                                                                                                              | :heavy_check_mark:                                                                                      | `onnxruntime`                                         | [ONNX models in GenAI format](https://onnxruntime.ai/docs/genai/howto/build-model.html) via a raw `InferenceSession` (adds ROCm/MIGraphX)                        | `loglikelihood`, `loglikelihood_rolling`                                       |
 | Windows ML                                                                                                                | :heavy_check_mark:                                                                                      | `winml`                                               | [ONNX models in GenAI format](https://code.visualstudio.com/docs/intelligentapps/modelconversion)                                                               | `generate_until`, `loglikelihood`, `loglikelihood_rolling`                     |
 | [Your local inference server!](docs/API_guide.md)                                                                         | :heavy_check_mark:                                                                                      | `local-completions` or `local-chat-completions`       | Support for OpenAI API-compatible servers, with easy customization for other APIs.                                                                              | `generate_until`, `loglikelihood`, `loglikelihood_rolling`                     |
 
@@ -831,6 +860,7 @@ These extras install dependencies required to run specific model backends:
 | optimum        | Intel OpenVINO models                            |
 | neuronx        | AWS Inferentia2 instances                        |
 | onnxruntime-genai | ONNX Runtime GenAI (cross-platform) - CPU/CUDA/DirectML/NPU |
+| onnxruntime    | ONNX Runtime raw session - adds ROCm/MIGraphX    |
 | winml          | Windows ML (ONNX Runtime GenAI) - CPU/GPU/NPU    |
 | sparsify       | Sparsify model steering                          |
 | sae_lens       | SAELens model steering                           |

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -45,6 +45,7 @@ MODEL_MAPPING = {
     "megatron_lm": "lm_eval.models.megatron_lm:MegatronLMEval",
     "nemo_lm": "lm_eval.models.nemo_lm:NeMoLM",
     "neuronx": "lm_eval.models.neuron_optimum:NeuronModelForCausalLM",
+    "onnxruntime": "lm_eval.models.onnxruntime_ort:ONNXRuntimeLM",
     "onnxruntime-genai": "lm_eval.models.onnxruntime_genai:ONNXRuntimeGenAILM",
     "openai-chat-completions": "lm_eval.models.openai_completions:OpenAIChatCompletion",
     "openai-completions": "lm_eval.models.openai_completions:OpenAICompletionsAPI",

--- a/lm_eval/models/_onnx_base.py
+++ b/lm_eval/models/_onnx_base.py
@@ -1,0 +1,311 @@
+"""Shared base for the ONNX backends that consume Model Builder exports.
+
+Both ONNX backends evaluate the same artifact -- an ONNX Runtime GenAI *Model
+Builder* output directory (ONNX graph(s), a ``genai_config.json`` manifest, and
+an HF tokenizer) -- and differ only in the engine used to run it:
+
+* :class:`lm_eval.models.onnxruntime_genai.ONNXRuntimeGenAILM` drives it through
+  the ``onnxruntime-genai`` runtime (``og.Model`` / ``og.Generator``).
+* :class:`lm_eval.models.onnxruntime_ort.ONNXRuntimeLM` drives the same graph
+  through a raw ``onnxruntime.InferenceSession``, which is the runtime a
+  deployment actually uses and reaches execution providers GenAI does not build
+  (e.g. ROCm / MIGraphX).
+
+All lm-eval logic lives here -- tokenization, single-pass log-likelihood
+(covering ``loglikelihood`` and ``multiple_choice``), rolling perplexity, and
+generation orchestration. Engines implement three primitives:
+
+* :meth:`_ONNXLMBase._load` -- open the model on the requested provider,
+* :meth:`_ONNXLMBase._forward_logits` -- one forward pass over a token list,
+* :meth:`_ONNXLMBase._generate` -- produce continuation token ids.
+"""
+
+import abc
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from tqdm import tqdm
+
+from lm_eval import utils
+from lm_eval.api.model import TemplateLM
+
+
+if TYPE_CHECKING:
+    from lm_eval.api.instance import Instance
+
+
+eval_logger = logging.getLogger(__name__)
+
+
+class _ONNXLMBase(TemplateLM, abc.ABC):
+    """Engine-agnostic lm-eval implementation for Model Builder ONNX exports."""
+
+    _DEFAULT_MAX_LENGTH = 2048
+
+    def __init__(
+        self,
+        pretrained: str,
+        execution_provider: str | None = None,
+        max_length: int | None = None,
+        batch_size: int = 1,
+        max_gen_toks: int = 256,
+        provider_options: dict[str, Any] | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize the backend.
+
+        Args:
+            pretrained: Path to a Model Builder output directory or a ``.onnx``
+                file inside one.
+            execution_provider: EP to run on. Accepted names are engine-specific;
+                see the concrete backend. When ``None`` (default), the providers
+                declared in ``genai_config.json`` are used as-is — matching how a
+                Model Builder export is meant to run on its target device. Pass
+                ``cpu`` to force CPU, or a provider name to override the export.
+            max_length: Maximum sequence length. Defaults to the
+                ``context_length`` from ``genai_config.json`` when available.
+            batch_size: Only 1 is supported; other values are coerced to 1.
+            max_gen_toks: Default maximum number of tokens to generate.
+            provider_options: Extra key/value options forwarded to the EP.
+        """
+        super().__init__()
+
+        self.pretrained = pretrained
+        self.model_dir = self._resolve_model_dir(pretrained)
+        self.execution_provider = execution_provider
+        self.provider_options = provider_options or {}
+        self._max_gen_toks = max_gen_toks
+
+        if batch_size != 1:
+            eval_logger.warning(
+                f"{type(self).__name__} currently supports batch size 1 only; "
+                f"overriding requested batch_size={batch_size}."
+            )
+        self.batch_size = 1
+
+        self._genai_config = self._read_genai_config(self.model_dir)
+        model_cfg = self._genai_config.get("model", {})
+        context_length = model_cfg.get("context_length")
+        self.max_length = max_length or context_length or self._DEFAULT_MAX_LENGTH
+
+        self._eot_token_id = self._resolve_eot_token_id(model_cfg)
+        self._bos_token_id = model_cfg.get("bos_token_id")
+
+        self._load_tokenizer()
+        self._load()
+
+    # ------------------------------------------------------------------ #
+    # Model directory / manifest handling
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _resolve_model_dir(pretrained: str) -> Path:
+        path = Path(pretrained)
+        if path.is_file() and path.suffix == ".onnx":
+            return path.parent
+        if path.is_dir():
+            return path
+        raise FileNotFoundError(
+            f"Model path {pretrained} not found or is not a directory / .onnx file"
+        )
+
+    @staticmethod
+    def _read_genai_config(model_dir: Path) -> dict[str, Any]:
+        config_path = model_dir / "genai_config.json"
+        if not config_path.exists():
+            eval_logger.warning(
+                f"No genai_config.json found in {model_dir}; falling back to defaults."
+            )
+            return {}
+        with open(config_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _resolve_eot_token_id(self, model_cfg: dict[str, Any]) -> int:
+        eos = model_cfg.get("eos_token_id")
+        if isinstance(eos, list):
+            eos = eos[0] if eos else None
+        if eos is not None:
+            return int(eos)
+        # Fall back to the tokenizer once it is loaded (see _load_tokenizer).
+        return None  # type: ignore[return-value]
+
+    def _load_tokenizer(self) -> None:
+        """Load the HF tokenizer shipped alongside the graph."""
+        from transformers import AutoTokenizer
+
+        self.tokenizer = AutoTokenizer.from_pretrained(str(self.model_dir))
+        if self._eot_token_id is None:
+            self._eot_token_id = (
+                self.tokenizer.eos_token_id
+                if self.tokenizer.eos_token_id is not None
+                else 0
+            )
+        if self._bos_token_id is None:
+            self._bos_token_id = self.tokenizer.bos_token_id
+
+    # ------------------------------------------------------------------ #
+    # Engine hooks
+    # ------------------------------------------------------------------ #
+    @abc.abstractmethod
+    def _load(self) -> None:
+        """Open the model on the requested execution provider."""
+
+    @abc.abstractmethod
+    def _forward_logits(self, tokens: list[int]) -> np.ndarray:
+        """Run one forward pass and return per-position logits.
+
+        Args:
+            tokens: The full input token sequence.
+
+        Returns:
+            A ``[seq_len, vocab]`` array where row ``i`` is the distribution over
+            the token at position ``i + 1`` given ``tokens[: i + 1]``.
+        """
+
+    @abc.abstractmethod
+    def _generate(self, tokens: list[int], gen_kwargs: dict[str, Any]) -> list[int]:
+        """Generate token ids from a prompt, excluding the prompt itself."""
+
+    # ------------------------------------------------------------------ #
+    # TemplateLM interface
+    # ------------------------------------------------------------------ #
+    @property
+    def eot_token_id(self) -> int:
+        return self._eot_token_id
+
+    @property
+    def prefix_token_id(self) -> int:
+        if self._bos_token_id is not None:
+            return int(self._bos_token_id)
+        return self._eot_token_id
+
+    @property
+    def max_gen_toks(self) -> int:
+        return self._max_gen_toks
+
+    def tok_encode(
+        self, string: str, add_special_tokens: bool | None = None, **kwargs
+    ) -> list[int]:
+        if add_special_tokens is None:
+            add_special_tokens = False
+        return self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
+
+    def tok_decode(self, tokens: list[int], **kwargs) -> str:
+        return self.tokenizer.decode(tokens, skip_special_tokens=True)
+
+    def _loglikelihood_tokens(
+        self,
+        requests: list[tuple[tuple[str, str] | None, list[int], list[int]]],
+        disable_tqdm: bool = False,
+        override_bs: int | None = None,
+    ) -> list[tuple[float, bool]]:
+        results: list[tuple[float, bool]] = []
+
+        for cache_key, context_enc, continuation_enc in tqdm(
+            requests, disable=disable_tqdm, desc="Computing log-likelihoods"
+        ):
+            if not continuation_enc:
+                results.append((0.0, True))
+                continue
+
+            # Feed the full sequence; keep the last max_length tokens so the
+            # continuation is always scored, mirroring HFLM's left-truncation.
+            # At least one preceding position is required to score the first
+            # continuation token, so cap contlen to leave room for context.
+            full = (context_enc + continuation_enc)[-self.max_length :]
+            contlen = min(len(continuation_enc), len(full) - 1)
+            ctxlen = len(full) - contlen
+
+            logits = self._forward_logits(full)
+            # Logits at position i predict token i+1, so the continuation is
+            # scored by rows [ctxlen-1 : ctxlen-1+contlen].
+            cont_logits = logits[ctxlen - 1 : ctxlen - 1 + contlen]
+            log_probs = _log_softmax(cont_logits)
+
+            # Left-truncation may have dropped leading continuation tokens.
+            targets = np.asarray(continuation_enc[-contlen:], dtype=np.int64)
+            token_ll = log_probs[np.arange(contlen), targets]
+            total_ll = float(token_ll.sum())
+            is_greedy = bool(np.all(log_probs.argmax(axis=-1) == targets))
+
+            results.append((total_ll, is_greedy))
+
+            if cache_key is not None:
+                self.cache_hook.add_partial(
+                    "loglikelihood", cache_key, (total_ll, is_greedy)
+                )
+
+        return results
+
+    def loglikelihood_rolling(
+        self, requests: list["Instance"], disable_tqdm: bool = False
+    ) -> list[float]:
+        loglikelihoods: list[float] = []
+
+        for (string,) in tqdm(
+            [req.args for req in requests],
+            disable=disable_tqdm,
+            desc="Computing rolling log-likelihoods",
+        ):
+            rolling_token_windows = [
+                (None,) + window
+                for window in map(
+                    utils.make_disjoint_window,
+                    utils.get_rolling_token_windows(
+                        token_list=self.tok_encode(string),
+                        prefix_token=self.prefix_token_id,
+                        max_seq_len=self.max_length,
+                        context_len=1,
+                    ),
+                )
+            ]
+
+            window_lls = self._loglikelihood_tokens(
+                rolling_token_windows, disable_tqdm=True
+            )
+            string_ll = sum(ll for ll, _ in window_lls)
+            loglikelihoods.append(string_ll)
+            self.cache_hook.add_partial("loglikelihood_rolling", (string,), string_ll)
+
+        return loglikelihoods
+
+    def generate_until(
+        self, requests: list["Instance"], disable_tqdm: bool = False
+    ) -> list[str]:
+        results: list[str] = []
+
+        for context, gen_kwargs in tqdm(
+            [req.args for req in requests],
+            disable=disable_tqdm,
+            desc="Generating text",
+        ):
+            gen_kwargs = dict(gen_kwargs)
+            until = gen_kwargs.pop("until", None)
+            if isinstance(until, str):
+                until = [until]
+            elif until is None:
+                until = []
+
+            prompt_tokens = self.tok_encode(context)
+            new_tokens = self._generate(prompt_tokens, gen_kwargs)
+            text = self.tok_decode(new_tokens)
+
+            for stop in until:
+                if stop:
+                    idx = text.find(stop)
+                    if idx != -1:
+                        text = text[:idx]
+
+            results.append(text)
+            self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text)
+
+        return results
+
+
+def _log_softmax(logits: np.ndarray) -> np.ndarray:
+    """Numerically stable log-softmax over the last axis."""
+    shifted = logits - logits.max(axis=-1, keepdims=True)
+    log_sum_exp = np.log(np.exp(shifted).sum(axis=-1, keepdims=True))
+    return shifted - log_sum_exp

--- a/lm_eval/models/onnxruntime_genai.py
+++ b/lm_eval/models/onnxruntime_genai.py
@@ -13,26 +13,26 @@ Example usage:
 The ``pretrained`` path is a Model Builder output directory (containing
 ``genai_config.json``, the ONNX graph(s), and an HF tokenizer) or a ``.onnx``
 file inside such a directory.
+
+All lm-eval logic lives in :class:`lm_eval.models._onnx_base._ONNXLMBase`,
+which is shared with the raw ``onnxruntime`` backend; this module implements
+only the GenAI engine primitives.
 """
 
-import json
 import logging
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
-from tqdm import tqdm
 
-from lm_eval import utils
-from lm_eval.api.model import TemplateLM
 from lm_eval.api.registry import register_model
-
-
-if TYPE_CHECKING:
-    from lm_eval.api.instance import Instance
+from lm_eval.models._onnx_base import _log_softmax, _ONNXLMBase
 
 
 eval_logger = logging.getLogger(__name__)
+
+# Re-exported for backwards compatibility: the scoring helper now lives in the
+# shared base module.
+__all__ = ["ONNXRuntimeGenAILM", "_log_softmax"]
 
 # ONNX Runtime GenAI treats CPU as "no execution provider appended" rather than
 # an appendable provider name, so these aliases are handled specially.
@@ -40,68 +40,12 @@ _CPU_EP_ALIASES = {"cpu", "cpuexecutionprovider"}
 
 
 @register_model("onnxruntime-genai")
-class ONNXRuntimeGenAILM(TemplateLM):
+class ONNXRuntimeGenAILM(_ONNXLMBase):
     """Cross-platform backend for Model Builder ONNX models via onnxruntime-genai.
 
-    All lm-eval scoring logic lives here (tokenization, single-pass logits,
-    log-likelihood, rolling perplexity, and generation). Subclasses need only
-    override :meth:`_select_ep` to change how execution providers are chosen
-    (see :class:`lm_eval.models.winml.WindowsML`).
+    Subclasses need only override :meth:`_select_ep` to change how execution
+    providers are chosen (see :class:`lm_eval.models.winml.WindowsML`).
     """
-
-    _DEFAULT_MAX_LENGTH = 2048
-
-    def __init__(
-        self,
-        pretrained: str,
-        execution_provider: str | None = None,
-        max_length: int | None = None,
-        batch_size: int = 1,
-        max_gen_toks: int = 256,
-        provider_options: dict[str, Any] | None = None,
-        **kwargs,
-    ) -> None:
-        """Initialize the backend.
-
-        Args:
-            pretrained: Path to a Model Builder output directory or a ``.onnx``
-                file inside one.
-            execution_provider: EP to run on (e.g. ``cpu``, ``cuda``, ``dml``,
-                ``VitisAI``). When ``None`` (default), the providers declared in
-                ``genai_config.json`` are used as-is — matching how a Model
-                Builder export is meant to run on its target device. Pass
-                ``cpu`` to force CPU, or a provider name to override the export.
-            max_length: Maximum sequence length. Defaults to the
-                ``context_length`` from ``genai_config.json`` when available.
-            batch_size: Only 1 is supported; other values are coerced to 1.
-            max_gen_toks: Default maximum number of tokens to generate.
-            provider_options: Extra key/value options forwarded to the EP.
-        """
-        super().__init__()
-
-        self.og = self._import_genai()
-        self.pretrained = pretrained
-        self.model_dir = self._resolve_model_dir(pretrained)
-        self.execution_provider = execution_provider
-        self.provider_options = provider_options or {}
-        self._max_gen_toks = max_gen_toks
-
-        if batch_size != 1:
-            eval_logger.warning(
-                f"{type(self).__name__} currently supports batch size 1 only; "
-                f"overriding requested batch_size={batch_size}."
-            )
-        self.batch_size = 1
-
-        self._genai_config = self._read_genai_config(self.model_dir)
-        model_cfg = self._genai_config.get("model", {})
-        context_length = model_cfg.get("context_length")
-        self.max_length = max_length or context_length or self._DEFAULT_MAX_LENGTH
-
-        self._eot_token_id = self._resolve_eot_token_id(model_cfg)
-        self._bos_token_id = model_cfg.get("bos_token_id")
-
-        self._load()
 
     @staticmethod
     def _import_genai():
@@ -116,39 +60,8 @@ class ONNXRuntimeGenAILM(TemplateLM):
         eval_logger.info(f"ONNX Runtime GenAI version: {og.__version__}")
         return og
 
-    @staticmethod
-    def _resolve_model_dir(pretrained: str) -> Path:
-        path = Path(pretrained)
-        if path.is_file() and path.suffix == ".onnx":
-            return path.parent
-        if path.is_dir():
-            return path
-        raise FileNotFoundError(
-            f"Model path {pretrained} not found or is not a directory / .onnx file"
-        )
-
-    @staticmethod
-    def _read_genai_config(model_dir: Path) -> dict[str, Any]:
-        config_path = model_dir / "genai_config.json"
-        if not config_path.exists():
-            eval_logger.warning(
-                f"No genai_config.json found in {model_dir}; falling back to defaults."
-            )
-            return {}
-        with open(config_path, encoding="utf-8") as f:
-            return json.load(f)
-
-    def _resolve_eot_token_id(self, model_cfg: dict[str, Any]) -> int:
-        eos = model_cfg.get("eos_token_id")
-        if isinstance(eos, list):
-            eos = eos[0] if eos else None
-        if eos is not None:
-            return int(eos)
-        # Fall back to the tokenizer once it is loaded (see _load).
-        return None  # type: ignore[return-value]
-
     # ------------------------------------------------------------------ #
-    # Engine hooks (override in subclasses to change engine / EP selection)
+    # Engine hooks
     # ------------------------------------------------------------------ #
     def _select_ep(self, config) -> None:
         """Configure execution providers on an ``og.Config``.
@@ -182,35 +95,20 @@ class ONNXRuntimeGenAILM(TemplateLM):
         eval_logger.info(f"Using execution provider: {ep}")
 
     def _load(self) -> None:
-        """Load the tokenizer and the onnxruntime-genai model."""
-        from transformers import AutoTokenizer
-
-        self.tokenizer = AutoTokenizer.from_pretrained(str(self.model_dir))
-        if self._eot_token_id is None:
-            self._eot_token_id = (
-                self.tokenizer.eos_token_id
-                if self.tokenizer.eos_token_id is not None
-                else 0
-            )
-        if self._bos_token_id is None:
-            self._bos_token_id = self.tokenizer.bos_token_id
-
+        """Load the onnxruntime-genai model on the requested provider."""
+        self.og = self._import_genai()
         config = self.og.Config(str(self.model_dir))
         self._select_ep(config)
         self.model = self.og.Model(config)
         eval_logger.info(f"Loaded onnxruntime-genai model from {self.model_dir}")
 
     def _forward_logits(self, tokens: list[int]) -> np.ndarray:
-        """Run one forward pass and return per-position logits.
-
-        Args:
-            tokens: The full input token sequence.
-
-        Returns:
-            A ``[seq_len, vocab]`` array where row ``i`` is the distribution over
-            the token at position ``i + 1`` given ``tokens[: i + 1]``.
-        """
         params = self.og.GeneratorParams(self.model)
+        # Without this, the search max_length defaults to the model's full
+        # context_length from genai_config.json, so every request allocates a
+        # KV cache for that whole span (34x slower on Qwen1.5-0.5B, identical
+        # logits). Only the prompt pass is needed here, so pin it to the input.
+        params.set_search_options(max_length=len(tokens), do_sample=False)
         generator = self.og.Generator(self.model, params)
         generator.append_tokens(np.asarray(tokens, dtype=np.int32))
         logits = np.asarray(generator.get_output("logits"), dtype=np.float32)
@@ -221,16 +119,6 @@ class ONNXRuntimeGenAILM(TemplateLM):
         return logits
 
     def _generate(self, tokens: list[int], gen_kwargs: dict[str, Any]) -> list[int]:
-        """Greedily (or with sampling) generate token ids from a prompt.
-
-        Args:
-            tokens: The prompt token ids.
-            gen_kwargs: Generation options (``max_gen_toks``, ``until``,
-                ``temperature``, ``top_p``, ``top_k``, ``do_sample``).
-
-        Returns:
-            The newly generated token ids (excluding the prompt).
-        """
         max_gen_toks = int(gen_kwargs.get("max_gen_toks", self.max_gen_toks))
         temperature = float(gen_kwargs.get("temperature", 0.0))
         top_p = float(gen_kwargs.get("top_p", 1.0))
@@ -261,145 +149,3 @@ class ONNXRuntimeGenAILM(TemplateLM):
             if len(seq) > len(tokens) + len(generated):
                 generated.append(int(seq[len(tokens) + len(generated)]))
         return generated
-
-    # ------------------------------------------------------------------ #
-    # TemplateLM interface
-    # ------------------------------------------------------------------ #
-    @property
-    def eot_token_id(self) -> int:
-        return self._eot_token_id
-
-    @property
-    def prefix_token_id(self) -> int:
-        if self._bos_token_id is not None:
-            return int(self._bos_token_id)
-        return self._eot_token_id
-
-    @property
-    def max_gen_toks(self) -> int:
-        return self._max_gen_toks
-
-    def tok_encode(
-        self, string: str, add_special_tokens: bool | None = None, **kwargs
-    ) -> list[int]:
-        if add_special_tokens is None:
-            add_special_tokens = False
-        return self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
-
-    def tok_decode(self, tokens: list[int], **kwargs) -> str:
-        return self.tokenizer.decode(tokens, skip_special_tokens=True)
-
-    def _loglikelihood_tokens(
-        self,
-        requests: list[tuple[tuple[str, str] | None, list[int], list[int]]],
-        disable_tqdm: bool = False,
-        override_bs: int | None = None,
-    ) -> list[tuple[float, bool]]:
-        results: list[tuple[float, bool]] = []
-
-        for cache_key, context_enc, continuation_enc in tqdm(
-            requests, disable=disable_tqdm, desc="Computing log-likelihoods"
-        ):
-            if not continuation_enc:
-                results.append((0.0, True))
-                continue
-
-            # Feed the full sequence; keep the last max_length tokens so the
-            # continuation is always scored, mirroring HFLM's left-truncation.
-            # At least one preceding position is required to score the first
-            # continuation token, so cap contlen to leave room for context.
-            full = (context_enc + continuation_enc)[-self.max_length :]
-            contlen = min(len(continuation_enc), len(full) - 1)
-            ctxlen = len(full) - contlen
-
-            logits = self._forward_logits(full)
-            # Logits at position i predict token i+1, so the continuation is
-            # scored by rows [ctxlen-1 : ctxlen-1+contlen].
-            cont_logits = logits[ctxlen - 1 : ctxlen - 1 + contlen]
-            log_probs = _log_softmax(cont_logits)
-
-            # Left-truncation may have dropped leading continuation tokens.
-            targets = np.asarray(continuation_enc[-contlen:], dtype=np.int64)
-            token_ll = log_probs[np.arange(contlen), targets]
-            total_ll = float(token_ll.sum())
-            is_greedy = bool(np.all(log_probs.argmax(axis=-1) == targets))
-
-            results.append((total_ll, is_greedy))
-
-            if cache_key is not None:
-                self.cache_hook.add_partial(
-                    "loglikelihood", cache_key, (total_ll, is_greedy)
-                )
-
-        return results
-
-    def loglikelihood_rolling(
-        self, requests: list["Instance"], disable_tqdm: bool = False
-    ) -> list[float]:
-        loglikelihoods: list[float] = []
-
-        for (string,) in tqdm(
-            [req.args for req in requests],
-            disable=disable_tqdm,
-            desc="Computing rolling log-likelihoods",
-        ):
-            rolling_token_windows = [
-                (None,) + window
-                for window in map(
-                    utils.make_disjoint_window,
-                    utils.get_rolling_token_windows(
-                        token_list=self.tok_encode(string),
-                        prefix_token=self.prefix_token_id,
-                        max_seq_len=self.max_length,
-                        context_len=1,
-                    ),
-                )
-            ]
-
-            window_lls = self._loglikelihood_tokens(
-                rolling_token_windows, disable_tqdm=True
-            )
-            string_ll = sum(ll for ll, _ in window_lls)
-            loglikelihoods.append(string_ll)
-            self.cache_hook.add_partial("loglikelihood_rolling", (string,), string_ll)
-
-        return loglikelihoods
-
-    def generate_until(
-        self, requests: list["Instance"], disable_tqdm: bool = False
-    ) -> list[str]:
-        results: list[str] = []
-
-        for context, gen_kwargs in tqdm(
-            [req.args for req in requests],
-            disable=disable_tqdm,
-            desc="Generating text",
-        ):
-            gen_kwargs = dict(gen_kwargs)
-            until = gen_kwargs.pop("until", None)
-            if isinstance(until, str):
-                until = [until]
-            elif until is None:
-                until = []
-
-            prompt_tokens = self.tok_encode(context)
-            new_tokens = self._generate(prompt_tokens, gen_kwargs)
-            text = self.tok_decode(new_tokens)
-
-            for stop in until:
-                if stop:
-                    idx = text.find(stop)
-                    if idx != -1:
-                        text = text[:idx]
-
-            results.append(text)
-            self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text)
-
-        return results
-
-
-def _log_softmax(logits: np.ndarray) -> np.ndarray:
-    """Numerically stable log-softmax over the last axis."""
-    shifted = logits - logits.max(axis=-1, keepdims=True)
-    log_sum_exp = np.log(np.exp(shifted).sum(axis=-1, keepdims=True))
-    return shifted - log_sum_exp

--- a/lm_eval/models/onnxruntime_ort.py
+++ b/lm_eval/models/onnxruntime_ort.py
@@ -1,0 +1,303 @@
+"""Raw ONNX Runtime backend for lm-eval-harness.
+
+Runs a Model Builder ONNX export through a plain ``onnxruntime.InferenceSession``
+-- the same runtime a deployment uses -- rather than through the
+``onnxruntime-genai`` loop. Two reasons to prefer it:
+
+* **Stack parity.** Scores come from the exact session/EP/kernels a customer
+  runs in production, so an eval number is attributable to the deployed stack.
+* **Provider reach.** It supports execution providers ``onnxruntime-genai`` does
+  not build, notably ROCm and MIGraphX for AMD GPUs.
+
+It shares all lm-eval logic with the ``onnxruntime-genai`` backend via
+:class:`lm_eval.models._onnx_base._ONNXLMBase`; only the forward pass differs.
+
+Example usage:
+    lm_eval --model onnxruntime --model_args pretrained=path/to/model_builder_output,execution_provider=cuda --tasks hellaswag --limit 10
+
+Scope: this backend implements the log-likelihood path, which covers
+``loglikelihood``, ``multiple_choice`` (mmlu/hellaswag/arc), and
+``loglikelihood_rolling`` (wikitext perplexity). Generative tasks are not
+supported yet -- the KV-cache decode loop is tracked separately.
+
+Graph assumptions are introspected, not hardcoded: ``position_ids`` is absent
+from GQA+rotary exports, and past/present KV tensor names follow the printf
+templates in ``genai_config.json``. Note that the graph must be loadable by the
+installed ``onnxruntime``: Model Builder emits contrib ops whose schemas evolve,
+so an ORT older than the builder may reject the graph outright (e.g. a 12-input
+``GroupQueryAttention`` fails to load on ORT 1.22).
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from lm_eval.api.registry import register_model
+from lm_eval.models._onnx_base import _ONNXLMBase
+
+
+eval_logger = logging.getLogger(__name__)
+
+# Friendly aliases -> onnxruntime execution provider names. Full ORT names are
+# accepted as-is, so new providers work without a code change.
+_EP_ALIASES = {
+    "cpu": "CPUExecutionProvider",
+    "cuda": "CUDAExecutionProvider",
+    "rocm": "ROCMExecutionProvider",
+    "migraphx": "MIGraphXExecutionProvider",
+    "dml": "DmlExecutionProvider",
+    "directml": "DmlExecutionProvider",
+    "openvino": "OpenVINOExecutionProvider",
+    "tensorrt": "TensorrtExecutionProvider",
+    "trt": "TensorrtExecutionProvider",
+    "vitisai": "VitisAIExecutionProvider",
+    "webgpu": "WebGpuExecutionProvider",
+    "qnn": "QNNExecutionProvider",
+}
+
+_ORT_TO_NUMPY = {
+    "tensor(float)": np.float32,
+    "tensor(float16)": np.float16,
+    "tensor(double)": np.float64,
+    "tensor(int64)": np.int64,
+    "tensor(int32)": np.int32,
+    "tensor(bool)": np.bool_,
+}
+
+
+@register_model("onnxruntime")
+class ONNXRuntimeLM(_ONNXLMBase):
+    """Model Builder ONNX evaluation through a raw ``InferenceSession``."""
+
+    # ------------------------------------------------------------------ #
+    # Engine hooks
+    # ------------------------------------------------------------------ #
+    def _load(self) -> None:
+        try:
+            import onnxruntime as ort
+        except ImportError as e:
+            raise ImportError(
+                "onnxruntime is required for the onnxruntime backend. Install a "
+                "matching EP wheel, e.g. `pip install onnxruntime` (CPU), "
+                "`pip install onnxruntime-gpu` (CUDA), or `pip install "
+                "onnxruntime-rocm` (ROCm). These wheels are mutually exclusive."
+            ) from e
+
+        self.ort = ort
+        eval_logger.info(f"ONNX Runtime version: {ort.__version__}")
+
+        graph_path = self._resolve_graph_path()
+        providers, provider_options = self._resolve_providers(ort)
+
+        self.session = ort.InferenceSession(
+            str(graph_path),
+            ort.SessionOptions(),
+            providers=providers,
+            provider_options=provider_options,
+        )
+        eval_logger.info(
+            f"Loaded {graph_path} with providers {self.session.get_providers()}"
+        )
+        self._introspect_graph()
+
+    def _forward_logits(self, tokens: list[int]) -> np.ndarray:
+        seq_len = len(tokens)
+        feeds: dict[str, np.ndarray] = {}
+
+        for name, dtype, shape in self._input_specs:
+            if name == "input_ids":
+                feeds[name] = np.asarray([tokens], dtype=dtype)
+            elif name == "attention_mask":
+                feeds[name] = np.ones((1, seq_len), dtype=dtype)
+            elif name == "position_ids":
+                feeds[name] = np.arange(seq_len, dtype=dtype).reshape(1, seq_len)
+            else:
+                # Past KV (and any other auxiliary input): start empty, so a
+                # single pass scores every position of the prompt.
+                concrete = [self._resolve_dim(d, seq_len) for d in shape]
+                feeds[name] = np.zeros(concrete, dtype=dtype)
+
+        logits = self.session.run([self._logits_name], feeds)[0]
+        logits = np.asarray(logits, dtype=np.float32)
+        if logits.ndim == 3:  # (batch, seq, vocab)
+            logits = logits[0]
+        elif logits.ndim != 2:
+            raise ValueError(
+                f"Unexpected logits shape from ONNX Runtime: {logits.shape}"
+            )
+        return logits
+
+    def _generate(self, tokens: list[int], gen_kwargs: dict[str, Any]) -> list[int]:
+        raise NotImplementedError(
+            "The `onnxruntime` backend does not implement generative tasks yet; "
+            "it supports loglikelihood, multiple_choice, and loglikelihood_rolling "
+            "(e.g. hellaswag, arc, mmlu, wikitext). For generative tasks such as "
+            "gsm8k, use `--model onnxruntime-genai` with the same model directory."
+        )
+
+    # ------------------------------------------------------------------ #
+    # Graph / provider resolution
+    # ------------------------------------------------------------------ #
+    def _resolve_graph_path(self) -> Path:
+        """Locate the ONNX graph: explicit file, manifest filename, then glob."""
+        explicit = Path(self.pretrained)
+        if explicit.is_file() and explicit.suffix == ".onnx":
+            return explicit
+
+        filename = (
+            self._genai_config.get("model", {}).get("decoder", {}).get("filename")
+        )
+        if filename:
+            candidate = self.model_dir / filename
+            if candidate.is_file():
+                return candidate
+            eval_logger.warning(
+                f"genai_config.json names {filename}, which is missing from "
+                f"{self.model_dir}; falling back to a directory scan."
+            )
+
+        candidates = sorted(self.model_dir.glob("*.onnx"))
+        if not candidates:
+            raise FileNotFoundError(f"No .onnx graph found in {self.model_dir}")
+        if len(candidates) > 1:
+            eval_logger.warning(
+                f"Multiple ONNX graphs in {self.model_dir} "
+                f"({[c.name for c in candidates]}); using {candidates[0].name}. "
+                "Pass the .onnx path directly to choose another."
+            )
+        return candidates[0]
+
+    def _declared_providers(self) -> list[tuple[str, dict[str, Any]]]:
+        """Providers the export declares, as ``(name, options)`` pairs.
+
+        ``InferenceSession`` ignores ``genai_config.json``, so we read
+        ``model.decoder.session_options.provider_options`` ourselves to keep the
+        default behavior aligned with the ``onnxruntime-genai`` backend.
+        """
+        session_options = (
+            self._genai_config.get("model", {})
+            .get("decoder", {})
+            .get("session_options", {})
+        )
+        declared: list[tuple[str, dict[str, Any]]] = []
+        for entry in session_options.get("provider_options") or []:
+            if not isinstance(entry, dict):
+                continue
+            for name, options in entry.items():
+                declared.append((name, dict(options) if options else {}))
+        return declared
+
+    def _resolve_providers(self, ort) -> tuple[list[str], list[dict[str, Any]]]:
+        """Resolve the ORT provider chain, with CPU appended as fallback.
+
+        Mirrors the ``onnxruntime-genai`` backend: when ``execution_provider`` is
+        ``None`` the providers declared in ``genai_config.json`` are honored, so
+        a CUDA/DML/NPU export is not silently downgraded to CPU. An explicit
+        ``execution_provider`` overrides the export, and ``provider_options``
+        applies to that named provider.
+        """
+        available = ort.get_available_providers()
+
+        def to_ort_name(name: str, source: str) -> str:
+            provider = _EP_ALIASES.get(name.lower(), name)
+            if provider not in available:
+                raise ValueError(
+                    f"Execution provider {provider!r} (from {source}) is not "
+                    f"available in this onnxruntime build. Available: {available}. "
+                    "Install the matching wheel (onnxruntime-gpu for CUDA, "
+                    "onnxruntime-rocm for ROCm, ...)."
+                )
+            return provider
+
+        if self.execution_provider is None:
+            declared = self._declared_providers()
+            if not declared:
+                # genai treats an empty provider list as CPU, so match that.
+                eval_logger.info(
+                    "No execution_provider given and genai_config.json declares "
+                    "none; running on CPU."
+                )
+                providers = ["CPUExecutionProvider"]
+                provider_options: list[dict[str, Any]] = [dict(self.provider_options)]
+            else:
+                providers = [
+                    to_ort_name(name, "genai_config.json") for name, _ in declared
+                ]
+                provider_options = [options for _, options in declared]
+                eval_logger.info(
+                    f"Using providers declared in genai_config.json: {providers}"
+                )
+        else:
+            requested = self.execution_provider
+            providers = [to_ort_name(requested, f"execution_provider={requested!r}")]
+            provider_options = [dict(self.provider_options)]
+            eval_logger.info(f"Using execution provider: {providers[0]}")
+
+        if "CPUExecutionProvider" not in providers:
+            # Model Builder graphs use contrib ops that some EPs do not
+            # implement (e.g. GroupQueryAttention has no ROCm kernel), so keep
+            # CPU available for per-node fallback rather than failing to load.
+            providers.append("CPUExecutionProvider")
+            provider_options.append({})
+        return providers, provider_options
+
+    def _introspect_graph(self) -> None:
+        """Record input specs and the logits output name from the live session."""
+        self._input_specs: list[tuple[str, Any, list[Any]]] = []
+        for inp in self.session.get_inputs():
+            dtype = _ORT_TO_NUMPY.get(inp.type)
+            if dtype is None:
+                raise NotImplementedError(
+                    f"Input {inp.name!r} has unsupported type {inp.type}. "
+                    "bfloat16 KV caches are not supported by this backend yet; "
+                    "export with -p fp16 or -p fp32 instead."
+                )
+            self._input_specs.append((inp.name, dtype, list(inp.shape)))
+
+        input_names = {name for name, _, _ in self._input_specs}
+        self._has_position_ids = "position_ids" in input_names
+
+        configured = (
+            self._genai_config.get("model", {})
+            .get("decoder", {})
+            .get("outputs", {})
+            .get("logits")
+        )
+        output_names = [out.name for out in self.session.get_outputs()]
+        if configured in output_names:
+            self._logits_name = configured
+        elif "logits" in output_names:
+            self._logits_name = "logits"
+        else:
+            self._logits_name = output_names[0]
+            eval_logger.warning(
+                f"No 'logits' output found in {output_names}; "
+                f"using {self._logits_name}."
+            )
+
+        eval_logger.info(
+            f"Graph inputs: {len(self._input_specs)} "
+            f"(position_ids={'present' if self._has_position_ids else 'absent'}), "
+            f"logits output: {self._logits_name}"
+        )
+
+    @staticmethod
+    def _resolve_dim(dim: Any, seq_len: int) -> int:
+        """Bind a symbolic ONNX dimension for a single prompt pass.
+
+        Past-sequence axes bind to 0 (empty KV cache); batch is 1; remaining
+        sequence axes bind to the prompt length. Checked in this order because
+        ``past_sequence_length`` also contains ``seq``.
+        """
+        if isinstance(dim, int):
+            return dim
+        name = (dim or "").lower()
+        if "batch" in name:
+            return 1
+        if "past" in name:
+            return 0
+        if "total" in name or "seq" in name:
+            return seq_len
+        return 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ ibm_watsonx_ai = ["ibm_watsonx_ai>=1.1.22", "python-dotenv"]
 # matching wheel instead of `onnxruntime-genai`, e.g. `onnxruntime-genai-cuda`
 # or `onnxruntime-genai-directml` (these are mutually exclusive).
 onnxruntime-genai = ["onnxruntime-genai", "transformers", "numpy"]
+# Raw ONNX Runtime backend. For non-CPU execution providers install the matching
+# wheel instead of `onnxruntime`, e.g. `onnxruntime-gpu` (CUDA) or
+# `onnxruntime-rocm` (ROCm) - these are mutually exclusive. The runtime must be
+# new enough to load the contrib-op schemas your Model Builder version emits.
+onnxruntime = ["onnxruntime>=1.23", "transformers", "numpy"]
 litellm = ["litellm>=1.60,<1.85", "aiohttp", "requests", "tenacity", "tqdm"]
 # mamba requires CUDA (nvcc) - cannot build on macOS/CPU-only systems
 # mamba = ["mamba_ssm", "causal-conv1d==1.0.2", "torch"]

--- a/tests/models/test_onnxruntime_parity.py
+++ b/tests/models/test_onnxruntime_parity.py
@@ -1,0 +1,325 @@
+"""Cross-backend parity tests: onnxruntime-genai vs raw onnxruntime.
+
+Both ONNX backends read the same Model Builder export and, on the same
+execution provider, ultimately call the same ORT kernels -- ``onnxruntime-genai``
+only manages the KV cache / position bookkeeping around them. So identical
+inputs must yield identical log-probs to floating-point tolerance, and each
+backend acts as the other's oracle: a divergence is either a bug in the manual
+input construction or a genuine EP/precision difference.
+
+The parity tests need both runtimes plus the Model Builder, and they build a tiny
+random Llama export on the fly (CPU execution provider), mirroring
+``tests/models/test_onnxruntime_genai.py``; they skip when those are missing, as
+they are in CI. The registration and provider-resolution tests need neither
+runtime and always run. To exercise everything locally:
+
+    python -m pytest tests/models/test_onnxruntime_parity.py -vv
+"""
+
+import tempfile
+
+import numpy as np
+import pytest
+
+from lm_eval.api.instance import Instance
+
+
+# Summed log-probs over a continuation: both engines run the same fp32 CPU
+# kernels, so agreement should be near-exact. Kept loose enough to absorb
+# accumulation-order differences between a single prompt pass and GenAI's
+# internal buffering.
+LOGLIKELIHOOD_ATOL = 1e-3
+
+PROMPT_PAIRS = [
+    ("The capital of France is", " Paris"),
+    ("The capital of France is", " London"),
+    ("Water boils at", " 100 degrees"),
+    ("Water boils at", " zero degrees"),
+    ("She opened the door and", " walked inside"),
+    ("She opened the door and", " the sky turned green"),
+    ("One plus one equals", " two"),
+    ("One plus one equals", " seven"),
+    ("The largest planet is", " Jupiter"),
+    ("The largest planet is", " Mercury"),
+    ("Cats are", " mammals"),
+    ("Cats are", " reptiles"),
+    ("In the morning I drink", " coffee"),
+    ("In the morning I drink", " concrete"),
+    ("Python is a", " programming language"),
+    ("Python is a", " kind of bread"),
+    ("The sun rises in the", " east"),
+    ("The sun rises in the", " refrigerator"),
+    ("Hello", " world"),
+    ("A triangle has", " three sides"),
+]
+
+
+def _build_tiny_model_dir():
+    """Build a tiny random Llama Model Builder export (fp32, CPU).
+
+    head_size must be a multiple of 16 for the genai CPU GroupQueryAttention
+    kernel, so hidden_size=128 / num_heads=8 -> head_size=16.
+    """
+    builder = pytest.importorskip("onnxruntime_genai.models.builder")
+    from transformers import AutoTokenizer, LlamaConfig, LlamaForCausalLM
+
+    src = tempfile.mkdtemp(prefix="ort_parity_src_")
+    out = tempfile.mkdtemp(prefix="ort_parity_out_")
+    cache = tempfile.mkdtemp(prefix="ort_parity_cache_")
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-LlamaForCausalLM"
+    )
+    config = LlamaConfig(
+        vocab_size=tokenizer.vocab_size,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+        max_position_embeddings=512,
+        tie_word_embeddings=True,
+    )
+    LlamaForCausalLM(config).save_pretrained(src)
+    tokenizer.save_pretrained(src)
+
+    try:
+        builder.create_model(None, src, out, "fp32", "cpu", cache)
+    except Exception as e:  # noqa: BLE001 - any builder failure means skip
+        pytest.skip(f"Model Builder could not create a CPU fixture: {e}")
+    return out
+
+
+def _make_requests(pairs):
+    return [
+        Instance(request_type="loglikelihood", doc={}, arguments=pair, idx=i)
+        for i, pair in enumerate(pairs)
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Registration: cheap, no runtime or model needed.
+# --------------------------------------------------------------------------- #
+def test_raw_backend_registered():
+    from lm_eval.api.registry import get_model
+
+    assert get_model("onnxruntime").__name__ == "ONNXRuntimeLM"
+
+
+def test_both_backends_share_one_base():
+    """The parity guarantee rests on a single shared implementation."""
+    from lm_eval.models._onnx_base import _ONNXLMBase
+    from lm_eval.models.onnxruntime_genai import ONNXRuntimeGenAILM
+    from lm_eval.models.onnxruntime_ort import ONNXRuntimeLM
+
+    assert issubclass(ONNXRuntimeGenAILM, _ONNXLMBase)
+    assert issubclass(ONNXRuntimeLM, _ONNXLMBase)
+    for method in ("_loglikelihood_tokens", "loglikelihood_rolling"):
+        assert getattr(ONNXRuntimeGenAILM, method) is getattr(_ONNXLMBase, method)
+        assert getattr(ONNXRuntimeLM, method) is getattr(_ONNXLMBase, method)
+
+
+# --------------------------------------------------------------------------- #
+# Provider resolution: no runtime needed, so these run in CI.
+# --------------------------------------------------------------------------- #
+class _FakeORT:
+    """Stands in for the ``onnxruntime`` module during provider resolution."""
+
+    def __init__(self, available):
+        self._available = available
+
+    def get_available_providers(self):
+        return list(self._available)
+
+
+def _make_provider_lm(execution_provider, declared=None, provider_options=None):
+    from lm_eval.models.onnxruntime_ort import ONNXRuntimeLM
+
+    lm = ONNXRuntimeLM.__new__(ONNXRuntimeLM)
+    lm.execution_provider = execution_provider
+    lm.provider_options = provider_options or {}
+    lm._genai_config = {
+        "model": {"decoder": {"session_options": {"provider_options": declared or []}}}
+    }
+    return lm
+
+
+def test_providers_default_honors_genai_config():
+    # Regression (mirrors test_select_ep_none_leaves_config_untouched for the
+    # genai backend): with no execution_provider, the providers Model Builder
+    # declared must be used, else a CUDA/DML/NPU export silently runs on CPU.
+    lm = _make_provider_lm(None, declared=[{"cuda": {"device_id": "0"}}])
+    providers, options = lm._resolve_providers(
+        _FakeORT(["CUDAExecutionProvider", "CPUExecutionProvider"])
+    )
+    assert providers == ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    assert options[0] == {"device_id": "0"}
+
+
+def test_providers_default_without_declaration_is_cpu():
+    """An empty provider list means CPU in genai, so match that."""
+    lm = _make_provider_lm(None, declared=[])
+    providers, _ = lm._resolve_providers(_FakeORT(["CPUExecutionProvider"]))
+    assert providers == ["CPUExecutionProvider"]
+
+
+def test_providers_explicit_request_overrides_declaration():
+    lm = _make_provider_lm("rocm", declared=[{"cuda": {}}])
+    providers, _ = lm._resolve_providers(
+        _FakeORT(
+            ["ROCMExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]
+        )
+    )
+    # CPU stays last as a per-node fallback for ops the EP lacks.
+    assert providers == ["ROCMExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_providers_explicit_cpu_forces_cpu():
+    lm = _make_provider_lm("cpu", declared=[{"cuda": {}}])
+    providers, _ = lm._resolve_providers(
+        _FakeORT(["CUDAExecutionProvider", "CPUExecutionProvider"])
+    )
+    assert providers == ["CPUExecutionProvider"]
+
+
+def test_unavailable_provider_raises():
+    lm = _make_provider_lm("cuda")
+    with pytest.raises(ValueError, match="not available"):
+        lm._resolve_providers(_FakeORT(["CPUExecutionProvider"]))
+
+
+# --------------------------------------------------------------------------- #
+# Parity: both engines, same export, same (CPU) execution provider.
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def tiny_model_dir():
+    pytest.importorskip("onnxruntime_genai")
+    pytest.importorskip("onnxruntime")
+    return _build_tiny_model_dir()
+
+
+@pytest.fixture(scope="module")
+def backends(tiny_model_dir):
+    from lm_eval.api.registry import get_model
+
+    args = f"pretrained={tiny_model_dir},execution_provider=cpu"
+    genai = get_model("onnxruntime-genai").create_from_arg_string(
+        args, {"batch_size": 1}
+    )
+    raw = get_model("onnxruntime").create_from_arg_string(args, {"batch_size": 1})
+    return genai, raw
+
+
+def test_forward_logits_parity(backends):
+    """The raw single-pass forward matches GenAI's prompt logits elementwise."""
+    genai, raw = backends
+    tokens = genai.tok_encode("The quick brown fox jumps over the lazy dog")
+    assert len(tokens) > 1
+
+    genai_logits = genai._forward_logits(tokens)
+    raw_logits = raw._forward_logits(tokens)
+
+    assert genai_logits.shape == raw_logits.shape
+    np.testing.assert_allclose(genai_logits, raw_logits, rtol=1e-3, atol=1e-3)
+
+
+def test_loglikelihood_parity(backends):
+    """Summed continuation log-probs and greedy flags agree across engines."""
+    genai, raw = backends
+    requests = _make_requests(PROMPT_PAIRS)
+
+    genai_results = genai.loglikelihood(requests, disable_tqdm=True)
+    raw_results = raw.loglikelihood(requests, disable_tqdm=True)
+
+    assert len(genai_results) == len(raw_results) == len(PROMPT_PAIRS)
+
+    diffs = []
+    for (context, continuation), (ll_g, greedy_g), (ll_r, greedy_r) in zip(
+        PROMPT_PAIRS, genai_results, raw_results, strict=True
+    ):
+        assert np.isfinite(ll_g) and np.isfinite(ll_r)
+        assert ll_g < 0.0, "a real continuation must have negative log-prob"
+        diffs.append(abs(ll_g - ll_r))
+        assert abs(ll_g - ll_r) < LOGLIKELIHOOD_ATOL, (
+            f"log-prob mismatch for {context!r} + {continuation!r}: "
+            f"genai={ll_g:.6f} raw={ll_r:.6f}"
+        )
+        # is_greedy drives multiple_choice scoring, so it must agree too.
+        assert greedy_g == greedy_r, (
+            f"is_greedy mismatch for {context!r} + {continuation!r}: "
+            f"genai={greedy_g} raw={greedy_r}"
+        )
+
+    print(f"\nmax summed-logprob diff over {len(diffs)} requests: {max(diffs):.3e}")
+
+
+def test_multiple_choice_argmax_parity(backends):
+    """The argmax over choices -- i.e. the predicted answer -- is identical.
+
+    This is what multiple_choice accuracy (mmlu/hellaswag/arc) reduces to, so
+    agreement here is the property that makes task metrics comparable.
+    """
+    genai, raw = backends
+    # Group the fixed pairs by context: each group is one multiple-choice item.
+    groups: dict[str, list[tuple[str, str]]] = {}
+    for context, continuation in PROMPT_PAIRS:
+        groups.setdefault(context, []).append((context, continuation))
+    groups = {ctx: pairs for ctx, pairs in groups.items() if len(pairs) > 1}
+    assert groups, "need at least one multi-choice group"
+
+    for context, pairs in groups.items():
+        requests = _make_requests(pairs)
+        genai_lls = [ll for ll, _ in genai.loglikelihood(requests, disable_tqdm=True)]
+        raw_lls = [ll for ll, _ in raw.loglikelihood(requests, disable_tqdm=True)]
+        assert int(np.argmax(genai_lls)) == int(np.argmax(raw_lls)), (
+            f"different answer chosen for {context!r}: genai={genai_lls} raw={raw_lls}"
+        )
+
+
+def test_rolling_perplexity_parity(backends):
+    """loglikelihood_rolling (wikitext-style perplexity) agrees across engines."""
+    genai, raw = backends
+    text = (
+        "The history of computing is long and winding. Early machines were "
+        "mechanical, then electromechanical, and finally electronic. Each step "
+        "made computation cheaper and more widely available, which in turn "
+        "changed what people expected a computer to be able to do."
+    )
+    requests = [
+        Instance(request_type="loglikelihood_rolling", doc={}, arguments=(text,), idx=0)
+    ]
+
+    (genai_ll,) = genai.loglikelihood_rolling(requests, disable_tqdm=True)
+    (raw_ll,) = raw.loglikelihood_rolling(requests, disable_tqdm=True)
+
+    assert np.isfinite(genai_ll) and np.isfinite(raw_ll)
+    # Rolling sums accumulate over windows, so scale tolerance with magnitude.
+    np.testing.assert_allclose(genai_ll, raw_ll, rtol=1e-4, atol=LOGLIKELIHOOD_ATOL)
+
+
+def test_raw_backend_reports_graph_contract(backends):
+    """The raw backend introspects the graph instead of assuming its inputs."""
+    _, raw = backends
+    input_names = {name for name, _, _ in raw._input_specs}
+    assert "input_ids" in input_names
+    assert "attention_mask" in input_names
+    assert any(name.startswith("past_key_values") for name in input_names)
+    assert raw._logits_name == "logits"
+    # position_ids is absent from GQA+rotary exports; either way the backend
+    # must agree with the graph rather than hardcode it.
+    assert raw._has_position_ids == ("position_ids" in input_names)
+
+
+def test_generative_tasks_rejected_clearly(backends):
+    """Until the decode loop lands, generate_until must fail with guidance."""
+    _, raw = backends
+    requests = [
+        Instance(
+            request_type="generate_until",
+            doc={},
+            arguments=("Question: 2+2?\nAnswer:", {"until": ["\n"]}),
+            idx=0,
+        )
+    ]
+    with pytest.raises(NotImplementedError, match="onnxruntime-genai"):
+        raw.generate_until(requests, disable_tqdm=True)


### PR DESCRIPTION
## Summary

Adds a second ONNX backend, `onnxruntime`, that scores Model Builder exports through `onnxruntime.InferenceSession` directly, alongside the `onnxruntime-genai` backend from #3960. The shared lm-eval scoring logic moves into `_ONNXLMBase` so both backends compute loglikelihoods from the same code rather than drifting apart.

Two reasons to carry both engines rather than picking one:

- **Execution provider reach.** There is no onnxruntime-genai build for ROCm or MIGraphX, so the raw session is currently the only way to evaluate those stacks from lm-eval.
- **Stack parity.** It exercises the same session/EP path that production serving uses, so when a number disagrees with the torch reference the discrepancy is attributable to a layer rather than to the harness.

Rebased onto `main` now that #3960 has merged, so the diff below is only this work.

## This is a move, not a reimplementation

The point of the refactor is that the second backend adds an engine, not a second copy of the scoring math:

| | |
|---|---|
| `onnxruntime_genai.py` | 405 → 151 lines (keeps only `_import_genai`, `_select_ep`, `_load`, `_forward_logits`, `_generate`) |
| lines removed from it that reappear verbatim in `_onnx_base.py` | 211 / 230 (92%) |
| `_onnx_base.py` lines already present in `onnxruntime_genai.py` on main | 219 / 255 (86%) |
| genuinely new lines in `_onnx_base.py` | 36 (module docstring, the three `abc` hooks, splitting `_load_tokenizer` out of `_load`) |
| `winml.py` | **untouched** — still inherits everything through `ONNXRuntimeGenAILM` |

Seven files change in total, and `test_winml.py` passes unmodified.

## Babber's provider fix is carried through, in both backends

#3960 landed 86555286 after review: `execution_provider` defaults to `None` and `_select_ep` returns early in that case, so the providers Model Builder wrote into `genai_config.json` survive instead of being cleared and silently downgraded to CPU.

That fix lives in exactly the code this PR moves, so it needed care rather than a plain rebase:

- The `execution_provider: str | None = None` default now lives in `_ONNXLMBase.__init__`, i.e. on the shared signature.
- `_select_ep` keeps main's early-return version verbatim in the genai backend.
- **The raw backend gets the same semantics.** `InferenceSession` doesn't read `genai_config.json`, so it now reads `model.decoder.session_options.provider_options` itself rather than defaulting to CPU. An explicit `execution_provider` overrides the export, and an empty declaration means CPU, matching genai's convention.

`test_select_ep_none_leaves_config_untouched` from #3960 passes here, and there are four new tests covering the raw backend's equivalent (unset honors the declaration, explicit override, explicit cpu, unavailable provider).

## Scope

`loglikelihood` and `loglikelihood_rolling`. `generate_until` raises `NotImplementedError` pointing at the genai backend, since a hand-rolled decode loop with rolling KV state is a separate change and genai already does it well. That covers multiple-choice and perplexity tasks; generative tasks should use `onnxruntime-genai`.

Requires `onnxruntime>=1.23` for the 12-input `GroupQueryAttention` schema current Model Builder emits.

## Validation

**Direct comparison against PyTorch.** Full arc_challenge (1,172 items) on the Phi-3.5-mini fp32 export, raw backend versus the `hf` backend on the same weights:

| backend | acc | acc_norm |
|---|---|---|
| `onnxruntime` (this PR) | 0.591296928327645 | 0.6092150170648464 |
| `onnxruntime-genai` | 0.591296928327645 | 0.6092150170648464 |
| torch (`hf`) | 0.591296928327645 | 0.6092150170648464 |

Identical to every digit. So this backend's task metrics are verified against torch directly, not only transitively through parity with the genai backend.

**Cross-backend parity, CPU.** Raw forward logits, summed loglikelihoods, multiple-choice argmax, rolling perplexity and the graph contract all agree between the two backends. Max logit difference `0.000e+00` on the fp32 fixture, and bit-identical summed log-probs on a real Qwen1.5-0.5B export. The parity fixture builds a 2-layer fp32 Llama on CPU, so it needs no accelerator and no network.

**These tests run in CI.** The parity module skips itself when the ONNX runtimes are absent, so no `--ignore` entry is needed and the workflow is untouched. Verified against an environment with no `onnxruntime` installed: 7 pass (registration, shared-base, provider resolution), 6 skip. With both runtimes present all 13 pass.

Totals: 13 parity + 12 genai + 3 winml = 28 passing. Ruff 0.16.3 clean.

**AMD GPU, MI250X via ROCmExecutionProvider.** hellaswag, 200 samples, int4 export:

| | acc | acc_norm | throughput |
|---|---|---|---|
| ROCm (MI250X) | 0.400 | 0.500 | 42 it/s (800 requests in 19s) |
| CPU, same graph | 0.405 | 0.500 | 19 it/s (800 requests in 41s) |

The one-sample `acc` gap is EP kernel/quantization difference on int4, not a harness disagreement — the CPU-vs-CPU cross-backend comparison above is exact.

Two ecosystem gaps this run exposed, neither actionable in this PR. Model Builder 0.14.1 emits 12-input GQA while the newest `onnxruntime-rocm` on PyPI (1.22.2.post3) accepts at most 11, so the ROCm run needed a 0.11.4 export. And on that graph the ROCm provider has no `GroupQueryAttention` kernel: ORT's own node placement puts 298 nodes on ROCm and 27 on CPU, where those 27 are all 24 `GroupQueryAttention` nodes plus 2 `Cast` and 1 `Shape`, with 26 `MemcpyToHost` / 26 `MemcpyFromHost` inserted to service them. So the 2.2x above is a floor, not a representative ROCm number.

## Test plan

- [x] `pytest tests/models/test_onnxruntime_parity.py` — 13 passed
- [x] `pytest tests/models/test_onnxruntime_genai.py` — 12 passed, including the post-review EP regression tests
- [x] `pytest tests/models/test_winml.py` — 3 passed, file unmodified
- [x] Skip-clean in an environment without onnxruntime (CI shape): 7 passed, 6 skipped
- [x] Real-model agreement across torch / genai / raw-ORT on Qwen1.5-0.5B
- [x] hellaswag on MI250X via ROCmExecutionProvider
- [x] `ruff check` / `ruff format --check` at the pinned 0.16.3
- [ ] CUDA and DirectML EPs unverified — no access to that hardware here
