### PR TITLE
fix(api): encode the continuation alone when a token spans the context join

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -374,6 +374,11 @@ class TemplateLM(LM):
         word-boundary tokenization. Causal models encode the full sequence then
         split; seq2seq models encode each part independently.
 
+        For causal models the split can leave the continuation with no tokens at
+        all, when the tokenizer merges the end of the context and the whole of
+        the continuation into a single token. The continuation is then encoded
+        on its own, so that there is something left to score.
+
         Note:
             Does NOT handle empty context — the caller is responsible for that
             (see ``loglikelihood``).
@@ -398,6 +403,16 @@ class TemplateLM(LM):
 
             context_enc_len = len(context_enc)
             continuation_enc = whole_enc[context_enc_len:]
+            if not continuation_enc:
+                # A single token spanned the join, so the split has nothing
+                # left to attribute to the continuation and there is nothing
+                # to score. Seen with extended or retrained vocabularies, one
+                # in which ": C" is a single token for instance; without this
+                # the run dies later on `assert len(continuation_enc) > 0`.
+                # See #1053, #1297, #3336.
+                continuation_enc = self.tok_encode(
+                    continuation, add_special_tokens=False
+                )
         else:
             # for SEQ2SEQ case we need to encode separately
             context_enc = self.tok_encode(context)

--- a/tests/models/test_encode_pair.py
+++ b/tests/models/test_encode_pair.py
@@ -1,0 +1,118 @@
+"""Tests for the context/continuation split in ``TemplateLM._encode_pair``.
+
+For causal models the pair is tokenized joined and the result cut at
+``len(tok_encode(context))``. That cut assumes no token spans the join. When
+one does -- reported for extended and retrained vocabularies, where an entry
+such as ``": C"`` covers the end of the context and the whole of a short
+continuation -- the cut leaves the continuation with no tokens and evaluation
+dies part-way through inference on ``assert len(continuation_enc) > 0``.
+
+See #1053, #1297 and #3336.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from lm_eval.api.model import TemplateLM
+
+
+# --------------------------------------------------------------------------
+# A toy tokenizer: greedy longest match over a fixed vocabulary, falling back
+# to one id per character. The entry that matters is ``": C"``, which is the
+# vocabulary shape reported in #1053; the rest is scaffolding so that ordinary
+# pairs tokenize the way a real BPE vocabulary would.
+# --------------------------------------------------------------------------
+
+_VOCAB = [": C", "Answer", "Question", " the", " C", "at", ":", " "]
+_IDS = {piece: 1000 + i for i, piece in enumerate(_VOCAB)}
+_LONGEST_FIRST = sorted(_VOCAB, key=len, reverse=True)
+
+
+def toy_encode(string: str, add_special_tokens=None, **kwargs) -> list[int]:
+    ids: list[int] = []
+    i = 0
+    while i < len(string):
+        for piece in _LONGEST_FIRST:
+            if string.startswith(piece, i):
+                ids.append(_IDS[piece])
+                i += len(piece)
+                break
+        else:
+            ids.append(ord(string[i]))
+            i += 1
+    return ids
+
+
+def make_lm(backend: str = "causal"):
+    lm = Mock()
+    lm.backend = backend
+    lm.tok_encode = toy_encode
+    lm._encode_pair = TemplateLM._encode_pair.__get__(lm, TemplateLM)
+    return lm
+
+
+# --------------------------------------------------------------------------
+
+
+def test_toy_vocabulary_really_merges_across_the_join():
+    """Guard the premise of the tests below, so they cannot pass vacuously."""
+    assert len(toy_encode("Answer: C")) == len(toy_encode("Answer:"))
+
+
+@pytest.mark.parametrize(
+    "context, continuation",
+    [
+        ("Answer:", " C"),
+        # the same pair as a task actually produces it: target_delimiter is
+        # " " by default, so the space arrives on the end of the context and
+        # _encode_pair moves it over before the split
+        ("Answer: ", "C"),
+    ],
+)
+def test_merged_boundary_leaves_something_to_score(context, continuation):
+    context_enc, continuation_enc = make_lm()._encode_pair(context, continuation)
+
+    assert continuation_enc, "continuation must not come back empty"
+    assert continuation_enc == toy_encode(" C", add_special_tokens=False)
+    assert context_enc == toy_encode("Answer:")
+
+
+def test_exact_split_is_untouched():
+    """The common case must produce byte-for-byte the tokens it always has."""
+    lm = make_lm()
+    context, continuation = "Question", " the"
+
+    whole_enc = toy_encode(context + continuation)
+    context_enc, continuation_enc = lm._encode_pair(context, continuation)
+
+    assert context_enc == toy_encode(context)
+    assert continuation_enc == whole_enc[len(context_enc) :]
+    assert continuation_enc == toy_encode(" the")
+
+
+def test_partial_merge_is_left_as_it_is():
+    """A token spanning the join but leaving tokens behind is out of scope.
+
+    ``"Answer: Cat"`` tokenizes as ``"Answer" | ": C" | "at"``, so the cut
+    leaves ``"at"`` rather than ``" Cat"``. Where the probability mass of the
+    spanning token belongs is a question about published numbers rather than a
+    crash, and this test records that the empty-continuation fallback does not
+    quietly answer it.
+    """
+    lm = make_lm()
+    whole_enc = toy_encode("Answer: Cat")
+
+    context_enc, continuation_enc = lm._encode_pair("Answer:", " Cat")
+
+    assert continuation_enc == whole_enc[len(context_enc) :]
+    assert continuation_enc == [_IDS["at"]]
+
+
+def test_seq2seq_backend_encodes_separately_as_before():
+    lm = make_lm(backend="seq2seq")
+
+    context_enc, continuation_enc = lm._encode_pair("Answer:", " C")
+
+    assert context_enc == toy_encode("Answer:")
+    assert continuation_enc == toy_encode(" C", add_special_tokens=False)


### PR DESCRIPTION
For causal models `TemplateLM._encode_pair` tokenizes the context and the continuation joined and then cuts the result at `len(tok_encode(context))`. That cut assumes no token spans the join. When one does, the cut leaves the continuation with **no tokens at all**, and the run dies part-way through inference:

    Running loglikelihood requests:   6%|██▉    | 3361/56168
    File "lm_eval/models/huggingface.py", line 1416, in _loglikelihood_tokens
        assert len(continuation_enc) > 0
    AssertionError

This is reported in #1297, in #1053 before it, and again in #3336 — six people across three threads, on Persimmon, on Mistral with an extended 120k vocabulary, on Phi-4-mini, on Llama-2-7b and on `pythia-160m`. In #1053 @haileyschoelkopf identified the cause exactly: *"the string `": C"` being a single token here in your vocab is what is causing a problem, exposing an edge case in the code we use to avoid tokenizing `context` and `continuation` entirely separately"*.

It is not exotic. Against current `main` with plain `EleutherAI/pythia-14m`, no extended vocabulary required:

    context='Ans'        continuation='wer'  len(context_enc)=2 len(whole_enc)=1  -> continuation_enc=[]
    context='hello wor'  continuation='ld'   len(context_enc)=2 len(whole_enc)=2  -> continuation_enc=[]
    context='Th'         continuation='e'    len(context_enc)=1 len(whole_enc)=1  -> continuation_enc=[]

50034 of that tokenizer's 50277 entries are two characters or more, and any of them can straddle a join. What keeps this rare in practice is that `target_delimiter` defaults to `" "`, so a continuation normally begins with a space and a space starts a new BPE word — which is also why it shows up on extended and retrained vocabularies far more than on the ones the harness is usually run with.

## The change

When the cut leaves nothing behind, encode the continuation on its own, which is what the `seq2seq` branch of the same function already does unconditionally:

```python
continuation_enc = whole_enc[context_enc_len:]
if not continuation_enc:
    continuation_enc = self.tok_encode(continuation, add_special_tokens=False)
```

This is the check @haileyschoelkopf gave in #1297, tested on the result rather than on `len(whole_enc) == len(context_enc)` — the joint encoding can come back *shorter* than the context's own, which is the `'Ans'`/`'wer'` case above, and the equality form would miss it.

Where the cut is valid — the overwhelmingly common case — nothing moves: the branch is not entered, and the tokens handed to the model are byte-for-byte what they are today. I checked that on ten ordinary task-shaped pairs (multiple-choice prompts ending in `Answer:`, hellaswag-style sentence completions, non-English) and the fallback fires on none of them.

## What this deliberately does not do

**The partial merge.** When the spanning token leaves the continuation with *some* tokens but not its own — `"Answer: Cat"` tokenizing as `"Answer" | ": C" | "at"`, so `"at"` is scored rather than `" Cat"` — this change leaves the behaviour exactly as it is. That case has no obviously right answer: the spanning token's probability mass genuinely belongs partly to each side, and picking a side moves published benchmark numbers. It looks like a maintainer's call rather than a bug fix, so there is a test in here that pins the current behaviour instead of changing it.

**The other three copies of the same split.** `lm_eval/models/nemo_lm.py:337`, `lm_eval/models/megatron_lm.py:758` and `lm_eval/models/hf_vlms.py:188` (`_encode_multimodal_pair`) each carry their own copy of this line and each has the same bug. I have not touched them because I have no way to exercise those backends, and an unproved change to a distributed backend seemed worse than saying so here. Happy to add the same guard to all three if you would rather have it in one pull request.

## On the assignment, since I would rather say it than have it noticed

#1297 and #1053 are both assigned to @haileyschoelkopf, and #1322 — their own draft for this — is still open. I did not want to sit on a fix for a two-and-a-half-year-old crash, and I did not want to walk past the assignment without a word either.

#1322 was opened 2024-01-19, and its body says it was *"probably blocked on getting huggingface/transformers#28010 merged"*. That merged on 2024-02-20. It has not been touched since the day it was opened, and `_encode_pair` has in the meantime moved out of `lm_eval/models/huggingface.py`, the file it edits, into `lm_eval/api/model.py`. Its scope is also wider than this — Llama's `SPIECE_UNDERLINE` / token 29871 as well as the empty continuation — and I have deliberately left that half alone.

I said all of this in #1297 before writing any code. @haileyschoelkopf, @baberabb — if you would rather finish #1322, say so and I will close this.

## Tests

`tests/models/test_encode_pair.py` is new. It uses a toy greedy-longest-match tokenizer whose vocabulary contains `": C"` — the entry named in #1053 — bound to `TemplateLM._encode_pair` with the `Mock` idiom already used in `tests/models/test_bos_handling.py`, so nothing is downloaded and nothing is random. It covers the merged boundary reached directly and reached the way a task reaches it (the space arriving on the end of the context), the exact-split case staying byte-for-byte identical, the partial merge staying as it is, and the `seq2seq` branch being untouched. The first test asserts the toy vocabulary really does merge, so the rest cannot pass vacuously.

Reverting the source change fails exactly the two merged-boundary cases, with `AssertionError: continuation must not come back empty`, and leaves the other four passing. The rest of the suite is green on CPU, rebased onto `bc4354e8`: **694 passed / 20 skipped / 0 failed**, plus `tests/test_evaluator.py` **8 passed** on its own (it is memory-hungry and I run it separately), with the five `--ignore`s the unit-test workflow uses.

One thing to expect on the checks: `ruff check` already fails on `lm_eval/api/model.py` before this change, with six findings at lines 55, 96, 111, 131, 149 and 360 — three `unnecessary-placeholder` and two `custom-type-var-for-self`, none of them in the range this touches. I confirmed that by linting the file with the change stashed, and left them alone rather than widening the diff. `ruff format` passes on both files.

Fixes #1297

The same crash is reported in #1053 and #3336.
