### PR TITLE
[Perf] Cache unicode punctuation table at module level in MultiChoiceRegexFilter

### DIFF
--- a/lm_eval/filters/extraction.py
+++ b/lm_eval/filters/extraction.py
@@ -119,6 +119,17 @@ class WhitespaceFilter(Filter):
         return [filter_set(resp) for resp in resps]
 
 
+import unicodedata
+
+# Module-level cached punctuation translation table to avoid re-scanning
+# all 1.1M unicode codepoints on every filter application.
+_PUNCT_TBL = dict.fromkeys(
+    i
+    for i in range(sys.maxunicode)
+    if unicodedata.category(chr(i)).startswith("P")
+)
+
+
 @register_filter("multi_choice_regex")
 class MultiChoiceRegexFilter(RegexFilter):
     """Extract a model's answer on multiple choice questions with letter answers.
@@ -157,8 +168,6 @@ class MultiChoiceRegexFilter(RegexFilter):
     def apply(
         self, resps: Iterable[Sequence[str]], docs: Sequence[dict[str, Any]]
     ) -> list[list[str]]:
-        import unicodedata
-
         def find_match(regex, resp, convert_dict: dict[str, str] | None = None):
             if convert_dict is None:
                 convert_dict = {}
@@ -177,13 +186,11 @@ class MultiChoiceRegexFilter(RegexFilter):
                     match = convert_dict[match]
             return match
 
-        punct_tbl = dict.fromkeys(
-            i
-            for i in range(sys.maxunicode)
-            if unicodedata.category(chr(i)).startswith("P")
-        )
-
         def filter_ignores(st):
+            if st is None:
+                return ""
+            if not isinstance(st, str):
+                st = str(st)
             if self.regexes_to_ignore is not None:
                 for s in self.regexes_to_ignore:
                     st = re.sub(s, "", st)
@@ -193,7 +200,7 @@ class MultiChoiceRegexFilter(RegexFilter):
 
             if self.ignore_punctuation:
                 # https://stackoverflow.com/a/266162
-                st = st.translate(punct_tbl)
+                st = st.translate(_PUNCT_TBL)
             return st
 
         filtered_resps = []

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -33,3 +33,16 @@ def test_format_span_normalizes_label_only():
     assert filt.apply(resps, [{}]) == [
         ["org: shell company $ loc: country club $ per: george"]
     ]
+
+
+def test_multi_choice_regex_with_punctuation_and_empty_responses():
+    filt = MultiChoiceRegexFilter(
+        regex_pattern=r"()()",
+        ignore_case=True,
+        ignore_punctuation=True,
+    )
+    resps = [["Hello, world! (A)", None, ""]]
+    docs = [{"choices": ["Hello world!", "Other choice"]}]
+
+    assert filt.apply(resps, docs) == [["(A)", "[invalid]", "[invalid]"]]
+


### PR DESCRIPTION
## Description
In `MultiChoiceRegexFilter.apply()`:
```python
punct_tbl = dict.fromkeys(
    i
    for i in range(sys.maxunicode)
    if unicodedata.category(chr(i)).startswith("P")
)
```
This expression scanned all 1,114,111 unicode codepoints on every single invocation of `apply()`, causing repeated computational overhead during evaluation runs when `ignore_punctuation=True`.

This PR:
1. Hoists `_PUNCT_TBL` to module level so it is evaluated once at module definition time.
2. Adds safe `None` and non-string handling in `filter_ignores`.
3. Adds unit test coverage in `tests/test_filters.py` for punctuation removal and non-string inputs.