### PR TITLE
mbpp: don't swallow the first keyword of unfenced code as a language tag

### DIFF
--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -30,8 +30,11 @@ def pass_at_1(
 
 
 def extract_code_blocks(text: str) -> str:
-    # Pattern to match ```...``` blocks
-    pattern = r"```(?:\w+)?\n?(.*?)\n?```"
+    # Pattern to match ```...``` blocks. The optional language tag must be followed by a newline: because "```" is
+    # prepended below, a response that starts directly with code (e.g. "def f():" or "from typing import List", as
+    # chat models often do under --apply_chat_template) would otherwise have its first keyword swallowed as the
+    # language tag, leaving " f():" behind and scoring 0 on syntactically valid code.
+    pattern = r"```(?:\w+[ \t]*\n)?\n?(.*?)\n?```"
     # (+ ```) as we add the opening "```python" to the gen_prefix
     matches = re.findall(pattern, r"```" + text, re.DOTALL)
     # if no matches, try to match ```...``` blocks (after removing the language)

--- a/tests/test_mbpp_utils.py
+++ b/tests/test_mbpp_utils.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+
+
+# `mbpp.utils` loads the `code_eval` metric at import time, which requires the
+# `evaluate` package and HF_ALLOW_CODE_EVAL=1.
+os.environ.setdefault("HF_ALLOW_CODE_EVAL", "1")
+mbpp_utils = pytest.importorskip(
+    "lm_eval.tasks.mbpp.utils",
+    reason="mbpp needs the `evaluate` package and the `code_eval` metric",
+)
+
+extract_code_blocks = mbpp_utils.extract_code_blocks
+
+
+@pytest.mark.parametrize(
+    "response, expected",
+    [
+        # Continuation of the "```python\n" generation prefix, closed by the model.
+        pytest.param(
+            "def add(a, b):\n    return a + b\n```",
+            "def add(a, b):\n    return a + b",
+            id="prefix-continuation",
+        ),
+        # Model restates the language tag before the code.
+        pytest.param(
+            "python\ndef add(a, b):\n    return a + b\n```",
+            "def add(a, b):\n    return a + b",
+            id="language-tag",
+        ),
+        # Unfenced code starting with a keyword: before the fix "def" / "from" /
+        # "import" was swallowed as the language tag and the code became invalid.
+        pytest.param(
+            "def add(a, b):\n    return a + b\n```\nExplanation.",
+            "def add(a, b):\n    return a + b",
+            id="def-not-swallowed",
+        ),
+        pytest.param(
+            "from math import gcd\ndef f(a, b):\n    return gcd(a, b)\n```",
+            "from math import gcd\ndef f(a, b):\n    return gcd(a, b)",
+            id="from-not-swallowed",
+        ),
+        pytest.param(
+            "import re\ndef f(s):\n    return re.sub('x', '', s)\n```",
+            "import re\ndef f(s):\n    return re.sub('x', '', s)",
+            id="import-not-swallowed",
+        ),
+    ],
+)
+def test_extract_code_blocks(response, expected):
+    assert extract_code_blocks(response) == expected


### PR DESCRIPTION
## Summary

`lm_eval/tasks/mbpp/utils.py::extract_code_blocks` prepends "```" to the model output and then matches

```
```(?:\w+)?\n?(.*?)\n?```
```

The optional language tag `(?:\w+)?` is not required to be followed by a newline. When the model answers with unfenced code that starts with a keyword (typical for chat models under `--apply_chat_template`, e.g. Qwen2.5-Instruct), the first keyword is consumed as the "language tag":

| response | extracted (before) | extracted (after) |
|---|---|---|
| `def add(a, b):\n    return a + b\n```` | ` add(a, b):\n    return a + b` → `SyntaxError` | `def add(a, b):\n    return a + b` |
| `from math import gcd\n...` | ` math import gcd\n...` | unchanged code |
| `import re\n...` | ` re\n...` | unchanged code |

The effect is a hard 0.0 on `mbpp_instruct` for such models even when every generated function is correct (we hit this with Qwen2.5-3B/7B-Instruct-derived checkpoints: `mbpp_instruct = 0.0000` while `humaneval_instruct` was normal).

This PR requires the language tag to be followed by a newline (`(?:\w+[ \t]*\n)?`). Fenced responses (`python\n...`, or the bare continuation of the `"```python\n"` generation prefix) extract exactly as before.

## Tests

`tests/test_mbpp_utils.py` covers the prefix-continuation, explicit-language-tag and the three unfenced cases (`def`, `from`, `import`). The module is imported with `pytest.importorskip` because `mbpp.utils` loads the `code_eval` metric at import time.
