### PR TITLE
fix(okapi): preserve multilingual ARC question and choice content

### DIFF
--- a/lm_eval/tasks/okapi/arc_multilingual/utils.py
+++ b/lm_eval/tasks/okapi/arc_multilingual/utils.py
@@ -1,14 +1,4 @@
-import re
-
 import datasets
-
-
-def preprocess(text):
-    text = text.strip()
-    text = text.replace(" [title]", ". ")
-    text = re.sub("\\[.*?\\]", "", text)
-    text = text.replace("  ", " ")
-    return text
 
 
 def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
@@ -16,9 +6,9 @@ def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
         # breakpoint()
         out_doc = {
             "id": doc["id"],
-            "query": "Question: " + preprocess(doc["instruction"]) + "\nAnswer:",
+            "query": "Question: " + doc["instruction"] + "\nAnswer:",
             "choices": [
-                preprocess(option)
+                option
                 for option in [
                     doc["option_a"],
                     doc["option_b"],

--- a/tests/test_okapi_arc_multilingual.py
+++ b/tests/test_okapi_arc_multilingual.py
@@ -1,0 +1,29 @@
+import datasets
+
+from lm_eval.tasks.okapi.arc_multilingual.utils import process_docs
+
+
+def test_process_docs_preserves_arc_content_verbatim():
+    dataset = datasets.Dataset.from_list(
+        [
+            {
+                "id": "example",
+                "instruction": "Allele [E] is dominant over [e]; parent [Ee] is heterozygous.",
+                "option_a": "[EE]",
+                "option_b": "[Ee]",
+                "option_c": "[ee]",
+                "option_d": "none",
+                "option_e": None,
+                "answer": "B",
+            }
+        ]
+    )
+
+    doc = process_docs(dataset)[0]
+
+    assert doc["query"] == (
+        "Question: Allele [E] is dominant over [e]; parent [Ee] is heterozygous.\n"
+        "Answer:"
+    )
+    assert doc["choices"] == ["[EE]", "[Ee]", "[ee]", "none"]
+    assert doc["gold"] == 1


### PR DESCRIPTION
## Problem

`okapi/arc_multilingual` currently runs ARC questions and choices through the same bracket/title cleanup used by HellaSwag. The sibling HellaSwag implementation documents bracket removal as cleanup for WikiHow artifacts; ARC has no corresponding source artifact, and the native English ARC task passes question/choice content through directly.

This is not only theoretical. In the current `alexandrainst/m_arc` Arabic train split, row `ARC-Challenge/train/Mercury_400893` contains genotype notation `[ E ]`, `[e]`, and `[Ee]`. The current preprocessing removes all three tokens from the question before evaluation. This is the failure mode reported in #2000.

## Fix

- Remove the HellaSwag-specific `preprocess()` path from multilingual ARC.
- Pass `instruction` and answer-option strings through unchanged.
- Add a regression test covering bracketed scientific notation in both the question and choices.

No dataset configuration, prompt scaffold, answer-key mapping, or metric is changed.

## Verification

- `python -m pytest -q tests/test_okapi_arc_multilingual.py` → `1 passed`
- `ruff check lm_eval/tasks/okapi/arc_multilingual/utils.py tests/test_okapi_arc_multilingual.py` → pass
- `ruff format --check ...` → both files already formatted
- `git diff --check` → pass
- Reproduced the real Arabic witness against upstream `b954108c9baaaa934b4ad842033b31a97ee30816`: current main removes `[ E ]`, `[e]`, `[Ee]`; the patch preserves all three.

Fixes #2000.