### PR TITLE
fix(scripts): repair requests_caching.py entrypoint (bad kwargs + helper defined after use)

### DIFF
--- a/scripts/requests_caching.py
+++ b/scripts/requests_caching.py
@@ -68,6 +68,16 @@ def run_model_for_task_caching(tasks: list[str], cache_requests: str):
     return eval_data
 
 
+def request_caching_arg_to_dict(cache_requests: str) -> dict:
+    request_caching_args = {
+        "cache_requests": cache_requests in {"true", "refresh"},
+        "rewrite_requests_cache": cache_requests == "refresh",
+        "delete_requests_cache": cache_requests == "delete",
+    }
+
+    return request_caching_args
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -89,15 +99,5 @@ if __name__ == "__main__":
     tasks = args.tasks.split(",")
 
     eval_data = run_model_for_task_caching(
-        tasks=tasks, model=MODEL, device=DEVICE, cache_requests=args.cache_requests
+        tasks=tasks, cache_requests=args.cache_requests
     )
-
-
-def request_caching_arg_to_dict(cache_requests: str) -> dict:
-    request_caching_args = {
-        "cache_requests": cache_requests in {"true", "refresh"},
-        "rewrite_requests_cache": cache_requests == "refresh",
-        "delete_requests_cache": cache_requests == "delete",
-    }
-
-    return request_caching_args


### PR DESCRIPTION
`scripts/requests_caching.py` cannot run at all today — it fails on the very first statement of its `__main__` block, and then fails again on a second, independent bug that the first one was hiding.

## Bug 1 — `TypeError`: two keyword arguments that the function does not accept

```python
def run_model_for_task_caching(tasks: list[str], cache_requests: str):   # line 35
...
    eval_data = run_model_for_task_caching(                              # line 91
        tasks=tasks, model=MODEL, device=DEVICE, cache_requests=args.cache_requests
    )
```

`model` and `device` are not parameters. Both are module-level constants (`MODEL`, `DEVICE`) that `run_model_for_task_caching` already reads directly from the module namespace, so they were never meant to be passed in:

```
TypeError: run_model_for_task_caching() got an unexpected keyword argument 'model'
```

## Bug 2 — `NameError`: the helper is defined *after* the block that uses it

`run_model_for_task_caching` calls `request_caching_arg_to_dict(...)` at line 49, but that function is defined at line 96 — *below* the `if __name__ == "__main__":` block. Module bodies execute top to bottom, so when the `__main__` block runs, the name is not yet bound:

```
NameError: name 'request_caching_arg_to_dict' is not defined
```

This one is invisible until bug 1 is fixed, which is why they are addressed together.

## Fix

- Drop the two extra keyword arguments from the call.
- Move `request_caching_arg_to_dict` above the `__main__` block, next to its only caller. The function body is unchanged — it is moved verbatim.

Net: +11 / −11 in one file, no behavior change beyond making the script actually run.

## Verification

Executed the real file (not a hand-copied excerpt) via `runpy.run_path(..., run_name="__main__")` with `torch`, `transformers` and `lm_eval` stubbed, using `--tasks=hellaswag --cache_requests=true`:

| file | result |
|---|---|
| current `main` | `TypeError: ... unexpected keyword argument 'model'` (raised at line 91) |
| bug 1 fixed only | `NameError: name 'request_caching_arg_to_dict' is not defined` |
| this PR | runs to completion |

With the patch, `simple_evaluate` is reached with the cache arguments correctly expanded:

```
cache_requests, delete_requests_cache, rewrite_requests_cache
```

plus `device`, `limit`, `model`, `model_args`, `tasks`, `write_out` — i.e. `--cache_requests=true|refresh|delete` now actually reaches the evaluator, which is the whole point of the script.

`ruff check` and `ruff format --diff` both pass against the repo's `pyproject.toml` configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
