### PR TITLE
fix(models): delegate BOS to the tokenizer in sglang and the API backends

### DIFF
--- a/docs/API_guide.md
+++ b/docs/API_guide.md
@@ -91,7 +91,9 @@ When initializing a `TemplateAPI` instance or a subclass, you can provide severa
 
 - `add_bos_token` (bool, optional):
   - Whether to add the beginning-of-sequence token to inputs (when tokenizing).
-  - Default is False.
+  - Default is None, which defers to the tokenizer's own configuration
+    (`tokenizer_config.json`). Set it to True to always add the token, or to
+    False to never add it.
 
 - `custom_prefix_token_id` (int, optional):
   - Custom token ID to use as a prefix for inputs.

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -32,7 +32,13 @@ from io import BytesIO
 from lm_eval import utils
 from lm_eval.api.instance import Instance
 from lm_eval.api.model import TemplateLM
-from lm_eval.models.utils import Collator, chunks, configure_pad_token
+from lm_eval.models.utils import (
+    Collator,
+    _add_special_kwargs,
+    chunks,
+    configure_pad_token,
+    has_bos_prefix,
+)
 
 
 if TYPE_CHECKING:
@@ -125,7 +131,7 @@ class TemplateAPI(TemplateLM):
         batch_size: str | int = 1,
         seed: int = 1234,
         max_length: int | None = 2048,
-        add_bos_token: bool = False,
+        add_bos_token: bool | None = None,
         custom_prefix_token_id: int | None = None,
         # send the requests as tokens or strings
         tokenized_requests: bool = True,
@@ -397,31 +403,62 @@ class TemplateAPI(TemplateLM):
         self,
         string: str,
         left_truncate_len: int | None = None,
-        add_special_tokens: bool = False,
+        add_special_tokens: bool | None = None,
         truncation: bool = False,
         **kwargs,
     ) -> list[list[int]] | list[int] | list[str]:
         if self.tokenizer_backend is None:
             return [string]
         elif self.tokenizer_backend == "huggingface":
-            # by default for CausalLM - false or self.add_bos_token is set
-            if not add_special_tokens:
-                add_special_tokens = False or self.add_bos_token
-            encoding: list[list[int]] | list[int] = self.tokenizer(
-                string,
-                add_special_tokens=add_special_tokens,
-                truncation=truncation,
-                return_attention_mask=False,
-            ).input_ids
+            # `add_special_tokens=None` and `self.add_bos_token=None` means nothing
+            # is passed to the tokenizer, so its own configuration decides whether
+            # a BOS token is prepended. Mirrors HFLM.tok_encode.
+            is_batched = not isinstance(string, str)
+            _string: list[str] = list(string) if is_batched else [string]
+
+            _bos_token = (
+                self.tokenizer.decode(self.prefix_token_id)
+                if self.prefix_token_id is not None
+                else None
+            )
+            special_tokens_kwargs = _add_special_kwargs(
+                add_special_tokens, self.add_bos_token
+            )
+
+            # A string that already begins with BOS must not be given a second one.
+            has_prefix_flags = [
+                isinstance(s, str) and has_bos_prefix(s, _bos_token) for s in _string
+            ]
+            idx_has = [i for i, f in enumerate(has_prefix_flags) if f]
+            idx_not = [i for i, f in enumerate(has_prefix_flags) if not f]
+
+            def _encode(strs: list[str], enc_kwargs) -> list[list[int]]:
+                if not strs:
+                    return []
+                return self.tokenizer(
+                    strs,
+                    truncation=truncation,
+                    return_attention_mask=False,
+                    **enc_kwargs,
+                ).input_ids
+
+            enc_has = _encode(
+                [_string[i] for i in idx_has],
+                {**special_tokens_kwargs, "add_special_tokens": False},
+            )
+            enc_not = _encode([_string[i] for i in idx_not], special_tokens_kwargs)
+
+            encoding: list[list[int]] = [None] * len(_string)  # type: ignore[list-item]
+            for j, i in enumerate(idx_has):
+                encoding[i] = enc_has[j]
+            for j, i in enumerate(idx_not):
+                encoding[i] = enc_not[j]
 
             # left-truncate the encoded context to be at most `left_truncate_len` tokens long
             if left_truncate_len:
-                if not isinstance(string, str):
-                    encoding = [enc[-left_truncate_len:] for enc in encoding]
-                else:
-                    encoding = encoding[-left_truncate_len:]
+                encoding = [enc[-left_truncate_len:] for enc in encoding]
 
-            return encoding
+            return encoding if is_batched else encoding[0]
         elif self.tokenizer_backend == "remote":
             if isinstance(string, str):
                 encoding = self.tokenizer.encode(string)
@@ -730,9 +767,7 @@ class TemplateAPI(TemplateLM):
                 *(req.args for req in requests), strict=False
             )
         if self.tokenized_requests:
-            encodings_list = self.tok_encode(
-                requests, add_special_tokens=self.add_bos_token
-            )
+            encodings_list = self.tok_encode(requests)
         else:
             encodings_list = [None] * len(requests)
         requests = [

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -10,7 +10,9 @@ from lm_eval.api.model import TemplateLM
 from lm_eval.api.registry import register_model
 from lm_eval.models.utils import (
     Collator,
+    _add_special_kwargs,
     handle_stop_sequences,
+    has_bos_prefix,
     postprocess_generated_text,
 )
 from lm_eval.utils import (
@@ -42,7 +44,7 @@ class SGLangLM(TemplateLM):
         max_batch_size=None,
         max_model_len: int = None,
         max_gen_toks: int = 256,
-        add_bos_token: Optional[bool] = False,
+        add_bos_token: Optional[bool] = None,
         ########## SGlang native args ##########
         # Todo(Jinwei): Include more args of SGLang Engine if needed. Refer to https://docs.sglang.ai/backend/server_arguments.html .
         tokenizer_path: Optional[str] = None,
@@ -114,11 +116,6 @@ class SGLangLM(TemplateLM):
         self.tokenizer = self.model.tokenizer_manager.tokenizer
         self._max_gen_toks = max_gen_toks
         self.add_bos_token = add_bos_token
-        if "gemma" in pretrained.lower():
-            self.add_bos_token = True
-            eval_logger.info(
-                "Found 'gemma' in model name, a BOS token will be used as Gemma series models underperform without it."
-            )
         self.custom_prefix_token_id = prefix_token_id
 
     def loglikelihood_rolling(
@@ -197,9 +194,7 @@ class SGLangLM(TemplateLM):
 
         # batch tokenize contexts
         context, all_gen_kwargs = zip(*(req.args for req in requests))
-        context_encoding: List[List[int]] = self.tok_encode(
-            context, add_special_tokens=self.add_bos_token
-        )
+        context_encoding: List[List[int]] = self.tok_encode(context)
         requests = [
             ((a, b), c) for a, b, c in zip(context, context_encoding, all_gen_kwargs)
         ]
@@ -348,26 +343,60 @@ class SGLangLM(TemplateLM):
         self,
         string: Union[str, List[str]],
         left_truncate_len: int = None,
-        add_special_tokens: bool = False,
+        add_special_tokens: bool | None = None,
         truncation: bool = False,
     ) -> Union[List[int], List[List[int]]]:
-        if not add_special_tokens:
-            add_special_tokens = False or self.add_bos_token
-        encoding: Union[List[List[int]], List[int]] = self.tokenizer(
-            string,
-            add_special_tokens=add_special_tokens,
-            truncation=truncation,
-            return_attention_mask=False,
-        ).input_ids
+        # `add_special_tokens=None` and `self.add_bos_token=None` means nothing is
+        # passed to the tokenizer, so its own configuration decides whether a BOS
+        # token is prepended. Mirrors HFLM.tok_encode and VLLM.tok_encode.
+        is_batched = not isinstance(string, str)
+        _string: list[str] = list(string) if is_batched else [string]
+
+        _bos_token = (
+            self.tokenizer.decode(self.prefix_token_id)
+            if self.prefix_token_id is not None
+            else None
+        )
+        special_tokens_kwargs = _add_special_kwargs(
+            add_special_tokens, self.add_bos_token
+        )
+
+        # A string that already starts with BOS — a chat template usually adds one
+        # — must not be given a second. Encode those with add_special_tokens=False
+        # and the rest as configured, then put the batch back in order.
+        has_prefix_flags = [
+            isinstance(s, str) and has_bos_prefix(s, _bos_token) for s in _string
+        ]
+        idx_has = [i for i, f in enumerate(has_prefix_flags) if f]
+        idx_not = [i for i, f in enumerate(has_prefix_flags) if not f]
+
+        def _encode(strs: list[str], kwargs) -> list[list[int]]:
+            if not strs:
+                return []
+            return self.tokenizer(
+                strs,
+                truncation=truncation,
+                return_attention_mask=False,
+                **kwargs,
+            ).input_ids
+
+        enc_has = _encode(
+            [_string[i] for i in idx_has],
+            {**special_tokens_kwargs, "add_special_tokens": False},
+        )
+        enc_not = _encode([_string[i] for i in idx_not], special_tokens_kwargs)
+
+        out: list[list[int]] = [None] * len(_string)  # type: ignore[list-item]
+        for j, i in enumerate(idx_has):
+            out[i] = enc_has[j]
+        for j, i in enumerate(idx_not):
+            out[i] = enc_not[j]
 
         # left-truncate the encoded context to be at most `left_truncate_len` tokens long
         if left_truncate_len:
-            if not isinstance(string, str):
-                encoding = [enc[-left_truncate_len:] for enc in encoding]
-            else:
-                encoding = encoding[-left_truncate_len:]
+            out = [enc[-left_truncate_len:] for enc in out]
 
-        return encoding
+        return out if is_batched else out[0]
 
     def tok_decode(self, tokens: List[int]) -> str:
         # Implement token-to-text decoding

--- a/tests/models/test_bos_handling.py
+++ b/tests/models/test_bos_handling.py
@@ -636,3 +636,155 @@ class TestEdgeCases:
 
         assert mock_vllm.tok_encode("") == []
         assert mock_vllm.tok_encode([]) == []
+
+
+# =============================================================================
+# Behavior 5: sglang and api_models delegate the same way (#3295)
+# =============================================================================
+
+
+def create_sglang_mock(tokenizer, add_bos_token):
+    """Create SGLang model mock with tokenization methods."""
+    from lm_eval.models.sglang_causallms import SGLangLM
+
+    mock = Mock()
+    mock.add_bos_token = add_bos_token
+    mock.prefix_token_id = tokenizer.bos_token_id or 0
+    mock.tokenizer = tokenizer
+    mock.tok_encode = SGLangLM.tok_encode.__get__(mock, SGLangLM)
+    return mock
+
+
+def create_api_mock(tokenizer, add_bos_token):
+    """Create TemplateAPI mock with the huggingface tokenizer backend."""
+    from lm_eval.models.api_models import TemplateAPI
+
+    mock = Mock()
+    mock.add_bos_token = add_bos_token
+    mock.prefix_token_id = tokenizer.bos_token_id or 0
+    mock.tokenizer = tokenizer
+    mock.tokenizer_backend = "huggingface"
+    mock.tok_encode = TemplateAPI.tok_encode.__get__(mock, TemplateAPI)
+    return mock
+
+
+@pytest.mark.parametrize("factory", [create_sglang_mock, create_api_mock])
+class TestSglangAndApiDelegateBos:
+    """
+    sglang and the API backends were left on the pre-#3347 behaviour.
+
+    They defaulted `add_bos_token` to False and passed it to the tokenizer
+    explicitly, which overrides a tokenizer whose own config asks for a BOS
+    token. These mirror the huggingface/vllm expectations above.
+    """
+
+    @pytest.mark.parametrize("tokenizer_name", ["pythia_tokenizer", "olmo_tokenizer"])
+    def test_none_uses_tokenizer_default(self, factory, tokenizer_name, request):
+        """
+        add_bos_token=None must defer to the tokenizer's own configuration.
+
+        Pythia does not add BOS by default; OLMo does. Before #3295 both
+        backends forced add_special_tokens=False, so the OLMo case lost its BOS.
+        """
+        tokenizer = request.getfixturevalue(tokenizer_name)
+        mock = factory(tokenizer, add_bos_token=None)
+
+        assert mock.tok_encode("Hello") == tokenizer.encode("Hello")
+
+    @pytest.mark.parametrize("tokenizer_name", ["pythia_tokenizer", "olmo_tokenizer"])
+    def test_explicit_true_adds_bos(self, factory, tokenizer_name, request):
+        """add_bos_token=True forces the BOS token on."""
+        tokenizer = request.getfixturevalue(tokenizer_name)
+        mock = factory(tokenizer, add_bos_token=True)
+
+        expected = tokenizer.encode("Hello", add_special_tokens=True)
+        assert mock.tok_encode("Hello") == expected
+
+    @pytest.mark.parametrize("tokenizer_name", ["pythia_tokenizer", "olmo_tokenizer"])
+    def test_explicit_false_suppresses_bos(self, factory, tokenizer_name, request):
+        """add_bos_token=False forces it off, even for a tokenizer that adds one."""
+        tokenizer = request.getfixturevalue(tokenizer_name)
+        mock = factory(tokenizer, add_bos_token=False)
+
+        expected = tokenizer.encode("Hello", add_special_tokens=False)
+        assert mock.tok_encode("Hello") == expected
+
+    @pytest.mark.parametrize("tokenizer_name", ["pythia_tokenizer", "olmo_tokenizer"])
+    def test_no_duplicate_bos(self, factory, tokenizer_name, request):
+        """A string that already starts with BOS must not be given a second."""
+        tokenizer = request.getfixturevalue(tokenizer_name)
+        mock = factory(tokenizer, add_bos_token=True)
+
+        encoded = mock.tok_encode(f"{tokenizer.bos_token}Hello")
+
+        assert encoded[:2] != [tokenizer.bos_token_id, tokenizer.bos_token_id]
+
+    @pytest.mark.parametrize("tokenizer_name", ["pythia_tokenizer", "olmo_tokenizer"])
+    def test_mixed_batch_keeps_order(self, factory, tokenizer_name, request):
+        """
+        A batch split by BOS presence must come back in the input order.
+
+        The implementation encodes the with-BOS and without-BOS strings as two
+        groups, so ordering is the thing a careless version gets wrong.
+        """
+        tokenizer = request.getfixturevalue(tokenizer_name)
+        mock = factory(tokenizer, add_bos_token=True)
+
+        strings = ["Alpha", f"{tokenizer.bos_token}Beta", "Gamma"]
+        batched = mock.tok_encode(strings)
+
+        assert len(batched) == 3
+        assert batched == [mock.tok_encode(s) for s in strings]
+
+    def test_explicit_add_special_tokens_overrides(self, factory, pythia_tokenizer):
+        """An explicit add_special_tokens argument beats add_bos_token."""
+        mock = factory(pythia_tokenizer, add_bos_token=True)
+
+        result = mock.tok_encode("Hello", add_special_tokens=False)
+
+        assert result == pythia_tokenizer.encode("Hello", add_special_tokens=False)
+
+
+def test_sglang_no_longer_special_cases_gemma():
+    """
+    The gemma-by-name branch is gone; the tokenizer config carries it.
+
+    Guards the substring match coming back: it set add_bos_token=True for any
+    model whose name contains "gemma", which is both too broad and unnecessary
+    now that an unset value defers to the tokenizer.
+    """
+    import inspect
+
+    from lm_eval.models import sglang_causallms
+
+    assert "gemma" not in inspect.getsource(sglang_causallms.SGLangLM.__init__).lower()
+
+
+@pytest.mark.parametrize(
+    "module_name, class_name",
+    [
+        ("lm_eval.models.huggingface", "HFLM"),
+        ("lm_eval.models.vllm_causallms", "VLLM"),
+        ("lm_eval.models.sglang_causallms", "SGLangLM"),
+        ("lm_eval.models.api_models", "TemplateAPI"),
+    ],
+)
+def test_add_bos_token_defaults_to_none(module_name, class_name):
+    """
+    Every backend must default `add_bos_token` to None, not False.
+
+    This is the defect #3295 reports. A False default is not "no opinion" — it
+    is passed to the tokenizer and *overrides* a tokenizer_config.json that asks
+    for a BOS token, so models that declare they need one silently do not get
+    one. None means nothing is passed and the tokenizer's own setting stands.
+    """
+    import importlib
+    import inspect
+
+    cls = getattr(importlib.import_module(module_name), class_name)
+    default = inspect.signature(cls.__init__).parameters["add_bos_token"].default
+
+    assert default is None, (
+        f"{class_name}.add_bos_token defaults to {default!r}; "
+        "a non-None default overrides the tokenizer's own configuration"
+    )


### PR DESCRIPTION
Fixes #3295.

#3347 made `add_bos_token` default to `None` so that an unset value defers to
the tokenizer's own configuration, and added `_add_special_kwargs` and
`has_bos_prefix` in `lm_eval/models/utils.py` to do it. It applied that to
`huggingface.py` and `vllm_causallms.py`. The two files the issue actually
names, `sglang_causallms.py` and `api_models.py`, were left on the old
behaviour:

| | `huggingface` / `vllm` | `sglang_causallms.py` | `api_models.py` |
| --- | --- | --- | --- |
| default | `add_bos_token: bool \| None = None` | `Optional[bool] = False` | `bool = False` |
| encode | `_add_special_kwargs(...)` — passes nothing when unset | `add_special_tokens = False or self.add_bos_token` | same |
| duplicate BOS | `has_bos_prefix` guard | none | none |
| gemma | delegated to the tokenizer | `if "gemma" in pretrained.lower()` | — |

A `False` default is not "no opinion". It is passed to the tokenizer and
overrides `tokenizer_config.json`, so a model that declares `add_bos_token:
true` — Llama 3.2 Instruct, OLMo, Gemma — is tokenized without its BOS on those
two backends. Nothing fails and nothing is logged; the accuracy number just
moves. vLLM's own FP8 guide points people at this harness and notes that BOS
presence has a strong effect on the result.

## The fix

Mirror #3347 into the two files, using the helpers it already added rather than
new ones.

- `add_bos_token` defaults to `None` on both.
- `tok_encode` builds its kwargs with `_add_special_kwargs(add_special_tokens,
  self.add_bos_token)`, which returns `{}` when both are unset, so the tokenizer
  decides.
- Strings that already begin with BOS — chat templates usually add one — are
  split out with `has_bos_prefix` and encoded with `add_special_tokens=False`,
  then the batch is reassembled in input order.
- The two `generate_until` call sites stop passing `add_special_tokens=self.add_bos_token`,
  which forced a bool and defeated the delegation.

**The gemma branch is deleted rather than kept.** Gemma's own tokenizer config
sets `add_bos_token: true`, so once the default delegates it gets the same token
by the general rule instead of by a substring match on the model name — which is
what @DarkLight1337 asked for in the thread, and what #3206 and #3347 already did
elsewhere. A name check also fired on any path containing "gemma", including
unrelated local directories.

I have left `apply_chat_template` alone. @baberabb, you said there that the
template already wraps the text in the right special tokens; I have no evidence
against that and it seems separate from the tokenizer-config default.

## Behaviour change

This changes the default on two backends. Anyone relying on
`add_bos_token=False` implicitly, while running a model whose tokenizer asks for
BOS, will see their numbers move. That is the same change of default #3347 made
for `huggingface` and `vllm`, and it moves towards the model's declared
configuration, but it is a change and passing `add_bos_token=False` restores the
old behaviour exactly.

## Docs

`docs/API_guide.md` documented `add_bos_token` as "Default is False" for the
API models. That line would otherwise be wrong, so it now says the default
defers to the tokenizer's configuration.

## Tests

In `tests/models/test_bos_handling.py`, alongside the existing HF and vLLM
cases and using the same mock-the-backend pattern.

`test_add_bos_token_defaults_to_none` is parametrized over all four backends and
is the claim of this PR in one assertion: `HFLM` and `VLLM` pass on unmodified
`main`, `SGLangLM` and `TemplateAPI` do not.

The rest cover, for both new backends and both a tokenizer that adds BOS by
default (OLMo) and one that does not (Pythia): unset defers to the tokenizer,
`True` forces it on, `False` forces it off, an existing BOS is never doubled, a
mixed batch comes back in input order, and an explicit `add_special_tokens`
argument still wins.

## `Linters`

This will be red, for the reason in #4065: the job runs pre-commit with
`--from-ref <base.sha> --to-ref HEAD`, so it lints touched files *whole*, and
both of these carry pre-existing findings under the current `ruff` pin that
`main` never re-lints. Measured on these three files with `ruff 0.16.3`:

```
main            72 errors
this branch     68 errors
```

Nothing new is introduced — the four fewer are `Union`/`List` annotations in
the code this PR rewrote. `ruff format --check`: all three already formatted.
