### PR TITLE
chore(api/task): fix pre-existing ruff violations blocking Linters CI

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -58,9 +58,6 @@ ALL_OUTPUT_TYPES = [
 eval_logger = logging.getLogger(__name__)
 
 
-TaskConfig = TaskConfig
-
-
 class Task(abc.ABC):
     """A task represents an entire benchmark including its dataset, problems,
     answers, and evaluation methods. See BoolQ for a simple example implementation
@@ -168,17 +165,14 @@ class Task(abc.ABC):
     @abc.abstractmethod
     def has_training_docs(self):
         """Whether the task has a training set"""
-        pass
 
     @abc.abstractmethod
     def has_validation_docs(self):
         """Whether the task has a validation set"""
-        pass
 
     @abc.abstractmethod
     def has_test_docs(self):
         """Whether the task has a test set"""
-        pass
 
     def training_docs(self) -> Iterable:
         """
@@ -397,7 +391,6 @@ class Task(abc.ABC):
             The number of times each instance in a dataset is inferred on. Defaults to 1,
             can be increased for techniques like majority voting.
         """
-        pass
 
     @abc.abstractmethod
     def process_results(self, doc, results):
@@ -410,7 +403,6 @@ class Task(abc.ABC):
         :param results:
             The results of the requests created in construct_requests.
         """
-        pass
 
     @abc.abstractmethod
     def aggregation(self):
@@ -419,7 +411,6 @@ class Task(abc.ABC):
             A dictionary where keys are the names of submetrics and values are
             functions that aggregate a list of metric scores
         """
-        pass
 
     @abc.abstractmethod
     def higher_is_better(self):
@@ -428,7 +419,6 @@ class Task(abc.ABC):
             A dictionary where keys are the names of submetrics and values are
             whether a higher value of the submetric is better
         """
-        pass
 
     def get_config(self, key: str) -> Any:
         return getattr(self._config, key, None)
@@ -724,7 +714,7 @@ class ConfigurableTask(Task):
                     agg_name = metric_config["aggregation"]
                     if isinstance(agg_name, str):
                         self._aggregation_list[metric_name] = get_aggregation(agg_name)
-                    elif callable(agg_name):  # noqa: E721
+                    elif callable(agg_name):
                         self._aggregation_list[metric_name] = metric_config[
                             "aggregation"
                         ]
@@ -916,7 +906,7 @@ class ConfigurableTask(Task):
             match samples:
                 case list(): return samples
                 case fsamples if callable(samples): return fsamples()
-                case _: raise Exception(
+                case _: raise TypeError(
                         "`fewshot_config['samples']` was incorrectly defined in the configuration. It should either be `list[dict]`, or callable returning this list."
                     ) from None
             # fmt: on
@@ -1200,9 +1190,7 @@ class ConfigurableTask(Task):
     def doc_to_text(self, doc, doc_to_text=None):
         if self.prompt is not None:
             doc_to_text = self.prompt
-        elif doc_to_text is not None:
-            doc_to_text = doc_to_text
-        else:
+        elif doc_to_text is None:
             doc_to_text = self.config.doc_to_text
 
         if isinstance(doc_to_text, int):
@@ -1236,9 +1224,7 @@ class ConfigurableTask(Task):
     def doc_to_target(self, doc: Mapping, doc_to_target=None) -> int | str | list:
         if self.prompt is not None:
             doc_to_target = self.prompt
-        elif doc_to_target is not None:
-            doc_to_target = doc_to_target
-        else:
+        elif doc_to_target is None:
             doc_to_target = self.config.doc_to_target
 
         if isinstance(doc_to_target, int):
@@ -1282,12 +1268,11 @@ class ConfigurableTask(Task):
     def doc_to_choice(self, doc: Any, doc_to_choice=None) -> list[str]:
         if self.prompt is not None:
             doc_to_choice = self.prompt
-        elif doc_to_choice is not None:
-            doc_to_choice = doc_to_choice
-        elif self.config.doc_to_choice is None:
-            eval_logger.error("doc_to_choice was called but not set in config")
-        else:
-            doc_to_choice = self.config.doc_to_choice
+        elif doc_to_choice is None:
+            if self.config.doc_to_choice is None:
+                eval_logger.error("doc_to_choice was called but not set in config")
+            else:
+                doc_to_choice = self.config.doc_to_choice
 
         if isinstance(doc_to_choice, str):
             if doc_to_choice in self.features:
@@ -1306,12 +1291,10 @@ class ConfigurableTask(Task):
             raise TypeError
 
     def doc_to_image(self, doc: Any, doc_to_image=None) -> int | str | list | None:
-        if doc_to_image is not None:
-            doc_to_image = doc_to_image
-        elif self.config.doc_to_image is not None:
+        if doc_to_image is None:
+            if self.config.doc_to_image is None:
+                return None
             doc_to_image = self.config.doc_to_image
-        else:
-            return None
 
         if isinstance(doc_to_image, list):
             image_feature = [
@@ -1329,12 +1312,10 @@ class ConfigurableTask(Task):
             return None
 
     def doc_to_audio(self, doc: Any, doc_to_audio=None) -> int | str | list | None:
-        if doc_to_audio is not None:
-            doc_to_audio = doc_to_audio
-        elif self.config.doc_to_audio is not None:
+        if doc_to_audio is None:
+            if self.config.doc_to_audio is None:
+                return None
             doc_to_audio = self.config.doc_to_audio
-        else:
-            return None
 
         if isinstance(doc_to_audio, list):
             audio_feature = [
@@ -1413,7 +1394,7 @@ class ConfigurableTask(Task):
         ):  # TODO: ensure that non-multimodal tasks aren't getting visual args
             multimodal_arg = {
                 **multimodal_arg,
-                **{"visual": self.doc_to_image(doc)},
+                "visual": self.doc_to_image(doc),
             }
 
         if (
@@ -1421,7 +1402,7 @@ class ConfigurableTask(Task):
         ):  # TODO: ensure that non-multimodal tasks aren't getting audio args
             multimodal_arg = {
                 **multimodal_arg,
-                **{"audio": self.doc_to_audio(doc)},
+                "audio": self.doc_to_audio(doc),
             }
 
         if bool(multimodal_arg):


### PR DESCRIPTION
Clears the 17 ruff violations `Linters` currently reports on `lm_eval/api/task.py`, which surface as a red CI check on every PR touching the file. Recent examples of PRs sitting with `Linters` red on this exact set of errors: #3891, #3951 (both fixing #3881), plus my cross-PR triage on #3881 that flagged this specifically. #3900 is the sibling cleanup on adjacent files (`anthropic_llms.py`, `sglang_causallms.py`, `global_piqa` templates) already claimed by #3922.

Grouped by rule, all fixes are behavior-preserving:

- **7 × PIE790 (unnecessary-placeholder)**: remove `pass` from `@abc.abstractmethod` bodies that consist of a docstring plus `pass`. Python treats a lone docstring as a valid function body, so the methods stay abstract and the docstring stays intact.

- **6 × PLW0127 (self-assigning-variable)**: restructure four `if/elif` chains that dispatched on `self.prompt` / kwarg / config to eliminate the redundant `x = x` self-assignments (`doc_to_text`, `doc_to_target`, `doc_to_choice`, `doc_to_image`, `doc_to_audio`). Chains preserve exact semantics across every input combination (prompt-set, kwarg-set, config-set, all-None). Also deletes the stray module-level `TaskConfig = TaskConfig` re-assignment left over from an old refactor; `TaskConfig` is imported at module top, so its public re-export path is unchanged (grep confirms no external code imports `TaskConfig` from `lm_eval.api.task`; all callers import from `lm_eval.config.task`).

- **2 × PIE800 (unnecessary-spread)**: inline `**{"visual": ...}` / `**{"audio": ...}` into their enclosing dict literals in the multi-modal-arg construction. Same resulting dict, one fewer temp.

- **1 × RUF100 (unused-noqa)**: drop the `# noqa: E721` on the `callable()` check. E721 doesn't apply to that expression, so the suppression is dead.

- **1 × TRY002 (raise-vanilla-class)**: replace `raise Exception(...)` with `raise TypeError(...)` in the `fewshot_config['samples']` match block. The failing case is `samples` being neither a `list` nor a callable, which is a type mismatch by definition. Backward compatible for any caller with `except Exception:`.

## Verification

- `ruff check lm_eval/api/task.py`: **17 → 0**, all checks pass.
- `python -c "from lm_eval.api.task import Task, ConfigurableTask, TaskConfig"`: imports resolve; `Task.__abstractmethods__` still lists all 9 abstract methods. The 7 methods whose `pass` was removed remain abstract.
- `pytest tests/test_tasks.py`: **16 passed**.

## Scope note

Deliberately narrow: `lm_eval/api/task.py` only. The wider `lm_eval/api/` tree still has ~68 pre-existing errors across other files; happy to send a follow-up if a broader cleanup would be useful, but keeping this reviewable in one file first.

No behavior change intended; opens up `Linters` green on future PRs against this file.
