### PR TITLE
Add FlexRank model evaluation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ low-rank submodels at multiple parameter budgets. Install the FlexRank runtime,
 then use the `flexrank` backend and select a submodel with either `size_ratio`
 or `compression_rate`:
 
+Until FlexRank is available on PyPI, install it from its source repository:
+
+```bash
+pip install "git+https://github.com/RickZack/FlexRank.git#subdirectory=flexrank"
+```
+
 ```bash
 lm_eval --model flexrank \
     --model_args pretrained=/path/to/flexrank-checkpoint,size_ratio=0.5,trust_remote_code=True \

--- a/README.md
+++ b/README.md
@@ -141,6 +141,44 @@ lm_eval --model hf \
 
 Models that are loaded via both `transformers.AutoModelForCausalLM` (autoregressive, decoder-only GPT style models) and `transformers.AutoModelForSeq2SeqLM` (such as encoder-decoder models like T5) in Huggingface are supported.
 
+#### FlexRank models
+
+[FlexRank](https://github.com/RickZack/FlexRank) checkpoints contain nested
+low-rank submodels at multiple parameter budgets. Install the FlexRank runtime,
+then use the `flexrank` backend and select a submodel with either `size_ratio`
+or `compression_rate`:
+
+```bash
+lm_eval --model flexrank \
+    --model_args pretrained=/path/to/flexrank-checkpoint,size_ratio=0.5,trust_remote_code=True \
+    --tasks hellaswag \
+    --device cuda:0 \
+    --batch_size 8
+```
+
+`size_ratio` is the target parameter budget relative to the original model.
+Alternatively, `compression_rate=0.5` requests a 50% reduction. FlexRank
+validates these arguments and selects the closest profile stored in the
+checkpoint, which can differ slightly from the requested ratio.
+
+To evaluate several profiles without reloading the checkpoint, pass a
+colon-separated `size_ratios` list:
+
+```bash
+lm_eval --model flexrank \
+    --model_args pretrained=/path/to/flexrank-checkpoint,size_ratios=1.0:0.75:0.5,trust_remote_code=True \
+    --tasks hellaswag \
+    --device cuda:0 \
+    --batch_size 8 \
+    --output_path results/flexrank
+```
+
+The model and tokenizer are loaded once. Each profile is otherwise evaluated
+as an independent run, with fresh task requests, reset random seeds and batch
+size state, profile-specific response caches, and a separate standard lm-eval
+result file whose `model_args` contains the evaluated `size_ratio`. YAML and
+JSON configurations may alternatively provide `size_ratios` as a list.
+
 Batch size selection can be automated by setting the  ```--batch_size``` flag to ```auto```. This will perform automatic detection of the largest batch size that will fit on your device. On tasks where there is a large difference between the longest and shortest example, it can be helpful to periodically recompute the largest batch size, to gain a further speedup. To do this, append ```:N``` to above flag to automatically recompute the largest batch size ```N``` times. For example, to recompute the batch size 4 times, the command would be:
 
 ```bash

--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -349,10 +349,19 @@ class Run(SubCommand):
 
         from lm_eval.config.evaluate_config import EvaluatorConfig
 
-        eval_logger = logging.getLogger(__name__)
-
         # Create and validate config (most validation now occurs in EvaluationConfig)
         cfg = EvaluatorConfig.from_cli(args)
+
+        if cfg.model == "flexrank" and "size_ratios" in cfg.model_args:
+            from lm_eval.models.flexrank import run_flexrank_size_sweep
+
+            return run_flexrank_size_sweep(cfg, Run._execute_config)
+        return Run._execute_config(cfg)
+
+    @staticmethod
+    def _execute_config(cfg) -> None:
+        """Run and report one evaluation from a validated config."""
+        eval_logger = logging.getLogger(__name__)
 
         from lm_eval import simple_evaluate
         from lm_eval.loggers import EvaluationTracker, TrackioLogger, WandbLogger

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -27,6 +27,7 @@ MODEL_MAPPING = {
     "anthropic-chat-completions": "lm_eval.models.anthropic_llms:AnthropicChat",
     "anthropic-completions": "lm_eval.models.anthropic_llms:AnthropicLM",
     "dummy": "lm_eval.models.dummy:DummyLM",
+    "flexrank": "lm_eval.models.flexrank:FlexRankLM",
     "ggml": "lm_eval.models.gguf:GGUFLM",
     "gguf": "lm_eval.models.gguf:GGUFLM",
     "hf": "lm_eval.models.huggingface:HFLM",

--- a/lm_eval/models/flexrank.py
+++ b/lm_eval/models/flexrank.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from lm_eval.api.registry import register_model
+from lm_eval.models.huggingface import HFLM
+
+
+if TYPE_CHECKING:
+    import transformers
+
+
+eval_logger = logging.getLogger(__name__)
+
+
+@register_model("flexrank")
+class FlexRankLM(HFLM):
+    """Hugging Face backend for evaluating a selected FlexRank submodel."""
+
+    _sweep_model: ClassVar[FlexRankLM | None] = None
+    _sweep_rng_state: ClassVar[dict[str, Any] | None] = None
+
+    @classmethod
+    def create_from_arg_obj(
+        cls,
+        arg_dict: dict[str, Any],
+        additional_config: dict[str, Any] | None = None,
+    ) -> FlexRankLM:
+        """Create normally, or select a profile on the active sweep model."""
+        if cls._sweep_model is None:
+            return super().create_from_arg_obj(arg_dict, additional_config)
+
+        cls._sweep_model.select_profile(
+            size_ratio=arg_dict.get("size_ratio"),
+            compression_rate=arg_dict.get("compression_rate"),
+        )
+        assert cls._sweep_rng_state is not None
+        restore_rng_state(cls._sweep_rng_state)
+        return cls._sweep_model
+
+    def __init__(
+        self,
+        pretrained: str | transformers.PreTrainedModel,
+        *,
+        size_ratio: float | None = None,
+        compression_rate: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Load a FlexRank checkpoint and select its evaluation profile.
+
+        Args:
+            pretrained: FlexRank checkpoint or initialized FlexRank model.
+            size_ratio: Target parameter budget relative to the original model.
+            compression_rate: Fraction of the original parameter budget to remove.
+            **kwargs: Arguments forwarded to :class:`HFLM`.
+        """
+        super().__init__(pretrained=pretrained, **kwargs)
+        self._place_data_parallel_model()
+        self.select_profile(size_ratio=size_ratio, compression_rate=compression_rate)
+
+    def select_profile(self, *, size_ratio=None, compression_rate=None) -> None:
+        """Select a FlexRank profile and reset profile-dependent runtime state."""
+        reduce_size = getattr(self.model, "reduce_size", None)
+        if not callable(reduce_size):
+            raise TypeError(
+                "The loaded checkpoint is not a FlexRank model: its model class "
+                "does not provide a callable `reduce_size` method. Load a checkpoint "
+                "exported by FlexRank and pass `trust_remote_code=True`."
+            )
+
+        reduce_size(size_ratio=size_ratio, compression_rate=compression_rate)
+        # A fresh process starts with no remembered automatic batch sizes.
+        # Clear them when reusing this wrapper so each profile behaves likewise.
+        self.batch_sizes = {}
+
+        selected_ratio = getattr(self.model, "virtual_size_ratio", None)
+        if selected_ratio is not None:
+            eval_logger.info(
+                "Selected FlexRank profile with size ratio %.6f", selected_ratio
+            )
+
+    def _get_accelerate_args(
+        self,
+        parallelize: bool | None = None,
+        device_map: str | None = "auto",
+        max_memory_per_gpu: int | str | None = None,
+        max_cpu_memory: int | str | None = None,
+        offload_folder: str | None = "./offload",
+        gpus: int | None = None,
+    ) -> dict:
+        """Avoid dispatching FlexRank before its runtime buffers materialize."""
+        accelerate_args = super()._get_accelerate_args(
+            parallelize=parallelize,
+            device_map=device_map,
+            max_memory_per_gpu=max_memory_per_gpu,
+            max_cpu_memory=max_cpu_memory,
+            offload_folder=offload_folder,
+            gpus=gpus,
+        )
+        single_device_map = isinstance(accelerate_args.get("device_map"), dict) and set(
+            accelerate_args["device_map"]
+        ) == {""}
+        if parallelize is False or single_device_map:
+            accelerate_args.pop("device_map", None)
+            accelerate_args.pop("max_memory", None)
+        return accelerate_args
+
+    def _place_data_parallel_model(self) -> None:
+        """Place models loaded by each Accelerate worker on its local device."""
+        if hasattr(self, "accelerator"):
+            self.model.to(self.device)
+
+
+def run_flexrank_size_sweep(cfg: Any, execute_one: Any) -> None:
+    """Evaluate FlexRank profiles independently while loading the model once."""
+    import copy
+
+    size_ratios = cfg.model_args["size_ratios"]
+    if isinstance(size_ratios, str):
+        size_ratios = [float(value) for value in size_ratios.split(":")]
+    elif not isinstance(size_ratios, (list, tuple)):
+        size_ratios = [size_ratios]
+
+    base_model_args = dict(cfg.model_args)
+    base_model_args.pop("size_ratios")
+    base_metadata = dict(cfg.metadata)
+    base_metadata.pop("size_ratios", None)
+
+    _seed_rngs(cfg.seed)
+    model = FlexRankLM.create_from_arg_obj(
+        base_model_args | {"size_ratio": size_ratios[0]},
+        {
+            "batch_size": cfg.batch_size,
+            "max_batch_size": cfg.max_batch_size,
+            "device": cfg.device,
+        },
+    )
+    FlexRankLM._sweep_model = model
+    FlexRankLM._sweep_rng_state = _capture_rng_state()
+
+    try:
+        for size_ratio in size_ratios:
+            profile_cfg = copy.copy(cfg)
+            profile_cfg.model_args = base_model_args | {"size_ratio": size_ratio}
+            profile_cfg.metadata = base_metadata | {"size_ratio": size_ratio}
+            profile_cfg.use_cache = (
+                f"{cfg.use_cache}_size_ratio_{size_ratio}"
+                if cfg.use_cache is not None
+                else None
+            )
+            execute_one(profile_cfg)
+    finally:
+        FlexRankLM._sweep_model = None
+        FlexRankLM._sweep_rng_state = None
+
+
+def _seed_rngs(seeds: list[int | None] | None) -> None:
+    """Apply the same pre-model-construction seeds as simple_evaluate."""
+    if not seeds:
+        return
+
+    import random
+
+    import numpy as np
+
+    from lm_eval.utils import set_torch_seed
+
+    if seeds[0] is not None:
+        random.seed(seeds[0])
+    if seeds[1] is not None:
+        np.random.seed(seeds[1])
+    if seeds[2] is not None:
+        set_torch_seed(seeds[2])
+
+
+def _capture_rng_state() -> dict[str, Any]:
+    """Capture RNG state after model construction for repeatable evaluation."""
+    import random
+
+    import numpy as np
+    import torch
+
+    return {
+        "python": random.getstate(),
+        "numpy": np.random.get_state(),
+        "torch": torch.get_rng_state(),
+        "cuda": torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None,
+    }
+
+
+def restore_rng_state(state: dict[str, Any]) -> None:
+    """Restore the post-model-construction RNG state for one profile."""
+    import random
+
+    import numpy as np
+    import torch
+
+    random.setstate(state["python"])
+    np.random.set_state(state["numpy"])
+    torch.set_rng_state(state["torch"])
+    if state["cuda"] is not None:
+        torch.cuda.set_rng_state_all(state["cuda"])

--- a/tests/models/test_flexrank.py
+++ b/tests/models/test_flexrank.py
@@ -1,0 +1,108 @@
+from unittest.mock import Mock
+
+import pytest
+
+from lm_eval.models.flexrank import FlexRankLM
+from lm_eval.models.huggingface import HFLM
+
+
+@pytest.fixture
+def mocked_hflm(monkeypatch):
+    model = Mock()
+    model.reduce_size = Mock()
+    model.virtual_size_ratio = 0.75
+
+    def init(instance, **kwargs):
+        instance._model = model
+
+    monkeypatch.setattr(HFLM, "__init__", init)
+    return model
+
+
+def test_selects_size_ratio(mocked_hflm):
+    FlexRankLM(pretrained="flexrank-checkpoint", size_ratio=0.75)
+
+    mocked_hflm.reduce_size.assert_called_once_with(
+        size_ratio=0.75, compression_rate=None
+    )
+
+
+def test_selects_compression_rate(mocked_hflm):
+    FlexRankLM(pretrained="flexrank-checkpoint", compression_rate=0.25)
+
+    mocked_hflm.reduce_size.assert_called_once_with(
+        size_ratio=None, compression_rate=0.25
+    )
+
+
+def test_forwards_unspecified_reduction_args(mocked_hflm):
+    FlexRankLM(pretrained="flexrank-checkpoint")
+
+    mocked_hflm.reduce_size.assert_called_once_with(
+        size_ratio=None, compression_rate=None
+    )
+
+
+def test_select_profile_resets_profile_dependent_state(mocked_hflm):
+    lm = FlexRankLM(pretrained="flexrank-checkpoint", size_ratio=0.75)
+    mocked_hflm.reduce_size.reset_mock()
+    lm.batch_sizes = {0: 8}
+
+    lm.select_profile(size_ratio=0.5)
+
+    mocked_hflm.reduce_size.assert_called_once_with(
+        size_ratio=0.5, compression_rate=None
+    )
+    assert lm.batch_sizes == {}
+
+
+def test_factory_reuses_active_sweep_model(mocked_hflm, monkeypatch):
+    lm = FlexRankLM(pretrained="flexrank-checkpoint", size_ratio=0.75)
+    mocked_hflm.reduce_size.reset_mock()
+    rng_state = {"state": "captured"}
+    restore = Mock()
+    monkeypatch.setattr(FlexRankLM, "_sweep_model", lm)
+    monkeypatch.setattr(FlexRankLM, "_sweep_rng_state", rng_state)
+    monkeypatch.setattr("lm_eval.models.flexrank.restore_rng_state", restore)
+
+    reused = FlexRankLM.create_from_arg_obj({"size_ratio": 0.5})
+
+    assert reused is lm
+    mocked_hflm.reduce_size.assert_called_once_with(
+        size_ratio=0.5, compression_rate=None
+    )
+    restore.assert_called_once_with(rng_state)
+
+
+def test_rejects_non_flexrank_checkpoint(monkeypatch):
+    def init(instance, **kwargs):
+        instance._model = object()
+
+    monkeypatch.setattr(HFLM, "__init__", init)
+
+    with pytest.raises(TypeError, match="does not provide.*`reduce_size`"):
+        FlexRankLM(pretrained="regular-hf-checkpoint")
+
+
+@pytest.mark.parametrize("parallelize", [False, None])
+def test_avoids_device_map_for_single_device_load(monkeypatch, parallelize):
+    monkeypatch.setattr(
+        HFLM,
+        "_get_accelerate_args",
+        lambda *args, **kwargs: {"device_map": {"": "cpu"}, "max_memory": None},
+    )
+
+    lm = object.__new__(FlexRankLM)
+
+    assert lm._get_accelerate_args(parallelize=parallelize) == {}
+
+
+def test_preserves_device_map_for_model_parallel_load(monkeypatch):
+    expected = {"device_map": "auto", "max_memory": {0: "10GiB"}}
+    monkeypatch.setattr(
+        HFLM, "_get_accelerate_args", lambda *args, **kwargs: expected.copy()
+    )
+
+    lm = object.__new__(FlexRankLM)
+
+    assert lm._get_accelerate_args(parallelize=True) == expected

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -15,6 +15,7 @@ from lm_eval._cli.utils import (
     try_parse_json,
 )
 from lm_eval._cli.validate import Validate
+from lm_eval.models.flexrank import FlexRankLM, run_flexrank_size_sweep
 
 
 class TestHarnessCLI:
@@ -295,6 +296,63 @@ class TestRunCommand:
         mock_config.from_cli.assert_called_once()
         mock_simple_evaluate.assert_called_once()
         mock_make_table.assert_called_once()
+
+    @patch.object(Run, "_execute_config")
+    @patch.object(FlexRankLM, "create_from_arg_obj")
+    def test_flexrank_size_sweep_reuses_model_with_isolated_runs(
+        self, mock_create_model, mock_execute_config
+    ):
+        cfg = MagicMock()
+        cfg.model = "flexrank"
+        cfg.model_args = {
+            "pretrained": "flexrank-checkpoint",
+            "size_ratios": "1.0:0.5",
+            "trust_remote_code": True,
+        }
+        cfg.metadata = dict(cfg.model_args)
+        cfg.batch_size = 4
+        cfg.max_batch_size = 16
+        cfg.device = "cuda:0"
+        cfg.use_cache = "flexrank-cache"
+        cfg.seed = [0, 1234, 1234, 1234]
+
+        model = MagicMock()
+        mock_create_model.return_value = model
+
+        rng_state = object()
+        with (
+            patch("lm_eval.models.flexrank._seed_rngs") as mock_seed_rngs,
+            patch(
+                "lm_eval.models.flexrank._capture_rng_state", return_value=rng_state
+            ) as mock_capture,
+        ):
+            run_flexrank_size_sweep(cfg, mock_execute_config)
+
+        mock_seed_rngs.assert_called_once_with(cfg.seed)
+        mock_capture.assert_called_once_with()
+        mock_create_model.assert_called_once_with(
+            {
+                "pretrained": "flexrank-checkpoint",
+                "trust_remote_code": True,
+                "size_ratio": 1.0,
+            },
+            {"batch_size": 4, "max_batch_size": 16, "device": "cuda:0"},
+        )
+        assert mock_execute_config.call_count == 2
+        for execute_call, ratio in zip(
+            mock_execute_config.call_args_list, (1.0, 0.5), strict=True
+        ):
+            profile_cfg = execute_call.args[0]
+            assert profile_cfg.model_args == {
+                "pretrained": "flexrank-checkpoint",
+                "trust_remote_code": True,
+                "size_ratio": ratio,
+            }
+            assert profile_cfg.metadata == profile_cfg.model_args
+            assert profile_cfg.use_cache == f"flexrank-cache_size_ratio_{ratio}"
+
+        assert FlexRankLM._sweep_model is None
+        assert FlexRankLM._sweep_rng_state is None
 
 
 class TestValidateCommand:


### PR DESCRIPTION
## Summary

Adds a `flexrank` backend for evaluating [FlexRank](https://github.com/RickZack/FlexRank) checkpoints at a selected `size_ratio` or `compression_rate`.

Multiple profiles can be evaluated in one invocation by passing colon-separated `size_ratios`. The model is loaded once, while each profile produces an independent standard lm-eval result with reset RNG and batch-size state.

```bash
lm-eval run \
    --model flexrank \
    --model_args pretrained=riccardozaccone96/flexrank-llama3.2-1B,size_ratios=1.0:0.75:0.5,trust_remote_code=True \
    --tasks hellaswag \
    --device cuda:0
```

`flexrank` is needed to support flexrank models but it is currently optional, and must currently be installed from its source repository. Usage and source-installation instructions are documented in the [README](https://github.com/RickZack/lm-evaluation-harness/blob/2be83688/README.md#flexrank-models).

## Testing

- `python -m pytest -q tests/models/test_flexrank.py tests/test_cli_subcommands.py` — 78 passed
- Ruff lint and formatting checks passed
- Multi-ratio and separate runs produced identical metrics and per-sample responses using `riccardozaccone96/flexrank-llama3.2-1B`