### PR TITLE
fix(onnx): cache generate_until under the request's own arguments

### DIFF
--- a/lm_eval/models/_onnx_base.py
+++ b/lm_eval/models/_onnx_base.py
@@ -276,12 +276,12 @@ class _ONNXLMBase(TemplateLM, abc.ABC):
     ) -> list[str]:
         results: list[str] = []
 
-        for context, gen_kwargs in tqdm(
+        for context, request_args in tqdm(
             [req.args for req in requests],
             disable=disable_tqdm,
             desc="Generating text",
         ):
-            gen_kwargs = dict(gen_kwargs)
+            gen_kwargs = dict(request_args)
             until = gen_kwargs.pop("until", None)
             if isinstance(until, str):
                 until = [until]
@@ -299,7 +299,11 @@ class _ONNXLMBase(TemplateLM, abc.ABC):
                         text = text[:idx]
 
             results.append(text)
-            self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text)
+            # Cache under the request's own arguments, as every other backend
+            # does. `CachingLM` reads entries back with
+            # `hash_args("generate_until", req.args)`, so a key built from the
+            # copy that `until` was popped out of can never match a lookup.
+            self.cache_hook.add_partial("generate_until", (context, request_args), text)
 
         return results
 

--- a/tests/models/test_onnxruntime_parity.py
+++ b/tests/models/test_onnxruntime_parity.py
@@ -120,6 +120,57 @@ def test_both_backends_share_one_base():
 
 
 # --------------------------------------------------------------------------- #
+# Response cache: no runtime needed either.
+# --------------------------------------------------------------------------- #
+def test_generate_until_caches_under_the_request_arguments(tmp_path):
+    """The key written must be the key `CachingLM` reads back.
+
+    `generate_until` pops `until` out of a copy of the generation kwargs before
+    calling the backend. Caching that copy writes a row under a key no lookup
+    ever forms, because `CachingLM` hashes `req.args`, so the entry is dead
+    weight in the sqlite file.
+    """
+    pytest.importorskip("sqlitedict")
+
+    from lm_eval.api.model import CachingLM, hash_args
+    from lm_eval.models._onnx_base import _ONNXLMBase
+
+    class _StubONNXLM(_ONNXLMBase):
+        def __init__(self):  # bypass model loading
+            self._max_gen_toks = 8
+
+        def _load(self):
+            raise AssertionError("the stub never loads a model")
+
+        def _forward_logits(self, tokens):
+            raise AssertionError("generate_until does not score")
+
+        def _generate(self, tokens, gen_kwargs):
+            assert "until" not in gen_kwargs, "backends receive kwargs without `until`"
+            return [1, 2, 3]
+
+        def tok_encode(self, string, **kwargs):
+            return [0]
+
+        def tok_decode(self, tokens, **kwargs):
+            return "generated\nrest"
+
+        @property
+        def eot_token_id(self):
+            return 0
+
+    args = ("What is 2 + 2?", {"until": ["\n"], "max_gen_toks": 8})
+    request = Instance(request_type="generate_until", doc={}, arguments=args, idx=0)
+
+    lm = CachingLM(_StubONNXLM(), str(tmp_path / "responses.db"))
+    assert lm.generate_until([request]) == ["generated"]
+
+    # One request, one row, and it is the row a second run would look up.
+    assert len(lm.dbdict) == 1
+    assert hash_args("generate_until", args) in lm.dbdict
+
+
+# --------------------------------------------------------------------------- #
 # Provider resolution: no runtime needed, so these run in CI.
 # --------------------------------------------------------------------------- #
 class _FakeORT:


### PR DESCRIPTION
## What is wrong

`_ONNXLMBase.generate_until` builds a copy of the generation kwargs, pops `until`
out of it so the backend never sees it, and then caches under that copy:

```python
gen_kwargs = dict(gen_kwargs)
until = gen_kwargs.pop("until", None)
...
self.cache_hook.add_partial("generate_until", (context, gen_kwargs), text)
```

`CachingLM` looks entries up with `hash_args("generate_until", req.args)`, and
`req.args` still carries `until`. `hash_args` is a sha256 over
`json.dumps([attr] + list(args))`, so a dict with `until` removed hashes to a
different key than the one any lookup will ever form. Every generative request
therefore leaves a row in the sqlite cache that nothing can read.

Measured through the real `CachingLM`, 50 generative requests with a task that
supplies `until`:

```
                        rows written   readable   dead
_ONNXLMBase (current)        100           50       50
every other backend           50           50        0
```

## What is not wrong

Caching still works, and I want to be clear about that rather than let the title
imply otherwise. `CachingLM._fn` writes the correct key itself after running the
model, so hits happen normally on a second run. The cost is the duplicate row per
request, which doubles the cache file on generative tasks, and the inconsistency
with the rest of the backends.

## The change

`huggingface.py` already does this correctly and it is worth copying rather than
inventing: it pops `until` and `max_gen_toks` out of a *normalized copy* and
caches the untouched original.

```python
kwargs = normalize_gen_kwargs(gen_kwargs, self.max_gen_toks)
until = handle_stop_sequences(kwargs.pop("until", None), eos=eos)
...
self.cache_hook.add_partial("generate_until", (context, gen_kwargs), s)
```

This PR does the same in the ONNX base: the loop variable keeps the request's own
arguments, the popping happens on the copy, and the cache call passes the
original. Behaviour for the backends themselves is unchanged, since `_generate`
still receives kwargs without `until`.

Affects `onnxruntime-genai` and `winml`. `onnxruntime` raises
`NotImplementedError` for generation, so it never reaches this path.

## Tests

Added to `tests/models/test_onnxruntime_parity.py`, in the section that needs no
runtime, so it runs in CI rather than skipping like the parity tests. It drives
the real `CachingLM` with a stub backend and asserts that one request leaves one
row, and that the row is under the key a second run would look up.

Reverting the source change fails it at `assert 2 == 1`, which is the doubled row
count above, so the test bites on this specific defect rather than on the feature
generally.

Run locally on Windows with Python 3.12:
`tests/models/test_onnxruntime_parity.py`, `test_onnxruntime_genai.py` and
`test_winml.py` give 8 passed, 8 skipped, the skips being the cases that need the
ONNX runtimes. `ruff check` and `ruff format --check` are clean on both files, and
were clean on `main` beforehand, so the formatting in the diff is mine and not
pre-existing drift.
