### PR TITLE
fix: hash multimodal cache arguments

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -227,8 +227,23 @@ class LM(abc.ABC):
 
 
 ### SQLite-based caching of LM responses
+def _json_default(obj: Any) -> Any:
+    if isinstance(obj, (bytes, bytearray, memoryview)):
+        return utils.convert_bytes_to_hash(obj)
+
+    try:
+        from PIL import Image
+    except ImportError:
+        Image = None
+
+    if Image is not None and isinstance(obj, Image.Image):
+        return utils.convert_pil_to_hash(obj)
+
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
 def hash_args(attr: str, args: Iterable[Any]) -> str:
-    dat = json.dumps([attr] + list(args))
+    dat = json.dumps([attr] + list(args), default=_json_default)
     return hashlib.sha256(dat.encode("utf-8")).hexdigest()
 
 

--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -3,12 +3,35 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from PIL import Image
 
+from lm_eval.api.model import hash_args
 from lm_eval.models.api_models import create_image_prompt
 from lm_eval.models.openai_completions import LocalCompletionsAPI
 
 
 TEST_AUTH_TOKEN = "secure-token"  # noqa: S105 - fixed test sentinel
+
+
+def test_hash_args_supports_content_sensitive_multimodal_values():
+    image = Image.new("RGB", (1, 1), (255, 0, 0))
+
+    same_image = Image.new("RGB", (1, 1), (255, 0, 0))
+    other_image = Image.new("RGB", (1, 1), (0, 255, 0))
+    assert hash_args(
+        "generate_until", (("prompt", {}, {"visual": [image]}),)
+    ) == hash_args("generate_until", (("prompt", {}, {"visual": [same_image]}),))
+    assert hash_args(
+        "generate_until", (("prompt", {}, {"visual": [image]}),)
+    ) != hash_args("generate_until", (("prompt", {}, {"visual": [other_image]}),))
+    assert hash_args(
+        "generate_until", (("prompt", {}, {"visual": [b"red"]}),)
+    ) != hash_args("generate_until", (("prompt", {}, {"visual": [b"green"]}),))
+
+
+def test_hash_args_rejects_unsupported_values():
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        hash_args("generate_until", (("prompt", {}, {"visual": [object()]}),))
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #4005

`hash_args` uses JSON serialization for response-cache keys, but multimodal request arguments can contain PIL images and byte-like values. Those values currently raise before inference when `--use_cache` is enabled.

This change adds a JSON fallback that reuses the existing content-hash helpers for PIL images and byte-like values. Unsupported objects still raise `TypeError`, and text-only cache keys keep their existing serialization. Regression tests cover identical and different image content, byte content, and unsupported values.

Validation: focused API and caching tests passed (23); Ruff format/check and `git diff --check` passed.

This contribution was prepared with assistance from an AI agent.