### PR TITLE
Allow braces in CLI key-value arguments

### DIFF
--- a/lm_eval/_cli/utils.py
+++ b/lm_eval/_cli/utils.py
@@ -23,7 +23,7 @@ def try_parse_json(value: str | dict[str, Any] | None) -> str | dict[str, Any] |
     try:
         return json.loads(value)
     except json.JSONDecodeError:
-        if "{" in value:
+        if value.lstrip().startswith("{"):
             raise ValueError(
                 f"Invalid JSON: {value}. Hint: Use double quotes for JSON strings."
             ) from None

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -832,6 +832,11 @@ class TestCLIUtils:
         result = try_parse_json("key=value,key2=value2")
         assert result == "key=value,key2=value2"
 
+    def test_try_parse_json_with_braces_in_plain_string(self):
+        """Test that braces within a key-value argument are not treated as JSON."""
+        value = "base_url=http://{yourip}:8000/v1/completions"
+        assert try_parse_json(value) == value
+
     def test_try_parse_json_with_invalid_json(self):
         """Test try_parse_json with invalid JSON."""
         with pytest.raises(ValueError) as exc_info:
@@ -960,6 +965,23 @@ class TestMergeDictAction:
 
         args = parser.parse_args(["--args", "key1=val1,key2=val2"])
         assert args.args == {"key1": "val1", "key2": "val2"}
+
+    def test_key_value_with_braces(self):
+        """Test the documented brace-containing local-server URL."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--args", nargs="+", action=MergeDictAction)
+
+        args = parser.parse_args(
+            [
+                "--args",
+                "model=facebook/opt-125m,base_url=http://{yourip}:8000/v1/completions,num_concurrent=1",
+            ]
+        )
+        assert args.args == {
+            "model": "facebook/opt-125m",
+            "base_url": "http://{yourip}:8000/v1/completions",
+            "num_concurrent": 1,
+        }
 
     def test_space_separated_key_value(self):
         """Test parsing space-separated key=value pairs."""


### PR DESCRIPTION
## Summary

- treat only values that begin with `{` (after leading whitespace) as malformed JSON candidates
- allow braces inside ordinary `key=value` CLI arguments, including the documented `{yourip}` local-server URL
- add unit and end-to-end regression coverage while preserving invalid JSON errors

## Testing

- `python3 -m pytest tests/test_cli_subcommands.py -k "try_parse_json or MergeDictAction" -q` (15 passed)
- `pre-commit run --files lm_eval/_cli/utils.py tests/test_cli_subcommands.py`

Fixes #4143