### PR TITLE
feat(plugins): record plugin provenance in results env metadata

### DIFF
--- a/lm_eval/api/registry.py
+++ b/lm_eval/api/registry.py
@@ -185,6 +185,20 @@ def _build_key_error_msg(name: str, alias: str, keys: Iterable[str]) -> str:
 
 _loaded_plugin_groups: set[str] = set()
 
+# Entry-point plugins (group, alias) whose component was actually materialized by
+# name during this process. Feeds run provenance (see collect_plugin_provenance).
+_used_plugins: set[tuple[str, str]] = set()
+
+# Entry-point groups that carry lm-eval plugins, used to enumerate the installed
+# snapshot for provenance.
+_PLUGIN_GROUPS: tuple[str, ...] = (
+    "lm_eval.models",
+    "lm_eval.filters",
+    "lm_eval.metrics",
+    "lm_eval.aggregations",
+    "lm_eval.tasks",
+)
+
 
 def load_plugins(group: str, registry: Registry) -> list[str]:
     """Register external components advertised via setuptools entry points.
@@ -222,10 +236,14 @@ def load_plugins(group: str, registry: Registry) -> list[str]:
 
     for ep in entry_points:
         if ep.name in registry:
-            eval_logger.debug(
-                "Plugin alias '%s' (group '%s') ignored; already registered.",
+            winner = registry.origin(ep.name) or "a built-in component"
+            eval_logger.warning(
+                "Plugin '%s' (group '%s', %s) is shadowed by %s already registered "
+                "under that name; the plugin will not be used.",
                 ep.name,
                 group,
+                ep.value,
+                winner,
             )
             continue
         # Registration is lazy: it stores the EntryPoint without importing the
@@ -265,6 +283,44 @@ def import_plugins(module_names: Iterable[str] | None) -> None:
             eval_logger.info("Imported plugin module '%s'.", name)
         except Exception as exc:  # noqa: BLE001 - tolerate bad plugin names
             eval_logger.warning("Failed to import plugin module '%s': %s", name, exc)
+
+
+def collect_plugin_provenance() -> dict[str, dict[str, dict[str, Any]]]:
+    """Snapshot the installed entry-point plugins for run provenance.
+
+    Enumerates every ``lm_eval.*`` entry-point group and records each installed
+    plugin, so a run traces its plugin environment and a stale or unexpected
+    plugin is visible in the results metadata. Enumeration does not import the
+    plugin, so this is cheap and side-effect free. Each entry is flagged
+    ``used=True`` only when its component was actually materialized by name during
+    this run (see ``Registry.get``).
+
+    Returns:
+        ``{short_group: {alias: {"target", "dist", "used"}}}`` where ``short_group``
+        is the group name without the ``lm_eval.`` prefix (e.g. ``"models"``).
+        Groups with no installed plugins are omitted; ``{}`` when none are found.
+    """
+    provenance: dict[str, dict[str, dict[str, Any]]] = {}
+    for group in _PLUGIN_GROUPS:
+        short = group.removeprefix("lm_eval.")
+        try:
+            entry_points = md.entry_points(group=group)
+        except Exception as exc:  # noqa: BLE001 - provenance must never break a run
+            eval_logger.debug(
+                "Could not enumerate entry points for '%s': %s", group, exc
+            )
+            continue
+        for ep in entry_points:
+            dist = getattr(ep, "dist", None)
+            dist_label = None
+            if dist is not None and getattr(dist, "name", None):
+                dist_label = f"{dist.name} {dist.version}".strip()
+            provenance.setdefault(short, {})[ep.name] = {
+                "target": ep.value,
+                "dist": dist_label,
+                "used": (group, ep.name) in _used_plugins,
+            }
+    return provenance
 
 
 class Registry(Generic[T]):
@@ -429,6 +485,10 @@ class Registry(Generic[T]):
                 # Re‑check under lock (another thread might have resolved it)
                 fresh = self._objs[alias]
                 if isinstance(fresh, (str, md.EntryPoint)):
+                    # An EntryPoint (not a built-in "module:obj" string) means a
+                    # plugin is being resolved by name; record it for provenance.
+                    if isinstance(fresh, md.EntryPoint):
+                        _used_plugins.add((fresh.group, alias))
                     concrete = self._materialise(fresh)
                     # Only update if not frozen (MappingProxyType)
                     if not isinstance(self._objs, MappingProxyType):

--- a/lm_eval/loggers/utils.py
+++ b/lm_eval/loggers/utils.py
@@ -76,9 +76,9 @@ def get_commit_from_path(repo_path: Path | str) -> str | None:
             git_hash = head_ref.read_text(encoding="utf-8").replace("\n", "")
         else:
             git_hash = None
-    except Exception as err:
+    except Exception as err:  # noqa: BLE001 - git hash is best-effort metadata
         logger.debug(
-            f"Failed to retrieve a Git commit hash from path: {str(repo_path)}. Error: {err}"
+            f"Failed to retrieve a Git commit hash from path: {repo_path!s}. Error: {err}"
         )
         return None
     return git_hash
@@ -106,14 +106,14 @@ def add_env_info(storage: dict[str, Any]):
             from torch.utils.collect_env import get_pretty_env_info
 
             pretty_env_info = get_pretty_env_info()
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - env dump is best-effort metadata
             pretty_env_info = str(err)
     else:
         pretty_env_info = "N/A (torch not installed)"
 
     try:
         lm_eval_version = version("lm_eval")
-    except Exception as err:
+    except Exception as err:  # noqa: BLE001 - version lookup is best-effort metadata
         lm_eval_version = str(err)
 
     if is_transformers_available():
@@ -123,11 +123,14 @@ def add_env_info(storage: dict[str, Any]):
     upper_dir_commit = get_commit_from_path(
         Path(os.getcwd(), "..")
     )  # git hash of upper repo if exists
+    from lm_eval.api.registry import collect_plugin_provenance
+
     added_info = {
         "pretty_env_info": pretty_env_info,
         "transformers_version": transformers_version,
         "lm_eval_version": lm_eval_version,
         "upper_git_hash": upper_dir_commit,  # in case this repo is submodule
+        "plugins": collect_plugin_provenance(),  # installed plugins, used flagged
     }
     storage.update(added_info)
 
@@ -153,7 +156,7 @@ def add_tokenizer_info(storage: dict[str, Any], lm):
                     "max_length": getattr(lm, "max_length", None),
                 }
                 storage.update(tokenizer_info)
-            except Exception as err:
+            except Exception as err:  # noqa: BLE001 - tokenizer info is best-effort
                 logger.debug(
                     f"Logging detailed tokenizer info failed with {err}, skipping..."
                 )
@@ -162,5 +165,5 @@ def add_tokenizer_info(storage: dict[str, Any], lm):
             logger.debug(
                 "LM does not have a 'tokenizer' attribute, not logging tokenizer metadata to results."
             )
-    except Exception:
+    except Exception:  # noqa: BLE001 - tokenizer info is best-effort
         logger.debug("Couldn't save tokenizer info.")

--- a/lm_eval/result_schema.py
+++ b/lm_eval/result_schema.py
@@ -59,6 +59,10 @@ EvalResults = TypedDict(
         "lm_eval_version": str,
         # Git hash of the parent repo, if this repo is a submodule.
         "upper_git_hash": str | None,
+        # Installed entry-point plugins, grouped by kind (models, filters,
+        # metrics, aggregations, tasks). Each entry is {target, dist, used},
+        # where "used" is True only if that plugin was resolved by name this run.
+        "plugins": dict[str, dict[str, dict[str, Any]]],
         # --- Tokenizer info (added by add_tokenizer_info()) ---
         #
         # Pad token and its ID as [token, token_id].

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -16,7 +16,7 @@ from lm_eval.api.registry import (
 _FAKE_MODULE = "lm_eval_fake_plugin_module"
 
 
-def _make_ep(name, obj, *, broken=False):
+def _make_ep(name, obj, *, broken=False, group="test"):
     """Build a real EntryPoint whose load() resolves against an in-memory module.
 
     Using a genuine md.EntryPoint (not a stub) ensures Registry.get() takes its
@@ -28,7 +28,7 @@ def _make_ep(name, obj, *, broken=False):
     if not broken:
         setattr(mod, attr, obj)
     return registry_mod.md.EntryPoint(
-        name=name, value=f"{_FAKE_MODULE}:{attr}", group="test"
+        name=name, value=f"{_FAKE_MODULE}:{attr}", group=group
     )
 
 
@@ -52,6 +52,7 @@ def _reset_plugin_state(monkeypatch):
     into each other regardless of ordering.
     """
     monkeypatch.setattr(registry_mod, "_loaded_plugin_groups", set())
+    monkeypatch.setattr(registry_mod, "_used_plugins", set())
     snapshots = {name: dict(getattr(registry_mod, name)._objs) for name in _REGISTRIES}
     yield
     for name, snapshot in snapshots.items():
@@ -115,16 +116,22 @@ def test_load_plugins_is_once_per_group(monkeypatch):
     assert load_plugins("lm_eval.things", reg) == []
 
 
-def test_load_plugins_does_not_override_builtin(monkeypatch):
+def test_load_plugins_does_not_override_builtin(monkeypatch, caplog):
     reg = Registry("thing")
     builtin = object()
     reg.register("taken", target="os:getcwd")  # pre-existing alias
     _patch_entry_points(monkeypatch, "lm_eval.things", [_make_ep("taken", builtin)])
 
-    discovered = load_plugins("lm_eval.things", reg)
+    with caplog.at_level("WARNING", logger="lm_eval.api.registry"):
+        discovered = load_plugins("lm_eval.things", reg)
 
     assert discovered == []  # collision skipped, not registered
     assert reg._objs["taken"] == "os:getcwd"
+    # The shadowed plugin is surfaced at WARNING so a silent clash leaves a trace.
+    assert any(
+        rec.levelname == "WARNING" and "taken" in rec.getMessage()
+        for rec in caplog.records
+    )
 
 
 def test_load_plugins_broken_entry_point_is_tolerated(monkeypatch):
@@ -375,3 +382,58 @@ def test_import_plugins_tolerates_bad_module():
 def test_import_plugins_noop_on_empty():
     import_plugins(None)
     import_plugins([])
+
+
+def test_collect_plugin_provenance_empty_when_none_installed(monkeypatch):
+    """No installed plugins -> empty snapshot (no crash, no keys)."""
+    from lm_eval.api.registry import collect_plugin_provenance
+
+    _patch_entry_points(monkeypatch, "lm_eval.models", [])  # every group empty
+    assert collect_plugin_provenance() == {}
+
+
+def test_collect_plugin_provenance_lists_installed_snapshot(monkeypatch):
+    """Every installed plugin appears, grouped by kind, regardless of use."""
+    from lm_eval.api.registry import collect_plugin_provenance
+
+    ep = _make_ep("plug-model", object(), group="lm_eval.models")
+    _patch_entry_points(monkeypatch, "lm_eval.models", [ep])
+
+    prov = collect_plugin_provenance()
+
+    assert "plug-model" in prov["models"]
+    entry = prov["models"]["plug-model"]
+    assert entry["target"] == ep.value
+    assert entry["used"] is False  # installed but not resolved this run
+
+
+def test_collect_plugin_provenance_flags_used_after_resolution(monkeypatch):
+    """A plugin is flagged used only once its component is materialized by name."""
+    from lm_eval.api.registry import collect_plugin_provenance
+
+    sentinel = object()
+    ep = _make_ep("plug-model", sentinel, group="lm_eval.models")
+    _patch_entry_points(monkeypatch, "lm_eval.models", [ep])
+
+    reg = Registry("model")
+    load_plugins("lm_eval.models", reg)
+    # Before resolution: installed, not used.
+    assert collect_plugin_provenance()["models"]["plug-model"]["used"] is False
+
+    # Resolving by name materializes the EntryPoint and records usage.
+    assert reg.get("plug-model") is sentinel
+    assert collect_plugin_provenance()["models"]["plug-model"]["used"] is True
+
+
+def test_provenance_reaches_results_env(monkeypatch):
+    """add_env_info writes the provenance snapshot into the results dict."""
+    from lm_eval.loggers.utils import add_env_info
+
+    ep = _make_ep("plug-model", object(), group="lm_eval.models")
+    _patch_entry_points(monkeypatch, "lm_eval.models", [ep])
+
+    results: dict = {}
+    add_env_info(results)
+
+    assert "plugins" in results
+    assert "plug-model" in results["plugins"]["models"]


### PR DESCRIPTION
## Motivation

Follow-ups from @baberabb's review on #4014 (both were flagged as non-blocking):

> 1. **Logging/provenance**: Right now discovery logs a one-line summary per entry-point group and nothing else, so if someone has a stale or unexpected plugin installed in their environment there's no trace of it in the run output. We should save it to the results metadata (we already have an `env` field).
> 3. **Tighter collision handling**: `load_plugins` currently skips an alias that's already registered and moves on at debug level. I think this could also be made a bit more transparent.

## What this PR does

**1. Plugin provenance in results `env` metadata.** A run now records an installed snapshot of every `lm_eval.*` entry-point plugin into the results metadata under a new `plugins` key (added by `add_env_info`, alongside `pretty_env_info` / `lm_eval_version`). The snapshot is grouped by kind (`models`, `filters`, `metrics`, `aggregations`, `tasks`); each entry is `{target, dist, used}`:

```json
"plugins": {
  "models": {
    "onnxruntime-genai": {
      "target": "lm_eval_onnx.models:ORTGenLM",
      "dist": "lm-eval-onnx 0.1.0",
      "used": true
    }
  }
}
```

- **Installed** = enumerated from entry points (import-free, so it also catches stale/unexpected plugins that were never resolved).
- **`used`** = `True` only when that plugin's component was actually materialized *by name* this run (recorded at the `EntryPoint` materialization point in `Registry.get`), so you can tell "installed" from "actually ran".

**2. Collision transparency.** `load_plugins` now logs a shadowed plugin at **WARNING** (naming the plugin target and the winning source) instead of DEBUG, so a plugin silently losing to a built-in name leaves a trace. Behavior is unchanged — built-ins still win.

## Validation

- New tests in `tests/test_plugins.py`: installed snapshot lists plugins; `used` flips only after resolution by name; provenance reaches the results dict via `add_env_info`; collision emits a WARNING.
- End-to-end with a real pip-installed entry-point plugin: confirmed the snapshot reports `used: false` when installed-but-unused and `used: true` after `--model <plugin>` resolves it, with the correct `dist` string.

Built on top of #4013 and #4014 (both merged).