### PR TITLE
Add ThinkRetrieve external model plugin example

### DIFF
--- a/examples/thinkretrieve/README.md
+++ b/examples/thinkretrieve/README.md
@@ -1,0 +1,106 @@
+# Evaluation integrations
+
+These integrations make ThinkRetrieve usable as a baseline in two established
+research ecosystems without adding either ecosystem as a package dependency.
+
+## lm-evaluation-harness
+
+Install `lm-eval` and `thinkretrieve[faiss]`, build a bank with
+`FaissRetriever.save`, then expose this directory to the harness:
+
+```sh
+python -m lm_eval \
+  --model thinkretrieve \
+  --model_args model=qwen3:4b,base_url=http://localhost:11434/v1,bank_path=/path/to/gsm8k_bank,think_budget=2048 \
+  --tasks gsm8k \
+  --include_path integrations/lm_eval
+```
+
+This is generation-only. It is appropriate for GSM8K-style tasks; likelihood
+tasks should fail clearly rather than report misleading scores. The adapter
+uses the task context as the question and lets ThinkRetrieve manage its own
+intermediate probe, retrieval, injection, and final answer.
+
+## FlashRAG
+
+`integrations/flashrag/thinkretrieve_pipeline.py` adapts a FlashRAG-style
+dataset (`question` plus `update_output`) while retaining ThinkRetrieve's
+worked-example bank and mid-trace injection. This is a small adapter intended
+for a FlashRAG experiment configuration, not a replacement for FlashRAG's
+document-retrieval pipelines.
+
+```python
+from integrations.flashrag.thinkretrieve_pipeline import ThinkRetrievePipeline
+
+pipeline = ThinkRetrievePipeline(
+    bank_path="gsm8k_bank",
+    model="qwen3:4b",
+    base_url="http://localhost:11434/v1",
+)
+dataset = pipeline.run(dataset)
+```
+
+Keep the paper citation in any result table or configuration README:
+
+```bibtex
+@article{thinkretrieve2026,
+  title = {ThinkRetrieve: Retrieval-Augmented Reasoning Traces for Test-Time Scaling},
+  author = {Singh, Vaibhav and Ghosal, Soumya Suvra and Gharat, Sarvesh and Pal, Soumyabrata and Narayanam, Ramasuri and Manocha, Dinesh},
+  journal = {arXiv preprint arXiv:2608.10928},
+  year = {2026},
+  doi = {10.48550/arXiv.2608.10928}
+}
+```
+
+These adapters are proposed upstream contributions. They should be benchmarked
+against the host project's conventions before opening a pull request.
+
+## Quick test
+
+From the ThinkRetrieve repository:
+
+```sh
+PYTHONPATH=thinkretrieve/src python -m pytest -q thinkretrieve/tests integrations/tests
+```
+
+This runs the library tests and the adapter tests without a GPU, API key, or
+FlashRAG/lm-eval installation. For a real smoke run, install the optional
+dependencies, build or download a saved FAISS bank, start Ollama, and run the
+lm-eval command above on two GSM8K examples first. Use a fresh output directory
+for each configuration.
+
+## Add it to lm-evaluation-harness
+
+1. Fork `EleutherAI/lm-evaluation-harness` and create a branch.
+2. Copy `integrations/lm_eval/thinkretrieve_lm.py` into your fork, or install
+   this repository and use `--include_path integrations/lm_eval`.
+3. Install `lm-eval` and `thinkretrieve[faiss]`.
+4. Run a two-example GSM8K smoke test, then a documented reproducible run.
+5. Add a short README section and tests, run the harness checks, and open a PR
+   explaining that this is a generation-only plugin.
+
+The harness documents this plugin approach in its [model guide](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/model_guide.md).
+
+## Add it to FlashRAG
+
+1. Fork `RUC-NLPIR/FlashRAG` and create a branch.
+2. Copy `integrations/flashrag/thinkretrieve_pipeline.py` into FlashRAG's
+   pipeline package and import it from that package's initializer if required.
+3. Add a config using a saved ThinkRetrieve example bank and an OpenAI-compatible
+   model endpoint.
+4. Run the host project's smallest reasoning benchmark and compare plain RAG,
+   extra thinking, and ThinkRetrieve with the same model and budget.
+5. Record the bank, model, seed, token accounting, latency, and failure cases;
+   add tests and open a PR with the paper citation.
+
+FlashRAG's pipeline implementation is the reference for its dataset and output
+conventions. Do not claim a benchmark improvement until this host-native run is
+complete.
+
+## ThinkBooster alternative
+
+For a test-time-scaling-focused contribution, fork `IINemo/thinkbooster`, add a
+`StrategyThinkRetrieve` class under `thinkbooster/strategies/`, register it in
+`tests/strategy_registry.py`, add the required unit/integration tests, and add a
+Hydra strategy config. Its [strategy guide](https://github.com/IINemo/thinkbooster/blob/main/docs/core/strategy_registration.md)
+lists the required files and checks.

--- a/examples/thinkretrieve/thinkretrieve_lm.py
+++ b/examples/thinkretrieve/thinkretrieve_lm.py
@@ -1,0 +1,118 @@
+"""Optional lm-evaluation-harness plugin for ThinkRetrieve.
+
+This module is deliberately kept outside the package's runtime dependencies.
+Install ``lm-eval`` and ``thinkretrieve[faiss]`` to use it::
+
+    python -m lm_eval --model thinkretrieve \
+      --model_args=model=qwen3:4b,base_url=http://localhost:11434/v1,bank_path=gsm8k_bank \
+      --tasks gsm8k --include_path integrations/lm_eval
+
+The harness passes one prompt at a time to ``generate_until``. The adapter
+uses the prompt as the ThinkRetrieve question and returns the final answer.
+It is intended for generative tasks (GSM8K-style), not log-likelihood tasks.
+The bank directory must be a ThinkRetrieve ``FaissRetriever.save`` output.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+try:
+    from lm_eval.api.instance import Instance
+    from lm_eval.api.model import LM
+    from lm_eval.api.registry import register_model
+except ImportError as exc:  # pragma: no cover - exercised only without lm-eval
+    raise ImportError(
+        "Install lm-eval to use the ThinkRetrieve harness plugin"
+    ) from exc
+
+from thinkretrieve import FaissRetriever, OpenAICompatBackend, ThinkRetrieve, ThinkRetrieveConfig
+
+
+def _args(raw: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for item in raw.split(","):
+        if not item.strip():
+            continue
+        key, sep, value = item.partition("=")
+        if not sep:
+            raise ValueError(f"model_args item needs key=value: {item!r}")
+        values[key.strip()] = value.strip()
+    return values
+
+
+@register_model("thinkretrieve")
+class ThinkRetrieveLM(LM):
+    """A generation-only lm-evaluation-harness model wrapper."""
+
+    REQUIRES_VLLM = False
+
+    def __init__(
+        self,
+        model: str,
+        bank_path: str,
+        base_url: str = "http://localhost:11434/v1",
+        api_key: str = "EMPTY",
+        think_budget: int = 2048,
+        max_insertions: int = 3,
+        device: Optional[str] = None,
+        **_: Any,
+    ) -> None:
+        del device  # Kept for CLI compatibility with harness model arguments.
+        self._model = model
+        self._backend = OpenAICompatBackend(
+            model=model, base_url=base_url, api_key=api_key
+        )
+        self._retriever = FaissRetriever.load(bank_path)
+        self._config = ThinkRetrieveConfig(
+            think_budget=int(think_budget), max_insertions=int(max_insertions)
+        )
+
+    @property
+    def eot_token_id(self) -> Optional[int]:
+        return None
+
+    @property
+    def max_length(self) -> int:
+        return self._config.think_budget + self._config.answer_max_tokens
+
+    @property
+    def max_gen_toks(self) -> int:
+        return self._config.answer_max_tokens
+
+    @property
+    def batch_size(self) -> int:
+        return 1
+
+    def tok_encode(self, string: str, **_: Any) -> List[int]:
+        # The adapter is generation-only; harness token accounting is an
+        # estimate because the remote backend owns tokenization.
+        return list(range(self._backend.count_tokens(string)))
+
+    def tok_decode(self, tokens: List[int], **_: Any) -> str:
+        return " " * len(tokens)
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Any]:
+        raise NotImplementedError(
+            "ThinkRetrieveLM supports generation tasks, not log-likelihood tasks"
+        )
+
+    def loglikelihood_rolling(self, requests: List[Instance]) -> List[Any]:
+        raise NotImplementedError(
+            "ThinkRetrieveLM supports generation tasks, not rolling likelihoods"
+        )
+
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        outputs: List[str] = []
+        for request in requests:
+            context = request.args[0]
+            result = ThinkRetrieve(
+                self._backend, self._retriever, self._config
+            ).run(context)
+            outputs.append(result.answer.strip())
+        return outputs
+
+
+def build_model(args: str) -> ThinkRetrieveLM:
+    """Small programmatic entry point useful in notebooks and tests."""
+    return ThinkRetrieveLM(**_args(args))


### PR DESCRIPTION
## Summary

This PR adds an example integration for ThinkRetrieve as an external generation-only model plugin for lm-evaluation-harness.

ThinkRetrieve performs test-time retrieval from a saved FAISS bank while the model is reasoning, then continues generation with the retrieved worked examples inserted into the reasoning trace.

## Added

 - `examples/thinkretrieve/thinkretrieve_lm.py`
 - Example configuration and usage instructions
 - Support for OpenAI-compatible endpoints such as Ollama
 - Configurable retrieval bank, thinking budget, and insertion count

 ## Usage

 ```bash
  python -m lm_eval \
    --model thinkretrieve \
    --model_args model=qwen3.5:4b,base_url=http://localhost:11434/v1,bank_path=/path/to/bank \
    --tasks gsm8k \
    --include_path examples/thinkretrieve
```

 This adapter currently supports generation tasks. Likelihood-based tasks raise NotImplementedError rather than reporting misleading scores.

## Validation
  
The ThinkRetrieve repository tests pass, and the plugin file compiles successfully.

## Citation

If this plugin is used in experiments, please cite:
```
@article{thinkretrieve2026,
    title={ThinkRetrieve: Retrieval-Augmented Reasoning Traces for Test-Time Scaling},
    author={Singh, Vaibhav and Ghosal, Soumya Suvra and Gharat, Sarvesh and Pal, Soumyabrata and Narayanam, Ramasuri and Manocha, Dinesh},
    journal={arXiv preprint arXiv:2608.10928},
    year={2026},
    doi={10.48550/arXiv.2608.10928}
  }
```