### PR TITLE
fix(med_prescriptions): require both keys before combining complaints and diagnosis

### DIFF
--- a/lm_eval/tasks/med_prescriptions/med_prescriptions_easy.yaml
+++ b/lm_eval/tasks/med_prescriptions/med_prescriptions_easy.yaml
@@ -18,4 +18,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 1.0
+  version: 1.1

--- a/lm_eval/tasks/med_prescriptions/utils.py
+++ b/lm_eval/tasks/med_prescriptions/utils.py
@@ -2152,7 +2152,10 @@ def get_diagnosis(doc):
     if "procedure" in results_dict:
         if "chief_complaints_diagnosis" in results_dict["procedure"]:
             diagnosis = results_dict["procedure"]["chief_complaints_diagnosis"]
-        elif "chief_complaints" and "diagnosis" in results_dict["procedure"]:
+        elif (
+            "chief_complaints" in results_dict["procedure"]
+            and "diagnosis" in results_dict["procedure"]
+        ):
             diagnosis = (
                 "Complains: "
                 + results_dict["procedure"]["chief_complaints"]


### PR DESCRIPTION
## Problem

`lm_eval/tasks/med_prescriptions/utils.py::get_diagnosis` guards the
"combine complaints + diagnosis" branch like this (main @ `4e7e0d4`, line 2155):

```python
if "procedure" in results_dict:
    if "chief_complaints_diagnosis" in results_dict["procedure"]:
        diagnosis = results_dict["procedure"]["chief_complaints_diagnosis"]
    elif "chief_complaints" and "diagnosis" in results_dict["procedure"]:
        diagnosis = (
            "Complains: "
            + results_dict["procedure"]["chief_complaints"]
            + ". Diagnosis: "
            + results_dict["procedure"]["diagnosis"]
        )
    else:
        diagnosis = "NA"
```

`and` binds looser than `in`, so the condition is
`bool("chief_complaints") and ("diagnosis" in results_dict["procedure"])`.
The first operand is a non-empty string literal — always `True` — so the guard
collapses to `"diagnosis" in results_dict["procedure"]` and never checks
`chief_complaints` at all.

A `procedure` entry that carries `diagnosis` without `chief_complaints` (and
without `chief_complaints_diagnosis`) therefore enters the branch and dies on
the very next line with `KeyError: 'chief_complaints'`. `get_diagnosis` is
called from `doc_to_text_easy` / `doc_to_text_hard`, which are the
`doc_to_text` functions for both `med_prescriptions_easy` and
`med_prescriptions_hard`, so a single such document aborts the whole eval run.

## Fix

Test both keys explicitly — one hunk, no other behavior change:

```python
    elif (
        "chief_complaints" in results_dict["procedure"]
        and "diagnosis" in results_dict["procedure"]
    ):
```

## Verification

Driving the real module (executed from source, `datasets` stubbed) through
`get_diagnosis`:

| `procedure` contents | before | after |
|---|---|---|
| `{"diagnosis": ...}` only | **`KeyError: 'chief_complaints'`** | `'NA'` |
| `{"chief_complaints": ..., "diagnosis": ...}` | `'Complains: … . Diagnosis: …'` | unchanged |
| `{"chief_complaints_diagnosis": ...}` | `'X'` | unchanged |
| neither key | `'NA'` | unchanged |

Every case that worked before produces byte-identical output; only the case
that crashed changes, and it changes to the fallback this function already
uses for incomplete records.

`ruff format` (v0.16.3, the version pinned in `.pre-commit-config.yaml`)
reports the patched file as already formatted.

## Deliberately not in scope

- **Using `diagnosis` alone** when `chief_complaints` is absent. That would be
  new behavior rather than a bug fix, and it is inconsistent with how the
  function already treats the mirror case (`chief_complaints` present,
  `diagnosis` absent → `"NA"`). Happy to add it if you would prefer it.
- **The pre-existing lint findings in this file** (`BLE001` ×5, `S110` ×2,
  `UP032` ×2). They are all on lines this PR does not touch and are present on
  `main` today, so the `Linters` job may report them for the changed file; the
  same thing happened on #4016, which was merged. I have left them alone rather
  than mixing unrelated churn into a one-line correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
