### PR TITLE
Fix/truthfulqa mc2 underflow

### DIFF
--- a/lm_eval/tasks/truthfulqa/utils.py
+++ b/lm_eval/tasks/truthfulqa/utils.py
@@ -11,8 +11,8 @@ def process_results_mc2(doc, results):
     ll, _ = zip(*results)
     ll = np.array(ll)
 
-    # Convert log-likelihoods to probabilities.
-    probs = np.exp(ll)
+    # Shift before exponentiating to avoid underflow for small likelihoods.
+    probs = np.exp(ll - np.max(ll))
 
     # Normalize probabilities.
     probs_norm = probs / np.sum(probs)
@@ -112,14 +112,14 @@ def process_results_gen(doc, results):
         "bleu_acc": bleu_acc,
         "bleu_diff": bleu_diff,
         "rouge1_max": rouge1_max,
-        "rouge1_acc": rouge1_acc,
         "rouge1_diff": rouge1_diff,
+        "rouge1_acc": rouge1_acc,
         "rouge2_max": rouge2_max,
-        "rouge2_acc": rouge2_acc,
         "rouge2_diff": rouge2_diff,
+        "rouge2_acc": rouge2_acc,
         "rougeL_max": rougeL_max,
-        "rougeL_acc": rougeL_acc,
         "rougeL_diff": rougeL_diff,
+        "rougeL_acc": rougeL_acc,
     }
 
 

--- a/lm_eval/tasks/truthfulqa/utils.py
+++ b/lm_eval/tasks/truthfulqa/utils.py
@@ -8,7 +8,7 @@ ROUGE_SCORER = None
 
 
 def process_results_mc2(doc, results):
-    ll, _ = zip(*results)
+    ll, _ = zip(*results, strict=False)
     ll = np.array(ll)
 
     # Shift before exponentiating to avoid underflow for small likelihoods.
@@ -112,14 +112,14 @@ def process_results_gen(doc, results):
         "bleu_acc": bleu_acc,
         "bleu_diff": bleu_diff,
         "rouge1_max": rouge1_max,
-        "rouge1_diff": rouge1_diff,
         "rouge1_acc": rouge1_acc,
+        "rouge1_diff": rouge1_diff,
         "rouge2_max": rouge2_max,
-        "rouge2_diff": rouge2_diff,
         "rouge2_acc": rouge2_acc,
+        "rouge2_diff": rouge2_diff,
         "rougeL_max": rougeL_max,
-        "rougeL_diff": rougeL_diff,
         "rougeL_acc": rougeL_acc,
+        "rougeL_diff": rougeL_diff,
     }
 
 
@@ -172,7 +172,7 @@ def rouge(refs, preds):
 
     # Accumulate confidence intervals.
     aggregator = scoring.BootstrapAggregator()
-    for ref, pred in zip(refs, preds):
+    for ref, pred in zip(refs, preds, strict=False):
         ref = _prepare_summary(ref)
         pred = _prepare_summary(pred)
         aggregator.add_scores(scorer.score(ref, pred))

--- a/tests/test_truthfulqa_mc2_stability.py
+++ b/tests/test_truthfulqa_mc2_stability.py
@@ -17,7 +17,9 @@ def _decimal_reference(log_likelihoods, labels):
     with localcontext() as ctx:
         ctx.prec = 80
         probabilities = [Decimal(str(float(score))).exp() for score in log_likelihoods]
-        correct = sum(p for p, label in zip(probabilities, labels) if label == 1)
+        correct = sum(
+            p for p, label in zip(probabilities, labels, strict=True) if label == 1
+        )
         return float(correct / sum(probabilities))
 
 

--- a/tests/test_truthfulqa_mc2_stability.py
+++ b/tests/test_truthfulqa_mc2_stability.py
@@ -1,0 +1,75 @@
+from decimal import Decimal, localcontext
+from itertools import permutations
+
+import numpy as np
+import pytest
+
+from lm_eval.tasks.truthfulqa.utils import process_results_mc2
+
+
+def _score(log_likelihoods, labels):
+    doc = {"mc2_targets": {"labels": labels}}
+    results = [(score, False) for score in log_likelihoods]
+    return process_results_mc2(doc, results)["acc"]
+
+
+def _decimal_reference(log_likelihoods, labels):
+    with localcontext() as ctx:
+        ctx.prec = 80
+        probabilities = [Decimal(str(float(score))).exp() for score in log_likelihoods]
+        correct = sum(p for p, label in zip(probabilities, labels) if label == 1)
+        return float(correct / sum(probabilities))
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("offset", [0.0, -1000.0, -10000.0])
+def test_mc2_preserves_relative_probability_for_small_likelihoods(dtype, offset):
+    scores = np.array([-1.0, -2.0, -3.0], dtype=dtype) + dtype(offset)
+    labels = [1, 0, 1]
+    with np.errstate(invalid="raise", divide="raise"):
+        actual = _score(scores, labels)
+    assert np.isfinite(actual)
+    assert actual == pytest.approx(_decimal_reference(scores, labels), rel=1e-6)
+
+
+@pytest.mark.parametrize("labels", [[1, 0, 0], [1, 1, 0], [1, 1, 1]])
+def test_mc2_equal_small_likelihoods(labels):
+    assert _score([-1000.0] * 3, labels) == pytest.approx(sum(labels) / 3)
+
+
+@pytest.mark.parametrize("offset", [-1000.0, -10000.0])
+def test_mc2_is_invariant_to_common_log_likelihood_shift(offset):
+    scores = np.array([-1.0, -2.0, -3.0, -4.0])
+    assert _score(scores + offset, [1, 0, 1, 0]) == pytest.approx(
+        _score(scores, [1, 0, 1, 0])
+    )
+
+
+def test_mc2_permuting_answers_and_labels_preserves_score():
+    scores = [-1000.0, -1001.0, -1002.0]
+    labels = [1, 0, 1]
+    expected = _decimal_reference(scores, labels)
+    for order in permutations(range(3)):
+        actual = _score([scores[i] for i in order], [labels[i] for i in order])
+        assert actual == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("labels, expected", [([1, 0], 1.0), ([0, 1], 0.0)])
+def test_mc2_handles_zero_probability_option(labels, expected):
+    assert _score([-1000.0, -np.inf], labels) == expected
+
+
+def test_mc2_does_not_turn_undefined_distribution_into_valid_score():
+    # All-impossible candidates have no normalizable mass, before or after this fix.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        assert np.isnan(_score([-np.inf, -np.inf], [1, 0]))
+
+
+def test_mc2_matches_existing_formula_in_nondegenerate_range():
+    rng = np.random.default_rng(42)
+    for _ in range(100):
+        scores = rng.uniform(-50.0, -1.0, size=8)
+        labels = rng.integers(0, 2, size=8)
+        probabilities = np.exp(scores)
+        expected = probabilities[labels == 1].sum() / probabilities.sum()
+        assert _score(scores, labels) == pytest.approx(expected, rel=1e-12, abs=1e-14)


### PR DESCRIPTION
## Description

Fix numerical underflow in TruthfulQA MC2 scoring.

`process_results_mc2()` previously exponentiated log-likelihoods directly before normalizing them. When all candidate log-likelihoods are sufficiently negative, every exponential can underflow to zero. Normalization then produces `0/0`, returning `NaN` even though the relative likelihoods are well-defined.

Subtract the maximum log-likelihood before exponentiation:

```python
probs = np.exp(ll - np.max(ll))
```

This common shift cancels during normalization, preserving the metric's mathematical definition while avoiding underflow of the entire probability vector.

For example:

```text
Log-likelihoods: [-1000, -1001]
Correct labels: [1, 0]

Before: NaN
After:  0.7310585786
```

No changes are made to the dataset, prompts, model execution, or metric definition. No new dependencies are introduced.

The existing `zip()` calls in the utility file also specify `strict=False` explicitly to satisfy lint checks without changing their behavior.

## Related Issues

No separate issue linked. This PR addresses finite-log-likelihood underflow specifically, rather than every possible cause of a NaN score.

## Type of Change

- [x] Bug fix

## Testing

Added 16 regression cases covering small finite likelihoods, float32 and float64 inputs, equal likelihoods, common score shifts, answer/label permutations, and zero-probability options.

Expected probabilities are checked against an 80-digit Decimal reference. Additional comparisons verify agreement with the previous formula in a nondegenerate numerical range.

Validation used a native editable project installation on Ubuntu with Python 3.12:

```bash
python -m pytest tests/test_truthfulqa_mc2_stability.py -q --tb=short
# 16 passed
```

The validation workflow also confirms that the unchanged implementation fails the regression suite without collection errors.

Ruff 0.16.3 lint and formatting checks pass for both changed files, as does `git diff --check`.

[Native validation run](https://github.com/Anormalm/lm-evaluation-harness/actions/runs/34042760149)

## Limitations

This change does not introduce a fallback score for an undefined distribution in which every candidate has log-likelihood `-inf`. The regression suite explicitly checks that this case is not converted into an apparently valid score.

## Checklist

- [x] Regression tests added
- [x] Focused tests pass in the native project environment
- [x] Changed files pass lint, formatting, and whitespace checks
- [x] I have reviewed the implementation and tests