### PR TITLE
Preserve None values when undistributing results

### DIFF
--- a/lm_eval/models/utils.py
+++ b/lm_eval/models/utils.py
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     TypeVar,
 )
+
 from typing_extensions import TypedDict
 
 from lm_eval.utils import maybe_warn, warning_once
@@ -185,12 +186,13 @@ def undistribute(iterable):
         [1, 2, 3]
 
     """
+    fillvalue = object()
     return [
         x
         for x in itertools.chain.from_iterable(
-            itertools.zip_longest(*[list(x) for x in iterable])
+            itertools.zip_longest(*[list(x) for x in iterable], fillvalue=fillvalue)
         )
-        if x is not None
+        if x is not fillvalue
     ]
 
 

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -1,6 +1,24 @@
 import pytest
 
-from lm_eval.models.utils import maybe_truncate, normalize_gen_kwargs, truncate_tokens
+from lm_eval.models.utils import (
+    maybe_truncate,
+    normalize_gen_kwargs,
+    truncate_tokens,
+    undistribute,
+)
+
+
+@pytest.mark.parametrize(
+    ("distributed", "expected"),
+    [
+        ([[1, 3, 5], [2, 4, 6]], [1, 2, 3, 4, 5, 6]),
+        ([[1, 4, 7], [2, 5], [3, 6]], [1, 2, 3, 4, 5, 6, 7]),
+        ([[1], [2], [3], [], []], [1, 2, 3]),
+        ([[1, None], [2, 3]], [1, 2, None, 3]),
+    ],
+)
+def test_undistribute(distributed, expected):
+    assert undistribute(distributed) == expected
 
 
 class TestTruncateTokens:


### PR DESCRIPTION
## Summary

- use a private sentinel to distinguish `zip_longest()` padding from genuine worker results
- preserve legitimate `None` values while reconstructing data-parallel result order
- add regression coverage for normal, uneven, empty, and `None`-containing worker partitions

## Validation

- `PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/models/test_model_utils.py -q` (43 passed)
- `PRE_COMMIT_HOME=/tmp/lm-eval-pre-commit pre-commit run --files lm_eval/models/utils.py tests/models/test_model_utils.py` (passed)

Fixes #4097