### PR TITLE
Make request-cache deletion idempotent

### DIFF
--- a/lm_eval/caching/cache.py
+++ b/lm_eval/caching/cache.py
@@ -77,7 +77,10 @@ def save_to_cache(file_name, obj):
 
 # NOTE the "key" param is to allow for flexibility
 def delete_cache(key: str = ""):
-    files = os.listdir(PATH)
+    try:
+        files = os.listdir(PATH)
+    except FileNotFoundError:
+        return
 
     for file in files:
         if file.startswith(key) and file.endswith(FILE_SUFFIX):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,6 +3,15 @@ import os
 from lm_eval.caching import cache
 
 
+def test_delete_cache_ignores_missing_directory(tmp_path, monkeypatch):
+    missing_cache = tmp_path / "never-created"
+    monkeypatch.setattr(cache, "PATH", str(missing_cache))
+
+    cache.delete_cache()
+
+    assert not missing_cache.exists()
+
+
 def test_long_cache_keys_are_hashed_below_filesystem_limit(tmp_path, monkeypatch):
     monkeypatch.setattr(cache, "PATH", str(tmp_path))
 


### PR DESCRIPTION
## Summary

- treat an absent request-cache directory as an idempotent no-op
- preserve errors for other invalid cache paths by catching only `FileNotFoundError`
- add a regression test confirming deletion does not create the missing directory

## Testing

```text
PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/test_cache.py -q
3 passed

PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/test_cli_subcommands.py -q -k cache_requests
1 passed, 67 deselected

PRE_COMMIT_HOME=/tmp/lm-eval-pre-commit pre-commit run --files lm_eval/caching/cache.py tests/test_cache.py
All hooks passed
```

Fixes #4028