### PR TITLE
fix(metrics): report a boundary interval where the stderr degenerates to 0.0

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -4,8 +4,8 @@ import os
 import random
 import re
 import string
-from collections.abc import Iterable
-from typing import Callable, List, Optional, Sequence, TypeVar
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeVar
 
 import numpy as np
 import sacrebleu
@@ -100,7 +100,7 @@ def bleu(items):
 
 @register_aggregation("chrf")
 def chrf(items):
-    """chrF is an evaluation metric for machine translation output based on
+    """ChrF is an evaluation metric for machine translation output based on
     character n-gram precision and recall.
 
     Computed with sacrebleu's defaults: char_order=6, word_order=0, beta=2.
@@ -588,7 +588,7 @@ def bootstrap_stderr(
 
 def stderr_for_metric(
     metric: Callable[[Sequence[T]], float], bootstrap_iters: int
-) -> Optional[Callable[[Sequence[T]], float]]:
+) -> Callable[[Sequence[T]], float] | None:
     """
     Return a function that estimates the standard error of `metric(xs)`.
 
@@ -619,10 +619,10 @@ def stderr_for_metric(
 
     stderr = {mean: mean_stderr, acc_all: acc_all_stderr}
 
-    return stderr.get(metric, None)
+    return stderr.get(metric)
 
 
-def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
+def pooled_sample_stderr(stderrs: list[float], sizes: list[int]):
     # Used to aggregate bootstrapped stderrs across subtasks in a group,
     # when we are weighting by the size of each subtask.
     #
@@ -640,7 +640,7 @@ def pooled_sample_stderr(stderrs: List[float], sizes: List[int]):
     return np.sqrt(pooled_sample_var / sum(sizes))
 
 
-def unweighted_mean_stderr(stderrs: List[float]) -> float:
+def unweighted_mean_stderr(stderrs: list[float]) -> float:
     # Used to aggregate stderrs across subtasks in a group when we are NOT weighting
     # by subtask size (weight_by_size=False), i.e. the group score is the simple
     # unweighted mean of the k subtask means. For k independent subtask means,
@@ -651,7 +651,7 @@ def unweighted_mean_stderr(stderrs: List[float]) -> float:
     return np.sqrt(sum(stderr**2 for stderr in stderrs)) / len(stderrs)
 
 
-def combined_sample_stderr(stderrs: List[float], sizes: List[int], metrics=None):
+def combined_sample_stderr(stderrs: list[float], sizes: list[int], metrics=None):
     assert metrics is not None, (
         "Need to pass a list of each subtask's metric for this stderr aggregation"
     )

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -343,6 +343,66 @@ def mean_stderr(arr):
     return sample_stddev(arr) / math.sqrt(len(arr))
 
 
+# Two-sided 95% coverage. Named so the interval helpers below don't carry a bare
+# 1.96, and so the coverage level is changeable in one place.
+Z_95 = 1.959963984540054
+
+# Suffix of the key that carries a boundary interval in a task's metric dict, e.g.
+# "acc_boundary_ci95,none". Only present for a metric whose score vector is
+# degenerate (see `boundary_ci`); readers must treat it as optional.
+BOUNDARY_CI_SUFFIX = "_boundary_ci95"
+
+
+def wilson_score_interval(
+    successes: float, n: int, z: float = Z_95
+) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion.
+
+    Unlike the Wald interval implied by `mean_stderr`, this stays inside [0, 1] and
+    keeps a width at p_hat = 0 and p_hat = 1, which is exactly where the Wald
+    standard error degenerates to a point.
+    """
+    if n <= 0:
+        raise ValueError("the Wilson interval is undefined for an empty sample")
+
+    p_hat = successes / n
+    denominator = 1 + z**2 / n
+    center = (p_hat + z**2 / (2 * n)) / denominator
+    margin = (z / denominator) * math.sqrt(p_hat * (1 - p_hat) / n + z**2 / (4 * n**2))
+    lower, upper = center - margin, center + margin
+
+    # At the boundaries the interval is closed exactly: with no successes the true
+    # rate can be 0, with no failures it can be 1. Pin those ends rather than let
+    # floating-point noise report a 1e-17 lower bound on a null result.
+    lower = 0.0 if successes <= 0 else max(0.0, lower)
+    upper = 1.0 if successes >= n else min(1.0, upper)
+    return lower, upper
+
+
+def boundary_ci(items: Sequence[T], z: float = Z_95) -> tuple[float, float] | None:
+    """Wilson interval for a score vector that sits entirely on 0 or entirely on 1.
+
+    Returns None for every other vector, including a constant vector off the
+    boundary (0.5 is not a degenerate proportion) and vectors of non-numeric items
+    such as the (reference, prediction) pairs some metrics aggregate.
+
+    Only the all-0 and all-1 cases are treated. There the sample variance is 0 by
+    construction, so the reported standard error is 0.0 at any sample size and says
+    nothing about how much evidence backs the null (or saturated) result.
+    """
+    if not items:
+        return None
+    if not all(isinstance(x, (int, float)) for x in items):
+        return None
+
+    observed = {float(x) for x in items}
+    if observed not in ({0.0}, {1.0}):
+        return None
+
+    successes = observed.pop() * len(items)
+    return wilson_score_interval(successes, len(items), z)
+
+
 @register_metric(
     metric="bypass",
     higher_is_better=True,

--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -392,10 +392,17 @@ def boundary_ci(items: Sequence[T], z: float = Z_95) -> tuple[float, float] | No
     """
     if not items:
         return None
-    if not all(isinstance(x, (int, float)) for x in items):
+    # Scores reach here as whatever a task's process_results returned: Python floats,
+    # but also numpy scalars, which are not all instances of int/float (np.bool_ and
+    # np.int64 are not). Convert instead of type-checking, and reject the strings and
+    # the (reference, prediction) pairs some metrics aggregate.
+    if any(isinstance(x, (str, bytes)) for x in items):
+        return None
+    try:
+        observed = {float(x) for x in items}
+    except (TypeError, ValueError):
         return None
 
-    observed = {float(x) for x in items}
     if observed not in ({0.0}, {1.0}):
         return None
 

--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -42,7 +42,7 @@ def print_writeout(task: Task) -> None:
                 f"Task: {task}; document {inst.doc_id}; context prompt (starting on next line):\
     \n{inst.args[0]}\n(end of prompt on previous line)\ntarget string or answer choice index (starting on next line):\n{task.doc_to_target(inst.doc)}\n(end of target on previous line)"
             )
-            eval_logger.info(f"Request: {str(inst)}")
+            eval_logger.info(f"Request: {inst!s}")
             break
 
 

--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import TypedDict
 
 from lm_eval.api.metrics import (
+    BOUNDARY_CI_SUFFIX,
+    boundary_ci,
     mean,
+    nanmean,
     stderr_for_metric,
 )
 from lm_eval.result_schema import EvalResults, _SampleCount, _TaskMetrics
@@ -218,9 +221,38 @@ def _compute_task_aggregations(
                 if metric in ["bleu", "chrf", "chrf++", "ter"]
                 else bootstrap_iters,
             )
-            agg_metrics[f"{metric}_stderr,{filter_key}"] = (
-                stderr_fn(items) if (stderr_fn and len(items) > 1) else "N/A"
-            )
+            stderr = stderr_fn(items) if (stderr_fn and len(items) > 1) else "N/A"
+            agg_metrics[f"{metric}_stderr,{filter_key}"] = stderr
+
+            # A score vector sitting entirely on 0 (or entirely on 1) has zero
+            # sample variance, so its standard error is 0.0 at every sample size:
+            # 25 documents and 5000 documents both publish "0.0 +- 0.0000". Report
+            # the Wilson interval beside it, which stays defined at the boundary
+            # and keeps the sample size visible. Purely additive: the stderr value
+            # itself is untouched, and the key is absent for every other vector.
+            #
+            # Restricted to mean aggregations: the interval describes a proportion,
+            # so it only bounds the published value when that value is the mean of
+            # the same 0/1 items. A median or sum of the same vector is a different
+            # statistic and gets no interval.
+            if (
+                stderr == 0.0
+                and agg_fn in (mean, nanmean)
+                and (interval := boundary_ci(items)) is not None
+            ):
+                agg_metrics[f"{metric}{BOUNDARY_CI_SUFFIX},{filter_key}"] = interval
+                lower, upper = interval
+                bound = (
+                    f"true rate <= {upper:.4f}"
+                    if lower == 0.0
+                    else f"true rate >= {lower:.4f}"
+                )
+                eval_logger.warning(
+                    f"[{task.task_name}] {metric} is at a boundary "
+                    f"({agg_metrics[metric_key]:.1f}) on all {len(items)} scored "
+                    f"documents, so its stderr is 0.0 by construction and does not "
+                    f"reflect the sample size. 95% Wilson bound: {bound}."
+                )
         else:
             agg_metrics[f"{metric}_stderr,{filter_key}"] = "N/A"
 

--- a/lm_eval/result_schema.py
+++ b/lm_eval/result_schema.py
@@ -112,6 +112,11 @@ class _TaskMetrics(TypedDict, Generic[T], extra_items=T):
 
     Fixed keys are ``name``, ``alias`` and ``sample_len``.  The remaining keys are
     dynamic ``metric,filter`` pairs like ``"acc,none"`` and ``"acc_stderr,none"``.
+
+    A ``"<metric>_boundary_ci95,<filter>"`` key holds a ``(lower, upper)`` Wilson
+    interval and is present only when that metric scored 0 (or 1) on every
+    document, where the standard error is 0.0 by construction. Readers must treat
+    it as optional.
     """
 
     name: str

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -508,7 +508,7 @@ def make_table(result_dict, column: str = "results", sort_results: bool = False)
         group_subtasks, set(result_dict[column].keys())
     )
 
-    if sort_results:  # noqa: SIM108
+    if sort_results:
         # sort entries alphabetically by task or group name.
         # NOTE: we default here to false, because order matters for multi-level table printing a la mmlu.
         # sorting here would mess that up

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -480,6 +480,8 @@ def make_table(result_dict, column: str = "results", sort_results: bool = False)
     """Generate table of results."""
     from pytablewriter import LatexTableWriter, MarkdownTableWriter
 
+    from lm_eval.api.metrics import BOUNDARY_CI_SUFFIX
+
     column_name = "Groups" if column == "groups" else "Tasks"
 
     all_headers = [
@@ -539,7 +541,7 @@ def make_table(result_dict, column: str = "results", sort_results: bool = False)
 
         for (mf), v in metric_items:
             m, _, f = mf.partition(",")
-            if m.endswith("_stderr"):
+            if m.endswith(("_stderr", BOUNDARY_CI_SUFFIX)):
                 continue
 
             hib = HIGHER_IS_BETTER_SYMBOLS.get(higher_is_better.get(m), "")
@@ -549,6 +551,14 @@ def make_table(result_dict, column: str = "results", sort_results: bool = False)
             if m + "_stderr" + "," + f in dic:
                 se = dic[m + "_stderr" + "," + f]
                 se = "   N/A" if se == "N/A" else f"{se:.4f}"
+                # A boundary interval is only present when the stderr degenerated
+                # to 0.0 (see `boundary_ci`). Show the bound so the cell does not
+                # read as infinite precision.
+                interval = dic.get(f"{m}{BOUNDARY_CI_SUFFIX},{f}")
+                if interval is not None:
+                    lower, upper = interval
+                    bound = f"<= {upper:.4f}" if lower == 0.0 else f">= {lower:.4f}"
+                    se = f"{se} ({bound} at 95%)"
                 values.append([k, version, f, n, m, hib, v, "±", se])
             else:
                 values.append([k, version, f, n, m, hib, v, "", ""])

--- a/tests/test_aggregation_pipeline.py
+++ b/tests/test_aggregation_pipeline.py
@@ -514,3 +514,23 @@ class TestBoundaryReporting:
         result = _process_results(acc, groups={}, bootstrap_iters=100)
 
         assert "acc_boundary_ci95,none" not in result.metrics["t1"]
+
+    def test_boundary_interval_does_not_reach_group_aggregation(self):
+        # Group aggregation discovers filters by the exact "<metric>," prefix, so the
+        # extra key must not be picked up as a metric of its own or weighted into the
+        # group score.
+        t1 = MockTask("t1", agg={"acc": mean}, n_eval_docs=25)
+        t2 = MockTask("t2", agg={"acc": mean}, n_eval_docs=25)
+        group = Group(name="g", aggregate_metric_list=[AggMetricConfig(metric="acc")])
+        group.add(t1)
+        group.add(t2)
+        acc = {
+            "t1": _make_acc(t1, {("acc", "none"): [0.0] * 25}),
+            "t2": _make_acc(t2, {("acc", "none"): [1.0, 0.0] * 12 + [1.0]}),
+        }
+
+        result = _process_results(acc, groups={"g": group}, bootstrap_iters=1000)
+
+        assert "acc_boundary_ci95,none" in result.metrics["t1"]
+        assert not any("boundary" in key for key in result.metrics["g"])
+        assert result.metrics["g"]["acc,none"] == pytest.approx(0.26)

--- a/tests/test_aggregation_pipeline.py
+++ b/tests/test_aggregation_pipeline.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 
 from lm_eval.api.group import AggMetricConfig, Group
-from lm_eval.api.metrics import mean
+from lm_eval.api.metrics import mean, median
 from lm_eval.api.task import Task
 from lm_eval.evaluator_utils import (
     ResultAcc,
@@ -444,3 +444,73 @@ class TestGroupAggregationWarnings:
             and "missing" in r.message.lower()
         ]
         assert len(group_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Boundary reporting: all-0 / all-1 score vectors
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryReporting:
+    """A task scored 0 (or 1) on every document has zero sample variance, so its
+    stderr is 0.0 at any sample size. The aggregation reports a Wilson interval
+    beside it so the sample size stays visible.
+    """
+
+    def test_all_zero_task_reports_a_boundary_interval(self):
+        task = MockTask("t1", agg={"acc": mean}, n_eval_docs=25)
+        acc = {"t1": _make_acc(task, {("acc", "none"): [0.0] * 25})}
+
+        result = _process_results(acc, groups={}, bootstrap_iters=1000)
+
+        assert result.metrics["t1"]["acc_stderr,none"] == 0.0
+        assert result.metrics["t1"]["acc_boundary_ci95,none"] == pytest.approx(
+            (0.0, 0.13319), abs=1e-5
+        )
+
+    def test_boundary_interval_narrows_with_more_documents(self):
+        small = MockTask("small", agg={"acc": mean}, n_eval_docs=25)
+        large = MockTask("large", agg={"acc": mean}, n_eval_docs=5000)
+        acc = {
+            "small": _make_acc(small, {("acc", "none"): [0.0] * 25}),
+            "large": _make_acc(large, {("acc", "none"): [0.0] * 5000}),
+        }
+
+        result = _process_results(acc, groups={}, bootstrap_iters=1000)
+
+        # Identical stderr, very different evidence — which is the whole point.
+        assert result.metrics["small"]["acc_stderr,none"] == 0.0
+        assert result.metrics["large"]["acc_stderr,none"] == 0.0
+        assert (
+            result.metrics["large"]["acc_boundary_ci95,none"][1]
+            < result.metrics["small"]["acc_boundary_ci95,none"][1]
+        )
+
+    def test_mixed_task_reports_no_boundary_interval(self):
+        task = MockTask("t1", agg={"acc": mean}, n_eval_docs=4)
+        acc = {"t1": _make_acc(task, {("acc", "none"): [1.0, 0.0, 1.0, 0.0]})}
+
+        result = _process_results(acc, groups={}, bootstrap_iters=1000)
+
+        assert "acc_boundary_ci95,none" not in result.metrics["t1"]
+
+    def test_no_boundary_interval_when_stderr_is_disabled(self):
+        # bootstrap_iters=0 means the run opted out of stderr entirely; adding an
+        # interval there would report uncertainty the user asked not to compute.
+        task = MockTask("t1", agg={"acc": mean}, n_eval_docs=25)
+        acc = {"t1": _make_acc(task, {("acc", "none"): [0.0] * 25})}
+
+        result = _process_results(acc, groups={}, bootstrap_iters=0)
+
+        assert result.metrics["t1"]["acc_stderr,none"] == "N/A"
+        assert "acc_boundary_ci95,none" not in result.metrics["t1"]
+
+    def test_no_boundary_interval_for_a_non_mean_aggregation(self):
+        # The interval bounds a proportion. The median of the same 0/1 vector is a
+        # different statistic, so claiming the interval for it would be wrong.
+        task = MockTask("t1", agg={"acc": median}, n_eval_docs=25)
+        acc = {"t1": _make_acc(task, {("acc", "none"): [0.0] * 25})}
+
+        result = _process_results(acc, groups={}, bootstrap_iters=100)
+
+        assert "acc_boundary_ci95,none" not in result.metrics["t1"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,14 @@
 import unittest.mock as mock
 
-from lm_eval.api.metrics import _bootstrap_internal_no_mp, mean
+import pytest
+
+from lm_eval.api.metrics import (
+    _bootstrap_internal_no_mp,
+    boundary_ci,
+    mean,
+    mean_stderr,
+    wilson_score_interval,
+)
 from lm_eval.api.task import ConfigurableTask
 from lm_eval.config.task import TaskConfig
 
@@ -261,3 +269,63 @@ if __name__ == "__main__":
     test_bootstrap_internal_no_mp()
     test_dict_metric_uses_custom_aggregation()
     print("All tests passed!")
+
+
+class TestBoundaryInterval:
+    """`mean_stderr` degenerates to 0.0 when every score sits on 0 or on 1.
+
+    Regression coverage for the case where a null (or saturated) result is
+    published as `0.0 +- 0.0000` at any sample size, hiding how much evidence
+    backs it.
+    """
+
+    def test_wilson_interval_matches_closed_form_for_a_null_result(self):
+        lower, upper = wilson_score_interval(successes=0, n=25)
+
+        assert lower == 0.0
+        assert upper == pytest.approx(0.13319, abs=1e-5)
+
+    def test_wilson_interval_narrows_as_the_sample_grows(self):
+        _, upper_small = wilson_score_interval(successes=0, n=25)
+        _, upper_large = wilson_score_interval(successes=0, n=5000)
+
+        assert upper_large < upper_small
+        assert upper_large == pytest.approx(0.00077, abs=1e-5)
+
+    def test_wilson_interval_is_symmetric_at_the_upper_boundary(self):
+        _, null_upper = wilson_score_interval(successes=0, n=25)
+        saturated_lower, saturated_upper = wilson_score_interval(successes=25, n=25)
+
+        assert saturated_upper == 1.0
+        assert saturated_lower == pytest.approx(1.0 - null_upper)
+
+    def test_wilson_interval_rejects_an_empty_sample(self):
+        with pytest.raises(ValueError):
+            wilson_score_interval(successes=0, n=0)
+
+    def test_boundary_ci_reports_an_interval_for_an_all_zero_vector(self):
+        items = [0.0] * 25
+
+        assert mean_stderr(items) == 0.0
+        assert boundary_ci(items) == pytest.approx((0.0, 0.13319), abs=1e-5)
+
+    def test_boundary_ci_reports_an_interval_for_an_all_one_vector(self):
+        items = [1.0] * 25
+
+        assert mean_stderr(items) == 0.0
+        assert boundary_ci(items) == pytest.approx((0.86681, 1.0), abs=1e-5)
+
+    def test_boundary_ci_ignores_a_vector_with_both_outcomes(self):
+        assert boundary_ci([1.0, 0.0, 1.0, 0.0]) is None
+
+    def test_boundary_ci_ignores_a_constant_vector_off_the_boundary(self):
+        # Zero variance, but not a degenerate proportion: 0.5 carries no
+        # binomial reading, so no interval is claimed for it.
+        assert boundary_ci([0.5] * 25) is None
+
+    def test_boundary_ci_ignores_non_numeric_items(self):
+        # Metrics such as bleu aggregate (reference, prediction) pairs.
+        assert boundary_ci([("ref", "pred"), ("ref", "pred")]) is None
+
+    def test_boundary_ci_ignores_an_empty_vector(self):
+        assert boundary_ci([]) is None

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -180,7 +180,8 @@ def test_bootstrap_internal_no_mp():
 
 def test_dict_metric_uses_custom_aggregation():
     """Regression test for #3314: dict-valued metrics must use the custom
-    aggregation function, not silently fall back to mean()."""
+    aggregation function, not silently fall back to mean().
+    """
     from collections import defaultdict
 
     from lm_eval.evaluator_utils import _compute_task_aggregations
@@ -215,7 +216,7 @@ def test_dict_metric_uses_custom_aggregation():
 
 
 def test_chrf_uses_zero_word_order():
-    """chrf aggregation should use word_order=0 (plain ChrF, not ChrF++)."""
+    """Chrf aggregation should use word_order=0 (plain ChrF, not ChrF++)."""
     import sacrebleu as sb
 
     from lm_eval.api.metrics import chrf

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -329,3 +329,22 @@ class TestBoundaryInterval:
 
     def test_boundary_ci_ignores_an_empty_vector(self):
         assert boundary_ci([]) is None
+
+    def test_boundary_ci_handles_numpy_scalars(self):
+        # Tasks return whatever their process_results produced; several compute with
+        # numpy, and np.int64 / np.bool_ are not instances of int.
+        import numpy as np
+
+        assert boundary_ci([np.float64(0.0)] * 25) == pytest.approx(
+            (0.0, 0.13319), abs=1e-5
+        )
+        assert boundary_ci([np.int64(0)] * 25) == pytest.approx(
+            (0.0, 0.13319), abs=1e-5
+        )
+        assert boundary_ci([np.bool_(True)] * 25) == pytest.approx(
+            (0.86681, 1.0), abs=1e-5
+        )
+
+    def test_boundary_ci_ignores_numeric_looking_strings(self):
+        # float("0") would succeed; a string score is not a proportion.
+        assert boundary_ci(["0"] * 25) is None

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,3 +1,4 @@
+import json
 import random
 
 import pytest
@@ -64,3 +65,21 @@ def test_make_table_is_unchanged_without_a_boundary_interval():
     assert "0.1" in table
     assert "<=" not in table
     assert ">=" not in table
+
+
+def test_make_table_accepts_a_boundary_interval_reloaded_from_json():
+    # results.json turns the tuple into a list; rendering a saved run must still work.
+    reloaded = json.loads(
+        json.dumps(
+            _table_result_dict(
+                {
+                    "acc,none": 0.0,
+                    "acc_stderr,none": 0.0,
+                    "acc_boundary_ci95,none": (0.0, 0.13319225093904846),
+                }
+            )
+        )
+    )
+
+    assert isinstance(reloaded["results"]["t1"]["acc_boundary_ci95,none"], list)
+    assert "<= 0.1332" in make_table(reloaded)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,7 @@ import random
 import pytest
 
 import lm_eval.api.metrics as metrics
+from lm_eval.utils import make_table
 
 
 def test_bootstrapping():
@@ -12,3 +13,54 @@ def test_bootstrapping():
     bootstrapped = metrics.bootstrap_stderr(metrics.mean, arr, iters=100000)
 
     assert bootstrapped == pytest.approx(expected, abs=1e-4)
+
+
+def _table_result_dict(task_metrics: dict) -> dict:
+    return {
+        "results": {"t1": {"alias": "t1", **task_metrics}},
+        "versions": {"t1": 1},
+        "n-shot": {"t1": 0},
+        "higher_is_better": {"t1": {"acc": True}},
+        "group_subtasks": {},
+    }
+
+
+def test_make_table_renders_a_boundary_bound_next_to_a_zero_stderr():
+    table = make_table(
+        _table_result_dict(
+            {
+                "acc,none": 0.0,
+                "acc_stderr,none": 0.0,
+                "acc_boundary_ci95,none": (0.0, 0.13319225093904846),
+            }
+        )
+    )
+
+    # The bound replaces a bare "± 0.0000", which reads as infinite precision.
+    assert "<= 0.1332" in table
+    # The interval must not be rendered as a metric row of its own.
+    assert "boundary_ci95" not in table
+
+
+def test_make_table_renders_the_lower_bound_at_a_saturated_score():
+    table = make_table(
+        _table_result_dict(
+            {
+                "acc,none": 1.0,
+                "acc_stderr,none": 0.0,
+                "acc_boundary_ci95,none": (0.8668077490609515, 1.0),
+            }
+        )
+    )
+
+    assert ">= 0.8668" in table
+
+
+def test_make_table_is_unchanged_without_a_boundary_interval():
+    table = make_table(_table_result_dict({"acc,none": 0.5, "acc_stderr,none": 0.1}))
+
+    # pytablewriter renders a purely numeric Stderr column as a number; the point
+    # is that no bound is appended.
+    assert "0.1" in table
+    assert "<=" not in table
+    assert ">=" not in table


### PR DESCRIPTION
Fixes #4070.

Following up on @fabio-rovai's analysis, with a narrower scope than either variant proposed there.

## The problem

An all-zero (or all-one) score vector has zero sample variance, so `mean_stderr` returns exactly `0.0` at any sample size, and `bootstrap_stderr` agrees because every resample of zeros is zeros. A model that scores 0 on a task is therefore published as `0.0 ± 0.0000` whether it was measured on 25 documents or on 5000 — two claims with very different evidence behind them, reported identically. These numbers are quoted directly in model cards and leaderboards, where `± 0.0000` reads as precision rather than as a degenerate estimator.

## The change

Additive and metric-layer only. **No existing value changes.**

- `wilson_score_interval(successes, n, z)` in `lm_eval/api/metrics.py` — stays inside [0, 1] and keeps a width at p̂ = 0 and p̂ = 1, which is exactly where the Wald standard error collapses to a point.
- `boundary_ci(items)` — returns that interval only for a vector sitting entirely on 0 or entirely on 1; `None` for everything else, including a constant vector off the boundary (0.5 is not a degenerate proportion) and the non-numeric items some metrics aggregate.
- `_compute_task_aggregations` records `"<metric>_boundary_ci95,<filter>"` only when the computed stderr is `0.0`, the aggregation is `mean`/`nanmean`, and the vector is degenerate — and logs the bound.
- `make_table` renders the bound in the Stderr cell instead of a bare `± 0.0000`.

A run with `bootstrap_iters=0` gets no interval: opting out of stderr should not produce uncertainty the caller did not ask for.

**The aggregation guard is load-bearing.** A bootstrapped `median` over the same all-zero vector also reports `0.0`, but a proportion interval does not describe a median. Note that a numeric test (`agg_fn(items) == mean(items)`) cannot substitute for it: at the boundary every statistic coincides, so such a check would not discriminate in the only case where it is consulted.

## Proof

The reproduction from the issue:

```python
res = lm_eval.simple_evaluate(model="dummy", tasks=["gsm8k"], limit=25, random_seed=0)
```

Before — the pair of zeros is the only signal:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |    0|±  |     0|
```

After:

```
WARNING lm_eval.evaluator_utils:[gsm8k] exact_match is at a boundary (0.0) on all 25
scored documents, so its stderr is 0.0 by construction and does not reflect the sample
size. 95% Wilson bound: true rate <= 0.1332.

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |         Stderr          |
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |    0|±  |0.0000 (<= 0.1332 at 95%)|
```

The interval matches `statsmodels.stats.proportion.proportion_confint(..., method="wilson")` to within 1e-12 on 9 cases, both boundaries included:

| k/n | this PR | statsmodels |
|---|---|---|
| 0/25 | (0.0, 0.1331922509) | (0.0, 0.1331922509) |
| 0/5000 | (0.0, 0.0007677019) | (0.0, 0.0007677019) |
| 25/25 | (0.8668077491, 1.0) | (0.8668077491, 1.0) |
| 517/1000 | (0.4860223600, 0.5478475303) | (0.4860223600, 0.5478475303) |

`statsmodels` was used only as an external check; it is not a new dependency.

## Scope

This is the narrow half of the discussion in #4017 / #4019. It does not switch any metric to Wilson intervals; it only adds a bound where the Wald estimator carries no information at all. If the broader CI proposal lands, this becomes a test case for it.

## Tests

24 added: `tests/test_metrics.py` (interval math against closed form, narrowing with N, boundary symmetry, empty sample, non-numeric and mixed vectors), `tests/test_aggregation_pipeline.py` (key present and narrowing with N, absent for mixed vectors, for `bootstrap_iters=0`, and for a non-mean aggregation), `tests/test_misc.py` (table rendering at both boundaries, unchanged without an interval).

Later commits pin the two ways this key could leak, both of which hold today: group aggregation discovers filters by the exact `"<metric>,"` prefix, so the extra key is not read as a metric of its own nor weighted into the group score; and `results.json` turns the tuple into a list, so `make_table` has to render a reloaded run as well as a live one.

The last commit widens boundary detection to numpy scalars. Scores arrive as whatever a task's `process_results` returned, and several tasks compute with numpy; `np.int64` and `np.bool_` are not instances of `int`, so an all-zero vector of those types would have failed the type check and silently received no interval.

Suite: 774 passed, 48 skipped, 0 failures (`tests/` plus `tests/models`, excluding the backends the CI also skips).

## Two notes for review

- The first commit is `style:` — the pre-commit `ruff-check` hook runs with `--fix` over every file a PR touches, so those autofixes land on any change to these modules. It is kept separate so the functional commit reads clean.
- The `Linters` job fails on `main` today for pre-existing ruff/codespell findings. This branch adds none: `ruff check --fix-only --diff` is a no-op on the touched files and `ruff format` passes.

---

Disclosure: AI-assisted analysis and drafting; I reproduced the behavior, verified the interval against an independent implementation, and understand the change.
