### PR TITLE
Fix `megatron_lm` backend against Megatron-LM `core_v0.18+`: argument parsing moved out of `initialize_megatron()`

### DIFF
--- a/lm_eval/models/megatron_lm.py
+++ b/lm_eval/models/megatron_lm.py
@@ -322,6 +322,14 @@ class MegatronLMEval(LM):
         from megatron.training.arguments import core_transformer_config_from_args
         from megatron.training.checkpointing import load_checkpoint
 
+        # Megatron moved argument parsing out of initialize_megatron() in
+        # core_v0.18. Detecting by import, not by version, because the refactor
+        # is not split by version number (commits both report version 0.18.0).
+        try:
+            from megatron.training.arguments import parse_and_validate_args
+        except ImportError:
+            parse_and_validate_args = None
+
         devices = kwargs["devices"]
         tp_size = kwargs["tensor_model_parallel_size"]
         pp_size = kwargs["pipeline_model_parallel_size"]
@@ -401,10 +409,21 @@ class MegatronLMEval(LM):
 
         try:
             # Initialize Megatron
-            initialize_megatron(
-                extra_args_provider=None,
-                args_defaults={"tokenizer_type": kwargs["tokenizer_type"]},
-            )
+            # parse_and_validate_args() must run first as it populates the global
+            # args, including --use-checkpoint-args, that initialize_megatron()
+            # then reads using get_args(). Previous Megatron parses args inside
+            # the initialize call instead.
+            if parse_and_validate_args is not None:
+                parse_and_validate_args(
+                    extra_args_provider=None,
+                    args_defaults={"tokenizer_type": kwargs["tokenizer_type"]},
+                )
+                initialize_megatron()
+            else:
+                initialize_megatron(
+                    extra_args_provider=None,
+                    args_defaults={"tokenizer_type": kwargs["tokenizer_type"]},
+                )
 
             args = get_args()
             self._args = args


### PR DESCRIPTION
## Summary

The `megatron_lm` backend cannot initialize against current Megatron-LM. It calls `initialize_megatron(extra_args_provider=..., args_defaults=...)`, a signature that Megatron removed when it extracted argument parsing into a `parse_and_validate_args()` function. This results in a `TypeError` when using Megatron-LM v0.18+.

## The bug

`MegatronLMEval._initialize_megatron()` calls:

```python
initialize_megatron(
    extra_args_provider=None,
    args_defaults={"tokenizer_type": kwargs["tokenizer_type"]},
)
```

Megatron commit `97aca2f88` removed `extra_args_provider`, `args_defaults`, `ignore_unknown_args` and `parsed_args` from
`initialize_megatron()` and moved argument parsing into a new caller-side `parse_and_validate_args()`. Using the old signature yields the traceback:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File ".../lm_eval/__main__.py", line 14, in <module>
    cli_evaluate()
  File ".../lm_eval/__main__.py", line 10, in cli_evaluate
    parser.execute(args)
  File ".../lm_eval/_cli/harness.py", line 60, in execute
    args.func(args)
  File ".../lm_eval/_cli/run.py", line 391, in _execute
    results = simple_evaluate(
              ^^^^^^^^^^^^^^^^
  File ".../lm_eval/utils.py", line 575, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File ".../lm_eval/evaluator.py", line 242, in simple_evaluate
    lm = lm_eval.api.registry.get_model(model).create_from_arg_obj(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lm_eval/api/model.py", line 169, in create_from_arg_obj
    return cls(**arg_dict, **additional_config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lm_eval/models/megatron_lm.py", line 217, in __init__
    self._initialize_megatron(
  File ".../lm_eval/models/megatron_lm.py", line 404, in _initialize_megatron
    initialize_megatron(
TypeError: initialize_megatron() got an unexpected keyword argument 'extra_args_provider'
```

Note that `parse_and_validate_args()` is also where `--use-checkpoint-args` is now handled, so `parse_and_validate_args()` must run first to populate the global args that `initialize_megatron()` then consumes.

## Reproduction

Any `megatron_lm` invocation against a Megatron release tag core_v0.18.0 or later fails with above error.

```bash
export MEGATRON_PATH=/path/to/Megatron-LM
python -m torch.distributed.run --standalone --nproc-per-node 1 -m lm_eval --model megatron_lm --model_args 'load=/path/to/checkpoints,ckpt_step=N' --tasks arc_easy --limit 50
```

## The fix

Use `parse_and_validate_args` if it can be imported and otherwise fallback to the previous `initialize_megatron` call.
Detection is by import, not by version number as there are commits reporting version 0.18 that do not carry that refactor.

## Verification

Verified against Megatron-LM v0.18.0. With the change, the backend initializes, loads a torch-dist checkpoint and scores `arc_easy`, reporting finite `acc` / `acc_norm`. Reverting the change reproduces the failure.

No unit test is added as the `megatron_lm` backend has no test coverage in `tests/`, but all existing tests pass.
`pre-commit run --files lm_eval/models/megatron_lm.py` passes.