### PR TITLE
Reject cyclic result hierarchies during table formatting

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -264,7 +264,7 @@ def pattern_match(patterns, source_list):
     for pattern in patterns:
         for matching in fnmatch.filter(source_list, pattern):
             task_names.add(matching)
-    return sorted(list(task_names))
+    return sorted(task_names)
 
 
 def softmax(x) -> np.ndarray:
@@ -452,9 +452,35 @@ def _build_hierarchy_info(
 
     Returns:
         (depth_map, ordered_keys) — depths for indentation, keys in display order
+
+    Raises:
+        ValueError: If the group hierarchy contains a cycle.
     """
     depth_map: dict[str, int] = {}
     ordered: list[str] = []
+
+    active: set[str] = set()
+    completed: set[str] = set()
+    path: list[str] = []
+
+    def validate(name: str) -> None:
+        if name in active:
+            cycle_start = path.index(name)
+            cycle = [*path[cycle_start:], name]
+            raise ValueError(f"Cycle detected in group hierarchy: {' -> '.join(cycle)}")
+        if name in completed:
+            return
+
+        active.add(name)
+        path.append(name)
+        for child in sorted(group_subtasks.get(name, [])):
+            validate(child)
+        path.pop()
+        active.remove(name)
+        completed.add(name)
+
+    for name in sorted(group_subtasks):
+        validate(name)
 
     def visit(name: str, depth: int):
         depth_map[name] = depth
@@ -508,7 +534,7 @@ def make_table(result_dict, column: str = "results", sort_results: bool = False)
         group_subtasks, set(result_dict[column].keys())
     )
 
-    if sort_results:  # noqa: SIM108
+    if sort_results:
         # sort entries alphabetically by task or group name.
         # NOTE: we default here to false, because order matters for multi-level table printing a la mmlu.
         # sorting here would mess that up
@@ -813,7 +839,9 @@ class RemoteTokenizer:
         resp = self._request_with_retries("POST", url, json=payload)
         tokens = resp.json().get("tokens")
         if not isinstance(tokens, list):
-            raise RuntimeError("Malformed response from /tokenize endpoint.")
+            raise RuntimeError(  # noqa: TRY004
+                "Malformed response from /tokenize endpoint."
+            )
         return tokens
 
     def decode(self, tokens: list[int]) -> str:
@@ -822,7 +850,9 @@ class RemoteTokenizer:
         resp = self._request_with_retries("POST", url, json=payload)
         prompt = resp.json().get("prompt")
         if not isinstance(prompt, str):
-            raise RuntimeError("Malformed response from /detokenize endpoint.")
+            raise RuntimeError(  # noqa: TRY004
+                "Malformed response from /detokenize endpoint."
+            )
         return prompt
 
     def batch_decode(self, tokens_list: list[list[int]]) -> list[str]:

--- a/tests/test_hierarchy_info.py
+++ b/tests/test_hierarchy_info.py
@@ -1,0 +1,49 @@
+import pytest
+
+from lm_eval.utils import _build_hierarchy_info
+
+
+@pytest.mark.parametrize(
+    "group_subtasks",
+    [
+        {"root": ["a"], "a": ["b"], "b": ["a"]},
+        {"a": ["b"], "b": ["a"]},
+    ],
+)
+def test_build_hierarchy_info_rejects_cycles(group_subtasks):
+    with pytest.raises(ValueError, match="Cycle detected in group hierarchy"):
+        _build_hierarchy_info(group_subtasks, set(group_subtasks))
+
+
+def test_build_hierarchy_info_preserves_nested_order():
+    group_subtasks = {
+        "root": ["group_b", "group_a"],
+        "group_a": ["task_a"],
+        "group_b": ["task_b"],
+    }
+
+    depth_map, ordered = _build_hierarchy_info(
+        group_subtasks, {"root", "group_a", "group_b", "task_a", "task_b"}
+    )
+
+    assert depth_map == {
+        "root": 0,
+        "group_a": 1,
+        "task_a": 2,
+        "group_b": 1,
+        "task_b": 2,
+    }
+    assert ordered == ["root", "group_a", "task_a", "group_b", "task_b"]
+
+
+def test_build_hierarchy_info_accepts_shared_children():
+    group_subtasks = {
+        "root": ["left", "right"],
+        "left": ["shared"],
+        "right": ["shared"],
+    }
+
+    depth_map, ordered = _build_hierarchy_info(group_subtasks, {"root"})
+
+    assert depth_map == {"root": 0, "left": 1, "shared": 2, "right": 1}
+    assert ordered == ["root"]


### PR DESCRIPTION
## Summary

- validate every result-hierarchy component before recursive display ordering
- report rooted and rootless cycles as a clear `ValueError` with the cycle path
- preserve existing ordering for valid nested and shared-child hierarchies
- add focused regression coverage for cyclic and valid graphs
- apply behavior-neutral cleanup required by the current Ruff rules for the touched utility module

## Validation

- `PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/test_hierarchy_info.py tests/test_evaluator.py -k 'hierarchy_info or make_table_regression' -q` (6 passed, 6 deselected)
- `PRE_COMMIT_HOME=/tmp/lm-eval-pre-commit pre-commit run --files lm_eval/utils.py tests/test_hierarchy_info.py` (passed)

The broader utility test module requires PyTorch, which is unavailable in the local environment; the upstream CPU test matrix will cover it.

Fixes #4133
