### PR TITLE
fix(api): key cached model responses by model as well as by request

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -80,7 +80,7 @@ lm-eval run --config my_config.yaml --tasks mmlu
 | `--tasks` | `-t` | Space or comma-separated list of task names or groups. Use `lm-eval ls tasks` to see available tasks. |
 | `--apply_chat_template` | | Apply chat template to prompts. Use without argument for default template, or specify template name. |
 | `--limit` | `-L` | Limit examples per task. Integer for count, float (0.0-1.0) for percentage. **For testing only.** |
-| `--use_cache` | `-c` | Path prefix for SQLite cache of model responses (e.g., `/path/to/cache_`). |
+| `--use_cache` | `-c` | Path prefix for SQLite cache of model responses (e.g., `/path/to/cache_`). Responses are keyed by the model as well as the request, so a cache written for one model is not reused for another; prefer one prefix per model to avoid re-running. |
 
 ### Evaluation Settings
 

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -299,9 +299,10 @@ class CachingLM:
             cache_db: Path to the SQLite cache database.
             model_identity: Which model these responses belong to. Part of every
                 cache key, so that a db written while evaluating one model can
-                never answer for another. Leaving it None keys the cache on the
-                request alone, which is what this class did before the identity
-                existed.
+                never answer for another. Leaving it None keys every entry under
+                a null identity rather than reproducing the pre-identity keys, so
+                a db written before this existed is not readable either way — the
+                warning below is what tells the user that.
         """
         from sqlitedict import SqliteDict
 

--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -252,8 +252,22 @@ def _multimodal_cache_default(obj: Any) -> Any:
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
-def hash_args(attr: str, args: Iterable[Any]) -> str:
-    dat = json.dumps([attr] + list(args), default=_multimodal_cache_default)
+# Key under which a cache db records which model wrote it. Not a response key:
+# it is a plain string, where every response key is a sha256 hex digest, so the
+# two can never collide.
+CACHE_IDENTITY_KEY = "__model_identity__"
+
+
+def hash_args(attr: str, args: Iterable[Any], model_identity: str | None = None) -> str:
+    """Key a cached response by what was asked *and* who was asked.
+
+    `model_identity` is a separate element of the hashed list rather than being
+    concatenated onto `attr`, so that no pair of (identity, attr) can be split
+    two ways into the same string.
+    """
+    dat = json.dumps(
+        [model_identity, attr] + list(args), default=_multimodal_cache_default
+    )
     return hashlib.sha256(dat.encode("utf-8")).hexdigest()
 
 
@@ -261,35 +275,88 @@ class CacheHook:
     def __init__(self, cachinglm: Optional["CachingLM"]) -> None:
         if cachinglm is None:
             self.dbdict: SqliteDict | None = None
+            self.model_identity: str | None = None
             return
 
         self.dbdict = cachinglm.dbdict
+        self.model_identity = cachinglm.model_identity
 
     def add_partial(self, attr: str, req: Iterable[Any], res: Any) -> None:
         if self.dbdict is None:
             return
-        hsh = hash_args(attr, req)
+        hsh = hash_args(attr, req, self.model_identity)
         self.dbdict[hsh] = res
 
 
 class CachingLM:
-    def __init__(self, lm: LM, cache_db: str) -> None:
+    def __init__(
+        self, lm: LM, cache_db: str, model_identity: str | None = None
+    ) -> None:
         """LM wrapper that returns cached results when available, falling back to the underlying model.
 
         Args:
             lm: The underlying language model to wrap.
             cache_db: Path to the SQLite cache database.
+            model_identity: Which model these responses belong to. Part of every
+                cache key, so that a db written while evaluating one model can
+                never answer for another. Leaving it None keys the cache on the
+                request alone, which is what this class did before the identity
+                existed.
         """
         from sqlitedict import SqliteDict
 
         self.lm: LM = lm
         self.cache_db: str = cache_db
+        self.model_identity: str | None = model_identity
         if os.path.dirname(cache_db):
             os.makedirs(os.path.dirname(cache_db), exist_ok=True)
         self.dbdict = SqliteDict(cache_db, autocommit=True)
+        self._check_model_identity()
 
         # add hook to lm
         lm.set_cache_hook(self.get_cache_hook())
+
+    def _check_model_identity(self) -> None:
+        """Say something when a db was written by a different model.
+
+        The identity is part of the key, so a mismatch is already safe — every
+        lookup simply misses and the model is run. It is not obvious, though:
+        without this the user sees a cache that silently stopped working, and
+        the one thing worth telling them is that it was somebody else's.
+        """
+        if self.model_identity is None:
+            # Nothing here can work out which model `self.lm` is; only the caller
+            # knows. Without it the key is the request alone, which is what
+            # shares one db between two models. simple_evaluate always passes an
+            # identity, so this is only reachable by constructing CachingLM
+            # directly.
+            eval_logger.warning(
+                f"Cache '{self.cache_db}' is being used without a model identity, so its "
+                "responses are keyed by the request alone. Two different models sharing this "
+                "db will read each other's responses. Pass model_identity= to prevent it."
+            )
+
+        # Presence of the key, not its value: a db written with no identity at
+        # all records None under it, which `.get()` cannot tell from absent.
+        if CACHE_IDENTITY_KEY in self.dbdict:
+            previous = self.dbdict[CACHE_IDENTITY_KEY]
+            if previous != self.model_identity:
+                eval_logger.warning(
+                    f"Cache '{self.cache_db}' was written for model '{previous}' and this run "
+                    f"is '{self.model_identity}'. Responses cached for the other model will "
+                    "not be used. Use one cache db per model to avoid re-running."
+                )
+            return
+
+        # Either a fresh db, or one written before responses were keyed by
+        # model. In the second case none of its entries can be hit any more.
+        if len(self.dbdict):
+            eval_logger.warning(
+                f"Cache '{self.cache_db}' does not record which model wrote it, so its "
+                "entries cannot be matched to one. They will be ignored and the model "
+                "will be run again."
+            )
+        self.dbdict[CACHE_IDENTITY_KEY] = self.model_identity
 
     def __getattr__(self, attr: str) -> Any:
         lm_attr = getattr(self.lm, attr)
@@ -306,7 +373,7 @@ class CachingLM:
                 f"Loading '{attr}' responses from cache '{self.cache_db}' where possible..."
             )
             for req in tqdm(requests, desc="Checking cached requests"):
-                hsh = hash_args(attr, req.args)
+                hsh = hash_args(attr, req.args, self.model_identity)
                 if attr == "generate_until" and req.args[1].get("do_sample", False):
                     # when we are doing non-greedy generation, don't use the cache
                     # (else every "randomly sampled" generation would be identical for repeats > 1).
@@ -341,7 +408,7 @@ class CachingLM:
                 res[resptr] = r
 
                 # caching
-                hsh = hash_args(attr, req.args)
+                hsh = hash_args(attr, req.args, self.model_identity)
                 self.dbdict[hsh] = r
             self.dbdict.commit()
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -51,6 +51,15 @@ if TYPE_CHECKING:
 eval_logger = logging.getLogger(__name__)
 
 
+def _resolve_model_name(model: str | LM) -> str:
+    """The name this run is reported under in ``results["config"]["model"]``."""
+    if isinstance(model, str):
+        return model
+    if hasattr(model, "config") and hasattr(model.config, "_name_or_path"):
+        return model.config._name_or_path
+    return type(model).__name__
+
+
 @positional_deprecated
 def simple_evaluate(
     model: str | LM,
@@ -285,6 +294,10 @@ def simple_evaluate(
     # LOCAL_RANK so each process gets its own cache db and only LOCAL_RANK==0
     # performs final result aggregation / I/O.
     cache_rank = lm.rank or int(os.environ.get("LOCAL_RANK", "0"))
+    # The same pair this run will be stamped with in results["config"] below.
+    # Cached responses are keyed by it so that a db written while evaluating one
+    # model can never answer for another and be reported under its name.
+    model_name = _resolve_model_name(model)
     if use_cache is not None:
         eval_logger.info(
             f"Using cache at {use_cache + '_rank' + str(cache_rank) + '.db'}"
@@ -297,6 +310,9 @@ def simple_evaluate(
             + "_rank"
             + str(cache_rank)
             + ".db",
+            model_identity=json.dumps(
+                [model_name, model_args], sort_keys=True, default=str
+            ),
         )
 
     if task_manager is None:
@@ -394,13 +410,6 @@ def simple_evaluate(
     # (torchrun), where every rank reports rank==0 but only one process should
     # build/return results so callers don't duplicate file writes.
     if lm.rank == 0 and int(os.environ.get("LOCAL_RANK", "0")) == 0:
-        if isinstance(model, str):
-            model_name = model
-        elif hasattr(model, "config") and hasattr(model.config, "_name_or_path"):
-            model_name = model.config._name_or_path
-        else:
-            model_name = type(model).__name__
-
         # add info about the model and few shot config
         results["config"] = {
             "model": model_name,

--- a/tests/test_multimodal_cache_keys.py
+++ b/tests/test_multimodal_cache_keys.py
@@ -50,10 +50,14 @@ def test_bytearray_matches_equivalent_bytes():
     )
 
 
-def test_text_only_keys_remain_compatible():
+def test_text_only_keys_are_not_touched_by_the_default_handler():
+    # The `default` handler is only consulted for values `json.dumps` cannot
+    # serialize, so a text-only request must hash exactly as plain `json.dumps`
+    # of the key would. The leading element is the model identity, which every
+    # key carries and which is None when the caller did not supply one.
     req = ("prompt", {"until": ["\n"]}, {})
     expected = hashlib.sha256(
-        json.dumps(["generate_until"] + list(req)).encode("utf-8")
+        json.dumps([None, "generate_until"] + list(req)).encode("utf-8")
     ).hexdigest()
     assert hash_args("generate_until", req) == expected
 

--- a/tests/test_response_cache.py
+++ b/tests/test_response_cache.py
@@ -1,0 +1,110 @@
+"""Tests for the `--use_cache` response cache (`lm_eval.api.model.CachingLM`)."""
+
+from lm_eval.api.instance import Instance
+from lm_eval.api.model import LM, CachingLM, hash_args
+
+
+class StubLM(LM):
+    """An LM that answers with fixed values and counts how often it is asked."""
+
+    def __init__(self, loglikelihood_value, generation):
+        super().__init__()
+        self._loglikelihood_value = loglikelihood_value
+        self._generation = generation
+        self.calls = {
+            "loglikelihood": 0,
+            "loglikelihood_rolling": 0,
+            "generate_until": 0,
+        }
+
+    def loglikelihood(self, requests):
+        self.calls["loglikelihood"] += len(requests)
+        return [self._loglikelihood_value] * len(requests)
+
+    def loglikelihood_rolling(self, requests):
+        self.calls["loglikelihood_rolling"] += len(requests)
+        return [self._loglikelihood_value[0]] * len(requests)
+
+    def generate_until(self, requests):
+        self.calls["generate_until"] += len(requests)
+        return [self._generation] * len(requests)
+
+
+def loglikelihood_request():
+    return Instance(
+        request_type="loglikelihood",
+        doc={},
+        arguments=("The capital of France is", " Paris"),
+        idx=0,
+    )
+
+
+def generate_request():
+    return Instance(
+        request_type="generate_until",
+        doc={},
+        arguments=("The capital of France is", {"until": ["\n"]}),
+        idx=0,
+    )
+
+
+def test_a_second_model_does_not_get_the_first_model_s_cached_responses(tmp_path):
+    """The defect in #4063: one db, two models, and the second is never run."""
+    db = str(tmp_path / "responses_rank0.db")
+
+    first = StubLM((-8.25, False), " i do not know")
+    cached_first = CachingLM(first, db, model_identity="model-a::pretrained=a")
+    assert cached_first.loglikelihood([loglikelihood_request()]) == [(-8.25, False)]
+    assert cached_first.generate_until([generate_request()]) == [" i do not know"]
+
+    second = StubLM((-0.10, True), " Paris")
+    cached_second = CachingLM(second, db, model_identity="model-b::pretrained=b")
+
+    assert cached_second.loglikelihood([loglikelihood_request()]) == [(-0.10, True)]
+    assert cached_second.generate_until([generate_request()]) == [" Paris"]
+    assert second.calls == {
+        "loglikelihood": 1,
+        "loglikelihood_rolling": 0,
+        "generate_until": 1,
+    }
+
+
+def test_the_same_model_still_hits_the_cache(tmp_path):
+    """The point of the flag has to keep working."""
+    db = str(tmp_path / "responses_rank0.db")
+    identity = "model-a::pretrained=a"
+
+    first = StubLM((-8.25, False), " i do not know")
+    CachingLM(first, db, model_identity=identity).loglikelihood(
+        [loglikelihood_request()]
+    )
+    assert first.calls["loglikelihood"] == 1
+
+    again = StubLM((-0.10, True), " Paris")
+    result = CachingLM(again, db, model_identity=identity).loglikelihood(
+        [loglikelihood_request()]
+    )
+
+    assert result == [(-8.25, False)]
+    assert again.calls["loglikelihood"] == 0
+
+
+def test_hash_args_separates_identities(tmp_path):
+    """The key itself, without the machinery around it."""
+    args = ("The capital of France is", " Paris")
+
+    assert hash_args("loglikelihood", args, "model-a") != hash_args(
+        "loglikelihood", args, "model-b"
+    )
+    assert hash_args("loglikelihood", args, "model-a") == hash_args(
+        "loglikelihood", args, "model-a"
+    )
+
+
+def test_hash_args_does_not_confuse_the_identity_and_the_request_type(tmp_path):
+    """Concatenating the two into one string would make these collide."""
+    args = ("ctx", " cont")
+
+    assert hash_args("likelihood", args, "modela") != hash_args(
+        "ikelihood", args, "modelal"
+    )


### PR DESCRIPTION
Fixes #4063.

`--use_cache` files responses under `hash_args(attr, req.args)`, which says
what was asked and nothing about who was asked. Two models evaluated on the
same tasks therefore produce byte-identical keys, and a db written while
measuring one model answers every request for the next one.

The second model is never called. The harness reports the first model's scores
in a results file whose `config` block names the second; nothing is logged and
nothing fails, so the contamination is invisible after the fact. On
multiple-choice tasks the loglikelihoods served this way are what `acc` and
`acc_norm` are computed from, so it is the headline number that moves.

Nothing tells a user to keep one db per model. The CLI help is *"Path to cache
model responses (skips repeated inference)"* and `docs/interface.md` says
*"Path prefix for SQLite cache of model responses"* — both read as a property
of the run, and a sweep over several models sharing one cache path is the
obvious way to use a flag described that way.

## The fix

`simple_evaluate` already computes `(model_name, model_args)` for
`results["config"]`, which is this project's own answer to whose numbers these
are. The bug is that the cache does not use it. So the computation moves above
the `CachingLM` construction and is passed in as `model_identity` — the same
pair the results file is stamped with, and no new concept. The later site
reuses it, so this removes a duplicate rather than adding one.

The identity is a **separate element** of the hashed list rather than being
concatenated onto `attr`. Concatenation would make
`hash_args("likelihood", args, "modela")` and
`hash_args("ikelihood", args, "modelal")` collide.

When `model` is an already-built `LM` rather than a string, `model_args` is
usually `None` and the name falls back to `config._name_or_path` or the class
name. That is weaker than a string alias, and it is exactly the provenance the
results file already reports for such a run — so the cache is no worse than
what the run already claims about itself.

## Existing cache files

Changing the key means entries in an existing db can never be hit again. That
is the safe direction — re-run rather than serve another model's numbers — but
it should not be silent, so the db records the identity it was written with and
`CachingLM` says so in three cases:

- the db was written for a different model — names both, and says the old
  responses will not be used;
- the db predates this change and records no identity — says its entries will
  be ignored and the model re-run;
- no identity was supplied at all, which keys the cache on the request alone.

That last case is what `CachingLM(lm, db)` did before, and it still does it, so
constructing the class directly stays backward compatible. `simple_evaluate`
always passes an identity.

A hard error on mismatch was considered and rejected: it would break working
setups on upgrade, and cold misses plus a loud warning get the same safety.
Documenting one-db-per-model without changing the key was also rejected — it is
the issue's own "at minimum" fallback, and it keeps a footgun whose failure mode
is a published number that is wrong with no trace.

## Tests

`tests/test_response_cache.py` is new. A stub `LM` that answers with fixed
values and counts how often it was asked — no network, no model download:

- a second model does not receive the first model's cached responses, and *is*
  asked (this is the issue);
- the same model still hits the cache, which is the thing a careless fix breaks;
- `hash_args` separates identities, and does not confuse the identity with the
  request type.

Full suite run serially, before and after: 728 passed / 0 failed before, 732
passed / 0 failed after, the four new tests being the difference. No test that
passed before fails now.

The `--use_cache` row in `docs/interface.md` gains a sentence, since the
behaviour it describes has changed and the wording there is part of how one db
ends up shared across a sweep.
