### PR TITLE
Evaluate every CoQA turn; keep legacy last-turn variant

### DIFF
--- a/lm_eval/tasks/coqa/default.yaml
+++ b/lm_eval/tasks/coqa/default.yaml
@@ -3,6 +3,7 @@ dataset_path: EleutherAI/coqa
 output_type: generate_until
 training_split: train
 validation_split: validation
+process_docs: !function utils.process_docs
 doc_to_text: !function utils.doc_to_text
 doc_to_target: !function utils.doc_to_target
 process_results: !function utils.process_results
@@ -19,4 +20,4 @@ metric_list:
     aggregation: mean
     higher_is_better: true
 metadata:
-  version: 3.0
+  version: 4.0

--- a/lm_eval/tasks/coqa/last_turn.yaml
+++ b/lm_eval/tasks/coqa/last_turn.yaml
@@ -1,0 +1,11 @@
+# Legacy single-turn variant of CoQA: only the last answer of each story is
+# predicted. Kept for comparability with older results; the official
+# per-turn evaluation (EleutherAI/lm-evaluation-harness#1231) is the
+# default `coqa` task.
+include: default.yaml
+task: coqa_last_turn
+# Null out the parent's per-turn expansion: this variant keeps the legacy
+# single-doc-per-story behavior (last answer only).
+process_docs:
+metadata:
+  version: 3.0

--- a/lm_eval/tasks/coqa/utils.py
+++ b/lm_eval/tasks/coqa/utils.py
@@ -3,12 +3,37 @@ from itertools import zip_longest
 import transformers.data.metrics.squad_metrics as squad_metrics
 
 
+def process_docs(dataset):
+    """Expand each story into one document per conversation turn.
+
+    The official CoQA evaluation (https://stanfordnlp.github.io/coqa/)
+    scores every turn, not just the last one: for turn ``t`` the model sees
+    the passage plus questions/answers 0..t-1 and must produce answer ``t``.
+    Each expanded doc carries its 0-based ``turn_id``; doc_to_text and
+    doc_to_target honor it and fall back to the last turn when absent.
+    """
+    docs = []
+    for doc in dataset:
+        n_turns = len(doc["questions"]["input_text"])
+        if n_turns == 0:
+            docs.append(doc)
+            continue
+        for turn_id in range(n_turns):
+            expanded = dict(doc)
+            expanded["turn_id"] = turn_id
+            docs.append(expanded)
+    return docs
+
+
 def doc_to_text(doc):
     # Given a passage p, the conversation history {q1, a1, . . . qi−1, ai−1}
-    # and a question qi, the task is to predict the answer ai
+    # and a question qi, the task is to predict the answer ai.
+    # `turn_id` selects which turn is queried (default: last turn).
+    turn_id = doc.get("turn_id", len(doc["questions"]["input_text"]) - 1)
     doc_text = doc["story"] + "\n\n"
     for q, a in zip_longest(
-        doc["questions"]["input_text"], doc["answers"]["input_text"][:-1]
+        doc["questions"]["input_text"][: turn_id + 1],
+        doc["answers"]["input_text"][:turn_id],
     ):  # omit target answer ai
         question = f"Q: {q}\n\n"
         answer = f"A: {a}\n\n" if a is not None else "A:"
@@ -17,17 +42,18 @@ def doc_to_text(doc):
 
 
 def doc_to_target(doc):
-    turn_id = len(doc["questions"]["input_text"])
     # Returns unique answers and valid alternatives (Some questions in CoQA have multiple valid answers).
+    # `turn_id` selects which turn is targeted (default: last turn).
+    turn_id = doc.get("turn_id", len(doc["questions"]["input_text"]) - 1)
     answers = []
-    answer_forturn = doc["answers"]["input_text"][turn_id - 1]
+    answer_forturn = doc["answers"]["input_text"][turn_id]
     answers.append(answer_forturn)
 
     additional_answers = doc.get("additional_answers")
     if additional_answers:
         for key in additional_answers:
             additional_answer_for_turn = additional_answers[key]["input_text"][
-                turn_id - 1
+                turn_id
             ]
             if additional_answer_for_turn.lower() not in map(str.lower, answers):
                 answers.append(additional_answer_for_turn)


### PR DESCRIPTION
## Motivation

Fixes #1231. The official CoQA evaluation scores every turn (each turn's answer given the passage + prior turns), and the authors' eval script averages over all `turn_id`s. This task only ever predicted each story's last answer.

Per @StellaAthena's comment, this keeps both variants and marks the issue's version as official.

## Modifications

- `utils.process_docs` expands each story into one doc per turn, carrying a 0-based `turn_id`.
- `doc_to_text`/`doc_to_target` honor `turn_id`, defaulting to the last turn, so behavior without expansion is byte-identical to before.
- `default.yaml`: wires `process_docs`, bumps task version 3.0 → 4.0 (result counts change: N docs per story instead of 1).
- New `last_turn.yaml` (`coqa_last_turn`, v3.0): includes the default config with `process_docs` nulled out, preserving the legacy single-answer behavior for comparability.

## Verification (CPU, no GPU)

- Expansion counts, per-turn prompts ending in an empty `A:`, full history present, no target leak, per-turn targets including `additional_answers` — checked on synthetic rows and on the first stories of the real `EleutherAI/coqa` validation split (e.g. 5 stories → 76 turn-docs, all correct).
- Legacy equivalence: docs without `turn_id` produce exactly the old prompt and target.
- Both yamls load through the repo's own `_yaml_loader` (include merge verified: child nulls out `process_docs`, inherits the rest).