### PR TITLE
test(minerva_math): drop the frozen leaderboard copy from the shared NORMS

### DIFF
--- a/tests/test_minerva_math.py
+++ b/tests/test_minerva_math.py
@@ -88,7 +88,12 @@ bare tuples ("0,1" x4, "3,5,7", "12,10,6", ...), and the fused gold can no
 longer match a model's "(0,1)" or "0, 1" spelling.
 """
 
-NORMS = (norm, norm_leaderboard, norm_putnam)
+# `leaderboard.math` is deliberately excluded: it reproduces Open LLM
+# Leaderboard v2 MATH-hard scoring and is frozen at that behavior (see the note
+# at the top of lm_eval/tasks/leaderboard/math/utils.py), so the fix above was
+# reverted there on purpose. What that copy actually does is pinned separately
+# in test_leaderboard_math_comma_handling_stays_frozen.
+NORMS = (norm, norm_putnam)
 
 
 def test_bare_digit_tuple_is_not_fused():
@@ -117,6 +122,23 @@ def test_malformed_grouping_is_left_untouched():
 def test_negative_thousands_grouping_is_stripped():
     for f in NORMS:
         assert f("-1,024") == "-1024"
+
+
+def test_leaderboard_math_comma_handling_stays_frozen():
+    """The frozen leaderboard copy keeps the pre-fix comma behavior.
+
+    Pinned rather than fixed: `leaderboard_math_hard` exists to reproduce the
+    published Open LLM Leaderboard v2 numbers, and changing its normalization
+    would silently make new runs incomparable with the historical ones. This
+    asserts the divergence is the intended one, so a future sync cannot quietly
+    port the Minerva fix across.
+    """
+    assert norm_leaderboard("0,1") == "01"
+    assert norm_leaderboard("3,5,7") == "357"
+    assert norm_leaderboard("12,34") == "1234"
+    assert norm_leaderboard("-1,024") == "-1,024"
+    # unchanged by the freeze: true thousands grouping is stripped either way
+    assert norm_leaderboard("100,000") == "100000"
 
 
 def test_equiv_harm_case_tuple_spelling_variants():


### PR DESCRIPTION
## What

`tests/test_minerva_math.py` fails on a clean `main` when `lm_eval[math]` is installed:

```
FAILED tests/test_minerva_math.py::test_bare_digit_tuple_is_not_fused
FAILED tests/test_minerva_math.py::test_malformed_grouping_is_left_untouched
FAILED tests/test_minerva_math.py::test_negative_thousands_grouping_is_stripped
3 failed, 27 passed
```

## Why

#4039 applied the thousands-separator fix to `minerva_math` and `putnam_axiom`, and deliberately reverted it in `leaderboard/math`, adding the note that file now carries:

> This file reproduces the Open LLM Leaderboard v2 MATH-hard scoring and must stay frozen: changing normalization or equivalence here silently invalidates comparison against the historical leaderboard numbers.

`norm_leaderboard` stayed in the `NORMS` tuple the same PR's tests iterate over, so three of them assert the fixed behavior against the copy that was intentionally left unfixed. The frozen copy is the only one that diverges:

| input | `minerva_math` | `putnam_axiom` | `leaderboard/math` (frozen) |
| --- | --- | --- | --- |
| `0,1` | `0,1` | `0,1` | `01` |
| `3,5,7` | `3,5,7` | `3,5,7` | `357` |
| `12,34` | `12,34` | `12,34` | `1234` |
| `-1,024` | `-1024` | `-1024` | `-1,024` |
| `100,000` | `100000` | `100000` | `100000` |

CI does not surface this: `unit_tests.yml` installs `.[dev,unitxt,hf]`, which pulls neither `antlr4-python3-runtime` nor `math_verify`, so the module is skipped by its `pytest.importorskip`. Anyone who installs the `[math]` extra that `minerva_math` requires sees the failures on checkout.

## Modifications

- `NORMS` now covers only the two copies the fix applies to.
- The frozen copy's actual comma behavior gets its own test, so the intended divergence is asserted rather than only described in a comment, and a later sync cannot quietly port the Minerva fix across.

`lm_eval/tasks/leaderboard/math/utils.py` is untouched, and no task code changes.

## Test

```
before:  3 failed, 27 passed
after:   31 passed
```

Python 3.11, `pip install -e ".[math]"`. `ruff check` and `ruff format` (v0.16.3, as pinned in `.pre-commit-config.yaml`) and `codespell` are clean on the changed file.

Two things I left out on purpose, happy to do either:

- The frozen-behavior test can be dropped if you would rather not assert the legacy output; the `NORMS` line alone makes the suite green.
- `.[dev,unitxt,hf,math]` resolves against current `main` without conflict (`antlr4-python3-runtime==4.11.0`, `math-verify==0.9.0`, `sympy==1.14.0`), so adding the extra to `unit_tests.yml` would make this module actually run in CI. That is a separate call on CI install time, so I did not fold it in here.
