### PR TITLE
feat(theoremqa): add TheoremQA text-only task

### DIFF
--- a/lm_eval/tasks/theoremqa/README.md
+++ b/lm_eval/tasks/theoremqa/README.md
@@ -1,0 +1,64 @@
+# theoremqa
+
+### Paper
+
+Title: `TheoremQA: A Theorem-driven Question Answering Dataset`
+
+Abstract: `The recent LLMs like GPT-4 and PaLM-2 have made tremendous progress in solving fundamental math problems like GSM8K by achieving over 90% accuracy. However, their capabilities to solve more challenging math problems which require domain-specific knowledge (i.e. theorem) have yet to be investigated. In this paper, we introduce TheoremQA, the first theorem-driven question-answering dataset designed to evaluate AI models' capabilities to apply theorems to solve challenging science problems.`
+
+Homepage: https://github.com/TIGER-AI-Lab/TheoremQA
+
+### Citation
+
+```
+@inproceedings{chen-etal-2023-theoremqa,
+    title     = {{T}heorem{QA}: A Theorem-driven Question Answering Dataset},
+    author    = {Wenhu Chen and Ming Yin and Max Ku and Pan Lu and Yixin Wan and Xueguang Ma and Jianyu Xu and Xinyi Wang and Tony Xia},
+    booktitle = {Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing},
+    year      = {2023},
+    pages     = {7889--7901},
+}
+```
+
+### Groups, Tags, and Tasks
+
+#### Tasks
+
+* `theoremqa`: 5-shot chain-of-thought evaluation over the text-only questions, scored with the reference repository's type-aware answer matching.
+
+### Implementation notes
+
+**Text-only subset.** The dataset ships 800 test rows, 53 of which carry a
+`Picture`. A text-only model cannot answer those, so `process_docs` drops the
+column and keeps the remaining **747** rows. The column is removed rather than
+ignored because `datasets` decodes `Image` features on access and raises
+`ImportError` without Pillow, which would otherwise break loading for anyone
+who installed the harness without the `dev` extra. Reported numbers are
+therefore not comparable to multimodal runs over the full 800.
+
+**Few-shot prompts are fixed, not sampled.** The dataset has only a `test`
+split, so sampling few-shot context would leak evaluation rows. The five
+prompts in `utils.list_fewshot_samples` are carried verbatim from the reference
+repository's `examples.py`, and none of the five questions appears in the 800
+test rows. One repair was needed: that file uses a non-raw string, so the third
+example's `\frac` reached runtime as a form feed.
+
+**Scoring** follows the reference `utils.py` / `number_utils.py`: comparison is
+driven by each row's `Answer_type`, floats match inside a 4% relative window,
+integers match after rounding, and lists match elementwise after sorting.
+Two deliberate deviations: the reference resolves predictions with
+`latex2sympy` and `eval()`, while this task parses numbers directly, so it adds
+no dependency and never executes model output. A prediction whose only form is
+LaTeX needing a CAS is therefore scored incorrect rather than evaluated.
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [X] Is the task an existing benchmark in the literature?
+  * [X] Have you referenced the original paper that introduced the task?
+  * [X] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/theoremqa/theoremqa.yaml
+++ b/lm_eval/tasks/theoremqa/theoremqa.yaml
@@ -1,0 +1,24 @@
+task: theoremqa
+dataset_path: TIGER-Lab/TheoremQA
+output_type: generate_until
+test_split: test
+process_docs: !function utils.process_docs
+doc_to_text: !function utils.doc_to_text
+doc_to_target: "{{Answer if few_shot is undefined else Solution}}"
+process_results: !function utils.process_results
+target_delimiter: " "
+num_fewshot: 5
+fewshot_config:
+  sampler: first_n
+  samples: !function utils.list_fewshot_samples
+generation_kwargs:
+  until:
+    - "Question:"
+  do_sample: false
+  temperature: 0.0
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/theoremqa/utils.py
+++ b/lm_eval/tasks/theoremqa/utils.py
@@ -1,0 +1,305 @@
+"""Evaluation utilities for TheoremQA.
+
+Scoring follows the official implementation
+(https://github.com/TIGER-AI-Lab/TheoremQA, `utils.py` / `number_utils.py`):
+answers are compared per `Answer_type`, floats within a 4% relative window,
+integers after rounding, and lists elementwise after sorting.
+
+Two deliberate deviations from the reference code:
+
+- The reference resolves predictions with `latex2sympy` and `eval()`. This
+  module parses numbers directly instead, so the task adds no dependency and
+  never executes model output. Predictions whose only form is LaTeX that needs
+  a CAS are scored incorrect rather than evaluated.
+- Rows carrying an image are dropped (see `process_docs`); the reference ships
+  them for multimodal runs.
+- An `option` answer must name exactly one choice. The reference only checks
+  that the gold label appears in the prediction, so an answer enumerating every
+  option scores correct there (11 of the 16 option rows).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from typing import Any
+
+import datasets
+
+
+BOOL_TRUE = ("true", "yes")
+BOOL_FALSE = ("false", "no")
+OPTIONS = ("(a)", "(b)", "(c)", "(d)", "(e)", "(f)")
+ANSWER_TRIGGER = "the answer is"
+NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?")
+FRACTION_RE = re.compile(r"^(-?\d+(?:\.\d+)?)\s*/\s*(-?\d+(?:\.\d+)?)$")
+REL_TOLERANCE = 0.04
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    """Keep the text-only rows and drop the image column.
+
+    53 of the 800 test rows carry a `Picture`, which a text-only task cannot
+    answer. The column is removed rather than ignored because `datasets`
+    decodes `Image` features on access and raises `ImportError` when Pillow is
+    absent, which would break loading for text-only users.
+    """
+    dataset = dataset.cast_column("Picture", datasets.Image(decode=False))
+    dataset = dataset.filter(lambda doc: doc["Picture"] is None)
+    return dataset.remove_columns("Picture")
+
+
+def doc_to_text(doc: dict[str, Any]) -> str:
+    return f"Question: {doc['Question']}\nAnswer:"
+
+
+def _strip_units(text: str) -> str:
+    """Drop the currency, percent, and degree marks the reference cleans."""
+    text = text.replace("%", "").replace("$", "").replace("¥", "")
+    return text.replace("°C", "").replace("°", "").strip()
+
+
+def _to_number(text: str | float) -> float | None:
+    """Parse one scalar without evaluating the string."""
+    if isinstance(text, (int, float)):
+        return float(text)
+    candidate = _strip_units(str(text)).replace(",", "").strip()
+    fraction = FRACTION_RE.match(candidate)
+    if fraction is not None:
+        numerator, denominator = float(fraction[1]), float(fraction[2])
+        return numerator / denominator if denominator else None
+    try:
+        return float(candidate)
+    except ValueError:
+        pass
+    numbers = NUMBER_RE.findall(candidate)
+    return float(numbers[-1]) if len(numbers) == 1 else None
+
+
+def _to_number_list(text: str) -> list[float] | None:
+    """Parse a bracketed list literal; `ast` keeps this away from `eval`."""
+    candidate = _strip_units(text)
+    if not (candidate.startswith(("[", "(")) and candidate.endswith(("]", ")"))):
+        return None
+    try:
+        parsed = ast.literal_eval(candidate)
+    except (ValueError, SyntaxError):
+        return None
+    if not isinstance(parsed, (list, tuple)):
+        return None
+    values = [_to_number(item) for item in parsed]
+    return None if any(value is None for value in values) else values
+
+
+def _numbers_match(prediction: float, gold: float, gold_is_integer: bool) -> bool:
+    if gold_is_integer:
+        return round(prediction) == round(gold)
+    return abs(prediction - gold) <= abs(gold) * REL_TOLERANCE
+
+
+def extract_answer(completion: str) -> str:
+    """Take the span after the answer trigger, else the last line."""
+    text = completion.split("Question:")[0].strip()
+    lowered = text.lower()
+    if ANSWER_TRIGGER in lowered:
+        text = text[lowered.rindex(ANSWER_TRIGGER) + len(ANSWER_TRIGGER) :]
+    else:
+        text = text.splitlines()[-1] if text.splitlines() else ""
+    return text.strip().rstrip(".").rstrip("/").strip()
+
+
+def is_correct(prediction: str, gold: str, answer_type: str) -> bool:
+    """Compare one prediction against the gold answer of its declared type."""
+    prediction = prediction.strip()
+    if not prediction:
+        return False
+    lowered = prediction.lower()
+    if answer_type == "bool":
+        wanted = gold.strip().lower() in BOOL_TRUE
+        said_true = any(token in lowered for token in BOOL_TRUE)
+        said_false = any(token in lowered for token in BOOL_FALSE)
+        if said_true == said_false:
+            return False
+        return said_true if wanted else said_false
+    if answer_type == "option":
+        # The reference accepts any prediction containing the gold label, which
+        # also passes an answer that enumerates every option. Require that
+        # exactly one label was named.
+        named = [option for option in OPTIONS if option in lowered]
+        return named == [gold.strip().lower()]
+    if answer_type.startswith("list of"):
+        predicted = _to_number_list(prediction)
+        expected = _to_number_list(gold)
+        if predicted is None or expected is None or len(predicted) != len(expected):
+            return False
+        integers = answer_type.endswith("integer")
+        return all(
+            _numbers_match(p, g, integers)
+            for p, g in zip(sorted(predicted), sorted(expected), strict=True)
+        )
+    predicted_number = _to_number(prediction)
+    expected_number = _to_number(gold)
+    if predicted_number is None or expected_number is None:
+        return lowered == gold.strip().lower()
+    return _numbers_match(predicted_number, expected_number, answer_type == "integer")
+
+
+def process_results(doc: dict[str, Any], results: list[str]) -> dict[str, float]:
+    prediction = extract_answer(results[0])
+    correct = is_correct(prediction, doc["Answer"], doc["Answer_type"])
+    return {"exact_match": float(correct)}
+
+
+def list_fewshot_samples() -> list[dict[str, str]]:
+    r"""The reference repository's five worked examples, carried verbatim.
+
+    The dataset ships only a `test` split, so few-shot context cannot be
+    sampled from the data without leaking evaluation rows; none of these five
+    questions appears in the 800 test rows. Text is copied from `examples.py`
+    upstream, with one repair: the third example's source uses a non-raw
+    string, so its `\\frac` reached runtime as a form feed.
+    """
+    return [
+        {
+            "Question": "In a 10 Gigabit Ethernet network, the average size of a "
+            "frame is 1500 bytes. If a burst of noise lasting 1ms "
+            "interrupts the network, how many frames are lost?",
+            "Solution": "First, calculate the data rate in bytes/s:\n"
+            "\n"
+            "10 Gigabit/s * (1 Byte / 8 bits) = 1.25 * 10^9 Bytes/s\n"
+            "\n"
+            "Next, calculate the data loss in bytes due to the noise:\n"
+            "\n"
+            "1 ms * 1.25 * 10^9 Bytes/s = 1.25 * 10^6 Bytes\n"
+            "\n"
+            "Finally, divide the data loss by the average frame size "
+            "to get the number of frames lost:\n"
+            "\n"
+            "1.25 * 10^6 Bytes / 1500 Bytes/frame ≈ 833.33 frames\n"
+            "The answer is 833.33",
+            "few_shot": "1",
+        },
+        {
+            "Question": "Given x = 0.157, what is the value of x \\times "
+            "\\frac{\\prod_{n=1}^\\infty (1 - \\frac{x^2}{n^2 "
+            "\\pi^2})}{\\sin(x)}?",
+            "Solution": "To evaluate the expression $x \\times "
+            "\\frac{\\prod_{n=1}^{\\infty} (1 - \\frac{x^2}{n^2 "
+            "\\pi^2})}{\\sin(x)}$ given x = 0.157, we first recognize "
+            "that the product in the numerator is related to the sine "
+            "function through the Euler's reflection formula for the "
+            "sine function, which can be expressed as:\n"
+            "\n"
+            "$$\\sin(x) = x \\prod_{n=1}^{\\infty} \\left(1 - "
+            "\\frac{x^2}{n^2 \\pi^2}\\right)$$\n"
+            "\n"
+            "Therefore, the given expression simplifies to: $x \\times "
+            "\\frac{\\sin(x)}{\\sin(x)}$\n"
+            "\n"
+            "Because sin(x) in the numerator and denominator cancels "
+            "out, the expression simplifies further to just x.\n"
+            "\n"
+            "So, given x = 0.157, the value of the expression is "
+            "0.157. This result is derived from the properties of the "
+            "sine function and does not require computational "
+            "evaluation.\n"
+            "The answer is 0.157",
+            "few_shot": "1",
+        },
+        {
+            "Question": "Consider the basis C of \\mathbb{R}^2 consisting of "
+            "vectors u_1 = [2, 4] and u_2 = [1, -1]. If y = [8, 12], "
+            "find the C-coordinate vector of y.",
+            "Solution": "The goal is to express y as a linear combination of the "
+            "basis vectors of C, i.e., $y = a\\cdot u_1 + b\\cdot "
+            "u_2$, where a and b are the scalar coefficients that we "
+            "want to find. These coefficients will form the "
+            "C-coordinate vector of y, which we'll denote as $[a, "
+            "b]_C$.\n"
+            "\n"
+            "Given:\n"
+            "- $u_1 = [2, 4]$,\n"
+            "- $u_2 = [1, -1]$,\n"
+            "- $y = [8, 12]$.\n"
+            "\n"
+            "We need to solve the system of linear equations:\n"
+            "2a + 1b = 8\n"
+            "4a - 1b = 12\n"
+            "\n"
+            "Let's solve this system of equations to find a and b.\n"
+            "\n"
+            "The solution to the system of equations is $a = "
+            "\\frac{10}{3} and b = \\frac{4}{3}$. Therefore, the "
+            "C-coordinate vector of y in the basis consisting of "
+            "vectors u_1 = [2, 4] and u_2 = [1, -1] is "
+            "$\\left[\\frac{10}{3}, \\frac{4}{3}\\right]_C$. \n"
+            "Let's calculate the numerical value of "
+            "$\\left[\\frac{10}{3}, \\frac{4}{3}\r"
+            "ight]_C$ as [3.33, 1.33].\n"
+            "The answer is [3.33, 1.33]",
+            "few_shot": "1",
+        },
+        {
+            "Question": "One can draw a simple, connected planar graph with 200 "
+            "vertices and 397 edges. Is this statement Trur or False?",
+            "Solution": "To determine the answer, we can use Euler's formula for "
+            "planar graphs, which states that for any finite, "
+            "connected, planar graph, $V - E + F = 2$, where V is the "
+            "number of vertices, E is the number of edges, and F is "
+            "the number of faces.\n"
+            "\n"
+            "Given the modified question, we have V = 200 vertices and "
+            "E = 397 edges. We want to find if we can have a graph "
+            "that satisfies these conditions, adhering to Euler's "
+            "formula.\n"
+            "\n"
+            "First, let's rearrange Euler's formula to solve for F:  F "
+            "= E - V + 2\n"
+            "\n"
+            "Substituting the given values: F = 397 - 200 + 2,  F = "
+            "199\n"
+            "\n"
+            "This means a graph with 200 vertices and 397 edges would "
+            "have 199 faces. However, to determine the truth of this "
+            "possibility, we should check if this graph doesn't "
+            "violate any other planar graph constraints, particularly "
+            "regarding the number of edges.\n"
+            "\n"
+            "For a simple, connected planar graph, there's also a "
+            "relationship between vertices, edges, and faces given by "
+            "the inequality: $E \\leq 3V - 6$\n"
+            "\n"
+            "Substituting V = 200 gives: $E \\leq 3*200 - 6 = 594$\n"
+            "\n"
+            "With E = 397, the condition $E \\leq 594$ is satisfied, "
+            "meaning it's theoretically possible in terms of the edge "
+            "condition for a planar graph.\n"
+            "\n"
+            "Therefore, one can draw a simple, connected planar graph "
+            "with 200 vertices and 397 edges, resulting in 199 faces, "
+            "without violating the conditions for it to be planar "
+            "according to both Euler's formula and the constraint on "
+            "the maximum number of edges.\n"
+            "The answer is True",
+            "few_shot": "1",
+        },
+        {
+            "Question": "Given a finite group G, and a collection of permutations "
+            "H on a set. Then (a) there always exists H such that G is "
+            "isomorphic to H; (b) for any H, G is isomorphic to H; (c) "
+            "G can never be isomorphic to H; (d) none of the above. "
+            "Which option is correct?",
+            "Solution": "This is based on Cayley's theorem, which states that "
+            "every group G is isomorphic to a subgroup of the "
+            "symmetric group acting on G. \n"
+            "In other words, for every finite group G, there exists a "
+            "collection of permutations H (which in this context, can "
+            "be thought of as the set of permutations representing the "
+            "action of G on itself) such that G is isomorphic to H.\n"
+            "\n"
+            "Therefore, there always exists H such that G is "
+            "isomorphic to H.\n"
+            "The answer is (a)",
+            "few_shot": "1",
+        },
+    ]

--- a/tests/test_theoremqa.py
+++ b/tests/test_theoremqa.py
@@ -1,0 +1,109 @@
+import datasets
+import pytest
+
+from lm_eval.tasks.theoremqa.utils import (
+    extract_answer,
+    is_correct,
+    list_fewshot_samples,
+    process_docs,
+    process_results,
+)
+
+
+@pytest.mark.parametrize(
+    "completion, expected",
+    [
+        ("The answer is 833.33", "833.33"),
+        ("...so it follows.\nThe answer is True.", "True"),
+        # the last trigger wins, as in the reference implementation
+        ("The answer is 3\nThe answer is 4", "4"),
+        # a continued few-shot block stops at the next question
+        ("The answer is 7\n\nQuestion: something else", "7"),
+        # no trigger: fall back to the final line
+        ("Working through it\n11760", "11760"),
+        ("", ""),
+    ],
+)
+def test_extract_answer(completion, expected):
+    assert extract_answer(completion) == expected
+
+
+@pytest.mark.parametrize(
+    "prediction, gold, answer_type, expected",
+    [
+        # floats carry the reference's 4% relative window
+        ("833.33", "833.33", "float", True),
+        ("850", "833.33", "float", True),
+        ("900", "833.33", "float", False),
+        ("-0.98", "-1.0", "float", True),
+        # integers compare after rounding, so the window does not apply
+        ("11760", "11760", "integer", True),
+        ("11759.6", "11760", "integer", True),
+        ("11800", "11760", "integer", False),
+        # fractions and units are parsed rather than rejected
+        ("10/3", "3.33", "float", True),
+        ("$42", "42", "integer", True),
+        ("5%", "5", "integer", True),
+        # bool accepts yes/no phrasing, and refuses an answer claiming both
+        ("True", "True", "bool", True),
+        ("Yes, such a graph exists", "True", "bool", True),
+        ("No", "True", "bool", False),
+        ("False", "False", "bool", True),
+        ("true or false depending on the case", "True", "bool", False),
+        # options match on the labelled choice anywhere in the span
+        ("(a)", "(a)", "option", True),
+        ("the correct option is (A)", "(a)", "option", True),
+        ("(b)", "(a)", "option", False),
+        # an answer naming every option must not pass on containment alone
+        ("(a), (b), (c), (d)", "(a)", "option", False),
+        # lists compare elementwise after sorting, and length must match
+        ("[1, 2, 3]", "[3, 2, 1]", "list of integer", True),
+        ("[1, 2]", "[1, 2, 3]", "list of integer", False),
+        ("[3.33, 1.33]", "[1.33, 3.33]", "list of float", True),
+        ("(3.33, 1.33)", "[1.33, 3.33]", "list of float", True),
+        ("3.33, 1.33", "[1.33, 3.33]", "list of float", False),
+        # unparsable predictions score wrong instead of raising
+        ("\\frac{10}{3}", "3.33", "float", False),
+        ("", "3.33", "float", False),
+    ],
+)
+def test_is_correct(prediction, gold, answer_type, expected):
+    assert is_correct(prediction, gold, answer_type) is expected
+
+
+def test_process_results_scores_one_doc():
+    doc = {"Question": "q", "Answer": "833.33", "Answer_type": "float"}
+    assert process_results(doc, ["The answer is 850"]) == {"exact_match": 1.0}
+    assert process_results(doc, ["The answer is 900"]) == {"exact_match": 0.0}
+
+
+def test_process_docs_drops_image_rows_and_column():
+    dataset = datasets.Dataset.from_dict(
+        {
+            "Question": ["text only", "needs a figure"],
+            "Answer": ["1", "2"],
+            "Answer_type": ["integer", "integer"],
+            "Picture": [None, {"bytes": b"not-a-real-image", "path": None}],
+        },
+        features=datasets.Features(
+            {
+                "Question": datasets.Value("string"),
+                "Answer": datasets.Value("string"),
+                "Answer_type": datasets.Value("string"),
+                "Picture": datasets.Image(decode=False),
+            }
+        ),
+    )
+
+    processed = process_docs(dataset)
+
+    assert "Picture" not in processed.column_names
+    assert processed["Question"] == ["text only"]
+
+
+def test_fewshot_samples_carry_a_target_and_a_flag():
+    samples = list_fewshot_samples()
+    assert len(samples) == 5
+    for sample in samples:
+        assert sample["few_shot"] == "1"
+        assert sample["Solution"].strip().splitlines()[-1].startswith("The answer is")


### PR DESCRIPTION
Closes #518. The issue is assigned to @ShayekhBinIslam from 2024-04 with no PR since, so I picked it up and said so on the issue before starting — happy to step aside if that assignment is still live.

## Changes

- Add `lm_eval/tasks/theoremqa/` — TheoremQA as a single `theoremqa` task, 5-shot chain-of-thought, `generate_until`. Data loads from `TIGER-Lab/TheoremQA`, which is parquet-native and needs no `trust_remote_code` under `datasets>=5`.
- Scoring follows the reference repository's `utils.py` / `number_utils.py`: comparison is driven by each row's `Answer_type`, floats match inside a 4% relative window, integers match after rounding, and lists match elementwise after sorting.
- **Text-only subset: 747 of 800 rows.** 53 rows carry a `Picture`, which a text-only model cannot answer. `process_docs` removes the column rather than ignoring it, because `datasets` decodes `Image` features on access and raises `ImportError` without Pillow — leaving the column in breaks loading for anyone who installed the harness without the `dev` extra. The README states the subset, so numbers are not compared against multimodal runs over the full 800.

  ```python
  >>> ds = load_dataset("TIGER-Lab/TheoremQA", split="test")          # 800
  >>> ds = ds.cast_column("Picture", datasets.Image(decode=False))
  >>> sum(1 for p in ds["Picture"] if p is not None)                  # 53
  >>> Counter(ds["Answer_type"])
  {'float': 378, 'integer': 216, 'bool': 115, 'list of integer': 61,
   'option': 18, 'list of float': 12}
  ```

- **Few-shot context is fixed, not sampled.** The dataset ships only a `test` split, so sampling would put evaluation rows in the prompt. `utils.list_fewshot_samples` carries the five worked examples from the reference repository's `examples.py` verbatim; none of the five questions appears in the 800 test rows. One repair was needed: that file uses a non-raw string, so the third example's `\frac` reached runtime as a form feed.
- Two deliberate deviations from the reference, both documented in the module docstring and README:
  - The reference resolves predictions with `latex2sympy` and `eval()`. This task parses numbers directly, so it adds no dependency and never executes model output. A prediction whose only form is LaTeX needing a CAS scores incorrect rather than being evaluated.
  - An `option` answer must name exactly one choice. The reference only checks that the gold label appears in the prediction, which also passes an answer enumerating every option — that path scored 11 of the 16 option rows correct on a prediction that named all of them.
- `tests/test_theoremqa.py`: 35 tests over answer extraction, per-type comparison, the image-row filter, and the few-shot samples.

## Reproduction

`EleutherAI/pythia-70m`, `--limit 10` at the task's default 5-shot and `--limit 5` at `--num_fewshot 0`. A 70M model cannot do theorem-driven QA, so zero is the expected result; the run is here to show the prompt path, the stop condition, and the scorer all fire end to end.

```
lm_eval --model hf --model_args pretrained=EleutherAI/pythia-70m \
  --tasks theoremqa --limit 10 --batch_size 8
```

| Run | docs (test, text-only) | n-shot | exact_match |
|-----|-----------------------:|-------:|------------:|
| default | 747 | 5 | 0.000 |
| `--num_fewshot 0` | 747 | 0 | 0.000 |

Since exact match is zero at this model size, I checked the scorer separately rather than inferring it from the table:

| Injected prediction | exact_match |
|---------------------|------------:|
| each doc's gold answer | 1.000 (747/747) |
| empty string | 0.000 |
| `The answer is True, False, (a), (b), 0, 1, [1, 2]` | 0.000 |

The third row is the enumeration case above; before the `option` rule was tightened it scored 0.015.

Few-shot and evaluation documents are disjoint — `fewshot_docs()` returns the five fixed samples and their questions do not intersect `eval_docs` (5 and 747, intersection 0).

## Task validity checklist

- [x] Is the task an existing benchmark in the literature? (TheoremQA, [EMNLP 2023](https://aclanthology.org/2023.emnlp-main.489/))
  - [x] Referenced the original paper.
  - [x] Reference implementation? Type-aware matching, the 4% float window and the integer rounding follow [TIGER-AI-Lab/TheoremQA](https://github.com/TIGER-AI-Lab/TheoremQA); the two deviations are listed above.
- [x] "Main" variant clearly denoted (single `theoremqa` task).
- [x] Short sentence on what the task evaluates in the README.
- [x] Noted which published setup is matched (5-shot CoT with the reference prompts, text-only subset).
