### PR TITLE
fix(ruler): resolve the tokenizer name before the cached lookup

### DIFF
--- a/lm_eval/tasks/ruler/README.md
+++ b/lm_eval/tasks/ruler/README.md
@@ -12,7 +12,7 @@ Homepage: `https://github.com/NVIDIA/RULER`
 
 > [!NOTE]
 > When using Ruler tasks, please note:
-> 1. A tokenizer is required for data processing. The system will use the `tokenizer` from model_args, or fall back to the tokenizer associated with the `pretrained` model name.
+> 1. A tokenizer is required for data processing. The system will use the `tokenizer` from model_args, falling back to `pretrained` and then to `model`, which is the name the API backends use. If none of the three is given the task stops and says so, since the data cannot be sized without one.
 > 2. The default maximum sequence length is 4096. For calculating metrics of different max seq lengths, specify additional lengths using the metadata parameter:
 >   `--metadata='{"max_seq_lengths":[4096,8192,16384,32768,65536,131072]}'`. The metadata parameter can also be passed to the TaskManager (metadata: dict).
 > 3. To prevent truncation of longer sequences, we recommend setting the max_length parameter in model_args:

--- a/lm_eval/tasks/ruler/common_utils.py
+++ b/lm_eval/tasks/ruler/common_utils.py
@@ -18,13 +18,39 @@ DEFAULT_SEQ_LENGTHS = [
     4096,
 ]
 
+# The keys a model name can arrive under. RULER tasks are handed the parsed
+# `--model_args`, and each backend names the model differently: `pretrained`
+# for local HuggingFace models, `model` for the API backends.
+TOKENIZER_ARG_KEYS = ("tokenizer", "pretrained", "model")
+
+
+def resolve_tokenizer_name(kwargs: dict) -> str | None:
+    """Pick the tokenizer name out of the model args a synthetic task is given.
+
+    Returns the first non-empty string among `tokenizer`, `pretrained` and
+    `model`, or None if there is none. Returning None rather than a container
+    matters: `get_tokenizer` is decorated with `functools.cache`, which hashes
+    its arguments before the body runs, so an unhashable default such as `{}`
+    raises `TypeError: unhashable type: 'dict'` and the assertion below never
+    gets the chance to say what is actually wrong.
+    """
+    for key in TOKENIZER_ARG_KEYS:
+        value = kwargs.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
 
 @cache
 def get_tokenizer(
     tokenizer=None, pretrained=None, **kwargs
 ) -> transformers.PreTrainedTokenizer | transformers.PreTrainedTokenizerFast:
     pretrained = tokenizer or pretrained
-    assert pretrained, "No tokenizer or pretrained provided."
+    assert pretrained, (
+        "No tokenizer or pretrained provided. RULER tasks generate their own "
+        "data and need a tokenizer to size it to each target length; pass one "
+        "with `--model_args tokenizer=<name>`."
+    )
     eval_logger.info("Using tokenizer %s for synthetic tasks.", pretrained)
     tok = AutoTokenizer.from_pretrained(pretrained, trust_remote_code=True)
 

--- a/lm_eval/tasks/ruler/cwe_utils.py
+++ b/lm_eval/tasks/ruler/cwe_utils.py
@@ -18,7 +18,11 @@ import datasets
 import wonderwords
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
+from lm_eval.tasks.ruler.common_utils import (
+    DEFAULT_SEQ_LENGTHS,
+    get_tokenizer,
+    resolve_tokenizer_name,
+)
 
 
 CONFIG = {
@@ -163,8 +167,7 @@ def sys_word_pair_random(
     return write_jsons
 
 
-def get_dataset(pretrained, seq: int | None = None, **kwargs):
-    tokenizer = get_tokenizer(pretrained)
+def get_dataset(tokenizer, seq: int | None = None, **kwargs):
     assert seq is not None, "max_seq_length must be specified"
     write_jsons = sys_word_pair_random(
         num_samples=500, max_seq_length=seq, tokenizer=tokenizer
@@ -173,9 +176,9 @@ def get_dataset(pretrained, seq: int | None = None, **kwargs):
 
 
 def get_cw_dataset(**kwargs):
-    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", {}))
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     df = (
-        get_dataset(pretrained, seq=seq)
+        get_dataset(tokenizer, seq=seq)
         for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
     )
 

--- a/lm_eval/tasks/ruler/fwe_utils.py
+++ b/lm_eval/tasks/ruler/fwe_utils.py
@@ -23,7 +23,11 @@ import numpy as np
 from scipy.special import zeta
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
+from lm_eval.tasks.ruler.common_utils import (
+    DEFAULT_SEQ_LENGTHS,
+    get_tokenizer,
+    resolve_tokenizer_name,
+)
 
 
 if TYPE_CHECKING:
@@ -150,8 +154,7 @@ def sys_kwext(
     return write_jsons
 
 
-def get_dataset(pretrained, max_seq_length=None, **kwargs):
-    tokenizer = get_tokenizer(pretrained)
+def get_dataset(tokenizer, max_seq_length=None, **kwargs):
     write_jsons = sys_kwext(
         tokenizer=tokenizer,
         max_seq_length=max_seq_length,
@@ -160,9 +163,9 @@ def get_dataset(pretrained, max_seq_length=None, **kwargs):
 
 
 def fwe_download(**kwargs):
-    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", {}))
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     df = (
-        get_dataset(pretrained, max_seq_length=seq)
+        get_dataset(tokenizer, max_seq_length=seq)
         for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
     )
 

--- a/lm_eval/tasks/ruler/niah_utils.py
+++ b/lm_eval/tasks/ruler/niah_utils.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING
 
 import datasets
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
+from lm_eval.tasks.ruler.common_utils import (
+    DEFAULT_SEQ_LENGTHS,
+    get_tokenizer,
+    resolve_tokenizer_name,
+)
 from lm_eval.tasks.ruler.prepare_niah import generate_samples, get_haystack
 
 
@@ -28,6 +32,7 @@ def download_dataset(df: Generator) -> dict[str, datasets.Dataset]:
 
 def niah_single_1(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="repeat"),
@@ -37,7 +42,7 @@ def niah_single_1(**kwargs):
             type_needle_k="words",
             type_needle_v="numbers",
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )
@@ -45,6 +50,7 @@ def niah_single_1(**kwargs):
 
 def niah_single_2(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="essay"),
@@ -54,7 +60,7 @@ def niah_single_2(**kwargs):
             type_needle_k="words",
             type_needle_v="numbers",
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )
@@ -62,6 +68,7 @@ def niah_single_2(**kwargs):
 
 def niah_single_3(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="essay"),
@@ -71,7 +78,7 @@ def niah_single_3(**kwargs):
             type_needle_k="words",
             type_needle_v="uuids",
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )
@@ -79,6 +86,7 @@ def niah_single_3(**kwargs):
 
 def niah_multikey_1(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="essay"),
@@ -89,7 +97,7 @@ def niah_multikey_1(**kwargs):
             type_needle_v="numbers",
             num_needle_k=4,
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )
@@ -97,6 +105,7 @@ def niah_multikey_1(**kwargs):
 
 def niah_multikey_2(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="needle"),
@@ -106,7 +115,7 @@ def niah_multikey_2(**kwargs):
             type_needle_k="words",
             type_needle_v="numbers",
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )
@@ -114,6 +123,7 @@ def niah_multikey_2(**kwargs):
 
 def niah_multikey_3(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="needle"),
@@ -123,7 +133,7 @@ def niah_multikey_3(**kwargs):
             type_needle_k="uuids",
             type_needle_v="uuids",
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )
@@ -131,6 +141,7 @@ def niah_multikey_3(**kwargs):
 
 def niah_multivalue(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="essay"),
@@ -141,7 +152,7 @@ def niah_multivalue(**kwargs):
             type_needle_v="numbers",
             num_needle_v=4,
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )
@@ -149,6 +160,7 @@ def niah_multivalue(**kwargs):
 
 def niah_multiquery(**kwargs):
     seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     return download_dataset(
         generate_samples(
             get_haystack(type_haystack="essay"),
@@ -159,7 +171,7 @@ def niah_multiquery(**kwargs):
             type_needle_v="numbers",
             num_needle_q=4,
             num_samples=500,
-            TOKENIZER=get_tokenizer(**kwargs),
+            TOKENIZER=tokenizer,
         )
         for seq in seq_lengths
     )

--- a/lm_eval/tasks/ruler/qa_utils.py
+++ b/lm_eval/tasks/ruler/qa_utils.py
@@ -22,7 +22,11 @@ import datasets
 import requests
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
+from lm_eval.tasks.ruler.common_utils import (
+    DEFAULT_SEQ_LENGTHS,
+    get_tokenizer,
+    resolve_tokenizer_name,
+)
 
 CONFIG = {
     "tokens_to_generate": 32,
@@ -250,8 +254,7 @@ def generate_samples(
     return write_jsons
 
 
-def get_dataset(pretrained, docs, qas, max_seq_length=None, **kwargs) -> list[dict]:
-    tokenizer = get_tokenizer(pretrained)
+def get_dataset(tokenizer, docs, qas, max_seq_length=None, **kwargs) -> list[dict]:
     write_jsons = generate_samples(
         tokenizer=tokenizer,
         docs=docs,
@@ -264,13 +267,15 @@ def get_dataset(pretrained, docs, qas, max_seq_length=None, **kwargs) -> list[di
 
 
 def get_qa_dataset(ds, **kwargs) -> dict[str, datasets.Dataset]:
-    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", {}))
+    # Resolved before the documents are fetched, so a missing tokenizer is
+    # reported immediately rather than after a large download.
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     if ds == "squad":
         qas, docs = read_squad()
     else:
         qas, docs = read_hotpotqa()
     df = (
-        get_dataset(pretrained=pretrained, docs=docs, qas=qas, max_seq_length=seq)
+        get_dataset(tokenizer=tokenizer, docs=docs, qas=qas, max_seq_length=seq)
         for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
     )
 

--- a/lm_eval/tasks/ruler/vt_utils.py
+++ b/lm_eval/tasks/ruler/vt_utils.py
@@ -25,7 +25,11 @@ import datasets
 import numpy as np
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer
+from lm_eval.tasks.ruler.common_utils import (
+    DEFAULT_SEQ_LENGTHS,
+    get_tokenizer,
+    resolve_tokenizer_name,
+)
 
 
 if TYPE_CHECKING:
@@ -245,9 +249,9 @@ def get_dataset(
 
 
 def get_vt_dataset(**kwargs) -> dict[str, datasets.Dataset]:
-    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", ""))
+    tokenizer = get_tokenizer(resolve_tokenizer_name(kwargs))
     df = (
-        get_dataset(tokenizer=get_tokenizer(pretrained), seq=seq)
+        get_dataset(tokenizer=tokenizer, seq=seq)
         for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
     )
 

--- a/tests/test_ruler.py
+++ b/tests/test_ruler.py
@@ -1,13 +1,27 @@
-"""Regression tests for the RULER synthetic samplers.
+"""Tests for the RULER synthetic tasks.
 
-Every sampler sizes its prompts by shrinking the context until it fits
-`max_seq_length`. When the smallest context a sample can have still overflows,
-the shrinking loops used to stop making progress and spin forever instead of
-giving up on the sample.
+Two independent things are covered here.
+
+**The samplers.** Every sampler sizes its prompts by shrinking the context
+until it fits `max_seq_length`. When the smallest context a sample can have
+still overflows, the shrinking loops used to stop making progress and spin
+forever instead of giving up on the sample.
+
+**Tokenizer resolution.** These tasks build their own data, so they are handed
+the parsed `--model_args` and have to find a model name in it. Nothing in that
+half downloads a dataset or loads a tokenizer: every case is one where
+resolution fails, which is exactly the path that used to crash.
+
+`cwe_utils` needs `wonderwords` from the `ruler` extra, which the unit-test
+workflow does not install; that builder is skipped rather than the whole
+module, so the rest still run in CI.
 """
+
+import importlib
 
 import pytest
 
+from lm_eval.tasks.ruler.common_utils import get_tokenizer, resolve_tokenizer_name
 from lm_eval.tasks.ruler.qa_utils import generate_samples
 
 
@@ -109,3 +123,129 @@ def test_generate_samples_drops_only_the_oversized():
         incremental=10,
     )
     assert [s["index"] for s in samples] == [0, 1, 3, 4]
+
+
+# Every task builder reachable from a `custom_dataset: !function ...` entry in
+# lm_eval/tasks/ruler/*.yaml, as a pytest param so that a builder whose
+# optional dependency is absent skips on its own.
+BUILDER_SPECS = [
+    ("qa_utils", ("get_squad", "get_hotpotqa")),
+    ("cwe_utils", ("get_cw_dataset",)),
+    ("fwe_utils", ("fwe_download",)),
+    ("vt_utils", ("get_vt_dataset",)),
+    (
+        "niah_utils",
+        (
+            "niah_single_1",
+            "niah_single_2",
+            "niah_single_3",
+            "niah_multikey_1",
+            "niah_multikey_2",
+            "niah_multikey_3",
+            "niah_multivalue",
+            "niah_multiquery",
+        ),
+    ),
+]
+
+
+def _builder_params():
+    params = []
+    for module_name, builder_names in BUILDER_SPECS:
+        try:
+            module = importlib.import_module(f"lm_eval.tasks.ruler.{module_name}")
+        except ImportError as exc:
+            params.extend(
+                pytest.param(
+                    None,
+                    id=name,
+                    marks=pytest.mark.skip(reason=f"{module_name}: {exc}"),
+                )
+                for name in builder_names
+            )
+            continue
+        params.extend(
+            pytest.param(getattr(module, name), id=name) for name in builder_names
+        )
+    return params
+
+
+BUILDERS = _builder_params()
+
+
+class TestResolveTokenizerName:
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            ({"tokenizer": "tok"}, "tok"),
+            ({"pretrained": "pre"}, "pre"),
+            ({"model": "mod"}, "mod"),
+            # `tokenizer` wins over `pretrained`, which wins over `model`.
+            ({"tokenizer": "tok", "pretrained": "pre", "model": "mod"}, "tok"),
+            ({"pretrained": "pre", "model": "mod"}, "pre"),
+            # An API backend names the model `model` and adds its own args.
+            ({"model": "org/name", "base_url": "http://localhost:8080/v1"}, "org/name"),
+        ],
+    )
+    def test_finds_the_model_name(self, kwargs, expected):
+        assert resolve_tokenizer_name(kwargs) == expected
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"base_url": "http://localhost:8080/v1"},
+            # Empty and non-string values are not usable names. A dict is the
+            # one that used to be passed through as a default.
+            {"tokenizer": ""},
+            {"pretrained": {}},
+            {"model": None},
+            {"tokenizer": ["a", "b"]},
+        ],
+    )
+    def test_returns_none_when_there_is_no_usable_name(self, kwargs):
+        assert resolve_tokenizer_name(kwargs) is None
+
+    def test_result_is_hashable_so_the_cached_lookup_can_accept_it(self):
+        # get_tokenizer is decorated with functools.cache, which hashes its
+        # arguments before the body runs.
+        hash(resolve_tokenizer_name({"pretrained": {}}))
+
+
+class TestGetTokenizer:
+    def test_missing_name_reaches_the_assertion(self):
+        with pytest.raises(AssertionError, match="No tokenizer or pretrained"):
+            get_tokenizer(None)
+
+    def test_the_message_names_the_argument_that_fixes_it(self):
+        with pytest.raises(AssertionError, match=r"--model_args tokenizer="):
+            get_tokenizer(None)
+
+
+class TestBuildersWithoutATokenizer:
+    """A missing tokenizer must be reported, not crashed on.
+
+    Before the fix, `qa_utils`, `cwe_utils` and `fwe_utils` defaulted to `{}`
+    and `niah_utils` forwarded every model arg, so the `functools.cache`
+    wrapper around `get_tokenizer` raised `TypeError: unhashable type: 'dict'`
+    and the assertion that explains the problem was unreachable.
+    """
+
+    @pytest.mark.parametrize("builder", BUILDERS)
+    def test_api_style_args_without_a_tokenizer_assert(self, builder):
+        # What `--model_args model=...,base_url=...` parses into for an API
+        # backend: no `tokenizer` and no `pretrained` key at all.
+        with pytest.raises(AssertionError, match="No tokenizer or pretrained"):
+            builder(base_url="http://localhost:8080/v1", num_concurrent=1)
+
+    @pytest.mark.parametrize("builder", BUILDERS)
+    def test_no_args_at_all_assert(self, builder):
+        with pytest.raises(AssertionError, match="No tokenizer or pretrained"):
+            builder()
+
+    @pytest.mark.parametrize("builder", BUILDERS)
+    def test_unhashable_model_args_do_not_leak_into_the_cache(self, builder):
+        # A list-valued model arg used to reach functools.cache through
+        # niah_utils' `get_tokenizer(**kwargs)` and raise TypeError there.
+        with pytest.raises(AssertionError, match="No tokenizer or pretrained"):
+            builder(stop=["\n", "###"], extra={"a": 1})


### PR DESCRIPTION
Every RULER task crashes before any inference when the tokenizer does not arrive as a plain string, and it crashes with an error that hides what is wrong:

    $ lm_eval --model local-chat-completions --tasks ruler_qa_hotpot \
        --model_args model=<name>,base_url=http://localhost:8080/v1/chat/completions
    TypeError: unhashable type: 'dict'

`get_tokenizer` in `lm_eval/tasks/ruler/common_utils.py` is decorated with `functools.cache`, which hashes its arguments before the body runs. Three of the four dataset builders resolve the tokenizer with `kwargs.get("tokenizer", kwargs.get("pretrained", {}))` and pass that straight in, so when neither key is present the `{}` default is hashed and raises. The `assert pretrained, "No tokenizer or pretrained provided."` on the next line is unreachable in those three — it is the message the user needs, and nobody has ever seen it.

`vt_utils.py` defaults to `""` instead and behaves correctly, which is what makes this a bug rather than a design choice. Against unmodified main, with an API backend's arguments and no tokenizer:

    get_squad      TypeError: unhashable type: 'dict'      qa_utils.py:206
    get_hotpotqa   TypeError: unhashable type: 'dict'      qa_utils.py:206
    fwe_download   TypeError: unhashable type: 'dict'      fwe_utils.py:146
    get_vt_dataset AssertionError: No tokenizer or pretrained provided.

There is a second, narrower way in. `niah_utils.py` calls `get_tokenizer(**kwargs)`, forwarding every model argument into the cached function. Its plain no-tokenizer case is fine — `base_url=` and friends are hashable, so it reaches the assertion correctly — but any unhashable value among the model arguments fails the hash, *even when a valid tokenizer was supplied*:

    >>> niah_single_1(tokenizer="gpt2", stop=["\n", "###"])
    TypeError: unhashable type: 'list'      niah_utils.py:34

The cause of the missing key is that the builders are handed the parsed `--model_args` (`evaluator.py` builds `metadata` from it, `api/task.py` splats it into `custom_dataset`), and the backends do not agree on what the model is called: local HuggingFace models pass `pretrained=`, the API backends pass `model=`. Only the first two were ever looked for.

This adds one helper, `resolve_tokenizer_name`, taking the first non-empty string among `tokenizer`, `pretrained` and `model`, and routes all eleven builders through it. `None` is hashable, so a genuinely missing tokenizer now reaches the assertion instead of the `TypeError`, and the message names the argument that fixes it. Resolution is also hoisted above the download in `get_qa_dataset` and out of the generator in `cwe`/`fwe`: on main the QA builders fetch SQuAD or HotpotQA *first* and crash afterwards, which is a slow way to be told you forgot an argument.

Worth being explicit about the limits of this. It does not make RULER run against a backend that supplies no usable tokenizer name — that case now gets the assertion, which is the honest outcome, and `--model_args tokenizer=<name>` remains the way to run these tasks. Nor does it touch the deeper report in the thread that task metadata does not reach a `custom_dataset` task; that is a separate change in `lm_eval/tasks/__init__.py` and I have left it alone. Accepting `model=` does mean a served alias that is not a HuggingFace id will now raise an ordinary `AutoTokenizer` error rather than the assertion; that seemed better than refusing a name that is usually correct, and this tokenizer only sizes the synthetic samples, so it cannot affect a score.

`tests/test_ruler.py` is new. It covers the resolution helper directly and then asserts, for every one of the eleven builders reachable from a `custom_dataset:` entry, that a missing tokenizer produces the assertion and not a `TypeError` — with API-style arguments, with no arguments, and with unhashable arguments. Nothing in it downloads a dataset or loads a tokenizer, since every case is one where resolution fails; that is only true because of the hoist above. `cwe_utils` and `niah_utils` need `wonderwords` and `nltk` from the `ruler` extra, which the unit test workflow does not install, so those builders skip individually rather than taking the whole module with them.

One thing to know: #3794 proposed a narrower version of this — extracting the model name from the dict inside `qa_utils.get_dataset` — and was closed by its author. This covers the other four call sites and the `{}` default that left the assertion dead.

Fixes #3441
