### PR TITLE
fix(mmlu_flan_cot_zeroshot): aggregate exact_match instead of nonexistent acc

### DIFF
--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu.yaml
@@ -5,28 +5,28 @@ task:
     task:
       - mmlu_flan_cot_zeroshot_stem
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: other
     task:
       - mmlu_flan_cot_zeroshot_other
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: social sciences
     task:
       - mmlu_flan_cot_zeroshot_social_sciences
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: humanities
     task:
       - mmlu_flan_cot_zeroshot_humanities
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
 aggregate_metric_list:
-  - metric: acc
+  - metric: exact_match
     weight_by_size: True
 metadata:
   version: 2


### PR DESCRIPTION
## Summary

`mmlu_flan_cot_zeroshot`'s group-level and subgroup-level results never populate a metric value, even though every leaf subtask scores correctly (as reported in #3986).

## Root cause

`lm_eval/tasks/mmlu/flan_cot_zeroshot/_mmlu.yaml` declares, at every group and subgroup level:

```yaml
aggregate_metric_list:
  - metric: acc
    weight_by_size: True
```

But the leaf tasks (via `_mmlu_flan_cot_zeroshot_template_yaml`) only emit `exact_match`, through the `strict-match` and `flexible-extract` filters — they never emit `acc`.

In `lm_eval/api/group.py`, `aggregate()` calls `_discover_filters_for_metric(metric, ...)`, which scans leaf metrics for `"{metric},{filter}"` keys. For `metric: acc` it finds nothing (the leaves only have `exact_match,strict-match` / `exact_match,flexible-extract`), so `filters_to_aggregate` is empty and no metric key is ever added to the group result. The rollup silently stays empty instead of erroring or falling back.

## Fix

Change the five `aggregate_metric_list` entries in `flan_cot_zeroshot/_mmlu.yaml` from `metric: acc` to `metric: exact_match`. With no explicit `filter_list`, `_discover_filters_for_metric` now auto-discovers both `strict-match` and `flexible-extract`, so each group/subgroup rolls up both `exact_match,strict-match` and `exact_match,flexible-extract` — matching exactly what the leaf tasks report.

This mirrors how the sibling `flan_cot_fewshot/_mmlu.yaml` already aggregates `exact_match` at its top level.

Config-only change; no leaf metrics or scores are altered — groups that previously returned nothing now return the correct aggregate.

Fixes #3986

🤖 Generated with [Claude Code](https://claude.com/claude-code)
