### PR TITLE
Create missing request-cache parent directories

### DIFF
--- a/lm_eval/caching/cache.py
+++ b/lm_eval/caching/cache.py
@@ -65,8 +65,7 @@ def load_from_cache(file_name: str, cache: bool = False):
 
 
 def save_to_cache(file_name, obj):
-    if not os.path.exists(PATH):
-        os.mkdir(PATH)
+    os.makedirs(PATH, exist_ok=True)
 
     file_path = _cache_file_path(file_name)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,6 +5,16 @@ import pytest
 from lm_eval.caching import cache
 
 
+def test_save_to_cache_creates_missing_parent_directories(tmp_path, monkeypatch):
+    nested_cache = tmp_path / "missing-parent" / "cache"
+    monkeypatch.setattr(cache, "PATH", str(nested_cache))
+
+    cache.save_to_cache("nested-key", {"ok": True})
+
+    assert nested_cache.is_dir()
+    assert cache.load_from_cache("nested-key", cache=True) == {"ok": True}
+
+
 def test_long_cache_keys_are_hashed_below_filesystem_limit(tmp_path, monkeypatch):
     monkeypatch.setattr(cache, "PATH", str(tmp_path))
 


### PR DESCRIPTION
## Summary

- recursively create the configured request-cache directory before saving
- accept an already existing cache directory without a check-then-create race
- add regression coverage for saving and loading through a nested path with missing parents

## Testing

```text
PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/test_cache.py -q
6 passed

PRE_COMMIT_HOME=/tmp/lm-eval-pre-commit pre-commit run --files lm_eval/caching/cache.py tests/test_cache.py
All hooks passed
```

Fixes #4046