### PR TITLE
fix(config): parse dictionary strings from YAML configs

### DIFF
--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -25,6 +25,7 @@ DICT_KEYS = [
     "metadata",
     "model_args",
     "gen_kwargs",
+    "trackio_args",
 ]
 
 
@@ -221,7 +222,7 @@ class EvaluatorConfig:
         config.update(cli_args)
 
         # Create an instance and validate
-        instance = cls(**config)._parse_dict_args()
+        instance = cls(**config)
         instance._configure()
 
         if used_config:
@@ -267,13 +268,13 @@ class EvaluatorConfig:
     def _parse_dict_args(self):
         # Parse string arguments that should be dictionaries
         for f in fields(self):
-            if f.type is dict and isinstance(getattr(self, f.name), str):
+            if f.name in DICT_KEYS and isinstance(getattr(self, f.name), str):
                 setattr(self, f.name, simple_parse_args_string(getattr(self, f.name)))
         return self
 
     def _configure(self):
         """Validate configuration and preprocess fields after creation."""
-        self._validate_arguments()._process_arguments()._set_trust_remote_code()
+        self._parse_dict_args()._validate_arguments()._process_arguments()._set_trust_remote_code()
 
         return self
 

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -565,6 +565,42 @@ class TestEvaluatorConfigFromCLI:
         assert cfg.gen_kwargs["temperature"] == 0.7
         assert cfg.gen_kwargs["max_tokens"] == 100
 
+    def test_string_dict_args_from_cli_config(self, tmp_path):
+        """Test that CLI-style dict strings from a config file are parsed."""
+        from argparse import Namespace
+
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        config_path = tmp_path / "eval.yaml"
+        config_path.write_text(
+            "tasks: [hellaswag]\n"
+            'model_args: "pretrained=gpt2,dtype=float16"\n'
+            'gen_kwargs: "temperature=0.7,max_tokens=100"\n'
+            'trackio_args: "project=lm-eval,name=test-run"\n'
+        )
+
+        cfg = EvaluatorConfig.from_cli(Namespace(config=str(config_path)))
+
+        assert cfg.model_args == {"pretrained": "gpt2", "dtype": "float16"}
+        assert cfg.gen_kwargs == {"temperature": 0.7, "max_tokens": 100}
+        assert cfg.trackio_args == {"project": "lm-eval", "name": "test-run"}
+
+    def test_string_dict_args_from_config(self, tmp_path):
+        """Test that from_config parses CLI-style dict strings."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        config_path = tmp_path / "eval.yaml"
+        config_path.write_text(
+            "tasks: [hellaswag]\n"
+            'model_args: "pretrained=gpt2,dtype=float16"\n'
+            'wandb_args: "project=lm-eval,name=test-run"\n'
+        )
+
+        cfg = EvaluatorConfig.from_config(config_path)
+
+        assert cfg.model_args == {"pretrained": "gpt2", "dtype": "float16"}
+        assert cfg.wandb_args == {"project": "lm-eval", "name": "test-run"}
+
     def test_none_args_use_defaults(self, tmp_path):
         """Test that None values fall back to defaults."""
         from argparse import Namespace


### PR DESCRIPTION
## Summary

- use the existing `DICT_KEYS` registry instead of comparing postponed dataclass annotations by identity
- parse dictionary-style strings through the shared configuration pipeline so both `from_cli()` and `from_config()` behave consistently
- include `trackio_args` with the other CLI-style dictionary fields

This allows YAML values such as `model_args: "pretrained=gpt2,dtype=float16"` to be converted before metadata and model configuration are processed. Native YAML mappings remain unchanged.

Fixes #4011.

## Testing

- `pytest -q tests/test_cli_subcommands.py` (70 passed)
- `pytest -x --showlocals -q -n=auto --ignore=tests/models/test_openvino.py --ignore=tests/models/test_hf_steered.py --ignore=tests/scripts/test_zeno_visualize.py` (613 passed, 14 skipped)
- `pre-commit run --files lm_eval/config/evaluate_config.py tests/test_cli_subcommands.py`