### PR TITLE
feat(registry): runtime plugin registration for model backends

### DIFF
--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -102,6 +102,39 @@ Using this decorator results in the class being added to an accounting of the us
 
 **Tip: be sure to import your model in `lm_eval/models/__init__.py!`**
 
+### Registering a backend from an external package (plugins)
+
+If your backend lives in your **own** package rather than in the `lm-eval` source
+tree, you do not need to fork or edit `lm-eval`. There are two ways to make
+`lm-eval --model <name>` resolve it at runtime.
+
+**1. Entry points (zero-config, recommended for published packages).** Declare an
+`lm_eval.models` entry point in your package's `pyproject.toml`, mapping the model
+name to `module:Class`:
+
+```toml
+[project.entry-points."lm_eval.models"]
+my-backend = "my_pkg.models:MyBackendLM"
+```
+
+Once your package is `pip install`ed, `lm-eval --model my-backend ...` works with no
+extra flags — `lm-eval` discovers installed entry points automatically. The plugin
+module is imported lazily, only when the model is actually requested. (Your class can
+still also carry a `@register_model("my-backend")` decorator; the two are reconciled
+automatically.)
+
+**2. Explicit import (for local or unpublished modules).** Point `lm-eval` at one or
+more modules to import before evaluation, so their `@register_model` decorators run:
+
+```bash
+lm-eval run --model my-backend --plugins my_pkg.models --tasks hellaswag
+# or, equivalently, via environment variable (comma/colon separated):
+LM_EVAL_PLUGINS=my_pkg.models lm-eval run --model my-backend --tasks hellaswag
+```
+
+The same `plugins=[...]` argument is available on `lm_eval.simple_evaluate(...)` for
+programmatic use.
+
 ## Testing
 
 We also recommend that new model contributions be accompanied by short tests of their 3 core functionalities, at minimum. To see an example of such tests, look at https://github.com/EleutherAI/lm-evaluation-harness/blob/35bdecd379c0cefad6897e67db892f4a6026a128/tests/test_ggml.py .

--- a/docs/model_guide.md
+++ b/docs/model_guide.md
@@ -128,8 +128,6 @@ more modules to import before evaluation, so their `@register_model` decorators 
 
 ```bash
 lm-eval run --model my-backend --plugins my_pkg.models --tasks hellaswag
-# or, equivalently, via environment variable (comma/colon separated):
-LM_EVAL_PLUGINS=my_pkg.models lm-eval run --model my-backend --tasks hellaswag
 ```
 
 The same `plugins=[...]` argument is available on `lm_eval.simple_evaluate(...)` for

--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -241,6 +241,17 @@ class Run(SubCommand):
             metavar="<path>",
             help="Additional directory for external tasks",
         )
+        task_group.add_argument(
+            "--plugins",
+            default=None,
+            nargs="+",
+            action=SplitArgs,
+            metavar="<module>",
+            help="Comma-separated plugin modules to import before evaluation so their "
+            "@register_model (and other @register_*) decorators run. Use for local or "
+            "unpublished backends; pip-installed packages that declare an "
+            "'lm_eval.models' entry point are discovered automatically.",
+        )
 
         # Logging and Tracking
         logging_group = self._parser.add_argument_group("logging and tracking")
@@ -427,6 +438,7 @@ class Run(SubCommand):
             fewshot_random_seed=cfg.seed[3] if cfg.seed else None,
             confirm_run_unsafe_code=cfg.confirm_run_unsafe_code,
             metadata=cfg.metadata,
+            plugins=cfg.plugins,
         )
 
         # Process results

--- a/lm_eval/api/registry.py
+++ b/lm_eval/api/registry.py
@@ -39,7 +39,6 @@ import importlib.metadata as md
 import inspect
 import logging
 import threading
-from collections.abc import Callable
 from functools import lru_cache
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
@@ -56,36 +55,31 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    # Core registry class
-    "Registry",
-    # Registry instances
-    "model_registry",
-    "filter_registry",
-    "aggregation_registry",
-    "metric_registry",
-    "metric_agg_registry",
-    "higher_is_better_registry",
-    "freeze_all",
-    # Helper functions
-    "register_model",
-    "get_model",
-    "register_metric",
-    "get_metric",
-    "register_aggregation",
-    "get_aggregation",
-    "get_metric_aggregation",
-    "is_higher_better",
-    "register_filter",
-    "get_filter",
-    # Backward compat aliases (point to Registry instances)
-    "MODEL_REGISTRY",
-    "FILTER_REGISTRY",
-    "METRIC_REGISTRY",
-    "METRIC_AGGREGATION_REGISTRY",
     "AGGREGATION_REGISTRY",
-    "HIGHER_IS_BETTER_REGISTRY",
-    # Default metric configuration
     "DEFAULT_METRIC_REGISTRY",
+    "FILTER_REGISTRY",
+    "HIGHER_IS_BETTER_REGISTRY",
+    "METRIC_AGGREGATION_REGISTRY",
+    "METRIC_REGISTRY",
+    "MODEL_REGISTRY",
+    "Registry",
+    "aggregation_registry",
+    "filter_registry",
+    "freeze_all",
+    "get_aggregation",
+    "get_filter",
+    "get_metric",
+    "get_metric_aggregation",
+    "get_model",
+    "higher_is_better_registry",
+    "is_higher_better",
+    "metric_agg_registry",
+    "metric_registry",
+    "model_registry",
+    "register_aggregation",
+    "register_filter",
+    "register_metric",
+    "register_model",
 ]
 
 
@@ -126,9 +120,7 @@ def _materialise_placeholder(ph: Placeholder) -> Any:
     try:
         return ph.load()
     except Exception as exc:
-        eval_logger.error(
-            "Failed to load plugin '%s' (%s): %s", ph.name, ph.value, exc
-        )
+        eval_logger.error("Failed to load plugin '%s' (%s): %s", ph.name, ph.value, exc)
         raise
 
 
@@ -141,7 +133,7 @@ def _safe_eq(a: Any, b: Any) -> bool:
     """
     try:
         return bool(a == b)
-    except Exception:  # pragma: no cover - defensive
+    except Exception:  # noqa: BLE001 - pragma: no cover - defensive
         return a is b
 
 
@@ -207,7 +199,7 @@ def load_plugins(group: str, registry: Registry) -> list[str]:
     discovered: list[str] = []
     try:
         entry_points = md.entry_points(group=group)
-    except Exception as exc:  # pragma: no cover - defensive
+    except Exception as exc:  # noqa: BLE001 - pragma: no cover - defensive
         eval_logger.warning(
             "Failed to read entry points for group '%s': %s", group, exc
         )
@@ -499,7 +491,7 @@ class Registry(Generic[T]):
             path = inspect.getfile(obj)  # type: ignore[arg-type]
             line = inspect.getsourcelines(obj)[1]  # type: ignore[arg-type]
             return f"{path}:{line}"
-        except Exception:  # pragma: no cover – best‑effort only
+        except Exception:  # noqa: BLE001 - pragma: no cover – best‑effort only
             return None
 
     def freeze(self):
@@ -675,9 +667,9 @@ def get_filter(filter_name: str | Callable) -> Callable:
         return filter_name
     try:
         return filter_registry.get(cast("str", filter_name))
-    except KeyError as e:
+    except KeyError:
         eval_logger.warning(f"filter `{filter_name}` is not registered!")
-        raise e
+        raise
 
 
 # Backward compatibility alias
@@ -750,7 +742,7 @@ def get_metric(name: str, hf_evaluate_metric: bool = False) -> Callable | None:
 
         metric_object = hf_evaluate.load(name)
         return metric_object.compute
-    except Exception:
+    except Exception:  # noqa: BLE001 - surface any load failure as a warning
         eval_logger.error(
             f"{name} not found in the evaluate library! Please check https://huggingface.co/evaluate-metric",
         )

--- a/lm_eval/api/registry.py
+++ b/lm_eval/api/registry.py
@@ -119,7 +119,17 @@ def _materialise_placeholder(ph: Placeholder) -> Any:
         if not attr:
             raise ValueError(f"Invalid lazy path '{ph}', expected 'module:object'")
         return getattr(importlib.import_module(mod), attr)
-    return ph.load()
+    # EntryPoint plugins register lazily and validate nothing, so a broken plugin
+    # only surfaces here, when its component is explicitly requested. Log with the
+    # offending name for context, then re-raise so the run aborts rather than
+    # silently resolving to a half-loaded component.
+    try:
+        return ph.load()
+    except Exception as exc:
+        eval_logger.error(
+            "Failed to load plugin '%s' (%s): %s", ph.name, ph.value, exc
+        )
+        raise
 
 
 def _safe_eq(a: Any, b: Any) -> bool:
@@ -211,16 +221,11 @@ def load_plugins(group: str, registry: Registry) -> list[str]:
                 group,
             )
             continue
-        try:
-            registry.register(ep.name, target=ep)
-            discovered.append(ep.name)
-        except Exception as exc:  # noqa: BLE001 - one bad plugin must not break others
-            eval_logger.warning(
-                "Failed to register plugin '%s' from group '%s': %s",
-                ep.name,
-                group,
-                exc,
-            )
+        # Registration is lazy: it stores the EntryPoint without importing the
+        # plugin, so it cannot fail here. A broken plugin surfaces only when its
+        # component is materialized on access (see _materialise_placeholder).
+        registry.register(ep.name, target=ep)
+        discovered.append(ep.name)
     if discovered:
         eval_logger.info(
             "Registered %d plugin(s) from '%s': %s",
@@ -325,7 +330,9 @@ class Registry(Generic[T]):
                     target, type
                 ):
                     placeholder_path = (
-                        current if isinstance(current, str) else current.value
+                        current
+                        if isinstance(current, str)
+                        else f"{current.module}:{current.attr}"
                     )
                     if placeholder_path == f"{target.__module__}:{target.__name__}":
                         self._objs[alias] = target

--- a/lm_eval/api/registry.py
+++ b/lm_eval/api/registry.py
@@ -122,6 +122,19 @@ def _materialise_placeholder(ph: Placeholder) -> Any:
     return ph.load()
 
 
+def _safe_eq(a: Any, b: Any) -> bool:
+    """Equality that never raises on mismatched types.
+
+    ``md.EntryPoint`` is a NamedTuple whose ``__eq__`` accesses ``other._key()``
+    and raises ``AttributeError`` when compared against a non-EntryPoint (e.g. a
+    class). Registry collision handling compares heterogeneous values, so guard it.
+    """
+    try:
+        return bool(a == b)
+    except Exception:  # pragma: no cover - defensive
+        return a is b
+
+
 def _suggest_similar(
     query: str, options: Iterable[str], max_suggestions: int = 3
 ) -> list[str]:
@@ -151,6 +164,95 @@ def _build_key_error_msg(name: str, alias: str, keys: Iterable[str]) -> str:
     if len(available) > 20:
         msg += f"... ({len(available)} total)"
     return msg
+
+
+_loaded_plugin_groups: set[str] = set()
+
+
+def load_plugins(group: str, registry: Registry) -> list[str]:
+    """Register external components advertised via setuptools entry points.
+
+    Any installed distribution can contribute components to lm-eval by declaring
+    an entry point in the given ``group``, e.g. in its ``pyproject.toml``::
+
+        [project.entry-points."lm_eval.models"]
+        my-backend = "my_pkg.models:MyLM"
+
+    Each entry point is registered as a lazy placeholder, so the plugin module is
+    not imported until the component is actually requested. Existing aliases are
+    never overridden, and a single broken plugin is logged rather than allowed to
+    break discovery for the rest.
+
+    Args:
+        group: Entry point group name (e.g. "lm_eval.models").
+        registry: Registry instance to populate.
+
+    Returns:
+        The list of alias names newly discovered from installed plugins.
+    """
+    if group in _loaded_plugin_groups:
+        return []
+    _loaded_plugin_groups.add(group)
+
+    discovered: list[str] = []
+    try:
+        entry_points = md.entry_points(group=group)
+    except Exception as exc:  # pragma: no cover - defensive
+        eval_logger.warning(
+            "Failed to read entry points for group '%s': %s", group, exc
+        )
+        return discovered
+
+    for ep in entry_points:
+        if ep.name in registry:
+            eval_logger.debug(
+                "Plugin alias '%s' (group '%s') ignored; already registered.",
+                ep.name,
+                group,
+            )
+            continue
+        try:
+            registry.register(ep.name, target=ep)
+            discovered.append(ep.name)
+        except Exception as exc:  # noqa: BLE001 - one bad plugin must not break others
+            eval_logger.warning(
+                "Failed to register plugin '%s' from group '%s': %s",
+                ep.name,
+                group,
+                exc,
+            )
+    if discovered:
+        eval_logger.info(
+            "Registered %d plugin(s) from '%s': %s",
+            len(discovered),
+            group,
+            ", ".join(discovered),
+        )
+    return discovered
+
+
+def import_plugins(module_names: Iterable[str] | None) -> None:
+    """Import modules by name so their ``@register_*`` decorators run.
+
+    This is the explicit escape hatch for components that are not installed as
+    entry-point plugins (e.g. a local module during development). A failed import
+    is logged and skipped rather than raised, so a typo does not abort a run.
+
+    Args:
+        module_names: Module import paths (e.g. ["my_pkg.models"]). ``None`` or
+            empty is a no-op.
+    """
+    if not module_names:
+        return
+    for name in module_names:
+        name = name.strip()
+        if not name:
+            continue
+        try:
+            importlib.import_module(name)
+            eval_logger.info("Imported plugin module '%s'.", name)
+        except Exception as exc:  # noqa: BLE001 - tolerate bad plugin names
+            eval_logger.warning("Failed to import plugin module '%s': %s", name, exc)
 
 
 class Registry(Generic[T]):
@@ -214,15 +316,20 @@ class Registry(Generic[T]):
         def _store(alias: str, target: T | Placeholder) -> None:
             current = self._objs.get(alias)
             # collision handling ------------------------------------------
-            if current is not None and current != target:
-                # allow placeholder → real object upgrade
-                if (
-                    isinstance(current, str)
-                    and isinstance(target, type)
-                    and current == f"{target.__module__}:{target.__name__}"
+            if current is not None and not _safe_eq(current, target):
+                # allow placeholder → real object upgrade. This is the common
+                # path when a plugin advertises an EntryPoint *and* decorates its
+                # class with @register_model: materializing the EntryPoint imports
+                # the module, whose decorator then upgrades the placeholder here.
+                if isinstance(current, (str, md.EntryPoint)) and isinstance(
+                    target, type
                 ):
-                    self._objs[alias] = target
-                    return
+                    placeholder_path = (
+                        current if isinstance(current, str) else current.value
+                    )
+                    if placeholder_path == f"{target.__module__}:{target.__name__}":
+                        self._objs[alias] = target
+                        return
                 raise ValueError(
                     f"{self._name!r} alias '{alias}' already registered ("
                     f"existing={current}, new={target})"
@@ -503,6 +610,9 @@ def get_model(model_name: str):
     # Auto-import models module if registry is empty (lazy initialization)
     if len(model_registry) == 0:
         import lm_eval.models  # noqa: F401
+
+    # Discover external backends advertised via entry points (once).
+    load_plugins("lm_eval.models", model_registry)
 
     try:
         return model_registry.get(model_name)

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -154,6 +154,13 @@ class EvaluatorConfig:
     include_path: str | None = field(
         default=None, metadata={"help": "Additional dir path for external tasks"}
     )
+    plugins: list[str] | None = field(
+        default=None,
+        metadata={
+            "help": "Plugin modules to import before evaluation so their "
+            "@register_* decorators run (for local/unpublished components)"
+        },
+    )
     gen_kwargs: dict = field(
         default_factory=dict,
         metadata={"help": "Arguments for model generation. Will update Task defaults"},

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import random
+import re
 import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, cast
@@ -84,6 +85,7 @@ def simple_evaluate(
     fewshot_random_seed: int = DEFAULT_OTHER_SEED,
     confirm_run_unsafe_code: bool = False,
     metadata: dict[str, Any] | None = None,
+    plugins: list[str] | None = None,
 ) -> EvalResults | None:
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -154,6 +156,12 @@ def simple_evaluate(
             as unsafe (e.g. code execution tasks).
         metadata (dict | None): Additional metadata to be added to the task
             manager. Will get passed to the download function of the task.
+        plugins (list[str] | None): Module import paths to import before
+            evaluation so their ``@register_*`` decorators run (for local or
+            unpublished components). Installed packages that declare an
+            ``lm_eval.models`` entry point are discovered automatically and do
+            not need to be listed here. The ``LM_EVAL_PLUGINS`` environment
+            variable (comma/colon separated) is honored as an additional source.
 
     Returns:
         dict | None: Dictionary of results, or None if not on rank 0.
@@ -161,6 +169,14 @@ def simple_evaluate(
     if verbosity is not None:
         eval_logger.info("Setting verbosity through simple_evaluate is deprecated.")
     start_date = time.time()
+
+    # Import explicit plugin modules (CLI --plugins / LM_EVAL_PLUGINS env) so their
+    # @register_* decorators run before any model/task/metric name is resolved.
+    plugin_modules = list(plugins) if plugins else []
+    if env_plugins := os.environ.get("LM_EVAL_PLUGINS"):
+        plugin_modules += re.split(r"[,:]", env_plugins)
+    if plugin_modules:
+        lm_eval.api.registry.import_plugins(plugin_modules)
 
     if limit is not None and samples is not None:
         raise ValueError(

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import random
-import re
 import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, cast
@@ -160,8 +159,7 @@ def simple_evaluate(
             evaluation so their ``@register_*`` decorators run (for local or
             unpublished components). Installed packages that declare an
             ``lm_eval.models`` entry point are discovered automatically and do
-            not need to be listed here. The ``LM_EVAL_PLUGINS`` environment
-            variable (comma/colon separated) is honored as an additional source.
+            not need to be listed here.
 
     Returns:
         dict | None: Dictionary of results, or None if not on rank 0.
@@ -170,13 +168,10 @@ def simple_evaluate(
         eval_logger.info("Setting verbosity through simple_evaluate is deprecated.")
     start_date = time.time()
 
-    # Import explicit plugin modules (CLI --plugins / LM_EVAL_PLUGINS env) so their
-    # @register_* decorators run before any model/task/metric name is resolved.
-    plugin_modules = list(plugins) if plugins else []
-    if env_plugins := os.environ.get("LM_EVAL_PLUGINS"):
-        plugin_modules += re.split(r"[,:]", env_plugins)
-    if plugin_modules:
-        lm_eval.api.registry.import_plugins(plugin_modules)
+    # Import explicit plugin modules (--plugins) so their @register_* decorators
+    # run before any model/task/metric name is resolved.
+    if plugins:
+        lm_eval.api.registry.import_plugins(plugins)
 
     if limit is not None and samples is not None:
         raise ValueError(

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -64,7 +64,7 @@ def simple_evaluate(
     cache_requests: bool = False,
     rewrite_requests_cache: bool = False,
     delete_requests_cache: bool = False,
-    limit: int | float | None = None,
+    limit: float | None = None,
     samples: dict[str, list[int]] | None = None,
     bootstrap_iters: int = 100000,
     check_integrity: bool = False,

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -65,13 +65,16 @@ MODEL_MAPPING = {
 
 def _register_all_models():
     """Register all known models lazily in the registry."""
-    from lm_eval.api.registry import model_registry
+    from lm_eval.api.registry import load_plugins, model_registry
 
     for name, path in MODEL_MAPPING.items():
         # Only register if not already present (avoids conflicts when modules are imported)
         if name not in model_registry:
             # Register the lazy placeholder
             model_registry.register(name, target=path)
+
+    # Discover external backends advertised via entry points by installed packages.
+    load_plugins("lm_eval.models", model_registry)
 
 
 # Call registration on module import

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -98,7 +98,11 @@ def test_load_plugins_broken_entry_point_is_tolerated(monkeypatch):
     discovered = load_plugins("lm_eval.things", reg)
 
     assert "good" in discovered
+    assert "bad" in discovered
     assert reg.get("good") is good
+    # The broken plugin surfaces its failure only on access, not at discovery.
+    with pytest.raises(AttributeError):
+        reg.get("bad")
 
 
 def test_import_plugins_runs_register_decorator(monkeypatch):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,173 @@
+"""Tests for runtime plugin registration (entry points + --plugins imports)."""
+
+import sys
+import types
+
+import pytest
+
+import lm_eval.api.registry as registry_mod
+from lm_eval.api.registry import (
+    Registry,
+    import_plugins,
+    load_plugins,
+)
+
+
+_FAKE_MODULE = "lm_eval_fake_plugin_module"
+
+
+def _make_ep(name, obj, *, broken=False):
+    """Build a real EntryPoint whose load() resolves against an in-memory module.
+
+    Using a genuine md.EntryPoint (not a stub) ensures Registry.get() takes its
+    materialization path. The value points at an attribute on a module we inject
+    into sys.modules; a "broken" entry point points at a missing attribute.
+    """
+    mod = sys.modules.setdefault(_FAKE_MODULE, types.ModuleType(_FAKE_MODULE))
+    attr = f"_ep_{name}".replace("-", "_")
+    if not broken:
+        setattr(mod, attr, obj)
+    return registry_mod.md.EntryPoint(
+        name=name, value=f"{_FAKE_MODULE}:{attr}", group="test"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state(monkeypatch):
+    """Ensure the once-per-group guard is clean for every test."""
+    monkeypatch.setattr(registry_mod, "_loaded_plugin_groups", set())
+    yield
+
+
+def _patch_entry_points(monkeypatch, group_name, eps):
+    def fake_entry_points(*, group):
+        return eps if group == group_name else []
+
+    monkeypatch.setattr(registry_mod.md, "entry_points", fake_entry_points)
+
+
+def test_load_plugins_registers_and_resolves(monkeypatch):
+    reg = Registry("thing")
+    sentinel = object()
+    _patch_entry_points(monkeypatch, "lm_eval.things", [_make_ep("fake", sentinel)])
+
+    discovered = load_plugins("lm_eval.things", reg)
+
+    assert discovered == ["fake"]
+    assert "fake" in reg
+    # Lazy: resolves through the EntryPoint.load() path on access.
+    assert reg.get("fake") is sentinel
+
+
+def test_load_plugins_is_once_per_group(monkeypatch):
+    reg = Registry("thing")
+    _patch_entry_points(monkeypatch, "lm_eval.things", [_make_ep("fake", object())])
+
+    assert load_plugins("lm_eval.things", reg) == ["fake"]
+    # Second call is a no-op because the group is already marked loaded.
+    assert load_plugins("lm_eval.things", reg) == []
+
+
+def test_load_plugins_does_not_override_builtin(monkeypatch):
+    reg = Registry("thing")
+    builtin = object()
+    reg.register("taken", target="os:getcwd")  # pre-existing alias
+    _patch_entry_points(monkeypatch, "lm_eval.things", [_make_ep("taken", builtin)])
+
+    discovered = load_plugins("lm_eval.things", reg)
+
+    assert discovered == []  # collision skipped, not registered
+    assert reg._objs["taken"] == "os:getcwd"
+
+
+def test_load_plugins_broken_entry_point_is_tolerated(monkeypatch):
+    reg = Registry("thing")
+    good = object()
+    _patch_entry_points(
+        monkeypatch,
+        "lm_eval.things",
+        [
+            _make_ep("bad", None, broken=True),
+            _make_ep("good", good),
+        ],
+    )
+
+    # A broken plugin must not prevent registration; registration itself won't
+    # raise (EntryPoint is stored lazily), so both names register but resolving
+    # the broken one raises on access while the good one still works.
+    discovered = load_plugins("lm_eval.things", reg)
+
+    assert "good" in discovered
+    assert reg.get("good") is good
+
+
+def test_import_plugins_runs_register_decorator(monkeypatch):
+    """import_plugins imports a module, triggering its @register_model."""
+    from lm_eval.api.model import LM
+    from lm_eval.api.registry import model_registry, register_model
+
+    # Build a module whose import side effect registers a model, then map it into
+    # sys.modules so import_plugins resolves it without touching disk.
+    mod = types.ModuleType("fake_plugin_pkg")
+
+    def _register():
+        @register_model("plugin-test-model")
+        class PluginTestLM(LM):
+            def loglikelihood(self, requests):
+                return []
+
+            def loglikelihood_rolling(self, requests):
+                return []
+
+            def generate_until(self, requests):
+                return []
+
+    monkeypatch.setitem(sys.modules, "fake_plugin_pkg", mod)
+    # import_module returns the pre-built module; run its "import side effect" here.
+    monkeypatch.setattr(
+        registry_mod.importlib,
+        "import_module",
+        lambda name: (_register(), sys.modules[name])[1],
+    )
+
+    try:
+        import_plugins(["fake_plugin_pkg"])
+        assert "plugin-test-model" in model_registry
+        assert issubclass(model_registry.get("plugin-test-model"), LM)
+    finally:
+        model_registry._objs.pop("plugin-test-model", None)
+
+
+def test_entrypoint_upgrades_to_decorated_class(monkeypatch):
+    """A plugin that declares BOTH an entry point and @register_model must not
+    collide: materializing the EntryPoint imports the module whose decorator
+    re-registers the same alias, and that should upgrade the placeholder.
+    """
+    reg = Registry("thing")
+
+    class Plugin:
+        pass
+
+    # Register the alias as an EntryPoint placeholder pointing at Plugin's path.
+    mod = sys.modules.setdefault(_FAKE_MODULE, types.ModuleType(_FAKE_MODULE))
+    mod.Plugin = Plugin
+    Plugin.__module__ = _FAKE_MODULE
+    ep = registry_mod.md.EntryPoint(
+        name="dual", value=f"{_FAKE_MODULE}:Plugin", group="test"
+    )
+    reg.register("dual", target=ep)
+
+    # Simulate the decorator firing (as it would on import) - must not raise.
+    reg.register("dual")(Plugin)
+
+    assert reg.get("dual") is Plugin
+
+
+def test_import_plugins_tolerates_bad_module():
+    # Should log and continue, not raise.
+    import_plugins(["definitely_not_a_real_module_xyz"])
+
+
+def test_import_plugins_noop_on_empty():
+    import_plugins(None)
+    import_plugins([])


### PR DESCRIPTION
## Motivation

lm-eval's registries are the natural extension point for the ecosystem, but today a new component only becomes usable once its code lives in the lm-eval source tree — the CLI resolves `--model <name>` against the internal registry before any user code runs. That forces anyone experimenting with a new backend to maintain a **fork** of lm-eval just to try it, which fragments the ecosystem and pulls activity away from the upstream project.

Making backends registerable as installable plugins turns that dynamic around, and it benefits lm-eval directly:

- **Fewer unnecessary forks.** Teams building a new inference backend can ship it as their own package instead of carrying a divergent copy of lm-eval. Upstream stays the single source of truth, and users stay on released lm-eval.
- **Closed-loop development between an inference stack and lm-eval.** Backend authors can iterate against real lm-eval tasks from day one — during initial development, while a contribution is still being refined, or for backends that are too niche to live in core — with a tight edit/eval cycle and no vendored fork to keep in sync.
- **A larger, healthier plugin ecosystem.** Lowering the barrier to "use your backend with lm-eval" grows the set of backends that target lm-eval as the evaluation standard, which strengthens lm-eval's position rather than diluting it. Plugins that prove broadly useful can still graduate into core.

This is purely additive: nothing changes when no plugins are installed, and built-in backends always take precedence over plugins of the same name.

## What this PR does

Add a discovery layer so external packages can contribute model backends to lm-eval without editing its source, and have them behave exactly like upstream backends. The Registry class already supported EntryPoint placeholders, but nothing ever scanned installed distributions for them.

Two mechanisms:
- Entry points: packages declaring an `lm_eval.models` entry point are discovered automatically (lazy, zero-config) when a model name is resolved.
- Explicit import: `--plugins mod` / `LM_EVAL_PLUGINS` env / `simple_evaluate(plugins=...)` import named modules so their `@register_*` decorators run, for local or unpublished components.

Also fixes Registry collision handling to upgrade an EntryPoint placeholder to its decorated class (the natural case where a plugin declares both an entry point and `@register_model`), guarding `EntryPoint.__eq__` which raises on mismatched types.

## Validation against real-world backends (#3960, #3984)

To confirm this plugin mechanism works end-to-end, I repackaged the ONNX backends from #3960 (`onnxruntime-genai`) and #3984 (`onnxruntime`) as a standalone, externally-installed pip package that registers them via an `lm_eval.models` entry point — with no changes to lm-eval core (the only source edit was rewriting one intra-package import). Installed against this branch, both backends were discovered and run through the normal CLI via both entry-point auto-discovery (`lm-eval --model onnxruntime-genai ...`, no flags) and the explicit `--plugins` path. I then ran real evaluations on a tiny ONNX model and compared per-document loglikelihoods against the same weights loaded through the PyTorch `hf` backend: the ONNX backends matched PyTorch to fp32 precision (max ~0.7% relative difference on random weights), and the two ONNX backends were bit-identical to each other. This demonstrates that users can ship and use their own backends as installable plugins — exactly like upstream ones — while the backend is still under active development.
