### PR TITLE
feat(evaluator): report per-metric sample counts in n-samples

### DIFF
--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -291,8 +291,17 @@ def _collect_results(
 
         # Compute n_samples: effective comes from sample_len (actual evaluated count)
         original = len(task.eval_docs)
+        # effective is one number for the whole task, but metrics do not always
+        # share a denominator. Report what each metric was actually scored on, so
+        # a metric that lost documents is visible rather than hidden behind the
+        # task-level count. This is the same quantity the warning above reports
+        # when the counts diverge, kept for the case where they do not.
+        per_metric = {
+            f"{metric},{filter_key}": len(items)
+            for (metric, filter_key), items in acc["raw_metrics"].items()
+        }
         result.n_samples[task_name] = _SampleCount(
-            original=original, effective=sample_len
+            original=original, effective=sample_len, per_metric=per_metric
         )
 
     return result

--- a/lm_eval/result_schema.py
+++ b/lm_eval/result_schema.py
@@ -137,6 +137,14 @@ class _SampleCount(TypedDict):
     effective: int
     """Actual number of documents actually evaluated (e.g. using limit)."""
 
+    per_metric: NotRequired[dict[str, int]]
+    """Number of documents each metric was actually scored on. Maps metric keys
+    like ``"acc,none"`` to a count. ``effective`` is a single number for the task,
+    but metrics do not always share a denominator: a document whose
+    ``process_results`` omits a key contributes to some metrics and not others.
+    This reports what each metric was scored on, mirroring the per-metric
+    ``sample_count`` that groups already carry."""
+
 
 class _EvalConfig(TypedDict, total=False):
     """Model and execution configuration stored in results."""

--- a/tests/test_evaluator_utils.py
+++ b/tests/test_evaluator_utils.py
@@ -850,8 +850,16 @@ class TestCollectResultsNSamples:
             "t2": make_result_acc(t2, {("acc", "none"): [0.0]}),
         }
         result = _collect_results(accs, bootstrap_iters=0)
-        assert result.n_samples["t1"] == {"original": 100, "effective": 3}
-        assert result.n_samples["t2"] == {"original": 200, "effective": 1}
+        assert result.n_samples["t1"] == {
+            "original": 100,
+            "effective": 3,
+            "per_metric": {"acc,none": 3},
+        }
+        assert result.n_samples["t2"] == {
+            "original": 200,
+            "effective": 1,
+            "per_metric": {"acc,none": 1},
+        }
 
     def test_n_samples_original_from_eval_docs(self):
         task = MockEvalTask("t1", agg={"acc": mean}, n_eval_docs=42)
@@ -859,3 +867,60 @@ class TestCollectResultsNSamples:
         result = _collect_results(accs, bootstrap_iters=0)
         assert result.n_samples["t1"]["original"] == 42
         assert result.n_samples["t1"]["effective"] == 2
+
+    def test_per_metric_counts_expose_a_metric_scored_on_fewer_documents(self):
+        """`effective` is one number for the task. When metrics disagree it takes
+        the largest, so a metric scored on fewer documents is invisible in it.
+        """
+        task = MockEvalTask("t1", agg={"acc": mean, "f1": mean}, n_eval_docs=6)
+        accs = {
+            "t1": make_result_acc(
+                task,
+                {
+                    ("acc", "none"): [1.0, 0.0, 1.0, 1.0, 0.0, 1.0],
+                    ("f1", "none"): [1.0, 1.0, 1.0, 1.0],
+                },
+            )
+        }
+        result = _collect_results(accs, bootstrap_iters=0)
+        n = result.n_samples["t1"]
+        assert n["effective"] == 6
+        assert n["per_metric"] == {"acc,none": 6, "f1,none": 4}
+
+    def test_per_metric_counts_reported_when_every_metric_dropped_together(self):
+        """The case the divergence warning cannot see: when all metrics omit the
+        same document the counts agree, nothing warns, and the aggregate is still
+        a mean over the survivors.
+        """
+        task = MockEvalTask("t1", agg={"acc": mean, "f1": mean}, n_eval_docs=6)
+        accs = {
+            "t1": make_result_acc(
+                task,
+                {
+                    ("acc", "none"): [1.0, 1.0, 1.0, 1.0],
+                    ("f1", "none"): [1.0, 1.0, 1.0, 1.0],
+                },
+            )
+        }
+        result = _collect_results(accs, bootstrap_iters=0)
+        n = result.n_samples["t1"]
+        assert n["original"] == 6
+        assert n["effective"] == 4
+        assert n["per_metric"] == {"acc,none": 4, "f1,none": 4}
+
+    def test_per_metric_counts_are_keyed_by_metric_and_filter(self):
+        task = MockEvalTask("t1", agg={"acc": mean}, n_eval_docs=4)
+        accs = {
+            "t1": make_result_acc(
+                task,
+                {
+                    ("acc", "none"): [1.0, 0.0, 1.0, 1.0],
+                    ("acc", "strict"): [1.0, 0.0],
+                },
+            )
+        }
+        result = _collect_results(accs, bootstrap_iters=0)
+        assert result.n_samples["t1"]["per_metric"] == {
+            "acc,none": 4,
+            "acc,strict": 2,
+        }


### PR DESCRIPTION
Refs #4062. This is the conservative option from that thread, opened so there is something concrete to accept or reject rather than a decision to make in the abstract. Easy to close if you would rather settle the scoring contract a different way.

## What is missing

`n-samples` reports one `effective` count per task, taken as the largest per-metric count. When metrics do not share a denominator that number describes only the metric that kept the most documents, and any metric scored on fewer is invisible.

The per-metric counts are already computed in `_compute_task_aggregations`, used for the divergence warning, and then discarded.

## The change

Carry them into `n-samples` as `per_metric`. Groups already report exactly this shape under `sample_count`, so this makes tasks consistent with groups rather than introducing a new idea.

```
"n-samples": {"my_task": {"original": 6, "effective": 6,
                          "per_metric": {"acc,none": 6, "f1,none": 4}}}
```

`per_metric` is `NotRequired`, additive, and no aggregate value changes.

## Why the warning is not enough on its own

The existing warning fires when metrics disagree. It cannot fire when every metric omits the same document, because then the counts agree and there is no divergence to detect. That is the case where the headline number moves, so it is the one worth reporting.

Verified with @AUTHENSOR's harness from #4062 (deterministic, no network or model inference), on identical model outputs where 2 of 6 documents refuse:

| state | before | after |
|---|---|---|
| every metric drops the same doc | `effective: 4` | `per_metric: {"acc,none": 4}` |
| acc keeps 6, f1 keeps 4 | `effective: 6` | `per_metric: {"acc,none": 6, "f1,none": 4}` |

Scores are unchanged in both: `acc=1.0`, `acc=0.667`, `f1=1.0` exactly as before.

To be clear about scope: this does not decide what an omitted metric key means. The same outputs still grade 1.0 or 0.667 depending on the task's convention. It makes the denominator legible so that ambiguity is visible rather than silent, and leaves the semantics to you.

## Tests

Four cases in `TestCollectResultsNSamples`: a metric scored on fewer documents than `effective`; every metric dropping together with no divergence to warn on; keying by metric and filter; and the two existing exact-shape assertions updated for the added key. All fail on `main` and pass here.

`tests/test_evaluator_utils.py`, `test_aggregation_pipeline.py` and `test_group.py`: 140 passed. `ruff check` reports the same 11 pre-existing findings as `main`, none added.
