### PR TITLE
fix(api): skip null cache keys in concurrent requests

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -550,7 +550,8 @@ class TemplateAPI(TemplateLM):
 
             if cache_keys:
                 for res, cache in zip(answers, cache_keys, strict=False):
-                    self.cache_hook.add_partial(cache_method, cache, res)
+                    if cache is not None:
+                        self.cache_hook.add_partial(cache_method, cache, res)
             return answers
         # If the retries also fail
         except BaseException as e:

--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -1,9 +1,11 @@
 import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from lm_eval.api.model import CacheHook, hash_args
 from lm_eval.models.api_models import create_image_prompt
 from lm_eval.models.openai_completions import LocalCompletionsAPI
 
@@ -244,6 +246,38 @@ class DummyAsyncContextManager:
 
     async def __aexit__(self, exc_type, exc, tb):
         pass
+
+
+def test_amodel_call_skips_none_cache_keys(api):
+    # Given
+    response = MagicMock()
+    response.ok = True
+    response.raise_for_status = MagicMock()
+    response.json = AsyncMock(return_value={"mocked": "response"})
+    session = MagicMock()
+    session.post.return_value = DummyAsyncContextManager(response)
+    api.parse_logprobs = MagicMock(return_value=[(-1.0, True), (-2.0, False)])
+    cache_key = ("context", "continuation")
+    expected_answers = [(-1.0, True), (-2.0, False)]
+    expected_cache = {hash_args("loglikelihood", cache_key): (-2.0, False)}
+    cache = {}
+    api.cache_hook = CacheHook(SimpleNamespace(dbdict=cache))
+
+    # When
+    answers = asyncio.run(
+        api.amodel_call(
+            session=session,
+            sem=asyncio.Semaphore(1),
+            messages=["first request", "second request"],
+            generate=False,
+            cache_keys=[None, cache_key],
+            ctxlens=[1, 1],
+        )
+    )
+
+    # Then
+    assert answers == expected_answers
+    assert cache == expected_cache
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Concurrent API log-likelihood requests include `None` cache-key sentinels for rolling-likelihood windows. Before this change, the asynchronous response path passed every key directly to `CacheHook.add_partial()`. `CacheHook` hashes each key by iterating it, so the sentinel caused `TypeError: NoneType object is not iterable` and aborted concurrent rolling-likelihood evaluation.

## Solution

Only call `add_partial()` when the corresponding cache key is not `None`. This mirrors the synchronous log-likelihood path: intermediate rolling windows are not partially cached, valid request keys remain cached, and `loglikelihood_rolling()` continues to cache the final document-level score.

## Validation

- Added an async `amodel_call()` regression using the real `CacheHook` and an in-memory cache mapping. It passes one `None` rolling-window sentinel and one valid key, then verifies the valid response is cached and the sentinel is not.
- Ran that same new test against the parent commit before the fix: it failed through `amodel_call` to `CacheHook.add_partial` to `hash_args` with `TypeError: NoneType object is not iterable`.
- Ran the patched API-model test module: `PYTHONPATH=$PWD PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/dariuszkajtoch/PycharmProjects/pretraining-evaluator-task-corrections/evaluator/.venv/bin/pytest tests/models/test_api.py -q` — 16 passed.
- Ran `ruff check lm_eval/models/api_models.py tests/models/test_api.py` and `ruff format --check lm_eval/models/api_models.py tests/models/test_api.py` — passed.