### PR TITLE
feat(tasks): add zero-shot CoT variants for MedMCQA and MedQA

### DIFF
--- a/lm_eval/tasks/medmcqa/medmcqa_cot_zeroshot.yaml
+++ b/lm_eval/tasks/medmcqa/medmcqa_cot_zeroshot.yaml
@@ -1,0 +1,28 @@
+task: medmcqa_cot_zeroshot
+dataset_path: openlifescienceai/medmcqa
+output_type: generate_until
+training_split: train
+validation_split: validation
+test_split: validation
+doc_to_text: !function utils_medmcqa.doc_to_text_cot
+doc_to_target: !function utils_medmcqa.doc_to_target_cot
+should_decontaminate: true
+doc_to_decontamination_query: "{{question}}"
+generation_kwargs:
+  until:
+    - "<eos>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 512
+filter_list:
+  - name: "regex-extractor"
+    filter:
+      - function: "regex"
+        regex_pattern: "Final Answer:\\s*(?:\\*\\*)?\\s*([A-D])"
+      - function: "take_first"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true

--- a/lm_eval/tasks/medmcqa/utils_medmcqa.py
+++ b/lm_eval/tasks/medmcqa/utils_medmcqa.py
@@ -22,3 +22,23 @@ def doc_to_text(doc) -> str:
         prompt += f"{choice.upper()}. {option}\n"
     prompt += "Answer:"
     return prompt
+
+def doc_to_text_cot(doc) -> str:
+    choices = [doc["opa"], doc["opb"], doc["opc"], doc["opd"]]
+    option_choices = {
+        "A": choices[0],
+        "B": choices[1],
+        "C": choices[2],
+        "D": choices[3],
+    }
+
+    prompt = "Question: " + doc["question"] + "\nChoices:\n"
+    for choice, option in option_choices.items():
+        prompt += f"{choice.upper()}. {option}\n"
+    
+    prompt += "First, think step-by-step. End your response with exactly this format:\nFinal Answer: X\n(where X is A, B, C, or D)."
+    return prompt
+
+def doc_to_target_cot(doc) -> str:
+    choices = ["A", "B", "C", "D"]
+    return choices[int(doc["cop"])]

--- a/lm_eval/tasks/medqa/medqa_4options_cot_zeroshot.yaml
+++ b/lm_eval/tasks/medqa/medqa_4options_cot_zeroshot.yaml
@@ -1,0 +1,26 @@
+task: medqa_4options_cot_zeroshot
+dataset_path: GBaker/MedQA-USMLE-4-options-hf
+output_type: generate_until
+training_split: train
+validation_split: validation
+test_split: test
+doc_to_text: !function preprocess_medqa.doc_to_text_cot
+doc_to_target: !function preprocess_medqa.doc_to_target_cot
+generation_kwargs:
+  until:
+    - "<eos>"
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 512
+filter_list:
+  - name: "regex-extractor"
+    filter:
+      - function: "regex"
+        regex_pattern: "Final Answer:\\s*(?:\\*\\*)?\\s*([A-D])"
+      - function: "take_first"
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true

--- a/lm_eval/tasks/medqa/preprocess_medqa.py
+++ b/lm_eval/tasks/medqa/preprocess_medqa.py
@@ -11,3 +11,20 @@ def doc_to_text(doc) -> str:
 
 def doc_to_target(doc) -> int:
     return doc["label"]
+
+def doc_to_text_cot(doc) -> str:
+    option_choices = {
+        "A": doc["ending0"],
+        "B": doc["ending1"],
+        "C": doc["ending2"],
+        "D": doc["ending3"],
+    }
+    answers = "".join((f"{k}. {v}\n") for k, v in option_choices.items())
+    
+    prompt = f"Question: {doc['sent1']}\n{answers}"
+    prompt += "First, think step-by-step. End your response with exactly this format:\nFinal Answer: X\n(where X is A, B, C, or D)."
+    return prompt
+
+def doc_to_target_cot(doc) -> str:
+    choices = ["A", "B", "C", "D"]
+    return choices[int(doc["label"])]


### PR DESCRIPTION
### Motivation

`medmcqa` and `medqa_4options` are `multiple_choice` tasks, scored by ranking the
log-likelihood of each option. This under-reports instruction-tuned models, which
are trained to reason before answering and can't do that under loglikelihood
ranking.

Reproducing Google's reported numbers for `google/medgemma-4b-it`:

| Setup | medmcqa | medqa_4options |
|---|---:|---:|
| `multiple_choice` (existing task) | 0.5190 | 0.5522 |
| **zero-shot CoT (this PR)** | **0.5596** | **0.6551** |
| Google's reported numbers | 0.5570 | 0.6440 |

The existing task falls well short on medqa_4options; with CoT both tasks land
within stderr of the published values.

### Changes

New tasks, following the `*_cot_zeroshot` convention used by `gsm8k_cot_zeroshot`:

- `medmcqa_cot_zeroshot`
- `medqa_4options_cot_zeroshot`

Both are `generate_until` with greedy decoding, a `regex-extractor` filter for a
`Final Answer: X` line (tolerating `**` bolding), and `exact_match` as the metric.

Supporting helpers added alongside the existing ones: `doc_to_text_cot` and
`doc_to_target_cot` in `utils_medmcqa.py` and `preprocess_medqa.py`. The `_cot`
targets return the answer letter as a string rather than the integer index, to
match what the filter extracts.

No existing task or config is modified.

### Reproduction

```shell
lm-eval run \
  --model vllm \
  --model_args pretrained=google/medgemma-4b-it,tensor_parallel_size=2,dtype=bfloat16 \
  --tasks medmcqa_cot_zeroshot,medqa_4options_cot_zeroshot \
  --apply_chat_template \
  --batch_size auto \
  --log_samples
```

### Open question

`until` is currently `["<eos>"]`, which is Gemma-specific. Harmless elsewhere, but
happy to drop it if you'd prefer these configs stay family-agnostic.