### PR TITLE
fix(cache): warn when a cache db is reused across different models

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -247,13 +247,26 @@ class CacheHook:
         self.dbdict[hsh] = res
 
 
+# Reserved key recording which model populated a cache db. Request keys are
+# sha256 hexdigests, so this cannot collide with one.
+MODEL_IDENTITY_KEY = "__lm_eval_model_identity__"
+
+
 class CachingLM:
-    def __init__(self, lm: LM, cache_db: str) -> None:
+    def __init__(
+        self, lm: LM, cache_db: str, model_identity: str | None = None
+    ) -> None:
         """LM wrapper that returns cached results when available, falling back to the underlying model.
 
         Args:
             lm: The underlying language model to wrap.
             cache_db: Path to the SQLite cache database.
+            model_identity: Identifier for the model populating the cache. Cache
+                keys are derived from request arguments alone, so a db reused
+                across models returns the first model's responses for the
+                second. Recorded on first use and compared afterwards to warn
+                when that happens. `None` skips the check, for callers that
+                cannot describe the model (e.g. a pre-initialized LM object).
         """
         from sqlitedict import SqliteDict
 
@@ -262,9 +275,40 @@ class CachingLM:
         if os.path.dirname(cache_db):
             os.makedirs(os.path.dirname(cache_db), exist_ok=True)
         self.dbdict = SqliteDict(cache_db, autocommit=True)
+        self._check_model_identity(model_identity)
 
         # add hook to lm
         lm.set_cache_hook(self.get_cache_hook())
+
+    def _check_model_identity(self, model_identity: str | None) -> None:
+        """Record the model that owns this cache, warning if it changed.
+
+        Responses are keyed on request arguments only, so nothing otherwise
+        prevents a db written by one model from being served to another --
+        producing identical metrics for different models with no error.
+        """
+        if model_identity is None:
+            if MODEL_IDENTITY_KEY in self.dbdict:
+                eval_logger.warning(
+                    f"Cache '{self.cache_db}' was written by {self.dbdict[MODEL_IDENTITY_KEY]}, "
+                    "but the current model could not be identified, so responses cannot be "
+                    "verified as belonging to it. Use a separate cache file per model."
+                )
+            return
+
+        previous = self.dbdict.get(MODEL_IDENTITY_KEY)
+        if previous is None:
+            self.dbdict[MODEL_IDENTITY_KEY] = model_identity
+            self.dbdict.commit()
+        elif previous != model_identity:
+            eval_logger.warning(
+                f"Cache '{self.cache_db}' was written by a different model.\n"
+                f"  cache was populated by: {previous}\n"
+                f"  currently evaluating:   {model_identity}\n"
+                "Cached responses are keyed on request arguments only, so this run will "
+                "reuse the other model's responses and report its scores. Use a separate "
+                "--use_cache path per model."
+            )
 
     def __getattr__(self, attr: str) -> Any:
         lm_attr = getattr(self.lm, attr)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -51,6 +51,28 @@ if TYPE_CHECKING:
 eval_logger = logging.getLogger(__name__)
 
 
+def _model_identity(model, model_args) -> str | None:
+    """Describe the model under evaluation, for cache-ownership checks.
+
+    Returns None when `model` is an already-initialized LM, since its
+    configuration is not reliably introspectable from here and a wrong
+    identity would be worse than none.
+    """
+    if not isinstance(model, str):
+        return None
+    if isinstance(model_args, str):
+        parsed = simple_parse_args_string(model_args)
+    elif isinstance(model_args, dict):
+        parsed = model_args
+    else:
+        parsed = {}
+    try:
+        rendered = json.dumps(parsed, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        rendered = str(sorted(parsed.items()))
+    return f"{model}({rendered})"
+
+
 @positional_deprecated
 def simple_evaluate(
     model: str | LM,
@@ -286,6 +308,10 @@ def simple_evaluate(
             + "_rank"
             + str(cache_rank)
             + ".db",
+            # Cache keys come from request arguments alone, so a db shared
+            # between models silently serves the first model's responses to the
+            # second. Pass what identifies this run so CachingLM can warn.
+            model_identity=_model_identity(model, model_args),
         )
 
     if task_manager is None:

--- a/tests/test_caching_lm_model_identity.py
+++ b/tests/test_caching_lm_model_identity.py
@@ -1,0 +1,118 @@
+"""Regression tests for cache reuse across different models.
+
+Cache keys are derived from request arguments only (`hash_args`), so a db
+populated by one model will serve its responses to another, reporting the first
+model's scores for the second with no error raised. See issue #2715.
+"""
+
+import logging
+
+import pytest
+
+from lm_eval.api.instance import Instance
+from lm_eval.api.model import LM, MODEL_IDENTITY_KEY, CachingLM
+from lm_eval.evaluator import _model_identity
+
+
+class _StubLM(LM):
+    """Returns a fixed response, and records how many requests reached it."""
+
+    def __init__(self, response):
+        super().__init__()
+        self.response = response
+        self.seen = 0
+
+    def loglikelihood(self, requests, disable_tqdm: bool = False):
+        self.seen += len(requests)
+        return [self.response] * len(requests)
+
+    def loglikelihood_rolling(self, requests, disable_tqdm: bool = False):
+        self.seen += len(requests)
+        return [0.0] * len(requests)
+
+    def generate_until(self, requests, disable_tqdm: bool = False):
+        self.seen += len(requests)
+        return ["out"] * len(requests)
+
+
+def _req():
+    return Instance(
+        request_type="loglikelihood",
+        doc={},
+        arguments=("ctx", "cont"),
+        idx=0,
+    )
+
+
+def test_identity_recorded_on_first_use(tmp_path):
+    db = str(tmp_path / "c.db")
+    lm = CachingLM(_StubLM((1.0, True)), db, model_identity="hf(a)")
+    assert lm.dbdict[MODEL_IDENTITY_KEY] == "hf(a)"
+
+
+def test_reusing_cache_across_models_warns(tmp_path, caplog):
+    db = str(tmp_path / "c.db")
+    first = CachingLM(_StubLM((1.0, True)), db, model_identity="hf(model-a)")
+    first.loglikelihood([_req()])
+
+    with caplog.at_level(logging.WARNING):
+        CachingLM(_StubLM((2.0, False)), db, model_identity="hf(model-b)")
+
+    assert any("different model" in r.message for r in caplog.records), (
+        "reusing a cache db across models must warn; without it the second model "
+        "silently reports the first model's scores"
+    )
+    assert any(
+        "model-a" in r.message and "model-b" in r.message for r in caplog.records
+    )
+
+
+def test_same_model_does_not_warn(tmp_path, caplog):
+    db = str(tmp_path / "c.db")
+    CachingLM(_StubLM((1.0, True)), db, model_identity="hf(same)")
+    with caplog.at_level(logging.WARNING):
+        CachingLM(_StubLM((1.0, True)), db, model_identity="hf(same)")
+    assert not any("different model" in r.message for r in caplog.records)
+
+
+def test_unidentifiable_model_warns_on_populated_cache(tmp_path, caplog):
+    # A pre-initialized LM cannot be fingerprinted, so the cache cannot be
+    # verified as belonging to it.
+    db = str(tmp_path / "c.db")
+    CachingLM(_StubLM((1.0, True)), db, model_identity="hf(model-a)")
+    with caplog.at_level(logging.WARNING):
+        CachingLM(_StubLM((2.0, False)), db, model_identity=None)
+    assert any("could not be identified" in r.message for r in caplog.records)
+
+
+def test_identity_key_does_not_collide_with_request_keys(tmp_path):
+    # Request keys are sha256 hexdigests; the reserved key must not look like one.
+    assert not all(c in "0123456789abcdef" for c in MODEL_IDENTITY_KEY)
+    db = str(tmp_path / "c.db")
+    lm = CachingLM(_StubLM((1.0, True)), db, model_identity="hf(a)")
+    lm.loglikelihood([_req()])
+    stored = [k for k in lm.dbdict.keys() if k != MODEL_IDENTITY_KEY]
+    assert len(stored) == 1
+    assert all(c in "0123456789abcdef" for c in stored[0])
+
+
+@pytest.mark.parametrize(
+    "model, model_args, expected",
+    [
+        ("hf", "pretrained=A", 'hf({"pretrained": "A"})'),
+        ("hf", {"pretrained": "B"}, 'hf({"pretrained": "B"})'),
+        ("hf", None, "hf({})"),
+    ],
+)
+def test_model_identity_rendering(model, model_args, expected):
+    assert _model_identity(model, model_args) == expected
+
+
+def test_model_identity_none_for_preinitialized_model():
+    assert _model_identity(_StubLM((1.0, True)), "pretrained=A") is None
+
+
+def test_model_identity_distinguishes_the_issue_2715_models():
+    a = _model_identity("hf", "pretrained=Qwen/Qwen2.5-3B")
+    b = _model_identity("hf", "pretrained=meta-llama/Llama-3.2-3B")
+    assert a != b


### PR DESCRIPTION
Fixes #2715.

## The problem

`CachingLM` keys entries with `hash_args(attr, req.args)` — the request type and its arguments. Nothing in the key identifies the model. A db populated by one model therefore serves its stored responses to the next model evaluated against the same file, and that model reports the first one's scores. No warning, no error; the two runs just produce identical metrics.

Reproduced with two stub models over one shared db (no GPU, no download):

```
model A returns: [(-1.0, True)]
model B returns: [(-1.0, True)]     # identical
model B queried: 0 requests         # never ran
```

This matches @baberabb's diagnosis in the issue: *"the current implementation simply checks if the inputs exist in the provided cache file, and does not take the model into account."*

## The approach

Two concerns were raised in the issue against deriving per-model cache files, and both still hold:

1. `simple_evaluate` accepts an already-initialized LM as well as a model string, and the former can't be reliably introspected.
2. It isn't clear which of `model_args` should scope a cache — `pretrained` obviously, but `max_length` and precision can move results too. Choosing wrong either fragments caches needlessly or keeps silently sharing them.

So this doesn't scope the cache. It records which model populated a db under a reserved key and compares on later opens, warning on a mismatch — the "warn and leave it to the user" outcome suggested in the issue, except the warning fires only on an actual mismatch rather than unconditionally, so it stays meaningful rather than becoming noise.

For the pre-initialized case, `_model_identity` returns `None`. That path warns only that the cache couldn't be verified against the current model, and never stamps a db — so it can't poison one for a later run that *can* be identified.

The reserved key is `__lm_eval_model_identity__`; request keys are sha256 hexdigests, so collision is impossible, and a test pins that.

## Alternatives

Including the identity in `hash_args` would prevent the collision outright rather than warn about it, but it invalidates every existing cache on upgrade — every entry becomes a miss. Making the mismatch a hard error instead of a warning is a one-line change if you'd prefer it. Happy to go either way.

## Tests

`tests/test_caching_lm_model_identity.py` — 10 tests, offline, no model download:

- identity recorded on first use
- reusing a db across models warns, and the message names both models
- same model does not warn
- unidentifiable model warns against a populated cache
- reserved key can't collide with request keys, and normal entries still round-trip
- identity rendering for str / dict / `None` `model_args`, `None` for a pre-initialized LM, and that the two models from the issue produce different identities

Without the change, the reuse test fails: the second model gets the first's cached response with nothing raised.

## Checks

- Full suite: **571 passed, 3 skipped, 0 failed** (`tests/`, excluding `tests/models`)
- `ruff check` and `ruff format` clean on the changed files, using the pinned `v0.16.3` from `.pre-commit-config.yaml`
- Ruff reports the same 7 pre-existing findings on this branch as on `main` — none added; they're on lines this PR doesn't touch
