### PR TITLE
fix: normalize YAML request cache options

### DIFF
--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import textwrap
@@ -9,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 
+from lm_eval._cli.utils import request_caching_arg_to_dict
 from lm_eval.utils import simple_parse_args_string
 
 
@@ -318,14 +320,19 @@ class EvaluatorConfig:
         return self
 
     def _process_arguments(self):
-        """Process samples argument - load from a file if needed."""
+        """Normalize arguments loaded from configuration files."""
         if isinstance(self.cache_requests, (bool, str)):
-            from lm_eval._cli.utils import request_caching_arg_to_dict
-
             cache_requests = self.cache_requests
             if isinstance(cache_requests, bool):
                 cache_requests = "true" if cache_requests else None
-            self.cache_requests = request_caching_arg_to_dict(cache_requests)
+            else:
+                cache_requests = cache_requests.lower()
+                if cache_requests in {"false", "no", "off"}:
+                    cache_requests = None
+            try:
+                self.cache_requests = request_caching_arg_to_dict(cache_requests)
+            except argparse.ArgumentTypeError as e:
+                raise ValueError(f"Invalid cache_requests configuration: {e}") from None
 
         if self.samples:
             if isinstance(self.samples, dict):

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -319,6 +319,14 @@ class EvaluatorConfig:
 
     def _process_arguments(self):
         """Process samples argument - load from a file if needed."""
+        if isinstance(self.cache_requests, (bool, str)):
+            from lm_eval._cli.utils import request_caching_arg_to_dict
+
+            cache_requests = self.cache_requests
+            if isinstance(cache_requests, bool):
+                cache_requests = "true" if cache_requests else None
+            self.cache_requests = request_caching_arg_to_dict(cache_requests)
+
         if self.samples:
             if isinstance(self.samples, dict):
                 self.samples = self.samples

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -646,6 +646,9 @@ class TestEvaluatorConfigFromFile:
                 },
             ),
             ("false", {}),
+            ('"false"', {}),
+            ('"no"', {}),
+            ('"off"', {}),
             (
                 "refresh",
                 {
@@ -665,7 +668,7 @@ class TestEvaluatorConfigFromFile:
         ],
     )
     def test_cache_requests_is_normalized(self, tmp_path, yaml_value, expected):
-        """Test that YAML request-cache options match their CLI equivalents."""
+        """Test that YAML request-cache options are normalized."""
         from lm_eval.config.evaluate_config import EvaluatorConfig
 
         yaml_config = tmp_path / "config.yaml"
@@ -676,6 +679,18 @@ class TestEvaluatorConfigFromFile:
         cfg = EvaluatorConfig.from_config(yaml_config)
 
         assert cfg.cache_requests == expected
+
+    def test_invalid_cache_requests_raises_value_error(self, tmp_path):
+        """Test that invalid YAML request-cache options raise config errors."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        yaml_config = tmp_path / "config.yaml"
+        yaml_config.write_text(
+            'tasks: [hellaswag]\ncache_requests: "bogus"\n', encoding="utf-8"
+        )
+
+        with pytest.raises(ValueError, match="invalid value 'bogus'"):
+            EvaluatorConfig.from_config(yaml_config)
 
     def test_cache_requests_dict_is_preserved(self, tmp_path):
         """Test that expanded YAML request-cache settings remain unchanged."""

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -631,6 +631,75 @@ class TestEvaluatorConfigFromCLI:
             EvaluatorConfig.from_cli(ns)
 
 
+class TestEvaluatorConfigFromFile:
+    """Test EvaluatorConfig values loaded from YAML files."""
+
+    @pytest.mark.parametrize(
+        ("yaml_value", "expected"),
+        [
+            (
+                "true",
+                {
+                    "cache_requests": True,
+                    "rewrite_requests_cache": False,
+                    "delete_requests_cache": False,
+                },
+            ),
+            ("false", {}),
+            (
+                "refresh",
+                {
+                    "cache_requests": True,
+                    "rewrite_requests_cache": True,
+                    "delete_requests_cache": False,
+                },
+            ),
+            (
+                "delete",
+                {
+                    "cache_requests": False,
+                    "rewrite_requests_cache": False,
+                    "delete_requests_cache": True,
+                },
+            ),
+        ],
+    )
+    def test_cache_requests_is_normalized(self, tmp_path, yaml_value, expected):
+        """Test that YAML request-cache options match their CLI equivalents."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        yaml_config = tmp_path / "config.yaml"
+        yaml_config.write_text(
+            f"tasks: [hellaswag]\ncache_requests: {yaml_value}\n", encoding="utf-8"
+        )
+
+        cfg = EvaluatorConfig.from_config(yaml_config)
+
+        assert cfg.cache_requests == expected
+
+    def test_cache_requests_dict_is_preserved(self, tmp_path):
+        """Test that expanded YAML request-cache settings remain unchanged."""
+        from lm_eval.config.evaluate_config import EvaluatorConfig
+
+        yaml_config = tmp_path / "config.yaml"
+        yaml_config.write_text(
+            "tasks: [hellaswag]\n"
+            "cache_requests:\n"
+            "  cache_requests: true\n"
+            "  rewrite_requests_cache: false\n"
+            "  delete_requests_cache: false\n",
+            encoding="utf-8",
+        )
+
+        cfg = EvaluatorConfig.from_config(yaml_config)
+
+        assert cfg.cache_requests == {
+            "cache_requests": True,
+            "rewrite_requests_cache": False,
+            "delete_requests_cache": False,
+        }
+
+
 class TestCLIUtils:
     """Test CLI utility functions."""
 


### PR DESCRIPTION
## What changed

- normalize boolean and string `cache_requests` values loaded from YAML
- reuse the CLI conversion so `true`, `refresh`, and `delete` have identical behavior
- preserve expanded dictionary configurations

## Why

YAML parses `cache_requests: true` as a boolean and leaves values such as `refresh` as strings. The run command expects a dictionary and calls `.get(...)`, causing an `AttributeError` before evaluation starts.

## Testing

- `python -m pytest tests/test_cli_subcommands.py -q` — 73 passed
- `pre-commit run --files lm_eval/config/evaluate_config.py tests/test_cli_subcommands.py`
