### PR TITLE
fix(evaluator): preserve original doc IDs for unsorted --samples

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -624,9 +624,15 @@ def evaluate(
         # Sort instances within each group
         for instances in instances_by_doc_id.values():
             instances.sort(key=lambda x: x.idx)
+        indices = samples.get(task_name, None) if samples is not None else None
+        # doc_iterator enumerates selected documents in dataset order, not caller order.
+        selected_doc_ids = (
+            sorted(set(indices).intersection(range(len(task.eval_docs))))
+            if indices
+            else None
+        )
         # iterate over different filters used
         for filter_key in task.instances[0].filtered_resps:
-            indices = samples.get(task_name, None) if samples is not None else None
             doc_iterator = task.doc_iterator(
                 rank=RANK,
                 limit=limit,
@@ -634,7 +640,9 @@ def evaluate(
                 samples=indices,
             )
             for doc_id, doc in doc_iterator:
-                doc_id_true = indices[doc_id] if indices else doc_id
+                doc_id_true = (
+                    selected_doc_ids[doc_id] if selected_doc_ids is not None else doc_id
+                )
                 requests = instances_by_doc_id[doc_id]
                 metrics = task.process_results(
                     doc, [req.filtered_resps[filter_key] for req in requests]

--- a/tests/test_sample_logging.py
+++ b/tests/test_sample_logging.py
@@ -1,0 +1,110 @@
+import pytest
+
+from lm_eval import evaluator
+from lm_eval.api.instance import Instance
+from lm_eval.api.metrics import mean
+from lm_eval.api.task import Task
+from lm_eval.models.dummy import DummyLM
+
+
+class _SampleLoggingTask(Task):
+    OUTPUT_TYPE = "generate_until"
+
+    def download(self, *args, **kwargs) -> None:
+        self.dataset = {
+            "test": [
+                {"marker": index, "prompt": f"document {index}"} for index in range(10)
+            ]
+        }
+
+    def has_training_docs(self) -> bool:
+        return False
+
+    def has_validation_docs(self) -> bool:
+        return False
+
+    def has_test_docs(self) -> bool:
+        return True
+
+    def test_docs(self):
+        return self.dataset["test"]
+
+    def doc_to_text(self, doc) -> str:
+        return doc["prompt"]
+
+    def doc_to_target(self, doc) -> str:
+        return "lol"
+
+    def construct_requests(self, doc, ctx, metadata=None, **kwargs):
+        return Instance(
+            request_type="generate_until",
+            doc=doc,
+            arguments=(ctx, {"until": ["\n"]}),
+            idx=0,
+            metadata=metadata,
+        )
+
+    def process_results(self, doc, results):
+        return {"score": 1.0}
+
+    def aggregation(self):
+        return {"score": mean}
+
+    def higher_is_better(self):
+        return {"score": True}
+
+
+def _evaluate_sample_logging(samples: list[int]):
+    task = _SampleLoggingTask(config={"task": "sample_logging", "num_fewshot": 0})
+    task.set_fewshot_seed(0)
+    result = evaluator.evaluate(
+        lm=DummyLM(),
+        task_dict={"tasks": {"sample_logging": task}, "groups": {}},
+        samples={"sample_logging": samples},
+        bootstrap_iters=0,
+        log_samples=True,
+    )
+    assert result is not None
+    return task, result["samples"]["sample_logging"]
+
+
+@pytest.mark.parametrize("samples", [[5, 2, 9], [5, 2, 2, 9]])
+def test_unsorted_samples_log_original_document_ids(samples):
+    task, logged_samples = _evaluate_sample_logging(samples)
+
+    assert [
+        (sample["doc_id"], sample["doc"]["marker"]) for sample in logged_samples
+    ] == [(2, 2), (5, 5), (9, 9)]
+    assert [
+        (instance.doc_id, instance.doc["marker"]) for instance in task.instances
+    ] == [(0, 2), (1, 5), (2, 9)]
+
+
+def test_empty_samples_preserve_unfiltered_logging():
+    task, logged_samples = _evaluate_sample_logging([])
+
+    assert [
+        (sample["doc_id"], sample["doc"]["marker"]) for sample in logged_samples
+    ] == [(index, index) for index in range(10)]
+    assert [instance.doc_id for instance in task.instances] == list(range(10))
+
+
+def test_sample_iterator_preserves_global_ordinals_across_ranks():
+    task = _SampleLoggingTask(config={"task": "sample_logging", "num_fewshot": 0})
+    samples = [5, 2, 9]
+
+    rank_zero = list(task.doc_iterator(rank=0, world_size=2, samples=samples))
+    rank_one = list(task.doc_iterator(rank=1, world_size=2, samples=samples))
+
+    assert [(doc_id, doc["marker"]) for doc_id, doc in rank_zero] == [
+        (0, 2),
+        (2, 9),
+    ]
+    assert [(doc_id, doc["marker"]) for doc_id, doc in rank_one] == [(1, 5)]
+
+
+def test_out_of_range_sample_still_raises():
+    task = _SampleLoggingTask(config={"task": "sample_logging", "num_fewshot": 0})
+
+    with pytest.raises(AssertionError, match="interval"):
+        list(task.doc_iterator(samples=[10]))


### PR DESCRIPTION
## Summary

Addresses the sample-logging half of #4084 only. The separate request-cache-key issue remains out of scope.

When `--samples` receives a non-ascending list, `Task.doc_iterator()` filters documents in dataset order and assigns selected-subset ordinals, but logging previously mapped those ordinals through the caller's original list order. For `[5, 2, 9]`, the verified baseline logged `(reported doc_id, document marker)` as:

```text
[(5, 2), (2, 5), (9, 9)]
```

This change derives the effective selected IDs in the same canonical dataset order as the iterator and uses that mapping only for the logged `doc_id`. The patched result is:

```text
[(2, 2), (5, 5), (9, 9)]
```

Internal `Instance.doc_id` values remain the selected-subset ordinals `(0, 1, 2)`, so request grouping, distributed rank slicing, write-out behavior, and serialized request/cache compatibility are unchanged.

## Regression coverage

The provider-free in-memory regression covers:

- non-ascending IDs (`[5, 2, 9]`)
- duplicate IDs retaining evaluate-once behavior (`[5, 2, 2, 9]`)
- the existing empty-list/unfiltered behavior
- global selected-subset ordinals across two ranks
- the existing positive out-of-range assertion

## Validation

- `.venv/bin/python -m pytest -q tests/test_sample_logging.py tests/test_evaluator_utils.py tests/test_serialization.py` — 78 passed
- `.venv/bin/python -m pytest -q tests/test_cli_subcommands.py tests/test_aggregation_pipeline.py tests/test_filters.py` — 103 passed
- `uvx pre-commit run --files lm_eval/evaluator.py tests/test_sample_logging.py` — all hooks passed
- provider-free before/after reproduction — baseline mismatch above; patched IDs match their document markers

No model download, provider credential, network call, or request-cache correctness claim is involved.

## AI assistance disclosure

AI tools assisted with repository search, test drafting, and independent review. I directed the work, reproduced the bug on the pinned upstream revision, reviewed the final two-file diff, and ran the validation above. A separate architecture review and a GPT-5.6 Pro adversarial review both recommended the localized evaluator-boundary mapping over changing shared iterator or `Instance` identifiers; I verified that recommendation against the repository source and tests before implementation.
