### PR TITLE
fix: make med_text_classification runnable outside the authoring cluster

### DIFF
--- a/lm_eval/tasks/med_text_classification/med_text_classification_easy.yaml
+++ b/lm_eval/tasks/med_text_classification/med_text_classification_easy.yaml
@@ -1,11 +1,8 @@
 tag:
   - med_text_classification
 task: med_text_classification_easy
-dataset_path: csv
+dataset_path: TimSchopf/medical_abstracts
 dataset_name: null
-dataset_kwargs:
-  data_files:
-    train: /gpfs/projects/bsc70/heka/data/datasets/med_text_class_train.csv
 output_type: multiple_choice
 training_split: train
 validation_split: train

--- a/lm_eval/tasks/med_text_classification/med_text_classification_hard.yaml
+++ b/lm_eval/tasks/med_text_classification/med_text_classification_hard.yaml
@@ -1,8 +1,7 @@
 include: med_text_classification_easy.yaml
 task: med_text_classification_hard
-dataset_kwargs:
-  data_files:
-    train: /gpfs/projects/bsc70/heka/data/datasets/mtsamples.csv
+dataset_path: harishnair04/mtsamples
+dataset_name: null
 process_docs: !function utils.process_docs_hard
 doc_to_text: !function utils.doc_to_text_hard
 doc_to_choice: !function utils.doc_to_choice_hard

--- a/lm_eval/tasks/med_text_classification/utils.py
+++ b/lm_eval/tasks/med_text_classification/utils.py
@@ -1,14 +1,17 @@
-import random
-
 import datasets
 
 
 def process_docs_hard(dataset: datasets.Dataset):
-    return dataset
+    # A small number of rows in the source dataset have a null transcription,
+    # which would make doc_to_text_hard emit the literal string "None".
+    return dataset.filter(lambda doc: doc["transcription"] is not None)
 
 
 def process_docs(dataset: datasets.Dataset):
     def _helper(doc):
+        # Map the upstream column names onto the ones used by this task.
+        doc["text"] = doc["medical_abstract"]
+        doc["class"] = doc["condition_label"]
         return doc
 
     num_entries = len(dataset)


### PR DESCRIPTION
## Problem

Both `med_text_classification` tasks load their data via absolute paths on a private cluster filesystem:

```yaml
dataset_path: csv
dataset_kwargs:
  data_files:
    train: /gpfs/projects/bsc70/heka/data/datasets/med_text_class_train.csv   # _easy
    train: /gpfs/projects/bsc70/heka/data/datasets/mtsamples.csv              # _hard
```

All three task names are registered and discoverable, so this is user-facing:

```
$ lm_eval --tasks med_text_classification_easy --model hf \
    --model_args pretrained=hf-internal-testing/tiny-random-gpt2 --limit 2 --device cpu
FileNotFoundError: Unable to find '/gpfs/projects/bsc70/heka/data/datasets/med_text_class_train.csv'
```

Confirmed registered:
```python
>>> [t for t in TaskManager().all_tasks if 'med_text' in t]
['med_text_classification', 'med_text_classification_easy', 'med_text_classification_hard']
```

I found this while scanning all 13,986 task YAMLs with the repo's own `load_yaml`; these were the only two tasks pointing at unreachable local paths (`grep` for `/gpfs/|/scratch/|/lustre/` now returns only one commented-out line elsewhere).

## Fix

Point both tasks at the public HF datasets they were clearly built from. I identified them from the task code itself, not by name similarity:

**`_easy` → [`TimSchopf/medical_abstracts`](https://huggingface.co/datasets/TimSchopf/medical_abstracts)** (Medical-Abstracts-TC-Corpus)
- `doc_to_choice_easy` lists exactly the corpus's 5 classes
- Label counts match the published corpus: 2530 / 1195 / 1540 / 2441
- `condition_label` ∈ {1..5}, matching the existing `int(doc["class"]) - 1` target logic
- Columns are `medical_abstract` / `condition_label`, so `process_docs` maps them to the `text` / `class` names the task code already expects

**`_hard` → [`harishnair04/mtsamples`](https://huggingface.co/datasets/harishnair04/mtsamples)**
- 4999 rows, and its 40 `medical_specialty` values are an **exact set match** for `doc_to_choice_hard` — including the leading space in each label, so `doc_to_target_hard`'s `choices.index(gold)` resolves unchanged:
```
in dataset but NOT in choices: []
in choices but NOT in dataset: []
EXACT MATCH: True
```

Two smaller changes in `utils.py`:
- `process_docs_hard` now filters the **33 rows whose `transcription` is null**, which would otherwise render as the literal string `"None"` in the prompt.
- Dropped the unused `random` import (pre-existing, but `ruff` fails on the touched file otherwise).

I deliberately did **not** change prompts, metrics, or `doc_to_*` logic — only data sourcing.

## Verification

Before (on `main`): `FileNotFoundError`. After:

```
|           Tasks            |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|med_text_classification_easy|      1|none  |     0|acc   |↑  |0.3333|±  |0.3333|
|med_text_classification_hard|      1|none  |     0|acc   |↑  |0.0000|±  |0.0000|
```

- Both tasks build: **1155** / **4966** docs (4999 − 33 nulls)
- All sampled targets in range; no prompt renders as `"None"`
- End-to-end `lm_eval` run on `hf-internal-testing/tiny-random-gpt2` completes 225 loglikelihood requests
- `ruff check` + `ruff format --check` clean
- `pytest tests/test_utils.py tests/test_janitor.py tests/test_tasks.py` → **81 passed, 1 skipped**

Accuracy values are meaningless (random-weight test model); they only demonstrate the tasks now run.

## Notes

- Similar recent fixes for reference: #3972, #3977, #3980. No existing issue/PR covers these tasks (searched `med_text_classification`).
- The original CSVs aren't public, so I can't byte-compare them against these datasets. The label-set and distribution matches above are strong evidence, but if the original author (BSC/HEKA) intended a specific split or preprocessing, please flag it — `_easy` keeps the existing "first 10%" `process_docs` behaviour, which now selects from the HF `train` split.
- Only `train` exists in `harishnair04/mtsamples`, so the task's existing `training/validation/test_split: train` mapping is preserved as-is.