### PR TITLE
Fix response-cache hashing for multimodal image requests

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -84,4 +84,4 @@ There are a number of distinct ways to contribute to LM Evaluation Harness, and 
 - **Adding new modeling / inference library integrations** - We hope to support a broad range of commonly-used inference libraries popular among the community, and welcome PRs for new integrations, so long as they are documented properly and maintainable.
 - **Proposing or Contributing New Features** - We want LM Evaluation Harness to support a broad range of evaluation usecases. If you have a feature that is not currently supported but desired, feel free to open an issue describing the feature and, if applicable, how you intend to implement it. We would be happy to give feedback on the cleanest way to implement new functionalities and are happy to coordinate with interested contributors via GH discussions or via discord.
 
-We hope that this has been helpful, and appreciate your interest in contributing! Further questions can be directed to [our Discord](discord.gg/eleutherai).
+We hope that this has been helpful, and appreciate your interest in contributing! Further questions can be directed to [our Discord](https://discord.gg/eleutherai).

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -4,9 +4,10 @@ import json
 import logging
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional
 
 from tqdm import tqdm
+from typing_extensions import Self
 
 from lm_eval import utils
 
@@ -18,8 +19,6 @@ if TYPE_CHECKING:
 
 
 eval_logger = logging.getLogger(__name__)
-
-T = TypeVar("T", bound="LM")
 
 
 class LM(abc.ABC):
@@ -52,7 +51,6 @@ class LM(abc.ABC):
             A list of ``(logprob, is_greedy)`` tuples — the log-probability of
             the continuation and whether it would be produced by greedy decoding.
         """
-        pass
 
     @abc.abstractmethod
     def loglikelihood_rolling(self, requests: list["Instance"]) -> list[float]:
@@ -93,7 +91,6 @@ class LM(abc.ABC):
             A list of ``(logprob,)`` tuples — the log-probability of the string
             conditioned on the BOS/EOS token (or ``prefix_token_id``).
         """
-        pass
 
     # TODO: Add an optional max length
     @abc.abstractmethod
@@ -108,7 +105,6 @@ class LM(abc.ABC):
         Returns:
             A list of generated continuation strings, one per request.
         """
-        pass
 
     def apply_chat_template(
         self, chat_history: list[dict[str, str]], add_generation_prompt=True
@@ -129,8 +125,8 @@ class LM(abc.ABC):
 
     @classmethod
     def create_from_arg_string(
-        cls: type[T], arg_string: str, additional_config: dict | None = None
-    ) -> T:
+        cls: type[Self], arg_string: str, additional_config: dict | None = None
+    ) -> Self:
         """Create an LM instance from a comma-separated argument string.
 
         Args:
@@ -147,10 +143,10 @@ class LM(abc.ABC):
 
     @classmethod
     def create_from_arg_obj(
-        cls: type[T],
+        cls: type[Self],
         arg_dict: dict[str, Any],
         additional_config: dict[str, Any] | None = None,
-    ) -> T:
+    ) -> Self:
         """Create an LM instance from a dictionary of arguments.
 
         Args:
@@ -227,8 +223,30 @@ class LM(abc.ABC):
 
 
 ### SQLite-based caching of LM responses
+def _handle_cache_arg(value: Any) -> dict[str, str]:
+    """Return a deterministic JSON representation for cache-key arguments."""
+    if isinstance(value, (bytes, bytearray)):
+        return {
+            "__lm_eval_cache_type__": type(value).__name__,
+            "sha256": hashlib.sha256(bytes(value)).hexdigest(),
+        }
+
+    try:
+        from PIL import Image
+    except ImportError:
+        Image = None  # type: ignore[assignment]
+
+    if Image is not None and isinstance(value, Image.Image):
+        return {
+            "__lm_eval_cache_type__": "pil_image",
+            "sha256": utils.convert_pil_to_hash(value),
+        }
+
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
 def hash_args(attr: str, args: Iterable[Any]) -> str:
-    dat = json.dumps([attr] + list(args))
+    dat = json.dumps([attr] + list(args), default=_handle_cache_arg)
     return hashlib.sha256(dat.encode("utf-8")).hexdigest()
 
 
@@ -357,7 +375,6 @@ class TemplateLM(LM):
         Must handle strings that already contain the BOS token when
         ``add_special_tokens`` is None. Otherwise, uses the flag as given.
         """
-        pass
 
     @abc.abstractmethod
     def _loglikelihood_tokens(

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -1,0 +1,99 @@
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from lm_eval import utils
+from lm_eval.api.model import CachingLM, hash_args
+
+
+class _FakeCache(dict):
+    def commit(self):
+        pass
+
+
+class _FakeLM:
+    def __init__(self):
+        self.call_count = 0
+
+    def generate_until(self, requests):
+        self.call_count += 1
+        return ["response"] * len(requests)
+
+
+def _caching_lm(lm):
+    caching_lm = object.__new__(CachingLM)
+    caching_lm.lm = lm
+    caching_lm.cache_db = "memory"
+    caching_lm.dbdict = _FakeCache()
+    return caching_lm
+
+
+def test_hash_args_preserves_json_compatible_cache_keys():
+    args = ("prompt", {"until": ["stop"], "temperature": 0})
+
+    expected_data = json.dumps(["generate_until"] + list(args))
+    expected_hash = hashlib.sha256(expected_data.encode("utf-8")).hexdigest()
+
+    assert hash_args("generate_until", args) == expected_hash
+
+
+def test_hash_args_hashes_byte_values_by_content():
+    first = hash_args("generate_until", ("prompt", {}, b"image-one"))
+    same = hash_args("generate_until", ("prompt", {}, b"image-one"))
+    different = hash_args("generate_until", ("prompt", {}, b"image-two"))
+
+    assert first == same
+    assert first != different
+
+
+def test_hash_args_distinguishes_byte_types_and_digest_strings():
+    value = b"image"
+    digest = hashlib.sha256(value).hexdigest()
+
+    bytes_hash = hash_args("generate_until", (value,))
+    bytearray_hash = hash_args("generate_until", (bytearray(value),))
+    digest_string_hash = hash_args("generate_until", (digest,))
+
+    assert len({bytes_hash, bytearray_hash, digest_string_hash}) == 3
+
+
+def test_hash_args_hashes_pil_images_by_content():
+    image_module = pytest.importorskip("PIL.Image")
+    first_image = image_module.new("RGB", (2, 2), "red")
+    same_image = image_module.new("RGB", (2, 2), "red")
+    different_image = image_module.new("RGB", (2, 2), "blue")
+
+    first = hash_args("generate_until", ("prompt", {}, {"visual": [first_image]}))
+    same = hash_args("generate_until", ("prompt", {}, {"visual": [same_image]}))
+    different = hash_args(
+        "generate_until", ("prompt", {}, {"visual": [different_image]})
+    )
+    digest_string = hash_args(
+        "generate_until",
+        ("prompt", {}, {"visual": [utils.convert_pil_to_hash(first_image)]}),
+    )
+
+    assert first == same
+    assert first != different
+    assert first != digest_string
+
+
+def test_caching_lm_reuses_multimodal_image_response():
+    image_module = pytest.importorskip("PIL.Image")
+    image = image_module.new("RGB", (2, 2), "red")
+    request = SimpleNamespace(args=("prompt", {}, {"visual": [image]}))
+    lm = _FakeLM()
+    caching_lm = _caching_lm(lm)
+
+    assert caching_lm.generate_until([request]) == ["response"]
+    assert caching_lm.generate_until([request]) == ["response"]
+    assert lm.call_count == 1
+
+
+def test_hash_args_rejects_unsupported_objects():
+    with pytest.raises(
+        TypeError, match="Object of type object is not JSON serializable"
+    ):
+        hash_args("generate_until", (object(),))


### PR DESCRIPTION
## Summary

- serialize PIL images, bytes, and bytearrays as compact, type-tagged SHA-256 content digests when building response-cache keys
- preserve the exact cache keys produced for existing JSON-compatible text requests
- add regression coverage for content stability, distinct media content and types, unsupported objects, and an end-to-end multimodal cache hit

This keeps the change focused on image request values. Audio arrays and backend-specific video objects need separate canonical identity rules and are outside this PR.

`lm_eval/api/model.py` also receives the behavior-neutral abstract-method and `Self` annotation cleanup required for the repository's current Ruff configuration to pass when this previously unlinted file is included in the changed-file set.

## Testing

```text
PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/test_api_model.py tests/test_cache.py tests/test_utils.py -q
73 passed

PRE_COMMIT_HOME=/tmp/lm-eval-pre-commit pre-commit run --files lm_eval/api/model.py tests/test_api_model.py
All hooks passed
```

Fixes #4005

Related prior attempt: #3379