### PR TITLE
fix(metrics): brier_score crash on docs with different choice counts

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -156,11 +156,16 @@ def ter(items):
 @register_aggregation("brier_score")
 def brier_score(items):  # This is a passthrough function
     gold, predictions = list(zip(*items))
-    bs, num_class = np.array(predictions).shape
-
-    gold = list(gold)
-    gold_one_hot = np.eye(num_class)[gold]
-    return np.mean(np.sum((predictions - gold_one_hot) ** 2, axis=1))
+    # Docs may have different numbers of choices (e.g. ARC mixes 3-, 4- and
+    # 5-option questions), so score each doc against a one-hot vector of its
+    # own length instead of stacking everything into one rectangular array.
+    scores = []
+    for g, pred in zip(gold, predictions, strict=True):
+        pred = np.asarray(pred, dtype=float)
+        gold_one_hot = np.zeros(len(pred))
+        gold_one_hot[g] = 1.0
+        scores.append(np.sum((pred - gold_one_hot) ** 2))
+    return np.mean(scores)
 
 
 @register_metric(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -245,6 +245,27 @@ def test_chrfpp_uses_word_order_two():
     )
 
 
+def test_brier_score_uniform_choice_counts():
+    """brier_score over docs that all have the same number of choices."""
+    from lm_eval.api.metrics import brier_score
+
+    items = [(0, [0.5, 0.5]), (1, [0.25, 0.75])]
+    # doc 1: (0.5-1)^2 + 0.5^2 = 0.5; doc 2: 0.25^2 + (0.75-1)^2 = 0.125
+    assert abs(brier_score(items) - 0.3125) < 1e-9
+
+
+def test_brier_score_ragged_choice_counts():
+    """brier_score must not crash when docs have different numbers of choices
+    (e.g. ARC mixes 3-, 4- and 5-option questions).
+    """
+    from lm_eval.api.metrics import brier_score
+
+    items = [(0, [0.7, 0.2, 0.1]), (1, [0.1, 0.6, 0.2, 0.1])]
+    # doc 1: (0.7-1)^2 + 0.2^2 + 0.1^2 = 0.14
+    # doc 2: 0.1^2 + (0.6-1)^2 + 0.2^2 + 0.1^2 = 0.22
+    assert abs(brier_score(items) - 0.18) < 1e-9
+
+
 def test_chrfpp_perfect_match():
     """chrf++ should return 100.0 for identical hypothesis and reference."""
     from lm_eval.api.metrics import chrfpp


### PR DESCRIPTION
## Root cause

The `brier_score` aggregation in `lm_eval/api/metrics.py` did `bs, num_class = np.array(predictions).shape`, stacking every doc's probability vector into one rectangular array. For `multiple_choice` tasks, `process_results` feeds it `(gold, prob_norm)` per doc, where `prob_norm = softmax(lls)` has length equal to that doc's choice count. Docs with differing option counts (ARC mixes 3-, 4- and 5-option questions) make this ragged, and NumPy ≥ 1.24 raises `ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions.` The crash lands at aggregation time — after all inference compute has been spent.

No in-tree task YAML sets `brier_score` by default, so this hits users who add it via `metric_list` on multiple-choice tasks — but it is a hard crash on a registered metric.

## Fix

Score each doc against a one-hot vector of its own length, then mean. On rectangular input this is numerically identical to the old vectorized form (verified over 200 randomized trials, agreement to 1e-12). Out-of-range gold still raises, unchanged from before. Two regression tests with closed-form expected values are added in the same commit.

## Verification

- Red (main, fix stashed): `python -m pytest tests/test_metrics.py -k brier` — `test_brier_score_ragged_choice_counts` fails with the exact ValueError at `metrics.py:159`; the uniform-choices test passes, confirming value compatibility of the old path.
- Green (with fix): `tests/test_metrics.py` — 10 passed.
- Neighbors: `tests/test_aggregation_pipeline.py tests/test_group.py tests/test_evaluator_utils.py` — 133 passed.
- Lint: ruff (repo's pre-commit pin) check + format on both changed files; the change removes one pre-existing violation and adds none.