### PR TITLE
Feat/plugin task registration

### DIFF
--- a/docs/new_task_guide.md
+++ b/docs/new_task_guide.md
@@ -363,6 +363,37 @@ task_manager = TaskManager(args.verbosity, include_path=args.include_path)
 
 Passing `--tasks /path/to/yaml/file` is also accepted.
 
+#### Shipping tasks in an installable package (plugins)
+
+If your tasks live in your **own** package, you can have `lm-eval` discover them
+automatically after `pip install`, without `--include_path` on every run. Declare an
+`lm_eval.tasks` entry point in your package's `pyproject.toml` pointing at the package
+that contains your task YAMLs:
+
+```toml
+[project.entry-points."lm_eval.tasks"]
+my_tasks = "my_pkg.tasks"
+
+[tool.setuptools.package-data]
+"my_pkg.tasks" = ["**/*.yaml"]
+```
+
+`lm-eval` resolves each entry point to the package directory and scans it recursively
+for `*.yaml` task configs, exactly like the built-in task tree. Once installed,
+`lm-eval --tasks my_task ...` and `lm-eval ls tasks` see your tasks with no extra flags.
+
+Precedence: built-in tasks load first, then plugin tasks, then `--include_path`. A
+task name provided via `--include_path` therefore overrides a plugin task of the same
+name (with the usual override warning), and a plugin task overrides a built-in.
+
+> **Note on run provenance.** Installed task plugins are listed in the results
+> metadata (`env.plugins`) as an *installed* snapshot only. Unlike model, filter,
+> metric, and aggregation plugins — which are resolved through the component
+> registry and so carry a `used` flag when actually exercised — tasks are
+> discovered by scanning directories, not through that registry. Task plugins
+> therefore never carry a per-plugin `used` flag; to see which tasks actually
+> ran, consult the top-level `results` keys instead.
+
 ### Advanced Group Configs
 
 While `tag` values are helpful when you want to be able to quickly and conveniently run a set of related tasks via `--tasks my_tag_name`, often, we wish to implement more complex logic. For example, the MMLU benchmark contains 57 *subtasks* that must all be *averaged* together in order to report a final 'MMLU score'.

--- a/lm_eval/tasks/manager.py
+++ b/lm_eval/tasks/manager.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import functools
+import importlib
+import importlib.metadata as md
+import importlib.util
+import logging
 import warnings
 from collections import defaultdict
 from itertools import chain
@@ -18,6 +23,96 @@ from lm_eval.tasks._yaml_loader import load_yaml
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
+
+
+log = logging.getLogger(__name__)
+
+TASKS_ENTRY_POINT_GROUP = "lm_eval.tasks"
+
+
+@functools.cache
+def discover_plugin_task_paths() -> tuple[Path, ...]:
+    """Resolve external task directories advertised via entry points.
+
+    Installed packages can contribute a directory of task YAMLs to lm-eval by
+    declaring an ``lm_eval.tasks`` entry point whose value points at the package
+    (or module) that holds them, e.g. in ``pyproject.toml``::
+
+        [project.entry-points."lm_eval.tasks"]
+        my_tasks = "my_pkg.tasks"
+
+    Each entry point is resolved to the directory containing that package/module,
+    which is then scanned recursively for ``*.yaml`` task configs exactly like the
+    built-in task tree. A broken entry point is logged and skipped rather than
+    allowed to break task discovery.
+
+    Entry-point metadata is process-stable, so the result is cached: discovery
+    runs once per process rather than on every ``TaskManager`` construction. Tests
+    that install fake entry points must call ``discover_plugin_task_paths
+    .cache_clear()``.
+
+    Returns:
+        Directory paths, de-duplicated, in entry-point iteration order.
+    """
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    try:
+        entry_points = md.entry_points(group=TASKS_ENTRY_POINT_GROUP)
+    except Exception as exc:  # noqa: BLE001 - pragma: no cover - defensive
+        log.warning(
+            "Failed to read entry points for '%s': %s", TASKS_ENTRY_POINT_GROUP, exc
+        )
+        return ()
+
+    for ep in entry_points:
+        try:
+            directory = _resolve_task_dir(ep.value)
+        except Exception as exc:  # noqa: BLE001 - one bad plugin must not break others
+            log.warning(
+                "Failed to resolve task plugin '%s' (%s): %s", ep.name, ep.value, exc
+            )
+            continue
+        if directory is None:
+            log.warning(
+                "Task plugin '%s' (%s) did not resolve to a directory; skipping.",
+                ep.name,
+                ep.value,
+            )
+            continue
+        if directory not in seen:
+            seen.add(directory)
+            paths.append(directory)
+            log.info("Discovered task plugin '%s' -> %s", ep.name, directory)
+    return tuple(paths)
+
+
+def _resolve_task_dir(value: str) -> Path | None:
+    """Resolve an entry-point value to a task directory.
+
+    The value is an import target, either a bare module/package (``my_pkg.tasks``)
+    or ``module:attr``. The directory returned is the package directory (for a
+    package) or the directory containing the module file (for a plain module).
+    """
+    module_name = value.split(":", 1)[0].strip()
+    if not module_name:
+        return None
+    # Prefer resolving via the module's location without importing its contents
+    # where possible, but importing is acceptable and reliable across layouts.
+    spec = importlib.util.find_spec(module_name)
+    if spec is None:
+        # Fall back to import (handles namespace edge cases / editable installs).
+        module = importlib.import_module(module_name)
+        spec = getattr(module, "__spec__", None)
+    if spec is None:
+        return None
+    # Package with a directory (has submodule_search_locations) -> that directory.
+    locations = list(getattr(spec, "submodule_search_locations", None) or [])
+    if locations:
+        return Path(locations[0]).resolve()
+    # Plain module -> the directory that contains its file.
+    if spec.origin and spec.origin != "built-in":
+        return Path(spec.origin).resolve().parent
+    return None
 
 
 class TaskDict(TypedDict):
@@ -78,9 +173,11 @@ class TaskManager:
         self._factory: TaskFactory = TaskFactory(meta=metadata)
 
         all_paths: list[Path] = []
-        # Process defaults FIRST, then include_path (later paths can override earlier)
+        # Process defaults FIRST, then plugin task dirs, then include_path
+        # (later paths override earlier, so user --include_path still wins).
         if include_defaults:
             all_paths.append(Path(__file__).parent)
+        all_paths += discover_plugin_task_paths()
         if include_path:
             all_paths += [
                 Path(p)

--- a/tests/test_task_plugins.py
+++ b/tests/test_task_plugins.py
@@ -1,0 +1,152 @@
+"""Tests for task-directory plugin discovery via entry points."""
+
+from pathlib import Path
+
+import pytest
+
+import lm_eval.tasks.manager as manager_mod
+from lm_eval.tasks.manager import TaskManager, discover_plugin_task_paths
+
+
+@pytest.fixture(autouse=True)
+def _clear_task_discovery_cache():
+    """Reset the once-per-process discovery cache around every test.
+
+    ``discover_plugin_task_paths`` is ``@functools.cache``d so it scans entry
+    points only once per process. Tests install different fake entry points, so
+    clear the cache before and after each so a cached result never leaks across
+    tests.
+    """
+    discover_plugin_task_paths.cache_clear()
+    yield
+    discover_plugin_task_paths.cache_clear()
+
+
+_TASK_YAML = """\
+task: {name}
+dataset_path: EleutherAI/lambada_openai
+dataset_name: default
+output_type: loglikelihood
+test_split: test
+doc_to_text: "{{{{text}}}}"
+doc_to_target: "{{{{text}}}}"
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: {version}
+"""
+
+
+def _make_task_package(tmp_path, pkg_name, task_name, version=1.0):
+    """Create an importable package on sys.path with one task YAML inside it."""
+    pkg_dir = tmp_path / pkg_name
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / f"{task_name}.yaml").write_text(
+        _TASK_YAML.format(name=task_name, version=version)
+    )
+    return pkg_dir
+
+
+def _patch_task_entry_points(monkeypatch, eps):
+    def fake_entry_points(*, group):
+        return eps if group == manager_mod.TASKS_ENTRY_POINT_GROUP else []
+
+    monkeypatch.setattr(manager_mod.md, "entry_points", fake_entry_points)
+
+
+def _ep(name, value):
+    return manager_mod.md.EntryPoint(
+        name=name, value=value, group=manager_mod.TASKS_ENTRY_POINT_GROUP
+    )
+
+
+def test_resolve_task_dir_for_package(tmp_path, monkeypatch):
+    _make_task_package(tmp_path, "plug_pkg_a", "plug_task_a")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    resolved = manager_mod._resolve_task_dir("plug_pkg_a")
+
+    assert resolved == (tmp_path / "plug_pkg_a").resolve()
+
+
+def test_discover_plugin_task_paths(tmp_path, monkeypatch):
+    _make_task_package(tmp_path, "plug_pkg_b", "plug_task_b")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _patch_task_entry_points(monkeypatch, [_ep("plug_b", "plug_pkg_b")])
+
+    paths = discover_plugin_task_paths()
+
+    assert (tmp_path / "plug_pkg_b").resolve() in paths
+
+
+def test_task_manager_includes_plugin_task(tmp_path, monkeypatch):
+    _make_task_package(tmp_path, "plug_pkg_c", "plug_task_c")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _patch_task_entry_points(monkeypatch, [_ep("plug_c", "plug_pkg_c")])
+
+    # include_defaults=False keeps this fast and isolated to the plugin path.
+    tm = TaskManager(include_defaults=False)
+
+    assert "plug_task_c" in tm.all_tasks
+
+
+def test_include_path_overrides_plugin_task(tmp_path, monkeypatch):
+    """A user --include_path task shadows a plugin task of the same name."""
+    _make_task_package(tmp_path, "plug_pkg_d", "shared_task", version=1.0)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _patch_task_entry_points(monkeypatch, [_ep("plug_d", "plug_pkg_d")])
+
+    override_dir = tmp_path / "override"
+    override_dir.mkdir()
+    (override_dir / "shared_task.yaml").write_text(
+        _TASK_YAML.format(name="shared_task", version=2.0)
+    )
+
+    tm = TaskManager(include_path=str(override_dir), include_defaults=False)
+
+    entry = tm.task_index["shared_task"]
+    # The include_path copy (version 2.0) must win over the plugin copy.
+    assert Path(entry.yaml_path).parent == override_dir.resolve() or str(
+        override_dir
+    ) in str(entry.yaml_path)
+
+
+def test_broken_task_entry_point_is_tolerated(monkeypatch):
+    _patch_task_entry_points(
+        monkeypatch, [_ep("broken", "nonexistent_module_xyz.tasks")]
+    )
+
+    # Must not raise - a bad plugin is logged and skipped.
+    paths = discover_plugin_task_paths()
+
+    assert all("nonexistent_module_xyz" not in str(p) for p in paths)
+
+
+def test_discovery_scans_entry_points_once(tmp_path, monkeypatch):
+    """Entry points are scanned once per process, not on every TaskManager.
+
+    Regression guard for the lazy-loading concern: without the cache,
+    constructing a TaskManager would re-enumerate entry points every time.
+    """
+    _make_task_package(tmp_path, "plug_pkg_once", "plug_task_once")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    calls = {"n": 0}
+    real_entry_points = manager_mod.md.entry_points
+
+    def counting_entry_points(*, group):
+        if group == manager_mod.TASKS_ENTRY_POINT_GROUP:
+            calls["n"] += 1
+            return [_ep("plug_once", "plug_pkg_once")]
+        return real_entry_points(group=group)
+
+    monkeypatch.setattr(manager_mod.md, "entry_points", counting_entry_points)
+
+    TaskManager(include_defaults=False)
+    TaskManager(include_defaults=False)
+
+    # Two constructions, but the cached helper enumerates entry points only once.
+    assert calls["n"] == 1


### PR DESCRIPTION
## Motivation

`--include_path` already lets users point lm-eval at an external task directory, but it has to be passed on every invocation and there's no way to *distribute* a task suite as an installable package. Teams that maintain their own benchmark suites end up either forking lm-eval to vendor their YAMLs or wiring `--include_path` into every script. Letting an installed package advertise its tasks brings the same plugin benefits to tasks:

- **Fewer unnecessary forks.** A team can `pip install` a task-suite package and have its tasks show up automatically, instead of carrying a modified lm-eval or copying YAMLs around.
- **Closed-loop development.** Task authors can develop a benchmark package alongside their models/pipelines and evaluate against it immediately, with a tight iteration cycle and nothing vendored to keep in sync.
- **A larger, healthier ecosystem.** Making task suites distributable encourages more work to target lm-eval's task format as the standard; broadly useful suites can still be upstreamed into core.

Purely additive and precedence-safe: built-in tasks load first, then plugin tasks, then `--include_path`, so a user's `--include_path` task still wins over a plugin task of the same name.

## What this PR does

Extend the entry-point plugin idea (introduced for models by #4013) to let installed packages contribute task YAMLs to lm-eval without `--include_path`. A package declares an `lm_eval.tasks` entry point pointing at the package that holds its task configs; `TaskManager` resolves each to a directory and scans it recursively, exactly like the built-in task tree.

Precedence is defaults < plugins < `--include_path`, so a user-provided `--include_path` task still overrides a plugin task of the same name (with the existing override warning), and a plugin task overrides a built-in. Broken or unresolvable entry points are logged and skipped rather than breaking discovery.

Unlike the model/filter/metric registries, tasks use directory scanning rather than the Registry class, so this reuses the entry-point convention but not the `load_plugins()` helper.
