### PR TITLE
Preserve signed integer types in CLI arguments

### DIFF
--- a/lm_eval/_cli/utils.py
+++ b/lm_eval/_cli/utils.py
@@ -101,8 +101,10 @@ def handle_cli_value_string(arg: str) -> bool | int | float | str:
         return True
     elif arg.lower() == "false":
         return False
-    elif arg.isnumeric():
+    try:
         return int(arg)
+    except ValueError:
+        pass
     try:
         return float(arg)
     except ValueError:

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,0 +1,32 @@
+import pytest
+
+from lm_eval._cli.utils import handle_cli_value_string, key_val_to_dict
+
+
+@pytest.mark.parametrize(
+    ("value", "expected", "expected_type"),
+    [
+        ("42", 42, int),
+        ("-1", -1, int),
+        ("+2", 2, int),
+        ("-0.5", -0.5, float),
+        ("1e3", 1000.0, float),
+        ('"123"', "123", str),
+        ("[1, -2]", [1, -2], list),
+        ('{"limit": -1}', {"limit": -1}, dict),
+    ],
+)
+def test_handle_cli_value_string_preserves_value_types(value, expected, expected_type):
+    result = handle_cli_value_string(value)
+
+    assert result == expected
+    assert type(result) is expected_type
+
+
+def test_key_val_to_dict_distinguishes_signed_integers_from_floats():
+    result = key_val_to_dict("top_k=-1,max_tokens=+2,temperature=-0.5")
+
+    assert result == {"top_k": -1, "max_tokens": 2, "temperature": -0.5}
+    assert type(result["top_k"]) is int
+    assert type(result["max_tokens"]) is int
+    assert type(result["temperature"]) is float


### PR DESCRIPTION
## Summary

- attempt integer conversion before float conversion for CLI key-value arguments
- preserve negative and explicitly positive integers as `int` values
- retain existing float, scientific-notation, quoted-string, and structured-literal behavior
- add direct and end-to-end regression coverage for value types

## Validation

- `PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/test_cli_utils.py -q` (9 passed)
- `PYTHONPATH=/tmp/lm-eval-test-deps:/tmp python3 -m pytest tests/test_cli_subcommands.py -k 'run_command_model_args or run_command_metadata' -q` (3 passed, 81 deselected)
- `PRE_COMMIT_HOME=/tmp/lm-eval-pre-commit pre-commit run --files lm_eval/_cli/utils.py tests/test_cli_utils.py` (passed)

Fixes #4135
