### PR TITLE
fix: normalize scalar `seed` from a config file the way the CLI does

### DIFF
--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -26,6 +26,8 @@ DICT_KEYS = [
     "model_args",
     "gen_kwargs",
 ]
+# Seeds for random, numpy, torch and fewshot sampling, in that order.
+DEFAULT_SEED = [0, 1234, 1234, 1234]
 
 
 @dataclass(slots=True)
@@ -176,8 +178,8 @@ class EvaluatorConfig:
     )
 
     # Reproducibility
-    seed: list = field(
-        default_factory=lambda: [0, 1234, 1234, 1234],
+    seed: list | int | None = field(
+        default_factory=lambda: list(DEFAULT_SEED),
         metadata={"help": "Seeds for random, numpy, torch, fewshot (random)"},
     )
 
@@ -273,7 +275,55 @@ class EvaluatorConfig:
 
     def _configure(self):
         """Validate configuration and preprocess fields after creation."""
-        self._validate_arguments()._process_arguments()._set_trust_remote_code()
+        self._validate_arguments()._process_arguments()._normalize_seed()._set_trust_remote_code()
+
+        return self
+
+    def _normalize_seed(self):
+        """Expand `seed` into one seed per generator.
+
+        `--seed` is converted by argparse before it reaches us, but a seed read
+        from a YAML config is used as-is, so a documented scalar like `seed: 42`
+        would end up being indexed as a list further down. Normalize both entry
+        points to the same shape here. `None` keeps meaning "do not seed".
+        """
+        if self.seed is None:
+            return self
+
+        values = (
+            list(self.seed) if isinstance(self.seed, (list, tuple)) else [self.seed]
+        )
+        if len(values) == 1:
+            values = values * len(DEFAULT_SEED)
+        elif len(values) == len(DEFAULT_SEED) - 1:
+            # `--seed 1,2,3` is accepted and the last seed is taken from the
+            # defaults, so accept the same shape here rather than making the
+            # config stricter than the flag it mirrors.
+            eval_logger.warning(
+                f"seed expects {len(DEFAULT_SEED)} values "
+                "(random, numpy, torch, fewshot). Missing values will be "
+                "filled with defaults."
+            )
+            values = values + DEFAULT_SEED[len(values) :]
+        if len(values) != len(DEFAULT_SEED):
+            raise ValueError(
+                f"seed expects a single value or {len(DEFAULT_SEED)} values "
+                f"(random, numpy, torch, fewshot), got {len(values)}: {self.seed!r}"
+            )
+
+        parsed = []
+        for value in values:
+            if value is None:
+                parsed.append(None)
+                continue
+            try:
+                parsed.append(int(value))
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"seed values must be integers or None, got {value!r}"
+                ) from None
+
+        self.seed = parsed
 
         return self
 

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -301,10 +301,8 @@ class EvaluatorConfig:
             # defaults, so accept the same shape here rather than making the
             # config stricter than the flag it mirrors.
             eval_logger.warning(
-                "seed expects %s values "
-                "(random, numpy, torch, fewshot). Missing values will be "
-                "filled with defaults.",
-                (len(DEFAULT_SEED)),
+                "seed expects %s values (random, numpy, torch, fewshot). Missing values will be filled with defaults.",
+                len(DEFAULT_SEED),
             )
             values = values + DEFAULT_SEED[len(values) :]
         if len(values) != len(DEFAULT_SEED):

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -301,9 +301,10 @@ class EvaluatorConfig:
             # defaults, so accept the same shape here rather than making the
             # config stricter than the flag it mirrors.
             eval_logger.warning(
-                f"seed expects {len(DEFAULT_SEED)} values "
+                "seed expects %s values "
                 "(random, numpy, torch, fewshot). Missing values will be "
-                "filled with defaults."
+                "filled with defaults.",
+                (len(DEFAULT_SEED)),
             )
             values = values + DEFAULT_SEED[len(values) :]
         if len(values) != len(DEFAULT_SEED):

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -952,3 +952,117 @@ log_samples: true
         # 0 is a valid explicit value and should override YAML
         assert cfg.num_fewshot == 0, "CLI 0 should override YAML's 5"
         assert cfg.batch_size == 1, "Truthy CLI value overrides YAML"
+
+
+def _run_seed_accessors(cfg):
+    """Read cfg.seed the way lm_eval/_cli/run.py hands seeds to simple_evaluate()."""
+    return (
+        cfg.seed[0] if cfg.seed else None,
+        cfg.seed[1] if cfg.seed else None,
+        cfg.seed[2] if cfg.seed else None,
+        cfg.seed[3] if cfg.seed else None,
+    )
+
+
+class TestEvaluatorConfigSeedNormalization:
+    """Test that a `seed` coming from a config file is normalized like --seed is."""
+
+    def test_scalar_seed_from_yaml_config(self, tmp_path):
+        """A scalar `seed: 42` in YAML should behave like `--seed 42`."""
+        from argparse import Namespace
+
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        yaml_config = tmp_path / "config.yaml"
+        yaml_config.write_text("""
+model: hf
+tasks:
+  - arc_easy
+seed: 42
+""")
+
+        cfg = EvaluatorConfig.from_cli(Namespace(config=str(yaml_config)))
+
+        assert cfg.seed == [42, 42, 42, 42]
+        assert _run_seed_accessors(cfg) == (42, 42, 42, 42)
+
+    def test_zero_seed_from_yaml_config_still_seeds(self, tmp_path):
+        """`seed: 0` must actually seed with 0, not silently disable seeding."""
+        from argparse import Namespace
+
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        yaml_config = tmp_path / "config.yaml"
+        yaml_config.write_text("""
+model: hf
+tasks:
+  - arc_easy
+seed: 0
+""")
+
+        cfg = EvaluatorConfig.from_cli(Namespace(config=str(yaml_config)))
+
+        assert cfg.seed == [0, 0, 0, 0]
+        assert _run_seed_accessors(cfg) == (0, 0, 0, 0)
+
+    def test_single_element_list_is_expanded(self):
+        """`seed: [42]` should expand to all four seeds, as the CLI does."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        cfg = EvaluatorConfig(tasks=["arc_easy"], seed=[42])._configure()
+
+        assert cfg.seed == [42, 42, 42, 42]
+        assert _run_seed_accessors(cfg) == (42, 42, 42, 42)
+
+    def test_string_scalar_seed_is_parsed(self):
+        """A quoted `seed: "42"` should not be indexed character by character."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        cfg = EvaluatorConfig(tasks=["arc_easy"], seed="42")._configure()
+
+        assert cfg.seed == [42, 42, 42, 42]
+
+    def test_four_element_list_is_unchanged(self):
+        """A fully specified seed list should pass through untouched."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        cfg = EvaluatorConfig(
+            tasks=["arc_easy"], seed=[0, 1234, 1234, 1234]
+        )._configure()
+
+        assert cfg.seed == [0, 1234, 1234, 1234]
+        assert _run_seed_accessors(cfg) == (0, 1234, 1234, 1234)
+
+    def test_none_seed_disables_seeding(self):
+        """`seed: null` keeps its meaning of not seeding anything."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        cfg = EvaluatorConfig(tasks=["arc_easy"], seed=None)._configure()
+
+        assert cfg.seed is None
+        assert _run_seed_accessors(cfg) == (None, None, None, None)
+
+    def test_partial_list_raises_clear_error(self):
+        """A wrong-length list should be rejected up front, not IndexError later."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        with pytest.raises(ValueError, match="seed"):
+            EvaluatorConfig(tasks=["arc_easy"], seed=[1, 2])._configure()
+
+    def test_three_seeds_are_filled_from_defaults_like_the_cli(self):
+        """`--seed 1,2,3` fills the last seed from the defaults; config matches."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        cfg = EvaluatorConfig(tasks=["arc_easy"], seed=[1, 2, 3])._configure()
+
+        assert cfg.seed == [1, 2, 3, 1234]
+        assert _run_seed_accessors(cfg) == (1, 2, 3, 1234)
+
+    def test_non_integer_seed_raises_clear_error(self):
+        """Seed entries that are not integers or None should be rejected."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        with pytest.raises(ValueError, match="seed"):
+            EvaluatorConfig(
+                tasks=["arc_easy"], seed=[0, "abc", 1234, 1234]
+            )._configure()


### PR DESCRIPTION
Fixes #4002.

A scalar `seed` from a YAML `--config` file was passed through to `run.py:420-423` unexpanded, so `cfg.seed[0]` raised `TypeError: 'int' object is not subscriptable`. The CLI never hit this because argparse converts `--seed` through `_int_or_none_list_arg_type` (`run.py:313`) before the value is stored; the config path had no equivalent step.

`EvaluatorConfig` now normalizes `seed` in `_configure()`, mirroring what that converter already accepts:

| input | result |
| --- | --- |
| `42` | `[42, 42, 42, 42]` |
| `[1, 2, 3]` | `[1, 2, 3, 1234]`, with the same "filled with defaults" warning the CLI emits |
| `[1, 2, 3, 4]` | unchanged |
| `null` | unchanged, still means "do not seed" |
| `[1, 2]` | `ValueError` naming the field, instead of an `IndexError` four lines later |

That covers three failures that all came from the missing expansion:

- `seed: 42` crashed, which is the documented `list/int` type in `docs/config_files.md`
- `seed: 0` silently disabled seeding entirely, because `0` is falsy and every `if cfg.seed` guard fell to `None`. That one is the reason I'd treat this as more than a crash fix: a run pinned to seed 0 for reproducibility was not seeded at all, and said nothing.
- `seed: [42]` raised `IndexError`

I also handled a quoted scalar (`seed: "42"`), which was quietly the worst of the set: `cfg.seed[0]` indexed the string and seeded with the character `"4"`.

`run.py` is untouched. Once the value is normalized, `[0, 0, 0, 0]` is a truthy list, so the existing `if cfg.seed` guards behave correctly and there was no reason to change them.

## Tests

Added to `tests/test_cli_subcommands.py`, alongside the existing seed cases:

- scalar `42` from a config, asserting all four accessors in `run.py` see `42`
- `seed: 0` actually seeds with `0` rather than disabling seeding
- `[42]` expands, `[1,2,3]` fills the last from defaults like the CLI does
- `null` still disables seeding
- `[1,2]` and a non-integer entry raise a `ValueError` mentioning the field
- quoted `"42"` parses to integers

The first four fail on `main`. Suite is 77 passed (68 before this change); `ruff check` and `ruff format --check` are clean on both files.
