### PR TITLE
fix(api): raise instead of emptying the prompt when max_gen_toks exceeds max_length

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -448,6 +448,39 @@ class TemplateAPI(TemplateLM):
                 encoding = self.tokenizer.encode_batch(string)
             return encoding
 
+    def _left_truncate_contexts(
+        self, encodings_list: list[list[int]], max_gen_toks: int
+    ) -> list[list[int]]:
+        """Left-truncate encoded contexts so they fit alongside `max_gen_toks`.
+
+        Raises:
+            ValueError: if no room is left for the context at all. Slicing with a
+                negative bound would otherwise flip the slice and drop every
+                prompt token, sending an empty prompt to the server.
+        """
+        max_context_len = self.max_length - max_gen_toks
+        if max_context_len <= 0:
+            raise ValueError(
+                f"No context budget remains: max_length ({self.max_length}) - "
+                f"max_gen_toks ({max_gen_toks}) = {max_context_len}. Raise the "
+                f"model's max_length (e.g. `--model_args max_length=...`) above "
+                f"max_gen_toks, or lower `max_gen_toks` in the task's "
+                f"`generation_kwargs`."
+            )
+
+        truncated = [x[-max_context_len:] for x in encodings_list]
+        num_truncated = sum(
+            len(after) < len(before)
+            for before, after in zip(encodings_list, truncated, strict=True)
+        )
+        if num_truncated:
+            eval_logger.warning(
+                f"{num_truncated} context(s) longer than max_length "
+                f"({self.max_length}) - max_gen_toks ({max_gen_toks}) = "
+                f"{max_context_len} tokens. They were left truncated."
+            )
+        return truncated
+
     def decode_batch(self, tokens: List[List[int]]) -> List[str]:
         if self.tokenizer_backend == "huggingface":
             return self.tokenizer.batch_decode(tokens)
@@ -758,16 +791,9 @@ class TemplateAPI(TemplateLM):
                     max_gen_toks = all_gen_kwargs[0].get(
                         "max_gen_toks", self._max_gen_toks
                     )
-                    max_context_len = self.max_length - max_gen_toks
-
-                    encodings_list = [x[-max_context_len:] for x in encodings_list]
-
-                    if any(
-                        len(x) + max_gen_toks > self.max_length for x in encodings_list
-                    ):
-                        eval_logger.warning(
-                            f"Some contexts exceeded (max length: ({self.max_length}) - max_gen_toks: ({max_gen_toks}). They were left truncated."
-                        )
+                    encodings_list = self._left_truncate_contexts(
+                        encodings_list, max_gen_toks
+                    )
 
                 req = encodings_list if self.tokenized_requests else contexts
                 outputs = retry(
@@ -812,16 +838,9 @@ class TemplateAPI(TemplateLM):
                     max_gen_toks = all_gen_kwargs[0].get(
                         "max_gen_toks", self._max_gen_toks
                     )
-                    max_context_len = self.max_length - max_gen_toks
-
-                    encodings_list = [x[-max_context_len:] for x in encodings_list]
-
-                    if any(
-                        len(x) + max_gen_toks > self.max_length for x in encodings_list
-                    ):
-                        eval_logger.warning(
-                            f"Some contexts exceeded (max length: ({self.max_length}) - max_gen_toks ({max_gen_toks}). They were left truncated."
-                        )
+                    encodings_list = self._left_truncate_contexts(
+                        encodings_list, max_gen_toks
+                    )
 
                 req = encodings_list if self.tokenized_requests else contexts
                 results = itertools.chain.from_iterable(

--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -375,3 +375,45 @@ def test_localchatcompletion_remote_tokenizer_unauthenticated(monkeypatch):
     assert captured["verify_certificate"] is False
     assert captured["ca_cert_path"] is None
     assert captured["auth_token"] is None
+
+
+def test_left_truncate_contexts_truncates_long_context(api):
+    # max_length is 2047 (2048 - 1); leaves a 1791-token budget.
+    encodings_list = [list(range(2000))]
+
+    truncated = api._left_truncate_contexts(encodings_list, max_gen_toks=256)
+
+    assert len(truncated[0]) == api.max_length - 256
+    # left truncation keeps the *end* of the context
+    assert truncated[0][-1] == 1999
+
+
+def test_left_truncate_contexts_leaves_short_context_untouched(api):
+    encodings_list = [list(range(100))]
+
+    truncated = api._left_truncate_contexts(encodings_list, max_gen_toks=256)
+
+    assert truncated == encodings_list
+
+
+def test_left_truncate_contexts_raises_when_budget_exhausted(api):
+    """Regression test for #3497.
+
+    aime25 sets `max_gen_toks: 32768`, which exceeds the default max_length. The
+    resulting negative bound used to flip the slice (`x[-(-30721):]` -> `x[30721:]`),
+    silently dropping every prompt token and sending an empty prompt to the server.
+    """
+    encodings_list = [list(range(120))]
+
+    with pytest.raises(ValueError, match="No context budget remains"):
+        api._left_truncate_contexts(encodings_list, max_gen_toks=32768)
+
+
+def test_negative_budget_would_flip_the_slice(api):
+    """Documents the exact mechanism behind #3497 so it cannot creep back in."""
+    encodings_list = [list(range(120))]
+    max_context_len = api.max_length - 32768
+
+    assert max_context_len < 0
+    # the unguarded slice silently discards the whole prompt
+    assert [x[-max_context_len:] for x in encodings_list] == [[]]


### PR DESCRIPTION
## Summary

Any `generate_until` task whose `max_gen_toks` exceeds the model's `max_length` has its prompt silently deleted before the request is sent. The context budget is computed as `self.max_length - max_gen_toks` and used directly as a slice bound; when it goes negative the slice inverts and returns an empty list, so the harness sends an empty prompt.

`aime25` sets `max_gen_toks: 32768` and `max_length` defaults to 2048, so every AIME run against an API backend hits this. `gsm8k` and `hellaswag` work in the same setup only because their `max_gen_toks` is 256.

## Reproduction

At `8a07e111`, against any OpenAI-compatible `/v1/completions` endpoint:

```bash
lm_eval --model local-completions --tasks aime25 --limit 1 \
  --model_args model=<model>,base_url=http://127.0.0.1:8000/v1/completions,tokenizer_backend=tiktoken,num_concurrent=1,max_retries=2
```

```
WARNING [models.api_models:768] Some contexts exceeded (max length: (2047) - max_gen_toks: (32768). They were left truncated.
WARNING [models.api_models:484] API request failed with error message: {"object": "error", "message": "Prompt cannot be empty", "type": "BadRequestError", ...}. Retrying...
requests.exceptions.HTTPError: 400 Client Error: Bad Request
```

A stub server logging the received payload confirms what actually goes on the wire is `prompt: [[]]`.

## Root cause

`TemplateAPI.generate_until`, `lm_eval/models/api_models.py` (the block appears twice — once in the concurrent path, once in the sequential one):

```python
max_gen_toks = all_gen_kwargs[0].get("max_gen_toks", self._max_gen_toks)
max_context_len = self.max_length - max_gen_toks          # 2047 - 32768 = -30721

encodings_list = [x[-max_context_len:] for x in encodings_list]   # <-- x[30721:] -> []
```

Negating a negative bound flips the slice: `x[-(-30721):]` is `x[30721:]`, which is empty for any real prompt. The intent is "keep the last `max_context_len` tokens"; with a negative budget it becomes "drop everything".

The loglikelihood path already guards the same arithmetic (`max(0, len(context_enc) + len(continuation_enc) - self.max_length)` at line 616); the generation path never got the same treatment.

## Why the existing warning did not surface it

The check immediately below tests *post*-truncation lengths:

```python
if any(len(x) + max_gen_toks > self.max_length for x in encodings_list):
    eval_logger.warning("Some contexts exceeded ... They were left truncated.")
```

After a correct truncation `len(x) <= self.max_length - max_gen_toks`, so the condition is always false and the warning never fires in normal operation. It fires only in the broken case — reporting "left truncated" at the exact moment the prompt was deleted in full, which points debugging away from the real problem.

## Fix

Both copies of the block are replaced with a single `_left_truncate_contexts` helper that:

- **Raises when the budget is non-positive** instead of emptying the prompt. The request is unsatisfiable by construction — the model cannot both emit `max_gen_toks` tokens and see any prompt — so failing with an actionable message is strictly better than sending an empty request, which either errors at the server or, on a more permissive one, scores generated-from-nothing output as if it were real.
- **Reports truncation against pre-truncation lengths**, so the warning describes what actually happened and includes the count.

The error names both levers:

```
ValueError: No context budget remains: max_length (2047) - max_gen_toks (32768) = -30721.
Raise the model's max_length (e.g. `--model_args max_length=...`) above max_gen_toks,
or lower `max_gen_toks` in the task's `generation_kwargs`.
```

With `max_length=40000` the same command now runs to completion with prompts intact.

## Scope / impact

Affects `TemplateAPI` and everything inheriting it (`local-completions`, `local-chat-completions`, `openai-completions`, …) whenever `tokenized_requests` is on. Any task with a large `max_gen_toks` is exposed: `aime`, `aime24`, `aime25` at 32768, and any user task that raises it above the configured `max_length`.

No published numbers change. On servers that reject empty prompts the run already failed; this converts a retry-loop-then-`HTTPError` into an immediate, explanatory error. Runs where the budget is positive are unaffected — the slice arithmetic is identical.

## Test plan

- [x] `python -m pytest tests/models/test_api.py -q` — 18 passed (14 on `main` before this change)
- [x] Four regression tests added: truncation of an over-long context, short contexts left untouched, the `#3497` config raising, and one pinning the slice-flip itself so it cannot creep back in
- [x] End-to-end against a stub `/v1/completions` server that rejects empty prompts: fails as reported on `main`, raises the new error with this patch, and completes normally with `max_length=40000`
- [x] `python -m pytest tests/ -q --ignore=tests/test_tasks.py --ignore=tests/models/test_openvino.py --ignore=tests/models/test_hf_steered.py --ignore=tests/scripts/test_zeno_visualize.py --ignore=tests/models/test_huggingface.py` — 561 passed, 30 failed; `main` gives 557 passed, **the same 30 failed**. The failures are in `test_bos_handling.py` / `test_evaluator.py` and are unrelated to this change (they need `accelerate`, absent in my env).
- [x] `ruff check` / `ruff format --check` clean on the changed lines

## Open question

This turns the reported case into a clear error, but a user running `aime25` against a 32k-context server still has to know to pass `max_length` — the 2048 default is what puts them there. Would you want `TemplateAPI` to infer `max_length` from the served model or tokenizer config instead? Happy to do it in a follow-up; it changes behaviour for existing users so I left it out here.

Fixes #3497
