### PR TITLE
replace sqlitedict cache with stdlib sqlite3 + JSON

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -2,6 +2,7 @@ import abc
 import hashlib
 import json
 import logging
+import sqlite3
 import os
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
@@ -12,8 +13,6 @@ from lm_eval import utils
 
 
 if TYPE_CHECKING:
-    from sqlitedict import SqliteDict
-
     from lm_eval.api.instance import Instance
 
 
@@ -235,7 +234,7 @@ def hash_args(attr: str, args: Iterable[Any]) -> str:
 class CacheHook:
     def __init__(self, cachinglm: Optional["CachingLM"]) -> None:
         if cachinglm is None:
-            self.dbdict: SqliteDict | None = None
+            self.dbdict: "JsonSqliteDict | None" = None
             return
 
         self.dbdict = cachinglm.dbdict
@@ -247,6 +246,77 @@ class CacheHook:
         self.dbdict[hsh] = res
 
 
+class JsonSqliteDict:
+    """A minimal sqlite-backed key/value store using JSON instead of pickle.
+
+    Replaces ``sqlitedict.SqliteDict`` for lm-eval's response cache. Only the
+    operations actually used by ``CachingLM`` are implemented: ``__contains__``,
+    ``__getitem__``, ``__setitem__`` and ``commit()``.
+    """
+
+    _LEGACY_TABLE: str = "unnamed"
+
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        self._conn = sqlite3.connect(filename)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self._conn.commit()
+        self._pending: int = 0
+        self._legacy: bool = self._is_legacy_table()
+
+    def _is_legacy_table(self) -> bool:
+        """Detect whether this DB was created by sqlitedict (pickle format)."""
+        try:
+            row = self._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE name='unnamed' AND type='table'"
+            ).fetchone()
+            return row is not None
+        except Exception:
+            return False
+
+    def __contains__(self, key: str) -> bool:
+        if self._legacy:
+            return False
+        row = self._conn.execute("SELECT 1 FROM cache WHERE key = ?", (key,)).fetchone()
+        return row is not None
+
+    def __getitem__(self, key: str) -> Any:
+        if self._legacy:
+            raise KeyError(key)
+        row = self._conn.execute(
+            "SELECT value FROM cache WHERE key = ?", (key,)
+        ).fetchone()
+        if row is None:
+            raise KeyError(key)
+        return json.loads(row[0])
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if self._legacy:
+            raise RuntimeError(
+                "Refusing to write to a legacy sqlitedict (pickle) cache. "
+                "Delete or migrate the cache file first."
+            )
+        self._conn.execute(
+            "INSERT INTO cache VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, json.dumps(value)),
+        )
+        self._pending += 1
+        if self._pending >= 100:
+            self.commit()
+
+    def commit(self) -> None:
+        if self._pending:
+            self._conn.commit()
+            self._pending = 0
+
+    def close(self) -> None:
+        self.commit()
+        self._conn.close()
+
+
 class CachingLM:
     def __init__(self, lm: LM, cache_db: str) -> None:
         """LM wrapper that returns cached results when available, falling back to the underlying model.
@@ -255,13 +325,11 @@ class CachingLM:
             lm: The underlying language model to wrap.
             cache_db: Path to the SQLite cache database.
         """
-        from sqlitedict import SqliteDict
-
         self.lm: LM = lm
         self.cache_db: str = cache_db
         if os.path.dirname(cache_db):
             os.makedirs(os.path.dirname(cache_db), exist_ok=True)
-        self.dbdict = SqliteDict(cache_db, autocommit=True)
+        self.dbdict = JsonSqliteDict(cache_db)
 
         # add hook to lm
         lm.set_cache_hook(self.get_cache_hook())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "rouge-score>=0.0.4",
     "sacrebleu>=1.5.0",
     "scikit-learn>=0.24.1",
-    "sqlitedict",
     "dill",
     "word2number",
     "more_itertools",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,3 +26,95 @@ def test_short_cache_keys_keep_readable_name(tmp_path, monkeypatch):
     cache_files = os.listdir(tmp_path)
     assert cache_files == [f"{cache_key}{cache.FILE_SUFFIX}"]
     assert cache.load_from_cache(cache_key, cache=True) == ["cached"]
+
+
+import sqlite3
+import tempfile
+
+import pytest
+
+from lm_eval.api.model import CachingLM, JsonSqliteDict
+
+
+def test_json_sqlite_dict_round_trip():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = f.name
+
+    try:
+        d = JsonSqliteDict(path)
+        assert "missing" not in d
+
+        d["a"] = (1.0, True)
+        d["b"] = 2.5
+        d["c"] = "hello"
+        d.commit()
+        d.close()
+
+        d2 = JsonSqliteDict(path)
+        assert "a" in d2
+        assert d2["a"] == [1.0, True]
+        assert d2["b"] == 2.5
+        assert d2["c"] == "hello"
+    finally:
+        if path:
+            import os
+            os.unlink(path)
+
+
+def test_json_sqlite_dict_refuses_legacy_pickle_cache():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = f.name
+
+    try:
+        # Recreate the schema sqlitedict uses so our detector sees it.
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE unnamed (key TEXT PRIMARY KEY, value BLOB)")
+        conn.commit()
+        conn.close()
+
+        d = JsonSqliteDict(path)
+        assert "key" not in d
+        with pytest.raises(RuntimeError):
+            d["key"] = "value"
+    finally:
+        if path:
+            import os
+            os.unlink(path)
+
+
+def test_caching_lm_do_sample_skips_cache(monkeypatch):
+    """Non-deterministic generate_until requests should not be cached."""
+    import lm_eval.api.model as model_module
+
+    called = []
+
+    class DummyLM:
+        def __init__(self):
+            self.cache_hook = model_module.CacheHook(None)
+
+        def generate_until(self, requests):
+            called.extend(requests)
+            return ["generated" for _ in requests]
+
+        def set_cache_hook(self, hook):
+            self.cache_hook = hook
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = f"{tmpdir}/cache.db"
+        lm = CachingLM(DummyLM(), cache_path)
+
+        # do_sample=True should bypass cache
+        from lm_eval.api.instance import Instance
+        req = Instance(
+            request_type="generate_until",
+            doc={},
+            arguments=(("prompt", {}), {"do_sample": True}),
+            idx=0,
+        )
+        lm.generate_until([req])
+        assert len(called) == 1
+
+        # A second identical request should still hit the model because it was never cached.
+        called.clear()
+        lm.generate_until([req])
+        assert len(called) == 1


### PR DESCRIPTION
Hi EleutherAI team,

This replaces `sqlitedict` in the response cache (`--use_cache`) with a stdlib `sqlite3` + JSON implementation.

Why: `sqlitedict` uses `pickle` and has CVE-2024-35515 / GHSA-g4r7-86gm-pgqc (CVSS 8.8). There is no patched release and the only values ever cached are `tuple[float, bool]`, `float`, and `str` — all JSON-safe.

What changed:
- New `JsonSqliteDict` in `lm_eval/api/model.py` implementing only the operations the cache uses.
- Dropped `sqlitedict` from `pyproject.toml`.
- Legacy pickle-format cache files are detected and rejected instead of being silently unpickled.
- Added unit tests for round-tripping all three cached value shapes, legacy-cache rejection, and the `do_sample` bypass path.

Fixes #3964