### PR TITLE
feat(tasks): add open-ended L-Eval benchmark tasks (#2180)

### DIFF
--- a/lm_eval/tasks/l_eval_open/l_eval_financial_qa.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_financial_qa.yaml
@@ -1,0 +1,23 @@
+task: l_eval_financial_qa
+dataset_path: L4NLP/LEval
+dataset_name: financial_qa
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/l_eval_gov_report_summ.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_gov_report_summ.yaml
@@ -1,0 +1,23 @@
+task: l_eval_gov_report_summ
+dataset_path: L4NLP/LEval
+dataset_name: gov_report_summ
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/l_eval_meeting_summ.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_meeting_summ.yaml
@@ -1,0 +1,23 @@
+task: l_eval_meeting_summ
+dataset_path: L4NLP/LEval
+dataset_name: meeting_summ
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/l_eval_multidoc_qa.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_multidoc_qa.yaml
@@ -1,0 +1,23 @@
+task: l_eval_multidoc_qa
+dataset_path: L4NLP/LEval
+dataset_name: multidoc_qa
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/l_eval_narrative_qa.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_narrative_qa.yaml
@@ -1,0 +1,23 @@
+task: l_eval_narrative_qa
+dataset_path: L4NLP/LEval
+dataset_name: narrative_qa
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/l_eval_open.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_open.yaml
@@ -1,0 +1,10 @@
+group: l_eval_open
+task:
+  - l_eval_financial_qa
+  - l_eval_gov_report_summ
+  - l_eval_meeting_summ
+  - l_eval_multidoc_qa
+  - l_eval_narrative_qa
+  - l_eval_paper_assistant
+  - l_eval_patent_summ
+  - l_eval_review_summ

--- a/lm_eval/tasks/l_eval_open/l_eval_paper_assistant.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_paper_assistant.yaml
@@ -1,0 +1,23 @@
+task: l_eval_paper_assistant
+dataset_path: L4NLP/LEval
+dataset_name: paper_assistant
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/l_eval_patent_summ.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_patent_summ.yaml
@@ -1,0 +1,23 @@
+task: l_eval_patent_summ
+dataset_path: L4NLP/LEval
+dataset_name: patent_summ
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/l_eval_review_summ.yaml
+++ b/lm_eval/tasks/l_eval_open/l_eval_review_summ.yaml
@@ -1,0 +1,23 @@
+task: l_eval_review_summ
+dataset_path: L4NLP/LEval
+dataset_name: review_summ
+dataset_kwargs:
+  trust_remote_code: true
+output_type: generate_until
+training_split: null
+validation_split: null
+test_split: test
+doc_to_text: !function utils.doc_to_text
+doc_to_target: !function utils.doc_to_target
+generation_kwargs:
+  until:
+    - "\n\nInstruction:"
+    - "</s>"
+    - "<|im_end|>"
+  max_gen_toks: 256
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: rouge
+    aggregation: mean
+    higher_is_better: true

--- a/lm_eval/tasks/l_eval_open/utils.py
+++ b/lm_eval/tasks/l_eval_open/utils.py
@@ -1,0 +1,23 @@
+def doc_to_text(doc):
+    """
+    Formats the L-Eval input document and instruction.
+    """
+    context = doc.get("input", "")
+    instructions = doc.get("instructions", [])
+    
+    if isinstance(instructions, list):
+        instruction_str = "\n".join(instructions)
+    else:
+        instruction_str = str(instructions)
+
+    return f"Document:\n{context}\n\nInstruction:\n{instruction_str}\n\nAnswer:"
+
+
+def doc_to_target(doc):
+    """
+    Extracts the reference answer/output string from the document.
+    """
+    outputs = doc.get("outputs", [])
+    if isinstance(outputs, list):
+        return outputs[0] if len(outputs) > 0 else ""
+    return str(outputs)


### PR DESCRIPTION
## Description

Adds the open-ended subtasks for the L-Eval long-context benchmark suite, completing the remaining tasks left from #3927.

Resolves #2180

## Tasks Added
Group: `l_eval_open`
- `l_eval_financial_qa`
- `l_eval_gov_report_summ`
- `l_eval_meeting_summ`
- `l_eval_multidoc_qa`
- `l_eval_narrative_qa`
- `l_eval_paper_assistant`
- `l_eval_patent_summ`
- `l_eval_review_summ`

## Verification
Verified locally with `EleutherAI/pythia-160m`:
```bash
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-160m --tasks l_eval_open --device cpu --limit 1
```