### PR TITLE
Fix --samples doc-id mapping for unsorted sample lists

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -633,8 +633,14 @@ def evaluate(
                 world_size=WORLD_SIZE,
                 samples=indices,
             )
+            # doc_iterator yields positions within the dataset-ordered
+            # selection, so map back through the sorted id list rather
+            # than the caller's (possibly unsorted) samples list
+            ordered_indices = sorted(indices) if indices else None
             for doc_id, doc in doc_iterator:
-                doc_id_true = indices[doc_id] if indices else doc_id
+                doc_id_true = (
+                    ordered_indices[doc_id] if ordered_indices else doc_id
+                )
                 requests = instances_by_doc_id[doc_id]
                 metrics = task.process_results(
                     doc, [req.filtered_resps[filter_key] for req in requests]

--- a/tests/test_evaluator_utils.py
+++ b/tests/test_evaluator_utils.py
@@ -859,3 +859,42 @@ class TestCollectResultsNSamples:
         result = _collect_results(accs, bootstrap_iters=0)
         assert result.n_samples["t1"]["original"] == 42
         assert result.n_samples["t1"]["effective"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Sampled doc-id mapping (regression for unsorted --samples lists)
+# ---------------------------------------------------------------------------
+
+
+class TestSampledDocIdMapping:
+    """doc_iterator yields positions in dataset order; logged doc ids must
+    map through the sorted selection, not the caller's list order."""
+
+    def _task_with_docs(self, n=10):
+        from tests.test_metrics import MockConfigurableTask
+
+        docs = [{"i": i} for i in range(n)]
+        task = MockConfigurableTask()
+        task.has_test_docs = lambda: True
+        task.test_docs = lambda: docs
+        return task
+
+    def test_iterator_yields_dataset_order_for_unsorted_samples(self):
+        task = self._task_with_docs()
+        yielded = [(pos, doc["i"]) for pos, doc in task.doc_iterator(samples=[5, 2, 9])]
+        # positions are 0..k-1; docs arrive in dataset order (2, 5, 9)
+        assert yielded == [(0, 2), (1, 5), (2, 9)]
+
+    def test_sorted_mapping_pairs_ids_with_docs(self):
+        # the evaluator's rule: doc_id_true = sorted(samples)[position]
+        samples = [5, 2, 9]
+        ordered = sorted(samples)
+        task = self._task_with_docs()
+        for pos, doc in task.doc_iterator(samples=samples):
+            doc_id_true = ordered[pos]
+            assert doc_id_true == doc["i"]
+
+    def test_sorted_mapping_identity_for_sorted_samples(self):
+        samples = [2, 5, 9]
+        ordered = sorted(samples)
+        assert ordered == samples  # the historical behavior is a special case


### PR DESCRIPTION
## The bug

With `--samples taskname=5,2,9`, `doc_iterator` iterates the selected documents in **dataset order** (docs 2, 5, 9 at positions 0, 1, 2), but the evaluator mapped positions through the caller's list **as given**:

```python
doc_id_true = indices[doc_id] if indices else doc_id
```

For the example list, the logged ids become `indices[0]=5, indices[1]=2, indices[2]=9`, so the sample holding dataset doc 2 is logged as doc 5 and vice versa. Every logged sample pairs one document's id with another document's content, silently. Sorted lists (the common case) are unaffected, which is why this has gone unnoticed: the corruption is data-dependent.

## The fix

Map positions through `sorted(samples)` instead of the caller's list order. One-line semantic change; sorted behavior is identical to before.

## Tests

Three regression tests in `tests/test_evaluator_utils.py`:

- the iterator's dataset-order contract for unsorted sample lists
- the corrected mapping pairs every logged id with the right document
- sorted lists remain exactly the historical behavior

## Impact

`log_samples` output feeds per-sample analysis and leaderboard inspection; mislabeled ids silently corrupt any tooling that joins samples back to the dataset by doc_id. Found during an external integrity audit of the harness (issue #4084 reports the finding; this PR carries the fix for the doc-id limb).