### PR TITLE
fix(tasks): replace np.NAN, removed in NumPy 2.0

### DIFF
--- a/lm_eval/tasks/bbq/utils.py
+++ b/lm_eval/tasks/bbq/utils.py
@@ -4,9 +4,6 @@ import datasets
 import numpy as np
 
 
-if np.__version__ >= "2.0":
-    np.NaN = np.nan
-
 # Possible unknown responses, copied from the HELM implementation
 UNKNOWN_RESPONSES = [
     "Unknown",
@@ -65,12 +62,12 @@ def agg_disamb_bias_scores(arr):
     # If all elements are NaN, then we simply return NaN
     # Because no examples for this bias type are evaluated
     if np.isnan(n_non_unk).all():
-        return np.NaN
+        return np.nan
 
     # The sum of an empty list is 0, but we want NaN
     # E.g., when only evaluating on one example (ambig/disambig)
-    n_biased_ans = np.NaN if n_biased_ans.size == 0 else np.nansum(n_biased_ans)
-    n_non_unk = np.NaN if n_non_unk.size == 0 else np.nansum(n_non_unk)
+    n_biased_ans = np.nan if n_biased_ans.size == 0 else np.nansum(n_biased_ans)
+    n_non_unk = np.nan if n_non_unk.size == 0 else np.nansum(n_non_unk)
 
     # Unfortunately, bias score for `n_non_unk = 0` is undefined,
     # but since we then also have `n_biased_ans = 0`, return 0
@@ -94,9 +91,9 @@ def agg_amb_bias_scores(arr):
 
     # If the inverse of the mask is empty
     # (meaning there are no amiguous examples),
-    # return np.NaN
+    # return np.nan
     if mask.all():
-        return np.NaN
+        return np.nan
 
     # Mask indicates disambiguated cases, so invert
     S_DIS = agg_disamb_bias_scores(zip(acc, n_biased_ans, n_non_unk, ~mask))
@@ -156,7 +153,7 @@ def _process_results(doc, answer: int):
         "disamb_bias_score": (acc, n_biased_ans, n_non_unk_ans, mask_disambiguated),
     }
     # Metrics specific to a category subset
-    # np.NaN for all other categories than the current one
+    # np.nan for all other categories than the current one
     # I.e., will be ignored when computing category specific metric
     metrics.update(
         {
@@ -179,11 +176,11 @@ def _process_results(doc, answer: int):
         }
     )
     metrics.update(
-        {"amb_bias_score_" + cat: (acc, np.NaN, np.NaN, np.NaN) for cat in CATEGORIES}
+        {"amb_bias_score_" + cat: (acc, np.nan, np.nan, np.nan) for cat in CATEGORIES}
     )
     metrics.update(
         {
-            "disamb_bias_score_" + cat: (acc, np.NaN, np.NaN, np.NaN)
+            "disamb_bias_score_" + cat: (acc, np.nan, np.nan, np.nan)
             for cat in CATEGORIES
         }
     )

--- a/lm_eval/tasks/careqa/utils_open.py
+++ b/lm_eval/tasks/careqa/utils_open.py
@@ -24,19 +24,19 @@ def doc_eval(pred, refs):
         bleu_results = bleu.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Bleu error: {e}")
-        bleu_results = {"bleu": np.NAN}
+        bleu_results = {"bleu": np.nan}
 
     try:
         rouge_results = rouge.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Rouge error: {e}")
-        rouge_results = {"rouge1": np.NAN, "rouge2": np.NAN, "rougeL": np.NAN}
+        rouge_results = {"rouge1": np.nan, "rouge2": np.nan, "rougeL": np.nan}
 
     try:
         bleurt_scores = bleurt.compute(predictions=pred, references=refs)["scores"]
     except Exception as e:
         print(f"Bleurt error: {e}")
-        bleurt_scores = [np.NAN]
+        bleurt_scores = [np.nan]
 
     try:
         bert_scores = bertscore.compute(predictions=pred, references=refs, lang="en")[
@@ -44,7 +44,7 @@ def doc_eval(pred, refs):
         ]
     except Exception as e:
         print(f"Bert error: {e}")
-        bert_scores = [np.NAN]
+        bert_scores = [np.nan]
 
     if bleu_results["bleu"] == 0:
         # Sometimes bleu is 0.0 and this breaks the stderr computation.
@@ -75,12 +75,12 @@ def process_results_gen(doc, results):
 
     if len(refs[0]) < 1 or len(pred[0]) < 1:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
         }
 
     results = doc_eval(pred, refs)
@@ -100,12 +100,12 @@ def process_results_gen_w_repeats(doc, results):
 
     if len(refs[0]) < 1 or len(pred[0]) < 1:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
         }
 
     results = doc_eval(pred, refs)

--- a/lm_eval/tasks/mediqa_qa2019/utils.py
+++ b/lm_eval/tasks/mediqa_qa2019/utils.py
@@ -26,19 +26,19 @@ def doc_eval(pred, refs):
         bleu_results = bleu.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Bleu error: {e}")
-        bleu_results = {"bleu": np.NAN}
+        bleu_results = {"bleu": np.nan}
 
     try:
         rouge_results = rouge.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Rouge error: {e}")
-        rouge_results = {"rouge1": np.NAN, "rouge2": np.NAN, "rougeL": np.NAN}
+        rouge_results = {"rouge1": np.nan, "rouge2": np.nan, "rougeL": np.nan}
 
     try:
         bleurt_scores = bleurt.compute(predictions=pred, references=refs)["scores"]
     except Exception as e:
         print(f"Bleurt error: {e}")
-        bleurt_scores = [np.NAN]
+        bleurt_scores = [np.nan]
 
     try:
         bert_scores = bertscore.compute(predictions=pred, references=refs, lang="en")[
@@ -46,7 +46,7 @@ def doc_eval(pred, refs):
         ]
     except Exception as e:
         print(f"Bert error: {e}")
-        bert_scores = [np.NAN]
+        bert_scores = [np.nan]
 
     if bleu_results["bleu"] == 0:
         # Sometimes bleu is 0.0 and this breaks the stderr computation.
@@ -77,12 +77,12 @@ def process_results_gen(doc, results):
 
     if len(refs[0]) < 1 or len(pred[0]) < 1:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
         }
 
     results = doc_eval(pred, refs)

--- a/lm_eval/tasks/medtext/utils.py
+++ b/lm_eval/tasks/medtext/utils.py
@@ -26,19 +26,19 @@ def doc_eval(pred, refs):
         bleu_results = bleu.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Bleu error: {e}")
-        bleu_results = {"bleu": np.NAN}
+        bleu_results = {"bleu": np.nan}
 
     try:
         rouge_results = rouge.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Rouge error: {e}")
-        rouge_results = {"rouge1": np.NAN, "rouge2": np.NAN, "rougeL": np.NAN}
+        rouge_results = {"rouge1": np.nan, "rouge2": np.nan, "rougeL": np.nan}
 
     try:
         bleurt_scores = bleurt.compute(predictions=pred, references=refs)["scores"]
     except Exception as e:
         print(f"Bleurt error: {e}")
-        bleurt_scores = [np.NAN]
+        bleurt_scores = [np.nan]
 
     try:
         bert_scores = bertscore.compute(predictions=pred, references=refs, lang="en")[
@@ -46,7 +46,7 @@ def doc_eval(pred, refs):
         ]
     except Exception as e:
         print(f"Bert error: {e}")
-        bert_scores = [np.NAN]
+        bert_scores = [np.nan]
 
     if bleu_results["bleu"] == 0:
         # Sometimes bleu is 0.0 and this breaks the stderr computation.
@@ -77,12 +77,12 @@ def process_results(doc, results):
 
     if len(refs[0]) < 1 or len(pred[0]) < 1:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
         }
 
     results = doc_eval(pred, refs)

--- a/lm_eval/tasks/meqsum/utils.py
+++ b/lm_eval/tasks/meqsum/utils.py
@@ -39,31 +39,31 @@ def process_results_gen(doc, results):
 
     if len(refs[0]) < 1 or len(pred[0]) < 1:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
         }
 
     try:
         bleu_results = bleu.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Bleu error: {e}")
-        bleu_results = {"bleu": np.NAN}
+        bleu_results = {"bleu": np.nan}
 
     try:
         rouge_results = rouge.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Rouge error: {e}")
-        rouge_results = {"rouge1": np.NAN, "rouge2": np.NAN, "rougeL": np.NAN}
+        rouge_results = {"rouge1": np.nan, "rouge2": np.nan, "rougeL": np.nan}
 
     try:
         bleurt_scores = bleurt.compute(predictions=pred, references=refs)["scores"]
     except Exception as e:
         print(f"Bleurt error: {e}")
-        bleurt_scores = [np.NAN]
+        bleurt_scores = [np.nan]
 
     try:
         bert_scores = bertscore.compute(predictions=pred, references=refs, lang="en")[
@@ -71,7 +71,7 @@ def process_results_gen(doc, results):
         ]
     except Exception as e:
         print(f"Bert error: {e}")
-        bert_scores = [np.NAN]
+        bert_scores = [np.nan]
 
     if bleu_results["bleu"] == 0:
         # Sometimes bleu is 0.0 and this breaks the stderr computation.

--- a/lm_eval/tasks/mimic_repsum/utils.py
+++ b/lm_eval/tasks/mimic_repsum/utils.py
@@ -30,19 +30,19 @@ def doc_eval(pred, refs):
         bleu_results = bleu.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Bleu error: {e}")
-        bleu_results = {"bleu": np.NAN}
+        bleu_results = {"bleu": np.nan}
 
     try:
         rouge_results = rouge.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Rouge error: {e}")
-        rouge_results = {"rouge1": np.NAN, "rouge2": np.NAN, "rougeL": np.NAN}
+        rouge_results = {"rouge1": np.nan, "rouge2": np.nan, "rougeL": np.nan}
 
     try:
         bleurt_scores = bleurt.compute(predictions=pred, references=refs)["scores"]
     except Exception as e:
         print(f"Bleurt error: {e}")
-        bleurt_scores = [np.NAN]
+        bleurt_scores = [np.nan]
 
     try:
         bert_scores = bertscore.compute(predictions=pred, references=refs, lang="en")[
@@ -50,7 +50,7 @@ def doc_eval(pred, refs):
         ]
     except Exception as e:
         print(f"Bert error: {e}")
-        bert_scores = [np.NAN]
+        bert_scores = [np.nan]
 
     if bleu_results["bleu"] == 0:
         # Sometimes bleu is 0.0 and this breaks the stderr computation.
@@ -129,13 +129,13 @@ def process_results(doc, results):
 
     if len(refs[0]) < 5 or len(pred[0]) < 5:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
-            "F1-Radgraph": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
+            "F1-Radgraph": np.nan,
         }
 
     results = doc_eval(pred, refs)
@@ -143,7 +143,7 @@ def process_results(doc, results):
     try:
         radgraph_score, _, _, _ = f1radgraph(hyps=pred, refs=refs)
     except Exception:
-        radgraph_score = np.NAN
+        radgraph_score = np.nan
 
     return {
         "bleu": results["bleu"],

--- a/lm_eval/tasks/mts_dialog/utils.py
+++ b/lm_eval/tasks/mts_dialog/utils.py
@@ -26,19 +26,19 @@ def doc_eval(pred, refs):
         bleu_results = bleu.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Bleu error: {e}")
-        bleu_results = {"bleu": np.NAN}
+        bleu_results = {"bleu": np.nan}
 
     try:
         rouge_results = rouge.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Rouge error: {e}")
-        rouge_results = {"rouge1": np.NAN, "rouge2": np.NAN, "rougeL": np.NAN}
+        rouge_results = {"rouge1": np.nan, "rouge2": np.nan, "rougeL": np.nan}
 
     try:
         bleurt_scores = bleurt.compute(predictions=pred, references=refs)["scores"]
     except Exception as e:
         print(f"Bleurt error: {e}")
-        bleurt_scores = [np.NAN]
+        bleurt_scores = [np.nan]
 
     try:
         bert_scores = bertscore.compute(predictions=pred, references=refs, lang="en")[
@@ -46,7 +46,7 @@ def doc_eval(pred, refs):
         ]
     except Exception as e:
         print(f"Bert error: {e}")
-        bert_scores = [np.NAN]
+        bert_scores = [np.nan]
 
     if bleu_results["bleu"] == 0:
         # Sometimes bleu is 0.0 and this breaks the stderr computation.
@@ -77,12 +77,12 @@ def process_results(doc, results):
 
     if len(refs[0]) < 5 or len(pred[0]) < 5:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
         }
 
     results = doc_eval(pred, refs)

--- a/lm_eval/tasks/olaph/utils.py
+++ b/lm_eval/tasks/olaph/utils.py
@@ -27,19 +27,19 @@ def doc_eval(pred, refs):
         bleu_results = bleu.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Bleu error: {e}")
-        bleu_results = {"bleu": np.NAN}
+        bleu_results = {"bleu": np.nan}
 
     try:
         rouge_results = rouge.compute(predictions=pred, references=refs)
     except Exception as e:
         print(f"Rouge error: {e}")
-        rouge_results = {"rouge1": np.NAN, "rouge2": np.NAN, "rougeL": np.NAN}
+        rouge_results = {"rouge1": np.nan, "rouge2": np.nan, "rougeL": np.nan}
 
     try:
         bleurt_scores = bleurt.compute(predictions=pred, references=refs)["scores"]
     except Exception as e:
         print(f"Bleurt error: {e}")
-        bleurt_scores = [np.NAN]
+        bleurt_scores = [np.nan]
 
     try:
         bert_scores = bertscore.compute(predictions=pred, references=refs, lang="en")[
@@ -47,7 +47,7 @@ def doc_eval(pred, refs):
         ]
     except Exception as e:
         print(f"Bert error: {e}")
-        bert_scores = [np.NAN]
+        bert_scores = [np.nan]
 
     if bleu_results["bleu"] == 0:
         # Sometimes bleu is 0.0 and this breaks the stderr computation.
@@ -91,12 +91,12 @@ def process_results(doc, results):
 
     if len(refs[0]) < 10 or len(pred[0]) < 10:
         return {
-            "bleu": np.NAN,
-            "rouge1": np.NAN,
-            "rouge2": np.NAN,
-            "rougeL": np.NAN,
-            "bleurt": np.NAN,
-            "bert_score": np.NAN,
+            "bleu": np.nan,
+            "rouge1": np.nan,
+            "rouge2": np.nan,
+            "rougeL": np.nan,
+            "bleurt": np.nan,
+            "bert_score": np.nan,
         }
 
     results = doc_eval(pred, refs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,8 @@ extend-select = [
     "FURB", "I", "TC", "RUF034",
      # flake8-bandit, simplify, pyupgrade, invalid-escape-sequence
     "S", "SIM", "S307", "UP", "W605",
+    # numpy 2.0 removals (np.NAN, np.float_, ...); numpy is unpinned
+    "NPY201",
 ]
 fixable = [
      # bugbear, pydocstyle, pycodestyle, unused-import
@@ -155,6 +157,8 @@ fixable = [
     "FURB", "I001", "RUF",
     # simplify, type-checking, pyupgrade, invalid-escape
     "SIM", "TC", "UP", "W605",
+    # numpy 2.0 removals
+    "NPY201",
 ]
 ignore = [
     "D10", "D200", "D202", "D205",


### PR DESCRIPTION
## What

`np.NAN` and `np.NaN` were removed in NumPy 2.0. `numpy` is unpinned in `pyproject.toml` and the unit-test job resolves `numpy==2.4.6`, so every remaining reference raises:

```
AttributeError: module 'numpy' has no attribute 'NAN'
```

103 references across 8 task modules. This replaces them with `np.nan`.

## Why it matters at runtime

These are not only in `except` handlers. `careqa`, `mediqa_qa2019`, `medtext`, `meqsum`, `mimic_repsum`, `mts_dialog` and `olaph` each return a dict of `np.NAN` from an ordinary short-prediction guard, e.g. `lm_eval/tasks/olaph/utils.py`:

```python
if len(refs[0]) < 10 or len(pred[0]) < 10:
    return {
        "bleu": np.NAN,
        ...
```

so any generation shorter than the task's threshold raises instead of scoring that sample NaN. Reproduced on `mediqa_qa2019` with an empty prediction (the `evaluate` metrics stubbed out, since the failing path never reaches them):

```
before: AttributeError: module 'numpy' has no attribute 'NAN'
after:  {'bleu': nan, 'rouge1': nan, 'rouge2': nan, 'rougeL': nan, 'bleurt': nan, 'bert_score': nan}
```

`lm_eval/tasks/bbq/utils.py` already carried a workaround for this:

```python
if np.__version__ >= "2.0":
    np.NaN = np.nan
```

That rebinds the attribute on the `numpy` module itself, so it also silently repairs `np.NaN` for anything else imported in the same process — including the seven other task modules, but only if `bbq` happened to be imported first. With the call sites fixed it is no longer needed and is removed.

## Modifications

- `np.NAN` / `np.NaN` to `np.nan` in the 8 task modules (applied with `ruff check --select NPY201 --fix`, plus two stale comments in `bbq`).
- Remove the `bbq` version-guarded monkey-patch.
- Add `NPY201` to `[tool.ruff.lint] extend-select` and `fixable` so this cannot come back. It reports nothing else on the tree.

## Test

- `ruff check --select NPY201 .` is clean afterwards; before it reported 103.
- Running ruff over the 8 touched files gives the **identical** 69-violation set before and after this change, so nothing new is introduced. Those 69 are pre-existing `BLE001` / `B904` / `RUF010` in these files and will show up in Linters because pre-commit runs with `--from-ref`/`--to-ref` over whatever a PR touches. I left them alone to keep this diff to the NumPy fix — happy to clean them here or in a follow-up, whichever you prefer.
- `ruff format --diff` clean on all 8 files.
- `bbq` aggregations unchanged after removing the monkey-patch: `agg_disamb_bias_scores` on an all-NaN disambiguated slice returns `nan`, `agg_amb_bias_scores` with no ambiguous examples returns `nan`, and a real slice returns the same score as before.
- No test module references these tasks, so there is no test to update; they are all gated behind the `evaluate` metric stack (`bleurt`, `bertscore`) that is not installed in CI.
