### PR TITLE
fix(minerva_math): score an answer identical to the gold as correct

### DIFF
--- a/lm_eval/tasks/minerva_math/utils.py
+++ b/lm_eval/tasks/minerva_math/utils.py
@@ -160,6 +160,13 @@ def is_equiv(x1: str, x2: str) -> bool:
     """
     x1 and x2 are normalized latex string
     """
+    # parse_latex raises on tuples, intervals and matrices, and the handler
+    # below then returns False for the pair -- so without this an answer
+    # identical to the gold is scored wrong. Only ever turns a False into a
+    # True: identical strings sympy can parse already compare equal below.
+    if isinstance(x1, str) and x1 and x1 == x2:
+        return True
+
     try:
         with timeout(seconds=5):
             try:

--- a/tests/test_minerva_math.py
+++ b/tests/test_minerva_math.py
@@ -1,0 +1,75 @@
+import pytest
+
+
+# `minerva_math.utils` imports math_verify and antlr4-python3-runtime at module
+# scope and raises without them. Those live in the [math] extra, which the unit
+# test workflow does not install, so this module skips there instead of failing.
+minerva_utils = pytest.importorskip(
+    "lm_eval.tasks.minerva_math.utils",
+    reason="minerva_math needs the [math] extra: "
+    "sympy, math_verify, antlr4-python3-runtime==4.11",
+)
+
+is_equiv = minerva_utils.is_equiv
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        # sympy's LaTeX parser raises on all of these, so before the fix
+        # `is_equiv(answer, answer)` was False and the task scored a
+        # character-for-character correct answer as wrong.
+        pytest.param("(2,4)", id="tuple"),
+        pytest.param("(-1,2,3)", id="triple"),
+        pytest.param("[2,5)", id="half-open-interval"),
+        pytest.param("(-\\infty,3]", id="unbounded-interval"),
+        pytest.param("\\begin{pmatrix}1\\\\2\\end{pmatrix}", id="column-matrix"),
+    ],
+)
+def test_unparseable_answer_matches_itself(answer):
+    """An answer identical to the gold is correct even if sympy cannot parse it."""
+    assert is_equiv(answer, answer)
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        pytest.param("2", id="integer"),
+        pytest.param("\\frac{1}{2}", id="fraction"),
+        pytest.param("x+1", id="expression"),
+        # sympy parses this one, so it reached the comparison below unaided --
+        # it is here rather than above because the test names should say which
+        # path an input actually takes.
+        pytest.param("\\text{east}", id="text-answer"),
+    ],
+)
+def test_parseable_answer_still_matches_itself(answer):
+    """The cases that already worked keep working."""
+    assert is_equiv(answer, answer)
+
+
+@pytest.mark.parametrize(
+    "x1, x2",
+    [
+        # Different answers of a kind sympy cannot parse must stay unequal --
+        # the shortcut is exact-match only and must not collapse these.
+        pytest.param("(2,4)", "(3,5)", id="different-tuples"),
+        pytest.param("[2,5)", "[2,6)", id="different-intervals"),
+        pytest.param("(2,4)", "(4,2)", id="reordered-tuple"),
+        pytest.param("\\text{east}", "\\text{west}", id="different-text"),
+    ],
+)
+def test_different_answers_are_not_equivalent(x1, x2):
+    assert not is_equiv(x1, x2)
+
+
+def test_two_empty_answers_are_not_a_match():
+    r"""Reachable rather than theoretical: `\text{}` is in REMOVED_EXPRESSIONS,
+    so `normalize_final_answer` strips such an answer to "" before it gets here.
+    """
+    assert not is_equiv("", "")
+
+
+def test_mathematically_equal_answers_still_compare_equal():
+    """The sympy path is still reached for strings that are not identical."""
+    assert is_equiv("\\frac{1}{2}", "0.5")


### PR DESCRIPTION
`is_equiv` scores an answer that is character-for-character identical to the gold as wrong whenever sympy cannot parse it:

    >>> is_equiv("(2,4)", "(2,4)")
    False
    >>> is_equiv("[2,5)", "[2,5)")
    False

Tuples, intervals and matrices are all affected, so on that slice every model scores 0 whatever it answered, and a correct answer is indistinguishable from a wrong one.

The function decides equivalence only by parsing both operands with `parse_latex` and subtracting them. `parse_latex` raises on those forms, and the handler returns False for the pair without ever comparing them.

This compares the strings before asking sympy. Both operands have already been through `normalize_final_answer` when they arrive, so it compares like with like, and it can only turn a False into a True — identical strings that sympy *can* parse already compared equal further down, so nothing that scored correct before changes. It sits ahead of the parse rather than inside the `except` so it also skips the five-second timeout on the common case. The guards are narrow on purpose: `isinstance` because the `TypeError` caught below shows non-str operands do reach here, and a truthiness test because two empty answers are not a match (`\text{}` is in `REMOVED_EXPRESSIONS`, so `normalize_final_answer` can produce `""`).

`tests/test_minerva_math.py` is new. `test_unparseable_answer_matches_itself` covers tuples, triples, both interval kinds and a column matrix, and all five fail on main. The file skips when the `[math]` extra is absent, since `minerva_math` imports `math_verify` and `antlr4` at module scope and the unit test workflow installs neither.

Two things worth knowing. #4032 changes `normalize_final_answer` in this same file and adds a `tests/test_minerva_math_utils.py`, so the two will conflict textually but not in substance. And `pre-commit` already fails on `minerva_math/utils.py` without this change — unused `antlr4` import, needless-bool, blind-except — which looks like #3900; I have left those alone, not least because the `antlr4` import is what makes the module's availability check fire.

Fixes #4030
