### PR TITLE
fix(evaluator): report a sample count that does not depend on metric order

### DIFF
--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -201,7 +201,13 @@ def _compute_task_aggregations(
 
         metric_key = f"{metric},{filter_key}"
         agg_metrics[metric_key] = agg_fn(items)
-        sample_len = len(items)  # TODO: reflects only the last metric's count
+        # Metrics can hold different numbers of values: a document whose
+        # process_results omits a key contributes to some metrics and not others.
+        # Assigning here would report whichever metric came last, so the same run
+        # reports a different count depending on dict ordering. The number of
+        # documents evaluated is the largest of the per-metric counts, since a
+        # document contributes at most one value to each metric.
+        sample_len = max(sample_len, len(items))
 
         if isinstance(bootstrap_iters, int) and bootstrap_iters > 0:
             stderr_fn = stderr_for_metric(

--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -188,6 +188,7 @@ def _compute_task_aggregations(
     """
     agg_metrics: dict[str, Any] = {}
     sample_len = 0
+    metric_lens: dict[str, int] = {}
 
     for (metric, filter_key), items in raw_metrics.items():
         try:
@@ -204,9 +205,10 @@ def _compute_task_aggregations(
         # Metrics can hold different numbers of values: a document whose
         # process_results omits a key contributes to some metrics and not others.
         # Assigning here would report whichever metric came last, so the same run
-        # reports a different count depending on dict ordering. The number of
-        # documents evaluated is the largest of the per-metric counts, since a
-        # document contributes at most one value to each metric.
+        # reports a different count depending on dict ordering. A document
+        # contributes at most one value to each metric, so the largest per-metric
+        # count is a lower bound on the number of documents evaluated.
+        metric_lens[metric_key] = len(items)
         sample_len = max(sample_len, len(items))
 
         if isinstance(bootstrap_iters, int) and bootstrap_iters > 0:
@@ -221,6 +223,24 @@ def _compute_task_aggregations(
             )
         else:
             agg_metrics[f"{metric}_stderr,{filter_key}"] = "N/A"
+
+    # Differing counts mean some documents were dropped from some metrics, so the
+    # single reported sample count does not describe every metric. Surface the
+    # per-metric counts, and the group-weighting consequence, rather than letting
+    # the discrepancy pass silently. Group.aggregate weights each subtask by this
+    # one task-level count (see lm_eval/api/group.py), so it has no way to give a
+    # metric the number of documents that metric was actually scored on.
+    # TODO: fix this: will need to return the per-metric counts and group.py to index them by metric_key
+    if len(set(metric_lens.values())) > 1:
+        counts = ", ".join(f"{key}={n}" for key, n in sorted(metric_lens.items()))
+        eval_logger.warning(
+            f"[{task.task_name}] Metrics were not scored on the same number of "
+            f"documents ({counts}). Each metric was aggregated over only the "
+            f"documents that produced it; reporting {sample_len} as the evaluated "
+            f"sample count. Size-weighted group aggregation applies that single "
+            f"count to every metric of this task, so any metric scored on fewer "
+            f"than {sample_len} documents is over-weighted in the group score."
+        )
 
     return agg_metrics, sample_len
 

--- a/tests/test_evaluator_utils.py
+++ b/tests/test_evaluator_utils.py
@@ -211,6 +211,32 @@ class TestComputeTaskAggregations:
         # len(items) <= 1 → "N/A"
         assert metrics["acc_stderr,none"] == "N/A"
 
+    def test_sample_count_does_not_depend_on_metric_order(self):
+        # Three documents were scored for acc; only one of them also produced f1,
+        # which is what a task does when a sample is unscorable for one metric
+        # (a refusal, an unparseable answer, an empty extraction).
+        task = MockEvalTask("t", agg={"acc": mean, "f1": mean})
+        acc_first = {("acc", "none"): [1.0, 0.0, 1.0], ("f1", "none"): [0.5]}
+        f1_first = {("f1", "none"): [0.5], ("acc", "none"): [1.0, 0.0, 1.0]}
+
+        _, count_acc_first = _compute_task_aggregations(
+            task, acc_first, bootstrap_iters=0
+        )
+        _, count_f1_first = _compute_task_aggregations(
+            task, f1_first, bootstrap_iters=0
+        )
+
+        assert count_acc_first == count_f1_first
+        assert count_acc_first == 3
+
+    def test_sample_count_unchanged_when_metrics_agree(self):
+        # The common case: every document produced every metric. The count is
+        # that shared length, exactly as before.
+        task = MockEvalTask("t", agg={"acc": mean, "f1": mean})
+        raw = {("acc", "none"): [1.0, 0.0], ("f1", "none"): [0.5, 0.25]}
+        _, count = _compute_task_aggregations(task, raw, bootstrap_iters=0)
+        assert count == 2
+
     def test_fallback_to_mean_for_unknown_metric(self):
         # Task has no aggregation for "custom_metric"
         task = MockEvalTask("t", agg={})

--- a/tests/test_evaluator_utils.py
+++ b/tests/test_evaluator_utils.py
@@ -237,6 +237,41 @@ class TestComputeTaskAggregations:
         _, count = _compute_task_aggregations(task, raw, bootstrap_iters=0)
         assert count == 2
 
+    def test_warns_when_metric_counts_differ(self, caplog):
+        # acc scored three documents, f1 only one. The single reported count
+        # cannot describe both, so the discrepancy is logged.
+        task = MockEvalTask("t", agg={"acc": mean, "f1": mean})
+        raw = {("acc", "none"): [1.0, 0.0, 1.0], ("f1", "none"): [0.5]}
+
+        with caplog.at_level(logging.WARNING):
+            _compute_task_aggregations(task, raw, bootstrap_iters=0)
+
+        warnings = [
+            r.message
+            for r in caplog.records
+            if "not scored on the same number of documents" in r.message
+        ]
+        assert len(warnings) == 1
+        # The per-metric counts are named, not just the fact that they differ.
+        assert "acc,none=3" in warnings[0]
+        assert "f1,none=1" in warnings[0]
+        # The downstream consequence is named too: Group.aggregate weights this
+        # task by the single reported count, over-weighting f1's one document.
+        assert "over-weighted" in warnings[0]
+
+    def test_no_warning_when_metric_counts_agree(self, caplog):
+        # The common case must stay quiet, or the warning is noise.
+        task = MockEvalTask("t", agg={"acc": mean, "f1": mean})
+        raw = {("acc", "none"): [1.0, 0.0], ("f1", "none"): [0.5, 0.25]}
+
+        with caplog.at_level(logging.WARNING):
+            _compute_task_aggregations(task, raw, bootstrap_iters=0)
+
+        assert not any(
+            "not scored on the same number of documents" in r.message
+            for r in caplog.records
+        )
+
     def test_fallback_to_mean_for_unknown_metric(self):
         # Task has no aggregation for "custom_metric"
         task = MockEvalTask("t", agg={})


### PR DESCRIPTION
## The number that is wrong

`_compute_task_aggregations` sets the sample count inside the loop over metrics:

```python
for (metric, filter_key), items in raw_metrics.items():
    ...
    sample_len = len(items)  # TODO: reflects only the last metric's count
```

So the value left standing is whichever metric happened to come last, and that is what
`n_samples.effective` reports in the results.

Metrics do not always hold the same number of values. A document whose `process_results`
omits a key contributes to some metrics and not others, which is how a task says it could
not score that one: a refusal, an unparseable answer, an empty extraction. When that
happens the per-metric counts differ and the reported count depends on dict ordering
rather than on the run.

Against `main`, the same raw metrics reported either 1 or 3, decided only by which key
came first:

| raw_metrics | reported effective |
|---|---|
| `{("acc","none"): [1.0, 0.0, 1.0], ("f1","none"): [0.5]}` | **1** |
| `{("f1","none"): [0.5], ("acc","none"): [1.0, 0.0, 1.0]}` | **3** |

Nothing raises, and 1 is a perfectly ordinary sample count.

## The change

Take the largest per-metric count. A document contributes at most one value to each
metric, so the largest count is the number of documents that produced any metric at all.

When every metric holds the same number of values, which is the common case, the reported
count is unchanged.

## Tests

Two in `TestComputeTaskAggregations`:

- the two orderings above now agree, and report 3
- the common case where all metrics agree still reports that shared length, which is what
  a careless fix breaks

Reverting the one-line change fails the first and leaves the second passing.
`tests/test_evaluator_utils.py` is 70 passed. `ruff format` and `ruff check` are clean on
both touched files.

## Scope

This does not address the wider question in #4062 of whether dropped documents should be
surfaced per metric, or warned about. That needs a decision on the scoring contract and is
not mine to make. This fixes only the order dependence in the count that ships today.
