### PR TITLE
Fix TER metric direction (higher_is_better) and correct chrF docstring

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -100,12 +100,17 @@ def bleu(items):
 
 @register_aggregation("chrf")
 def chrf(items):
-    """chrF++ is a tool for automatic evaluation of machine translation output
-    based on character n-gram precision and recall enhanced with word n-grams.
+    """chrF is an evaluation metric for machine translation output based on
+    character n-gram precision and recall.
+
+    This computes chrF, not chrF++: sacrebleu defaults to word_order=0, and
+    chrF++ is the word_order=2 variant. See #2256 for making the orders
+    configurable.
+
     Source: https://github.com/m-popovic/chrF
     Paper: https://www.aclweb.org/anthology/W15-3049.pdf
 
-    Higher is better  # TODO I think
+    Higher is better
     """
     refs = list(zip(*items))[0]
     preds = list(zip(*items))[1]
@@ -371,7 +376,7 @@ def chrf_fn(items):  # This is a passthrough function
 
 @register_metric(
     metric="ter",
-    higher_is_better=True,
+    higher_is_better=False,
     output_type="generate_until",
     aggregation="ter",
 )


### PR DESCRIPTION
`ter` is registered with `higher_is_better=True`. TER is an edit rate, so lower is better — and this file already says so: the `ter` aggregation docstring at `lm_eval/api/metrics.py:129` reads **"Lower is better"**, 250 lines above the registration that claims the opposite.

Checked against sacrebleu 2.5.1 rather than from the paper:

```python
refs = [["the cat sat on the mat"]]
sacrebleu.corpus_ter(["the cat sat on the mat"], refs).score          # 0.0
sacrebleu.corpus_ter(["completely different words entirely"], refs)   # 100.0
```

## What inherits it

`register_metric` forwards `higher_is_better` into `higher_is_better_registry` (`lm_eval/api/registry.py:597`), and `ConfigurableTask` falls back to it whenever a `metric_list` entry omits the key — `lm_eval/api/task.py:741-751`, which also logs a warning saying which default it took.

Resolving every task YAML through the harness's own include rule (`lm_eval/tasks/_yaml_loader.py:207`, `merged.update(cfg)` — local keys replace inherited ones wholesale, no deep merge of `metric_list`) gives an exact split:

**8 tasks inherit the wrong default.** `lm_eval/tasks/translation/wmt_common_yaml` declares a bare `- metric: ter`, and no task including it defines its own `metric_list`:

`wmt14-en-fr`, `wmt14-fr-en`, `wmt16-de-en`, `wmt16-en-de`, `wmt16-en-ro`, `wmt16-ro-en`, `iwslt2017-ar-en`, `iwslt2017-en-ar`

**84 tasks already set `higher_is_better: false` themselves** — every FLORES pair under `basque_bench`, `catalan_bench`, `galician_bench`, `portuguese_bench` and `spanish_bench`, plus the four `phrases_*` tasks; 13 config files, expanded across language pairs. Six Darija-Bench group files say `false` too.

That is thirteen independent task authors reaching the same conclusion about the default and patching around it locally, which seems like reason enough to fix the default rather than keep asking task authors to.

(`darija_bench/darija_translation/translation_common_yaml` and `.../darija_transliteration/transliteration_common_yaml` also declare a bare `ter`, but every task file including them redefines `metric_list` — so no Darija task computes `ter` at all, and those two declarations are unreachable either way.)

## Changes

1. **`higher_is_better=True` → `False`** on the `ter` registration. Fixes the eight tasks above and makes the 84 existing overrides redundant rather than load-bearing. I left the overrides in place: they still agree with the new default, and removing them would bury a one-line fix in a thirteen-file diff. Happy to follow up separately if you'd like them cleaned out.

2. **`chrf` docstring.** It described chrF++ — "enhanced with word n-grams" — while `corpus_chrf` is called with defaults, and sacrebleu's default is `word_order=0`. sacrebleu names the result itself: `corpus_chrf(...).name` is `chrF2` at defaults and `chrF2++` only at `word_order=2`. Corrected to say what the code computes, with a pointer to #2256 for making `char_order`/`word_order` configurable. Also dropped the `# TODO I think` beside "Higher is better" — chrF is an F-score, so the direction is not in doubt; the uncertainty was the docstring's, not the metric's.

No behaviour change beyond the one flag. `chrf`'s own `higher_is_better=True` was already correct.

## Notes for review

- Nothing in the test suite pins ter's direction: `tests/test_metrics.py` sets `_higher_is_better` only for `pass_at_k`, `tests/test_registry.py` exercises the mechanism with a synthetic metric, and the `tests/testdata/wmt*-res.json` files record scores with no direction field. So this breaks no test — and I'd be glad to add an assertion over `higher_is_better_registry` if you want it pinned going forward.
- `_propagate_higher_is_better` sets a group's direction to `None` when its children disagree; the eight affected tasks all agree with each other today, so their groups flip cleanly rather than becoming ambiguous.
- I did not take on #2256's configurability work. This is only the docstring correction that stops the file from naming a metric it doesn't compute.
