### PR TITLE
style(metrics): make lm_eval/api/metrics.py ruff-clean

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -4,8 +4,8 @@ import os
 import random
 import re
 import string
-from collections.abc import Iterable
-from typing import Callable, List, Optional, Sequence, TypeVar
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeVar
 
 import numpy as np
 import sacrebleu
@@ -62,7 +62,7 @@ def bits_per_byte(items):
 def f1_score(items):
     from sklearn.metrics import f1_score
 
-    unzipped_list = list(zip(*items))
+    unzipped_list = list(zip(*items, strict=False))
     golds = unzipped_list[0]
     preds = unzipped_list[1]
     fscore = f1_score(golds, preds)
@@ -74,7 +74,7 @@ def f1_score(items):
 def matthews_corrcoef(items):
     from sklearn.metrics import matthews_corrcoef
 
-    unzipped_list = list(zip(*items))
+    unzipped_list = list(zip(*items, strict=False))
     golds = unzipped_list[0]
     preds = unzipped_list[1]
     return matthews_corrcoef(golds, preds)
@@ -92,15 +92,16 @@ def bleu(items):
 
     Higher is better
     """
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
+    unzipped_list = list(zip(*items, strict=False))
+    refs = unzipped_list[0]
+    preds = unzipped_list[1]
     refs, preds = _sacreformat(refs, preds)
     return sacrebleu.corpus_bleu(preds, refs).score
 
 
 @register_aggregation("chrf")
 def chrf(items):
-    """chrF is an evaluation metric for machine translation output based on
+    """The chrF metric evaluates machine translation output based on
     character n-gram precision and recall.
 
     Computed with sacrebleu's defaults: char_order=6, word_order=0, beta=2.
@@ -111,8 +112,9 @@ def chrf(items):
 
     Higher is better
     """
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
+    unzipped_list = list(zip(*items, strict=False))
+    refs = unzipped_list[0]
+    preds = unzipped_list[1]
     refs, preds = _sacreformat(refs, preds)
     return sacrebleu.corpus_chrf(preds, refs).score
 
@@ -131,8 +133,9 @@ def chrfpp(items):
 
     Higher is better
     """
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
+    unzipped_list = list(zip(*items, strict=False))
+    refs = unzipped_list[0]
+    preds = unzipped_list[1]
     refs, preds = _sacreformat(refs, preds)
     return sacrebleu.corpus_chrf(preds, refs, word_order=2).score
 
@@ -147,16 +150,17 @@ def ter(items):
 
     Lower is better
     """
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
+    unzipped_list = list(zip(*items, strict=False))
+    refs = unzipped_list[0]
+    preds = unzipped_list[1]
     refs, preds = _sacreformat(refs, preds)
     return sacrebleu.corpus_ter(preds, refs).score
 
 
 @register_aggregation("brier_score")
 def brier_score(items):  # This is a passthrough function
-    gold, predictions = list(zip(*items))
-    bs, num_class = np.array(predictions).shape
+    gold, predictions = list(zip(*items, strict=False))
+    _, num_class = np.array(predictions).shape
 
     gold = list(gold)
     gold_one_hot = np.eye(num_class)[gold]
@@ -331,12 +335,12 @@ def bits_per_byte_fn(items):  # This is a passthrough function
 
 def pop_stddev(arr):
     mu = mean(arr)
-    return math.sqrt(sum([(x - mu) ** 2 for x in arr]) / len(arr))
+    return math.sqrt(sum((x - mu) ** 2 for x in arr) / len(arr))
 
 
 def sample_stddev(arr: Sequence[T]) -> float:
     mu = mean(arr)
-    return math.sqrt(sum([(x - mu) ** 2 for x in arr]) / (len(arr) - 1))
+    return math.sqrt(sum((x - mu) ** 2 for x in arr) / (len(arr) - 1))
 
 
 def mean_stderr(arr):
@@ -422,10 +426,11 @@ def ter_fn(items):  # This is a passthrough function
 def acc_all(items):
     # Only count as correct if all answers are labeled correctly for each question
     question_scoring_dict = {}
-    preds = list(zip(*items))[0]
-    docs = list(zip(*items))[1]
+    unzipped_list = list(zip(*items, strict=False))
+    preds = unzipped_list[0]
+    docs = unzipped_list[1]
 
-    for doc, pred in zip(docs, preds):
+    for doc, pred in zip(docs, preds, strict=False):
         paragraph_id = doc["idx"]["paragraph"]
         question_id = doc["idx"]["question"]
         if (paragraph_id, question_id) not in question_scoring_dict:
@@ -441,10 +446,11 @@ def acc_all(items):
 def acc_all_stderr(items):
     # Only count as correct if all answers are labeled correctly for each question
     question_scoring_dict = {}
-    preds = list(zip(*items))[0]
-    docs = list(zip(*items))[1]
+    unzipped_list = list(zip(*items, strict=False))
+    preds = unzipped_list[0]
+    docs = unzipped_list[1]
 
-    for doc, pred in zip(docs, preds):
+    for doc, pred in zip(docs, preds, strict=False):
         question_id = doc["idx"]["question"]
         if question_id not in question_scoring_dict:
             question_scoring_dict[question_id] = []
@@ -466,7 +472,7 @@ def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
 
 
 def weighted_mean(items):
-    a, b = zip(*items)
+    a, b = zip(*items, strict=False)
     return sum(a) / sum(b)
 
 
@@ -489,7 +495,7 @@ def _sacreformat(refs, preds):
         refs = list(refs)
     if not is_non_str_iterable(refs[0]):
         refs = [[ref] for ref in refs]
-    refs = list(zip(*refs))
+    refs = list(zip(*refs, strict=False))
     # Note the number of refs in each ref list much match the number of preds
 
     # We expect preds to be List[str] or List[List[str]]. Must become List[str]
@@ -588,7 +594,7 @@ def bootstrap_stderr(
 
 def stderr_for_metric(
     metric: Callable[[Sequence[T]], float], bootstrap_iters: int
-) -> Optional[Callable[[Sequence[T]], float]]:
+) -> Callable[[Sequence[T]], float] | None:
     """
     Return a function that estimates the standard error of `metric(xs)`.
 
@@ -619,10 +625,10 @@ def stderr_for_metric(
 
     stderr = {mean: mean_stderr, acc_all: acc_all_stderr}
 
-    return stderr.get(metric, None)
+    return stderr.get(metric)
 
 
-def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
+def pooled_sample_stderr(stderrs: list[float], sizes: list[int]):
     # Used to aggregate bootstrapped stderrs across subtasks in a group,
     # when we are weighting by the size of each subtask.
     #
@@ -634,13 +640,16 @@ def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
     # this empirically seems to match running `stderr_for_metric` on all instances
     # from the subtasks concatenated with each other.
     pooled_sample_var = (
-        sum([(size - 1) * stderr**2 * size for size, stderr in zip(sizes, stderrs)])
+        sum(
+            (size - 1) * stderr**2 * size
+            for size, stderr in zip(sizes, stderrs, strict=False)
+        )
     ) / (sum(sizes) - len(sizes))
 
     return np.sqrt(pooled_sample_var / sum(sizes))
 
 
-def unweighted_mean_stderr(stderrs: List[float]) -> float:
+def unweighted_mean_stderr(stderrs: list[float]) -> float:
     # Used to aggregate stderrs across subtasks in a group when we are NOT weighting
     # by subtask size (weight_by_size=False), i.e. the group score is the simple
     # unweighted mean of the k subtask means. For k independent subtask means,
@@ -651,7 +660,7 @@ def unweighted_mean_stderr(stderrs: List[float]) -> float:
     return np.sqrt(sum(stderr**2 for stderr in stderrs)) / len(stderrs)
 
 
-def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None):
+def combined_sample_stderr(stderrs: list[float], sizes: list[int], metrics=None):
     assert metrics is not None, (
         "Need to pass a list of each subtask's metric for this stderr aggregation"
     )
@@ -669,7 +678,7 @@ def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None)
     curr_size = sizes[0]
     curr_score = metrics[0]
 
-    for stderr, size, score in zip(stderrs[1:], sizes[1:], metrics[1:]):
+    for stderr, size, score in zip(stderrs[1:], sizes[1:], metrics[1:], strict=False):
         curr_score = ((curr_score * curr_size) + (score * size)) / (
             curr_size + size
         )  # NOTE: this assumes our aggregation fn is "mean"
@@ -692,4 +701,6 @@ def aggregate_subtask_metrics(metrics, sizes, weight_by_size=True):
 
     assert len(metrics) == len(sizes)
 
-    return sum([metric * size for metric, size in zip(metrics, sizes)]) / sum(sizes)
+    return sum(
+        metric * size for metric, size in zip(metrics, sizes, strict=False)
+    ) / sum(sizes)


### PR DESCRIPTION
## What

Makes `lm_eval/api/metrics.py` pass `ruff check` and `ruff format`. No behaviour changes.

## Why

The `Linters` job runs pre-commit with `--from-ref ${{ base.sha }} --to-ref HEAD`, so ruff lints each changed file *in full*, not just the changed lines. `lm_eval/api/metrics.py` currently carries 43 violations on `main`, so any PR that touches this file gets a red `Linters` check for reasons unrelated to its own diff. #3780 (chrf++, merged 2026-08-27) is an example, and #4067 is another.

`main` itself stays green because pushes to `main` lint against `HEAD~1`, which usually does not include this file.

## What changed

Ruff's own safe fixes, plus the remaining rules resolved by hand. Every edit preserves behaviour:

| Rule | Change |
|---|---|
| B905 `zip-without-explicit-strict` (22) | Added `strict=False`. `False`, not `True`, is the value that provably preserves current behaviour; tightening any individual call site to `strict=True` is a separate decision that deserves its own argument. |
| RUF015 `unnecessary-iterable-allocation-for-first-element` (6) | `refs = list(zip(*items))[0]` / `preds = list(zip(*items))[1]` become one transpose bound to `unzipped_list`, which is the form `f1_score` and `matthews_corrcoef` already use in this file. Also drops a redundant second pass over `items`. |
| C419 `unnecessary-comprehension-in-call` (4) | `sum([...])` to `sum(...)` over a generator. |
| RUF059 `unused-unpacked-variable` (1) | The unused `bs` in `bs, num_class = np.array(predictions).shape` becomes `_`. |
| UP035 / UP006 / UP045 / SIM910 / D403 | `Callable` and `Sequence` from `collections.abc`, `Optional[X]` to `X | None`, `List` to `list`, `stderr.get(metric, None)` to `stderr.get(metric)`, and the `chrf` docstring reworded to start with a capitalised word rather than recapitalising "chrF", which is the metric's proper name. |

I deliberately did not touch the ruff configuration or add any per-file ignores.

Prepared with Claude Code (agent-assisted); the verification below was run locally.

## Verification

`ruff check` and `ruff format --check` both pass on the file with the pinned `v0.16.3` from `.pre-commit-config.yaml`.

Behaviour was checked by differential testing rather than by inspection: the old and new modules were loaded side by side and compared over 574 randomised inputs covering `f1_score`, `matthews_corrcoef`, `bleu`, `chrf`, `chrfpp`, `ter`, `brier_score`, `pop_stddev`, `sample_stddev`, `mean_stderr`, `acc_all`, `acc_all_stderr`, `weighted_mean`, `_sacreformat`, `pooled_sample_stderr`, `unweighted_mean_stderr`, `combined_sample_stderr`, `aggregate_subtask_metrics` and `stderr_for_metric`. Returned values agree exactly, and so does which exception is raised where one is raised.

## Note on overlap

This touches `brier_score`, which #4067 rewrites. Whichever lands first, I will rebase the other. If you would rather review them as one change, say so and I will fold this into #4067 instead.
