### PR TITLE
fix(metrics): median rounds up, acc_all_stderr groups by the wrong key

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -3,6 +3,7 @@ import math
 import os
 import random
 import re
+import statistics
 import string
 from collections.abc import Iterable
 from typing import Callable, List, Optional, Sequence, TypeVar
@@ -38,7 +39,9 @@ def mean(arr):
 
 @register_aggregation("median")
 def median(arr):
-    return sorted(arr)[len(arr) // 2]
+    # statistics.median averages the two middle values for an even-sized sample;
+    # indexing at len(arr) // 2 returns the upper one instead.
+    return statistics.median(arr)
 
 
 # Certain metrics must be calculated across all documents in a benchmark.
@@ -439,18 +442,22 @@ def acc_all(items):
 
 
 def acc_all_stderr(items):
-    # Only count as correct if all answers are labeled correctly for each question
+    # Only count as correct if all answers are labeled correctly for each question.
+    # Key on (paragraph, question) exactly as acc_all does: question indices restart
+    # inside every paragraph, so keying on the question alone merges answers from
+    # unrelated paragraphs and describes a different population than the metric.
     question_scoring_dict = {}
     preds = list(zip(*items))[0]
     docs = list(zip(*items))[1]
 
     for doc, pred in zip(docs, preds):
+        paragraph_id = doc["idx"]["paragraph"]
         question_id = doc["idx"]["question"]
-        if question_id not in question_scoring_dict:
-            question_scoring_dict[question_id] = []
+        if (paragraph_id, question_id) not in question_scoring_dict:
+            question_scoring_dict[(paragraph_id, question_id)] = []
 
         gold_label = doc["label"] == 1
-        question_scoring_dict[question_id].append(gold_label == pred)
+        question_scoring_dict[(paragraph_id, question_id)].append(gold_label == pred)
 
     acc = mean_stderr([int(all(x)) for x in question_scoring_dict.values()])
     return acc

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -253,6 +253,78 @@ def test_chrfpp_perfect_match():
     assert chrfpp(items) == 100.0
 
 
+def test_median_averages_the_two_middle_values():
+    """An even-sized sample has no single middle element."""
+    import statistics
+
+    from lm_eval.api.metrics import median
+
+    for arr in ([0.0, 1.0], [1, 2, 3, 4], [1, 2, 3], [0, 0, 0, 1], [5]):
+        assert median(arr) == statistics.median(arr)
+
+
+def _multirc_item(paragraph, question, answer, label, pred):
+    doc = {
+        "idx": {"paragraph": paragraph, "question": question, "answer": answer},
+        "label": label,
+    }
+    return pred, doc
+
+
+def _multirc_items():
+    """Four paragraphs, two questions each, two answers each; one answer wrong.
+
+    Question indices restart inside every paragraph, which is what separates the
+    two groupings.
+    """
+    items = []
+    for paragraph in range(4):
+        for question in range(2):
+            for answer in range(2):
+                label = 1 if answer == 0 else 0
+                pred = label == 1
+                if (paragraph, question, answer) == (0, 0, 1):
+                    pred = not pred
+                items.append(_multirc_item(paragraph, question, answer, label, pred))
+    return items
+
+
+def test_acc_all_stderr_groups_the_same_way_as_acc_all():
+    """The stderr must describe the population its own metric scores.
+
+    Keyed on the question alone the four paragraphs collapse into two groups and
+    the stderr comes out four times too large.
+    """
+    from lm_eval.api.metrics import acc_all, acc_all_stderr, mean_stderr
+
+    items = _multirc_items()
+    groups = {}
+    for pred, doc in items:
+        key = (doc["idx"]["paragraph"], doc["idx"]["question"])
+        groups.setdefault(key, []).append((doc["label"] == 1) == pred)
+    expected = mean_stderr([int(all(scores)) for scores in groups.values()])
+
+    assert len(groups) == 8
+    assert acc_all(items) == 0.875
+    assert acc_all_stderr(items) == expected == 0.125
+
+
+def test_acc_all_stderr_survives_one_question_index_per_paragraph():
+    """Keyed on the question alone this collapsed to a single group, and
+    `mean_stderr` then divided by `len(arr) - 1`.
+    """
+    from lm_eval.api.metrics import acc_all_stderr
+
+    items = [
+        _multirc_item(0, 0, 0, 1, True),
+        _multirc_item(0, 0, 1, 0, False),
+        _multirc_item(1, 0, 0, 1, True),
+        _multirc_item(1, 0, 1, 0, False),
+    ]
+
+    assert acc_all_stderr(items) == 0.0
+
+
 if __name__ == "__main__":
     test_acc_mutual_info_slicing()
     test_acc_mutual_info_different_predictions()


### PR DESCRIPTION
## What

Two registered helpers in `lm_eval/api/metrics.py` compute something other than what they claim.

### `median` returns the upper middle value

```python
@register_aggregation("median")
def median(arr):
    return sorted(arr)[len(arr) // 2]
```

For an even-sized sample there is no single middle element:

```
median([0.0, 1.0]) -> 1.0     statistics.median -> 0.5
median([1, 2, 3, 4]) -> 3     statistics.median -> 2.5
```

`median` is also in the `bootstrappable` list in `stderr_for_metric`, so the bootstrap stderr inherits the same skew.

### `acc_all_stderr` groups by a different key than `acc_all`

`acc_all` keys its per-question groups on `(paragraph, question)`; `acc_all_stderr` keys them on `question` alone. MultiRC numbers questions from zero inside each paragraph, so the stderr is computed over a different — and much smaller — population than the metric it belongs to.

Four paragraphs, two questions each, two answers each, one answer wrong:

```
(paragraph, question) groups: 8      question-only groups: 2
acc_all                     : 0.875
acc_all_stderr              : 0.5      <- four times too large
stderr over acc_all's own grouping: 0.125
```

And when every paragraph reuses the same question indices, the collapse leaves a single group, `mean_stderr` divides by `len(arr) - 1`, and the call raises instead of returning a number:

```
>>> acc_all_stderr(items)   # 2 paragraphs, question index 0 in both
ZeroDivisionError: float division by zero
```

## Blast radius

None in-tree. `aggregation: median` appears in no `metric_list` (`AggMetricConfig` rejects it as a group aggregation too), and no task registers `acc_all`. Both are public, registered names that a task using `--include_path` can select, which is why they are worth having right rather than deleting.

## Test

Three tests added to `tests/test_metrics.py`; all three fail on `main` and pass with this change:

```
on main:      3 failed, 8 passed   (one of them by raising ZeroDivisionError)
with this PR: 11 passed
```

Against the full CI dependency set (`.[dev,unitxt,hf]`, Python 3.10), running the unit-test job's selection locally:

```
main:         51 failed, 659 passed, 44 skipped, 4 errors
with this PR: 51 failed, 662 passed, 44 skipped, 4 errors
```

with a byte-identical failure/error set — the +3 are the new tests. Every one of those 51 is a `huggingface.co` connection error in my sandbox, not a code failure.

`ruff check` reports the identical set of pre-existing violations on both files before and after, so nothing new is introduced; `ruff format` is clean. Those pre-existing ones will light up Linters because pre-commit runs over whatever a PR touches — happy to clean them here or separately, whichever you prefer.
