### PR TITLE
fix(common_voice_en): repoint at an accessible dataset (#3955)

### DIFF
--- a/lm_eval/tasks/common_voice/common_voice_en.yaml
+++ b/lm_eval/tasks/common_voice/common_voice_en.yaml
@@ -2,17 +2,23 @@ task: common_voice_en
 task_alias: common_voice_en
 
 # subset only. The real dataset (mozilla-foundation/common_voice_17_0) is to huge
-dataset_path: fixie-ai/endpointing-audio
-dataset_name: common_voice_17_0-en
+# and gated. The previous stand-in (fixie-ai/endpointing-audio) is no longer
+# public and now 401s for everyone, so point at the ungated fixie-ai mirror and
+# pin a single test shard -- the full test split is ~8GB and train is ~44GB.
+# The revision is pinned so eval inputs stay reproducible. See issue #3955.
+dataset_path: fixie-ai/common_voice_17_0
+dataset_kwargs:
+  data_files:
+    test: en/test-00000-of-00019.parquet
+  revision: 34f78a43893414e7b6e271ba94c1d5e05f18b239
 
-training_split: train
 test_split: test
 
 output_type: generate_until
 
 doc_to_audio: !function utils.doc_to_audio
 doc_to_text: !function utils.doc_to_text
-doc_to_target: "{{transcript}}"
+doc_to_target: "{{sentence}}"
 
 generation_kwargs:
   until:
@@ -28,4 +34,4 @@ metric_list:
 
 # any metadata you need. Does not affect how the task is processed
 metadata:
-  version: 1.0
+  version: 2.0


### PR DESCRIPTION
## Problem

Fixes #3955.

`common_voice_en` points at `fixie-ai/endpointing-audio`, which is no longer public. The Hub returns HTTP 401 for anonymous users and for authenticated users outside the owning org:

```console
$ curl -s -o /dev/null -w "%{http_code}\n" https://huggingface.co/api/datasets/fixie-ai/endpointing-audio
401
```

Since `common_voice_en` is the only task in the family, the whole `common_voice` folder is currently unloadable for everyone. This is an access problem, not the `datasets>=4` script-loading breakage tracked in #3171.

## Fix

Repoint at `fixie-ai/common_voice_17_0`, which is public and ungated (`gated: false`, `private: false`). Concretely:

- **`dataset_path`** → `fixie-ai/common_voice_17_0`.
- **`dataset_kwargs.data_files`** pins a single test shard. The full `en` test split is ~8&nbsp;GB and train is ~44&nbsp;GB, so loading the whole config would be far heavier than the "subset only" stand-in the YAML comment describes. One shard is 863 rows / ~410&nbsp;MB. This mirrors what `lm_eval/tasks/c4/c4.yaml` already does for the same "source is too huge" problem.
- **`dataset_kwargs.revision`** pins the dataset commit so eval inputs stay reproducible, same reasoning as the RULER host fix in #3806.
- **`doc_to_target`** → `{{sentence}}`. The mirror names the reference text `sentence`; there is no `transcript` column.
- **`training_split`** dropped — only the test shard is fetched and the task is 0-shot.
- **`metadata.version`** bumped to `2.0`, since scores are not comparable to the old subset.

`utils.py` is unchanged: the `audio` column is still an `Audio` feature, so `doc_to_audio` keeps working as-is.

## Verification

Built the task through `TaskManager` on the pristine tree and on this branch.

**Before** (pristine `main` @ `8a07e111`):

```
BUILD FAILED: DatasetNotFoundError Dataset 'fixie-ai/endpointing-audio' doesn't exist on the Hub or cannot be accessed.
```

**After** (this branch):

```
BUILD OK: ConfigurableTask
has_training_docs: False
has_test_docs: True
num test docs: 863
doc_to_target -> 'Joe Keaton disapproved of films, and Buster also had reservations about the medium.'
doc_to_text   -> 'Listen to the audio <audio> and output what a human has said on it. Answer:'
doc_to_audio  -> list len 1 keys ['array', 'sampling_rate']
```

One caveat on the harness, stated plainly: `datasets>=4` decodes `Audio` through `torchcodec`, which is not installed in my environment, so I stubbed `Audio.decode_example` with a `soundfile`-based decoder equivalent to the pre-4.0 behaviour. That gap is orthogonal to this change — it would bite the old config identically — and everything this PR actually touches (dataset resolution, split wiring, and the `doc_to_*` templates) is exercised for real above. I have not run a full generation against a live audio model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
