### PR TITLE
Enable function resolving for custom tasks

### DIFF
--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -376,7 +376,7 @@ class EvaluatorConfig:
             task_names = []
             yaml_path = Path(task_list[0]) / "*.yaml"
             for yaml_file in glob.glob(str(yaml_path)):
-                config = load_yaml(yaml_file, resolve_func=False)
+                config = load_yaml(yaml_file, resolve_func=True)
                 task_names.append(config)
             self.tasks = task_names
             return task_manager
@@ -397,7 +397,7 @@ class EvaluatorConfig:
                 # Custom config file(s) - support glob patterns
                 matches = []
                 for yaml_file in glob.glob(task):
-                    config = load_yaml(yaml_file, resolve_func=False)
+                    config = load_yaml(yaml_file, resolve_func=True)
                     matches.append(config)
             match_dict[task] = matches
 

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -477,6 +477,110 @@ doc_to_target: "{{answer}}"
         with pytest.raises(ValueError, match="Tasks not found"):
             cfg.process_tasks()
 
+    @staticmethod
+    def _write_custom_task(directory):
+        """Write a self-contained task YAML plus the sibling utils.py it references.
+
+        The YAML uses `!function` in every place a custom callable is accepted:
+        `process_docs`, `metric`, and `aggregation`.
+        """
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "utils.py").write_text(
+            "def process(dataset):\n"
+            "    return dataset\n"
+            "\n"
+            "\n"
+            "def exact(references, predictions):\n"
+            "    return float(references[0].strip() == predictions[0].strip())\n"
+            "\n"
+            "\n"
+            "def mean(items):\n"
+            "    return sum(items) / len(items) if items else 0.0\n"
+        )
+        (directory / "data.json").write_text('[{"question": "2+2?", "answer": "4"}]\n')
+
+        task_yaml = directory / "custom_fn_task.yaml"
+        task_yaml.write_text(f"""
+task: custom_fn_task
+dataset_path: json
+dataset_kwargs:
+  data_files:
+    test: {directory / "data.json"}
+test_split: test
+output_type: generate_until
+process_docs: !function utils.process
+doc_to_text: "{{{{question}}}}"
+doc_to_target: "{{{{answer}}}}"
+generation_kwargs:
+  until: ["\\n"]
+metric_list:
+  - metric: !function utils.exact
+    aggregation: !function utils.mean
+    higher_is_better: true
+""")
+        return task_yaml
+
+    def test_custom_yaml_file_resolves_function_refs(self, tmp_path):
+        """`!function` refs must resolve to callables when a YAML path is passed to --tasks.
+
+        Regression guard: the TaskManager refactor (#3549) loaded these configs with
+        `resolve_func=False`, the mode meant for building the task *index*. Nothing
+        downstream re-resolves them, because `entry_from_config` produces an Entry with
+        `yaml_path=None` and the factory then uses the dict verbatim.
+        """
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        task_yaml = self._write_custom_task(tmp_path / "task")
+
+        cfg = EvaluatorConfig(tasks=[str(task_yaml)], output_path=str(tmp_path))
+        cfg._configure()
+        cfg.process_tasks()
+
+        (spec,) = cfg.tasks
+        assert callable(spec["process_docs"])
+        assert callable(spec["metric_list"][0]["metric"])
+        assert callable(spec["metric_list"][0]["aggregation"])
+
+    def test_custom_yaml_directory_resolves_function_refs(self, tmp_path):
+        """Same as above for the directory branch of process_tasks (--tasks <dir>)."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        task_dir = tmp_path / "task"
+        self._write_custom_task(task_dir)
+
+        cfg = EvaluatorConfig(tasks=[str(task_dir)], output_path=str(tmp_path))
+        cfg._configure()
+        cfg.process_tasks()
+
+        (spec,) = cfg.tasks
+        assert callable(spec["process_docs"])
+        assert callable(spec["metric_list"][0]["metric"])
+        assert callable(spec["metric_list"][0]["aggregation"])
+
+    def test_custom_metric_survives_into_built_task(self, tmp_path):
+        """A custom metric must still be a live callable on the constructed Task.
+
+        This covers the *silent* half of the regression: an unresolved metric ref is a
+        string, so it misses the registry, warns, and drops out of `process_results()`
+        entirely -- a run completes and simply reports no metric.
+        """
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        task_yaml = self._write_custom_task(tmp_path / "task")
+
+        cfg = EvaluatorConfig(tasks=[str(task_yaml)], output_path=str(tmp_path))
+        cfg._configure()
+        task_manager = cfg.process_tasks()
+        task = task_manager.load(cfg.tasks)["tasks"]["custom_fn_task"]
+
+        assert list(task.aggregation()) == ["exact"]
+        assert callable(task.aggregation()["exact"])
+        assert task.higher_is_better() == {"exact": True}
+
+        doc = {"question": "2+2?", "answer": "4"}
+        assert task.process_results(doc, ["4"]) == {"exact": 1.0}
+        assert task.process_results(doc, ["5"]) == {"exact": 0.0}
+
 
 class TestEvaluatorConfigFromCLI:
     """Test EvaluatorConfig.from_cli defaults and argument handling."""


### PR DESCRIPTION
This PR enables function resolving for custom tasks specified with `--task` argument so as to load custom metrics.