### PR TITLE
fix(hf): pass max_cpu_memory through to accelerate's max_memory

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -538,7 +538,6 @@ class HFLM(TemplateLM):
 
         args = {}
         if parallelize:  # Model parallelism will be used
-            max_memory = {}
             if max_memory_per_gpu is not None:  # Using the provided memory requirements
                 max_memory_per_gpu_map = {
                     device_idx: max_memory_per_gpu for device_idx in range(gpus)
@@ -557,14 +556,15 @@ class HFLM(TemplateLM):
                 else:
                     max_memory_per_gpu_map = max_memory_all_gpus
 
-            args["max_memory"] = max_memory_per_gpu_map
+            max_memory = dict(max_memory_per_gpu_map)
+            if max_cpu_memory is not None:
+                max_memory["cpu"] = max_cpu_memory
+
+            args["max_memory"] = max_memory
             args["device_map"] = "auto" if device_map is None else device_map
             eval_logger.info(
                 f"Model parallel was set to True, setting max memory per GPU to {max_memory_per_gpu_map} and device map to {args.get('device_map')}"
             )
-
-            if max_cpu_memory is not None:
-                max_memory["cpu"] = max_cpu_memory
 
             args["offload_folder"] = offload_folder
         elif (


### PR DESCRIPTION
## Problem

`max_cpu_memory` is a documented `--model_args` option ([README](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/README.md#model-apis-and-inference-servers): *"the max amount of CPU memory to use when offloading the model weights to RAM"*, and the `HFLM.__init__` docstring: *"Maximum CPU memory to use for offloading when `parallelize=True`"*), but it never reaches `accelerate`.

In `HFLM._get_accelerate_args`, the `parallelize=True` branch builds an empty `max_memory` dict, then hands `accelerate` a *different* dict and writes the CPU budget into the empty one:

```python
max_memory = {}                                  # never read again
...
args["max_memory"] = max_memory_per_gpu_map      # <- what accelerate actually gets
...
if max_cpu_memory is not None:
    max_memory["cpu"] = max_cpu_memory           # <- writes into the dead dict
```

So `args["max_memory"]` only ever contains per-GPU entries. `AutoModel.from_pretrained` receives no `"cpu"` key, `accelerate` falls back to its own CPU estimate from `get_max_memory()`, and the user's setting is silently discarded — no warning, no error. It affects both ways of reaching the branch (`max_memory_per_gpu` given, or the estimated per-GPU map).

## Fix

Build the dict that is actually passed:

```python
max_memory = dict(max_memory_per_gpu_map)
if max_cpu_memory is not None:
    max_memory["cpu"] = max_cpu_memory

args["max_memory"] = max_memory
```

Nothing else changes: when `max_cpu_memory is None` the dict is exactly the per-GPU map it was before, and the existing log line still reports the per-GPU map.

## Verification

Called `HFLM._get_accelerate_args` directly (no model download needed) on this repo at `8a07e11`:

| case | before | after |
|---|---|---|
| `max_memory_per_gpu="20GiB", max_cpu_memory="100GiB", gpus=2` | `{0: '20GiB', 1: '20GiB'}` — **cpu dropped** | `{0: '20GiB', 1: '20GiB', 'cpu': '100GiB'}` |
| same, `max_cpu_memory=None` | `{0: '20GiB', 1: '20GiB'}` | `{0: '20GiB', 1: '20GiB'}` (unchanged) |

`ruff check` / `ruff format` at the pinned `v0.15.12` report nothing new for the touched lines (the file's pre-existing `PLW1508` / `C408` / `BLE001` hits are untouched and also present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
