### PR TITLE
Align pubmedqa task name in README with yaml

### DIFF
--- a/lm_eval/tasks/pubmedqa/README.md
+++ b/lm_eval/tasks/pubmedqa/README.md
@@ -40,7 +40,7 @@ Homepage: https://pubmedqa.github.io/
 
 #### Tasks
 
-* `pubmed_qa`
+* `pubmedqa`
 
 ### Checklist
 


### PR DESCRIPTION
Change from `pubmed_qa` to `pubmedqa`.