### PR TITLE
fix(mmlu_flan_cot_fewshot): aggregate exact_match in the sub-groups

### DIFF
--- a/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_fewshot/_mmlu.yaml
@@ -5,25 +5,25 @@ task:
     task:
       - mmlu_flan_cot_fewshot_stem
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: other
     task:
       - mmlu_flan_cot_fewshot_other
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: social sciences
     task:
       - mmlu_flan_cot_fewshot_social_sciences
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
   - group: humanities
     task:
       - mmlu_flan_cot_fewshot_humanities
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
         weight_by_size: True
 aggregate_metric_list:
   - aggregation: mean


### PR DESCRIPTION
## Problem

The `mmlu_flan_cot_fewshot` leaf tasks emit **`exact_match`** (defined in
`_mmlu_flan_cot_fewshot_template_yaml`). The top-level `aggregate_metric_list`
in `flan_cot_fewshot/_mmlu.yaml` correctly rolls up `exact_match`, but the four
sub-group aggregates — `stem`, `other`, `social sciences`, `humanities` — still
declare `metric: acc`.

No task in this family produces an `acc` metric, so `aggregate_metric_list`
finds nothing to aggregate and those per-category rollups come back **silently
empty** — the same failure mode fixed for `mmlu_flan_cot_zeroshot` in #3987
(issue #3986). The fewshot config had only its top-level metric corrected; its
sub-groups were left on the wrong name.

## Fix

Change the four sub-group aggregates from `metric: acc` to `metric: exact_match`,
matching the metric the leaf tasks actually emit and the top-level rollup.

```diff
   - group: stem
     ...
     aggregate_metric_list:
-      - metric: acc
+      - metric: exact_match
```
(and likewise for `other`, `social sciences`, `humanities`)

Config-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
