### PR TITLE
test(decontamination): re-enable tests/test_janitor.py

### DIFF
--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -1,8 +1,3 @@
-import pytest
-
-
-pytest.skip("Need to confirm if tests are still compatible", allow_module_level=True)
-
 import os
 from collections import defaultdict
 
@@ -37,7 +32,7 @@ JANITOR_FILTH2 = "filth lots of filthy dirty filth"
 
 
 def simple_ngram(sequence, n):
-    ngrams = list()
+    ngrams = []
     ngram = []
     for x in sequence:
         ngram.extend([x])


### PR DESCRIPTION
## What

`tests/test_janitor.py` has been skipped at import since #3549:

```python
pytest.skip("Need to confirm if tests are still compatible", allow_module_level=True)
```

This re-enables it. The 12 tests pass unchanged; no source or test logic is modified.

## Why it looks safe to turn back on

`lm_eval/decontamination/janitor.py` imports only the standard library plus the optional `janitor_util` C++ extension, and the test module imports only `os`, `collections` and that module. Nothing in either touches `TaskManager`, so the skip reads as collateral from that refactor rather than a real incompatibility. Decontamination is still wired in (`should_decontaminate` / `doc_to_decontamination_query` in `lm_eval/config/task.py` and `lm_eval/api/task.py`, plus `docs/decontamination.md`), so the coverage is not for a dead feature.

## Test

- 12 passed on 3.10, 3.11, 3.12 and 3.13, in about 0.15 s. 20 consecutive runs, 0 failures; the module has no clock, RNG or filesystem dependency.
- `janitor_util` is compiled by hand (`scripts/clean_training_data/README.md`) and is in no extra, so CI exercises the same pure-Python path these runs did.
- The tests are not vacuous: mutating the window bound in `form_ngrams` (`while n > 1` to `while n > 2`) turns 8 of the 12 red, while a no-op signature change leaves all 12 green.
- `pre-commit run --files tests/test_janitor.py` passes with the pinned hook versions and `SKIP=no-commit-to-branch,mypy`.

## The second hunk

`ngrams = list()` becomes `ngrams = []` in a test helper. `unit_tests.yml` runs pre-commit with `--from-ref`/`--to-ref`, so ruff only ever sees the files a PR touches; this pre-existing C408 has therefore never been reported, and it would fail the Linters job on the first commit to touch this file. It is not auto-fixable here, since `C` is not in `[tool.ruff.lint] fixable`.

## Left alone

`tests/test_unitxt_tasks.py` was disabled by the same commit with the same placeholder reason. It imports `TaskManager` internals and pulls datasets, so I could not verify it offline and did not touch it.
