### PR TITLE
test: add evaluator validation regression coverage

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -83,6 +83,43 @@ def test_evaluator(
     )
 
 
+def test_simple_evaluate_rejects_limit_and_samples():
+    with pytest.raises(
+        ValueError,
+        match="Either 'limit' or 'samples' must be None",
+    ):
+        evaluator.simple_evaluate(
+            model="hf",
+            tasks=["arc_easy"],
+            limit=1,
+            samples={"arc_easy": [0]},
+        )
+
+
+def test_evaluate_rejects_limit_and_samples():
+    with pytest.raises(
+        ValueError,
+        match="Either 'limit' or 'samples' must be None",
+    ):
+        evaluator.evaluate(
+            lm=None,
+            task_dict={},
+            limit=1,
+            samples={"arc_easy": [0]},
+        )
+
+
+def test_simple_evaluate_rejects_empty_tasks():
+    with pytest.raises(
+        ValueError,
+        match="No tasks specified",
+    ):
+        evaluator.simple_evaluate(
+            model="hf",
+            tasks=[],
+        )
+
+
 @pytest.mark.parametrize(
     "task_name,limit,model,model_args",
     [


### PR DESCRIPTION
## Summary

Adds regression tests for deterministic validation behavior in `simple_evaluate()` and `evaluate()`.

The tests cover:

* rejecting `limit` and `samples` when both are provided to `simple_evaluate()`
* rejecting `limit` and `samples` when both are provided to `evaluate()`
* rejecting an empty task list in `simple_evaluate()`

This is a small piece of the evaluator-level regression coverage discussed in #1883 and is separate from the numerical/GPU regression testing work.

## Testing

```text
pytest tests/test_evaluator.py -q -k "rejects or make_table"
5 passed, 6 deselected

ruff check tests/test_evaluator.py
All checks passed!

ruff format --check tests/test_evaluator.py
All files already formatted.
```
