### PR TITLE
fix(tasks): duplicate keys in task YAMLs

### DIFF
--- a/lm_eval/tasks/evalita_llm/_evalita-mp_ner-fic_group_p1.yaml
+++ b/lm_eval/tasks/evalita_llm/_evalita-mp_ner-fic_group_p1.yaml
@@ -1,15 +1,11 @@
 include: _ner_template_yaml
 dataset_name: fic
 test_split: reduced_test
-test_split: dev
 fewshot_split: dev
 task_alias: prompt-1
 tag: evalita-mp_ner-v2_tasks_fic
 task: evalita-mp_ner-v2_fic_p1
 
-#
-doc_to_target: !function utils.filter_per_entities_from_lines
-doc_to_target: entities
 
 # English
 #doc_to_text: "Given the following text, write the entity mentions in the text, indicating their type: [PER] (person), [LOC] (location), [ORG] (organization). Respond with the following format: Entity$Type. Separate each entity-type pair with the '%' character. Text: {{text}}"

--- a/lm_eval/tasks/tinyBenchmarks/tinyGSM8k.yaml
+++ b/lm_eval/tasks/tinyBenchmarks/tinyGSM8k.yaml
@@ -27,7 +27,6 @@ generation_kwargs:
   do_sample: false
   temperature: 0.0
 repeats: 1
-num_fewshot: 5
 filter_list:
   - name: "strict-match"
     filter:

--- a/lm_eval/tasks/tinyBenchmarks/tinyMMLU.yaml
+++ b/lm_eval/tasks/tinyBenchmarks/tinyMMLU.yaml
@@ -10,7 +10,6 @@ output_type: multiple_choice
 doc_to_text: "{{input_formatted}}"
 doc_to_choice: ["A", "B", "C", "D"]
 doc_to_target: answer
-num_fewshot: 0
 metric_list:
   - metric: acc_norm
     aggregation: !function agg_functions.agg_gpirt_mmlu

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_canonical.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_canonical.yaml
@@ -6,4 +6,3 @@ metadata:
   num_samples: 21
   task_pretty_name: Canonical
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_chinese.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_chinese.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: Chinese
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_decorative_unicode.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_decorative_unicode.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: "Decorative Unicode"
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_farsi.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_farsi.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: Farsi
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_italian.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_italian.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: Italian
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_latex.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_latex.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: LaTeX
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_space_removal.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_space_removal.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: "Space removal"
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_spelled_out.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_spelled_out.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: "Spelled out"
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_turkish.yaml
+++ b/lm_eval/tasks/toksuite/toksuite_math/toksuite_math_turkish.yaml
@@ -6,4 +6,3 @@ metadata:
   task_pretty_name: Turkish
   num_samples: 21
   version: 1.0.2
-  canonical_task: toksuite_math_canonical

--- a/lm_eval/tasks/turblimp/turblimp_group.yaml
+++ b/lm_eval/tasks/turblimp/turblimp_group.yaml
@@ -20,7 +20,6 @@ aggregate_metric_list:
   - metric: acc
     aggregation: mean
     weight_by_size: false
-aggregate_metric_list:
   - metric: acc_norm
     aggregation: mean
     weight_by_size: false

--- a/lm_eval/tasks/zhoblimp/zhoblimp_group.yaml
+++ b/lm_eval/tasks/zhoblimp/zhoblimp_group.yaml
@@ -122,7 +122,6 @@ aggregate_metric_list:
   - metric: acc
     aggregation: mean
     weight_by_size: false
-aggregate_metric_list:
   - metric: acc_norm
     aggregation: mean
     weight_by_size: false

--- a/tests/test_task_yaml_duplicate_keys.py
+++ b/tests/test_task_yaml_duplicate_keys.py
@@ -1,0 +1,53 @@
+"""A task YAML must not declare the same key twice.
+
+PyYAML keeps the last value and reports nothing, so a repeated key drops
+configuration silently: `turblimp_group.yaml` and `zhoblimp_group.yaml` lost
+their entire `acc` aggregate metric that way. An overridden `!function` is
+worse than silent, because the tag is still resolved while the document is
+parsed, so a stale reference raises even though the line it sits on is dead.
+"""
+
+import collections
+from pathlib import Path
+
+import yaml
+
+
+TASKS_DIR = Path(__file__).parent.parent / "lm_eval" / "tasks"
+
+
+def _duplicate_keys(node: yaml.Node) -> set[str]:
+    """Keys declared more than once in the same mapping, at any depth."""
+    duplicates: set[str] = set()
+    pending = [node]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, yaml.MappingNode):
+            counts = collections.Counter(key.value for key, _ in current.value)
+            duplicates.update(key for key, count in counts.items() if count > 1)
+            pending.extend(value for _, value in current.value)
+        elif isinstance(current, yaml.SequenceNode):
+            pending.extend(current.value)
+    return duplicates
+
+
+def test_no_task_yaml_declares_a_key_twice():
+    offenders = {}
+    for path in sorted(TASKS_DIR.rglob("*.yaml")):
+        with path.open(encoding="utf-8") as handle:
+            try:
+                # compose() builds nodes without constructing objects, so
+                # `!function` targets are never imported and a task's optional
+                # dependencies do not have to be installed to run this.
+                document = yaml.compose(handle, Loader=yaml.SafeLoader)
+            except yaml.YAMLError:
+                continue  # malformed yaml is not this test's concern
+        if document is None:
+            continue
+        duplicates = _duplicate_keys(document)
+        if duplicates:
+            offenders[str(path.relative_to(TASKS_DIR))] = sorted(duplicates)
+
+    assert not offenders, "duplicate keys silently drop config:\n" + "\n".join(
+        f"  {name}: {', '.join(keys)}" for name, keys in sorted(offenders.items())
+    )


### PR DESCRIPTION
## What

Fourteen task YAMLs declare the same key twice. PyYAML keeps the last value and reports nothing, so the earlier one is dropped silently.

## The three tiers

**1. Breaks loading — `evalita_llm/_evalita-mp_ner-fic_group_p1.yaml`**

```yaml
test_split: reduced_test
test_split: dev
...
doc_to_target: !function utils.filter_per_entities_from_lines
doc_to_target: entities
```

`utils.filter_per_entities_from_lines` does not exist. An overridden `!function` is still resolved while the document is parsed, so the dead line raises anyway:

```
AttributeError: Module '.../evalita_llm/utils.py' has no function 'filter_per_entities_from_lines'
```

`evalita-mp_ner-v2_fic_p1` therefore cannot be loaded at all on current `main`. The repeated `test_split` also leaves it on `dev`, where its siblings `adg_p1`, `wn_p1` and `fic_p2` all use `reduced_test`, and the surviving `doc_to_target: entities` overrides the `_ner_template_yaml` value that those siblings inherit.

Both duplicated keys are removed, so the file matches its siblings. With `resolve_func=False` it now differs from `adg_p1` only in `dataset_name`, `tag` and `task`; with `resolve_func=True` it fails exactly where `adg_p1` does in an environment missing the task's optional deps, rather than on its own dead reference.

**2. Drops configuration — `turblimp/turblimp_group.yaml`, `zhoblimp/zhoblimp_group.yaml`**

```yaml
aggregate_metric_list:
  - metric: acc
    ...
aggregate_metric_list:
  - metric: acc_norm
    ...
```

The `acc` entry is discarded, so these groups only ever aggregate `acc_norm`:

```
before: aggregate_metric_list -> ['acc_norm']
after:  aggregate_metric_list -> ['acc', 'acc_norm']
```

Both benchmarks' `_template_yaml` declares `acc` and `acc_norm` as a single two-entry `metric_list`, so the group now mirrors the tasks it aggregates. This changes what the group reports (it gains an aggregated `acc`); the per-task numbers are untouched, since `acc` was already being computed. Say the word if you would rather have a `metadata: version` bump alongside it.

**3. No effect, same value twice**

`tinyBenchmarks/tinyGSM8k.yaml` and `tinyMMLU.yaml` repeat `num_fewshot` (5 and 0), and nine `toksuite_math` YAMLs repeat `metadata.canonical_task`. Both copies carry identical values, so the resolved config is unchanged — verified before and after.

## Test

`tests/test_task_yaml_duplicate_keys.py` walks every task YAML with `yaml.compose`, which builds nodes without constructing objects, so `!function` targets are never imported and no task's optional dependencies are needed to run it. It checks nested mappings too, which is how the nine `toksuite` cases inside `metadata` show up.

```
on main:       1 failed  (lists all 14 files and the duplicated keys)
with this PR:  1 passed in 10.4s
```

`pre-commit run --files` passes on all fifteen changed files with the pinned hook versions.
