### PR TITLE
fix(tasks): raise instead of exiting the process from task code

### DIFF
--- a/lm_eval/tasks/score/utils.py
+++ b/lm_eval/tasks/score/utils.py
@@ -17,12 +17,9 @@ import json
 import logging
 import re
 import string
-import sys
-from functools import partial
 from itertools import combinations
-from typing import Any, Dict, List
+from typing import Any
 
-import numpy as np
 from datasets import Dataset
 
 
@@ -49,9 +46,10 @@ def process_docs_add_prompts(
     try:
         with open(template_file_path) as f:
             prompt_templates = json.load(f)[templates_key]
-    except FileNotFoundError:
-        eval_logger.error("Prompt templates not found")
-        sys.exit()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Prompt templates not found: {template_file_path}"
+        ) from exc
     if dataset_specific_preprocess is not None:
         doc = dataset_specific_preprocess(doc)
 
@@ -83,9 +81,10 @@ def option_order_robustness_process_docs(
             prompt_template = json.load(f)[templates_key]
             prompt = prompt_template["prompt"]
             options_format = prompt_template["options_format"]
-    except FileNotFoundError:
-        eval_logger.error("Prompt templates not found")
-        sys.exit()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Prompt templates not found: {template_file_path}"
+        ) from exc
 
     if dataset_specific_preprocess is not None:
         doc = dataset_specific_preprocess(doc)
@@ -143,9 +142,10 @@ def non_greedy_robustness_process_docs(
             prompt_template = json.load(f)[templates_key]
             prompt = prompt_template["prompt"]
             options_format = prompt_template.get("options_format", None)
-    except FileNotFoundError:
-        eval_logger.error("Prompt templates not found")
-        sys.exit()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Prompt templates not found: {template_file_path}"
+        ) from exc
 
     if dataset_specific_preprocess is not None:
         doc = dataset_specific_preprocess(doc)
@@ -217,7 +217,7 @@ def translate_model_answer_to_labels(answer, labels, option_format=None):
     return answer
 
 
-def calculate_consistency_rate(responses: List[List[str]]) -> float:
+def calculate_consistency_rate(responses: list[list[str]]) -> float:
     """
     Calculate the Consistency Rate (CR) for a given set of responses.
 
@@ -240,7 +240,7 @@ def calculate_consistency_rate(responses: List[List[str]]) -> float:
     return total_similarity / total_combinations if total_combinations > 0 else 0.0
 
 
-def prompt_consistency_rate(results: List[Dict[str, Any]]) -> float:
+def prompt_consistency_rate(results: list[dict[str, Any]]) -> float:
     """
     Calculate the Consistency Rate (CR) for a given set of responses.
 
@@ -263,7 +263,7 @@ def prompt_consistency_rate(results: List[Dict[str, Any]]) -> float:
     return calculate_consistency_rate(question_answers_list)
 
 
-def options_consistency_rate(results: List[Dict[str, Any]], labels) -> float:
+def options_consistency_rate(results: list[dict[str, Any]], labels) -> float:
     """
     Calculate the Consistency Rate (CR) for a given set of responses.
 

--- a/lm_eval/tasks/slr_bench/lm_eval_slr_bench.py
+++ b/lm_eval/tasks/slr_bench/lm_eval_slr_bench.py
@@ -1,12 +1,11 @@
 import shutil
-import sys
 
 from evaluate import load
 
 
 if shutil.which("swipl") is None:
-    sys.exit(
-        "Error: SWI-Prolog (swipl) is not installed or not in PATH. Please install SWI-Prolog to use this task."
+    raise RuntimeError(
+        "SWI-Prolog (swipl) is not installed or not in PATH. Please install SWI-Prolog to use this task."
     )
 
 try:


### PR DESCRIPTION
## What

Two task modules end the caller's process instead of raising.

## `lm_eval/tasks/score/utils.py` — exits with status 0 on an error

Three copies of:

```python
except FileNotFoundError:
    eval_logger.error("Prompt templates not found")
    sys.exit()
```

`sys.exit()` with no argument exits with status **0**, so a missing prompt template ends the run and reports success. Anything reading the exit code — a shell script, a sweep runner, CI — sees a clean pass with no results.

Calling `process_docs_add_prompts` with a template path that does not exist:

```
before: returncode=0   stderr: Prompt templates not found
after:  returncode=1   stderr: FileNotFoundError: Prompt templates not found:
                               /nonexistent/prompt_templates.json
```

`TEMPLATE_FILE_PATH` is built from `os.path.dirname(__file__)` and `prompt_templates.json` ships via `package-data`, so this is a defensive branch rather than something users hit in a normal install — but an error path that reports success is worse than no error path, and the raise costs nothing.

## `lm_eval/tasks/slr_bench/lm_eval_slr_bench.py` — `SystemExit` at import

```python
if shutil.which("swipl") is None:
    sys.exit("Error: SWI-Prolog (swipl) is not installed or not in PATH. ...")
```

`slr_bench_common_yaml` resolves `process_results: !function lm_eval_slr_bench.process_results`, so loading any of the five slr_bench tasks imports this module. `SystemExit` derives from `BaseException`, so it passes straight through `except Exception` and terminates whatever is walking the task tree:

```
>>> TaskManager().load(["slr_bench_easy"])
before: SystemExit: Error: SWI-Prolog (swipl) is not installed or not in PATH...
        isinstance(e, Exception) -> False
after:  RuntimeError: SWI-Prolog (swipl) is not installed or not in PATH...
```

Every other missing-dependency guard in `lm_eval/tasks` raises (`ModuleNotFoundError`, `ImportError`); this is the only one that exits. `RuntimeError` rather than `ModuleNotFoundError` because the missing thing is an external binary, not an importable module — happy to change it if you would rather it match the module guards exactly.

## Test

- The two before/after transcripts above.
- Running `ruff check` over both files reports the **identical** set of pre-existing violations before and after, so nothing new is introduced; `ruff format` is clean. `import sys` is dropped from both files because it becomes unused.
- Message wording is unchanged apart from dropping the redundant `Error: ` prefix, which a raised exception already conveys, and adding the template path that the log line did not carry.
