### PR TITLE
fix(basqueglue): load the f1 metric with evaluate

### DIFF
--- a/lm_eval/tasks/basqueglue/utils.py
+++ b/lm_eval/tasks/basqueglue/utils.py
@@ -1,8 +1,6 @@
 import html
 import re
 
-from datasets import load_metric
-
 
 def general_detokenize(string):
     string = re.sub(r"\s+([.,;:!?)])", r"\1", string)
@@ -60,7 +58,9 @@ def coref_doc_to_text(x):
 
 
 def micro_f1_score(items):
-    f1_metric = load_metric("f1")
+    import evaluate
+
+    f1_metric = evaluate.load("f1")
     golds, preds = list(zip(*items))
     f1_score = f1_metric.compute(references=golds, predictions=preds, average="micro")[
         "f1"
@@ -69,7 +69,9 @@ def micro_f1_score(items):
 
 
 def vaxx_f1_score(items):
-    f1_metric = load_metric("f1")
+    import evaluate
+
+    f1_metric = evaluate.load("f1")
     golds, preds = list(zip(*items))
     f1_class = f1_metric.compute(
         references=golds, predictions=preds, labels=[0, 2], average=None


### PR DESCRIPTION
## What

`lm_eval/tasks/basqueglue/utils.py` imports a name that no longer exists:

```python
from datasets import load_metric
```

`datasets.load_metric` was removed in `datasets` 3.0, and `unit_tests.yml` resolves `datasets==5.0.1`. The import is at module scope, so the whole module is unimportable, and five of the six BasqueGLUE tasks resolve a `!function` from it — they fail to **load**, not merely to score:

| yaml | task | reference | on current `main` |
| --- | --- | --- | --- |
| `bec.yaml` | `bec2016eu` | `utils.micro_f1_score` | `ImportError` |
| `bhtc.yaml` | `bhtc_v2` | `utils.micro_f1_score` | `ImportError` |
| `coref.yaml` | `epec_koref_bin` | `utils.coref_doc_to_text` | `ImportError` |
| `vaxx.yaml` | `vaxx_stance` | `utils.vaxx_f1_score` | `ImportError` |
| `wic.yaml` | `wiceu` | `utils.process_wic_docs` | `ImportError` |
| `qnli.yaml` | `qnlieu` | — | loads |

```
ImportError: cannot import name 'load_metric' from 'datasets'
```

Note that `coref` and `wic` do not use the F1 metric at all; they break only because the dead import sits at the top of the module they share.

## Modifications

Load the metric with `evaluate`, which is the same move #2351 made for `squadv2`, with the import inside the function as that fix and `kobest/utils.py` do. The metric and every `compute()` argument are unchanged, so scores are unaffected.

## Test

Loading each YAML through `lm_eval.tasks._yaml_loader.load_yaml`:

```
before: bec/bhtc/coref/vaxx/wic -> ImportError, qnli -> OK
after:  all six load
```

`ruff check` reports the same 2 pre-existing `B905` in this file before and after, so nothing new is introduced; `ruff format` is clean.

I could not exercise `evaluate.load("f1")` itself here (no network to the hub in this environment), but it is the loader already used at 17 call sites in `lm_eval/tasks/`, and `evaluate` is a core dependency. If you would rather not download a metric during scoring, `scikit-learn` is also a core dependency and `kobest/utils.py` computes its F1 with `sklearn.metrics.f1_score` directly — happy to switch to that instead.
